### PR TITLE
fix: populate merged PR counts and add org/owner filtering

### DIFF
--- a/src/commands/daily.ts
+++ b/src/commands/daily.ts
@@ -37,6 +37,18 @@ export async function runDaily(options: DailyOptions): Promise<void> {
     console.error(`Warning: ${failures.length} PR fetch(es) failed`);
   }
 
+  // Fetch merged PR counts to populate repo scores for accurate statistics
+  // Reset stale repos first (so excluded/removed repos get zeroed)
+  const mergedCounts = await prMonitor.fetchUserMergedPRCounts();
+  for (const score of Object.values(stateManager.getState().repoScores)) {
+    if (!mergedCounts.has(score.repo)) {
+      stateManager.updateRepoScore(score.repo, { mergedPRCount: 0 });
+    }
+  }
+  for (const [repo, count] of mergedCounts) {
+    stateManager.updateRepoScore(repo, { mergedPRCount: count });
+  }
+
   // Generate digest from fresh data
   const digest = prMonitor.generateDigest(prs);
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -271,7 +271,8 @@ export interface AgentConfig {
   // Search preferences
   languages: string[]; // e.g., ["typescript", "javascript", "ruby"]
   labels: string[]; // e.g., ["good first issue", "help wanted"]
-  excludeRepos: string[]; // repos to skip
+  excludeRepos: string[]; // repos to skip (e.g., "owner/repo")
+  excludeOrgs?: string[]; // orgs to skip (e.g., "ClearMatch")
 
   // Trusted projects (where we've had PRs merged)
   trustedProjects: string[];


### PR DESCRIPTION
## Summary
- Add `fetchUserMergedPRCounts()` to query GitHub for merged PRs and populate `repoScores` on each daily run (fixes merged count always showing 0)
- Auto-filter PRs to own repos (owner matches githubUsername)
- Add `excludeOrgs` config for filtering entire organizations
- Zero out stale repo scores for excluded/removed repos on each run

## Test plan
- [x] `npm test` - all 56 tests pass
- [x] Live test: `daily` command shows correct merged count (25 after filtering)
- [x] Excluded orgs and own repos are filtered out of counts