### PR TITLE
fix: deduplicate CI check runs to prevent false failure reports

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "AI-powered autopilot for managing open source contributions - track PRs, respond to maintainers, discover issues, and maintain contribution velocity",
   "author": {
     "name": "John Costa"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-02-07
+
+### Fixed
+
+- Deduplicate CI check runs by name to prevent superseded failures from incorrectly flagging PRs
+  - GitHub's `checks.listForRef` returns all historical runs including re-runs
+  - Now keeps only the most recent run per unique check name
+  - Fixes false "CI Failing" status when a check is re-run and passes
+
+### Added
+
+- Tests for CI status deduplication logic in `pr-monitor.test.ts`
+
 ## [0.4.0] - 2025-02-07
 
 ### Added
@@ -60,6 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR monitoring and health checking
 - Dashboard HTML generation
 
+[0.4.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.1.0...v0.2.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,8 +110,9 @@ The CLI bundle is gitignored and built automatically on first run. During develo
 1. Fork and clone
 2. Create feature branch: `git checkout -b feature/your-feature`
 3. Make changes and test: `npm test`
-4. Commit with conventional format: `feat:`, `fix:`, `refactor:`
-5. Push and open PR
+4. **Bump version and update changelog** (see Versioning below)
+5. Commit with conventional format: `feat:`, `fix:`, `refactor:`
+6. Push and open PR
 
 **Important:**
 - Do NOT push directly to main
@@ -120,10 +121,12 @@ The CLI bundle is gitignored and built automatically on first run. During develo
 
 ### Versioning
 
-- `.claude-plugin/plugin.json` is the source of truth for the plugin version (the marketplace reads it)
-- `package.json` version must always match `plugin.json`
-- Follow [semver](https://semver.org/): new feature = minor bump, bug fix = patch bump
-- Update `CHANGELOG.md` with every release
+**Every PR must include a version bump and changelog entry.**
+
+- Bump the version in **both** `.claude-plugin/plugin.json` and `package.json` (they must always match)
+- Follow [semver](https://semver.org/): bug fix = patch, new feature = minor
+- Add a new section to `CHANGELOG.md` with the bumped version and a description of your changes (use `Added`, `Changed`, `Fixed` headings)
+- Add a comparison link at the bottom of `CHANGELOG.md` for the new version
 
 **AI Attribution Rule (CRITICAL):**
 NEVER add AI attribution to commits, comments, PRs, or any content submitted to external repositories unless explicitly required by that repo's contribution guidelines. This includes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,8 @@ git checkout -b fix/your-bug-fix
 - Add tests if applicable
 - Run `npm test` to ensure tests pass
 - Run `npm run build` to ensure it compiles
+- **Bump the version** in both `package.json` and `.claude-plugin/plugin.json` (they must match). Follow [semver](https://semver.org/): bug fix = patch, new feature = minor
+- **Update `CHANGELOG.md`** with a new version section describing your changes (use `Added`, `Changed`, `Fixed` headings as appropriate). Add a comparison link at the bottom of the file
 
 ### 4. Commit
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "AI-powered autopilot for managing open source contributions with Claude Code",
   "type": "module",
   "main": "dist/index.js",

--- a/src/core/pr-monitor.test.ts
+++ b/src/core/pr-monitor.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for PRMonitor CI status deduplication
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+let mockOctokitInstance: any;
+
+vi.mock('./github.js', () => ({
+  getOctokit: vi.fn(() => mockOctokitInstance),
+}));
+
+vi.mock('./state.js', () => ({
+  getStateManager: vi.fn(() => ({
+    getState: () => ({ config: { githubUsername: 'testuser' } }),
+  })),
+}));
+
+// Import after mocks are set up
+const { PRMonitor } = await import('./pr-monitor.js');
+
+describe('PRMonitor CI status deduplication', () => {
+  const emptyCombinedStatus = {
+    data: {
+      state: 'success',
+      statuses: [],
+    },
+  };
+
+  it('should use latest check run when same check has multiple runs', async () => {
+    // Simulate owncast scenario: "Validate PR checklist" ran 4 times,
+    // 2 old failures followed by 2 newer successes
+    mockOctokitInstance = {
+      repos: {
+        getCombinedStatusForRef: vi.fn().mockResolvedValue(emptyCombinedStatus),
+      },
+      checks: {
+        listForRef: vi.fn().mockResolvedValue({
+          data: {
+            check_runs: [
+              {
+                name: 'Validate PR checklist',
+                status: 'completed',
+                conclusion: 'failure',
+                started_at: '2026-02-07T02:02:00Z',
+              },
+              {
+                name: 'Validate PR checklist',
+                status: 'completed',
+                conclusion: 'failure',
+                started_at: '2026-02-07T19:47:00Z',
+              },
+              {
+                name: 'Validate PR checklist',
+                status: 'completed',
+                conclusion: 'success',
+                started_at: '2026-02-07T19:16:00Z',
+              },
+              {
+                name: 'Validate PR checklist',
+                status: 'completed',
+                conclusion: 'success',
+                started_at: '2026-02-08T03:32:00Z', // Most recent
+              },
+            ],
+          },
+        }),
+      },
+    };
+
+    const monitor = new PRMonitor('fake-token');
+    const result = await (monitor as any).getCIStatus('owncast', 'owncast', 'abc123');
+
+    expect(result.status).toBe('passing');
+    expect(result.failingCheckNames).toEqual([]);
+  });
+
+  it('should report failing when the latest run of a check is a failure', async () => {
+    mockOctokitInstance = {
+      repos: {
+        getCombinedStatusForRef: vi.fn().mockResolvedValue(emptyCombinedStatus),
+      },
+      checks: {
+        listForRef: vi.fn().mockResolvedValue({
+          data: {
+            check_runs: [
+              {
+                name: 'Build',
+                status: 'completed',
+                conclusion: 'success',
+                started_at: '2026-02-07T10:00:00Z',
+              },
+              {
+                name: 'Build',
+                status: 'completed',
+                conclusion: 'failure',
+                started_at: '2026-02-07T12:00:00Z', // More recent failure
+              },
+            ],
+          },
+        }),
+      },
+    };
+
+    const monitor = new PRMonitor('fake-token');
+    const result = await (monitor as any).getCIStatus('owner', 'repo', 'abc123');
+
+    expect(result.status).toBe('failing');
+    expect(result.failingCheckNames).toEqual(['Build']);
+  });
+
+  it('should handle multiple different checks independently', async () => {
+    mockOctokitInstance = {
+      repos: {
+        getCombinedStatusForRef: vi.fn().mockResolvedValue(emptyCombinedStatus),
+      },
+      checks: {
+        listForRef: vi.fn().mockResolvedValue({
+          data: {
+            check_runs: [
+              // "Lint" failed then passed
+              {
+                name: 'Lint',
+                status: 'completed',
+                conclusion: 'failure',
+                started_at: '2026-02-07T10:00:00Z',
+              },
+              {
+                name: 'Lint',
+                status: 'completed',
+                conclusion: 'success',
+                started_at: '2026-02-07T12:00:00Z',
+              },
+              // "Test" only has a passing run
+              {
+                name: 'Test',
+                status: 'completed',
+                conclusion: 'success',
+                started_at: '2026-02-07T11:00:00Z',
+              },
+            ],
+          },
+        }),
+      },
+    };
+
+    const monitor = new PRMonitor('fake-token');
+    const result = await (monitor as any).getCIStatus('owner', 'repo', 'abc123');
+
+    expect(result.status).toBe('passing');
+    expect(result.failingCheckNames).toEqual([]);
+  });
+
+  it('should report failing when one check passes but another still fails', async () => {
+    mockOctokitInstance = {
+      repos: {
+        getCombinedStatusForRef: vi.fn().mockResolvedValue(emptyCombinedStatus),
+      },
+      checks: {
+        listForRef: vi.fn().mockResolvedValue({
+          data: {
+            check_runs: [
+              {
+                name: 'Lint',
+                status: 'completed',
+                conclusion: 'success',
+                started_at: '2026-02-07T12:00:00Z',
+              },
+              {
+                name: 'Test',
+                status: 'completed',
+                conclusion: 'failure',
+                started_at: '2026-02-07T12:00:00Z',
+              },
+            ],
+          },
+        }),
+      },
+    };
+
+    const monitor = new PRMonitor('fake-token');
+    const result = await (monitor as any).getCIStatus('owner', 'repo', 'abc123');
+
+    expect(result.status).toBe('failing');
+    expect(result.failingCheckNames).toEqual(['Test']);
+  });
+});


### PR DESCRIPTION
## Summary

- **Bug:** `getCIStatus` iterated over all check runs from GitHub's `checks.listForRef` API without deduplicating by name. When a CI check is re-run (e.g., after fixing a checklist issue), GitHub returns both old and new runs. The old failures incorrectly flagged PRs as "CI Failing" even when the latest run passed.
- **Fix:** Added deduplication logic that groups check runs by name and keeps only the most recent run per unique check name (compared by `started_at` timestamp).
- **Docs:** Updated CONTRIBUTING.md and CLAUDE.md to require version bump and changelog entry in every PR (not just at release time).

Bumps version to 0.4.1.

## Test plan

- [x] Added 4 unit tests in `pr-monitor.test.ts` covering: same check with multiple runs (latest passes), latest run fails, multiple independent checks, mixed pass/fail across different checks
- [x] All 60 tests pass (`npm test`)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] Bundle builds successfully (`npm run bundle`)
- [x] Verified fix end-to-end: ran `daily --json` against real PRs — owncast#4713 now correctly reports as `healthy`/`passing` instead of `failing_ci`