### PR TITLE
feat: track closed PRs for accurate merge rate and visibility

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "AI-powered autopilot for managing open source contributions - track PRs, respond to maintainers, discover issues, and maintain contribution velocity",
   "author": {
     "name": "John Costa"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-02-08
+
+### Added
+
+- Track closed PRs from GitHub — queries `is:pr is:closed is:unmerged` to populate `closedWithoutMergeCount` in repo scores
+- Recently closed PRs section in daily digest and dashboard — surfaces PRs closed without merge in the last 7 days
+- `fetchUserClosedPRCounts()` and `fetchRecentlyClosedPRs()` methods in PRMonitor
+- `ClosedPR` type and `recentlyClosedPRs` field in `DailyDigest`
+- `recently_closed` actionable issue type for structured output
+
+### Fixed
+
+- Merge rate was always 100% because `closedWithoutMergeCount` was never populated from GitHub
+- Closed PRs were invisible — a PR closed by a maintainer would silently vanish from the dashboard
+
 ## [0.4.1] - 2026-02-07
 
 ### Fixed
@@ -73,6 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR monitoring and health checking
 - Dashboard HTML generation
 
+[0.5.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.2.0...v0.3.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "AI-powered autopilot for managing open source contributions with Claude Code",
   "type": "module",
   "main": "dist/index.js",

--- a/src/commands/daily.ts
+++ b/src/commands/daily.ts
@@ -4,7 +4,7 @@
  * v2: No local state tracking - everything is fetched fresh
  */
 
-import { getStateManager, PRMonitor, getGitHubToken, type DailyDigest, type FetchedPR, type PRCheckFailure, type MaintainerActionHint } from '../core/index.js';
+import { getStateManager, PRMonitor, getGitHubToken, type DailyDigest, type FetchedPR, type PRCheckFailure, type MaintainerActionHint, type ClosedPR } from '../core/index.js';
 import { outputJson, outputJsonError, type DailyOutput, type CapacityAssessment, type ActionableIssue } from '../formatters/json.js';
 
 interface DailyOptions {
@@ -37,9 +37,16 @@ export async function runDaily(options: DailyOptions): Promise<void> {
     console.error(`Warning: ${failures.length} PR fetch(es) failed`);
   }
 
-  // Fetch merged PR counts to populate repo scores for accurate statistics
+  // Fetch merged PR counts, closed PR counts, and recently closed PRs in parallel
+  const [mergedResult, closedCounts, recentlyClosedPRs] = await Promise.all([
+    prMonitor.fetchUserMergedPRCounts(),
+    prMonitor.fetchUserClosedPRCounts(),
+    prMonitor.fetchRecentlyClosedPRs(),
+  ]);
+
+  const { repos: mergedCounts, monthlyCounts } = mergedResult;
+
   // Reset stale repos first (so excluded/removed repos get zeroed)
-  const { repos: mergedCounts, monthlyCounts } = await prMonitor.fetchUserMergedPRCounts();
   for (const score of Object.values(stateManager.getState().repoScores)) {
     if (!mergedCounts.has(score.repo)) {
       stateManager.updateRepoScore(score.repo, { mergedPRCount: 0 });
@@ -49,11 +56,16 @@ export async function runDaily(options: DailyOptions): Promise<void> {
     stateManager.updateRepoScore(repo, { mergedPRCount: count, lastMergedAt: lastMergedAt || undefined });
   }
 
+  // Populate closedWithoutMergeCount in repo scores
+  for (const [repo, count] of closedCounts) {
+    stateManager.updateRepoScore(repo, { closedWithoutMergeCount: count });
+  }
+
   // Store monthly merged counts for the contribution timeline chart
   stateManager.setMonthlyMergedCounts(monthlyCounts);
 
   // Generate digest from fresh data
-  const digest = prMonitor.generateDigest(prs);
+  const digest = prMonitor.generateDigest(prs, recentlyClosedPRs);
 
   // Store digest in state so dashboard can render it
   stateManager.setLastDigest(digest);
@@ -68,7 +80,7 @@ export async function runDaily(options: DailyOptions): Promise<void> {
     // Include pre-formatted summary for Claude to display verbatim
     const summary = formatSummary(digest, capacity);
     // New action-first flow fields
-    const actionableIssues = collectActionableIssues(prs);
+    const actionableIssues = collectActionableIssues(prs, recentlyClosedPRs);
     const briefSummary = formatBriefSummary(digest, actionableIssues.length);
     outputJson<DailyOutput>({ digest, updates: [], capacity, summary, briefSummary, actionableIssues, failures });
   } else {
@@ -172,6 +184,16 @@ function formatSummary(digest: DailyDigest, capacity: CapacityAssessment): strin
     lines.push('');
   }
 
+  // Recently Closed (closed without merge)
+  if (digest.recentlyClosedPRs.length > 0) {
+    lines.push('### 🚫 Recently Closed');
+    for (const pr of digest.recentlyClosedPRs) {
+      const closedDate = pr.closedAt ? new Date(pr.closedAt).toLocaleDateString() : '';
+      lines.push(`- [${pr.repo}#${pr.number}](${pr.url}): ${pr.title}${closedDate ? ` (closed ${closedDate})` : ''}`);
+    }
+    lines.push('');
+  }
+
   // Capacity
   const capacityIcon = capacity.hasCapacity ? '✅' : '⚠️';
   const capacityLabel = capacity.hasCapacity ? 'Ready for new work' : 'Focus on existing PRs';
@@ -256,6 +278,15 @@ function printDigest(digest: DailyDigest, capacity: CapacityAssessment): void {
     console.log('');
   }
 
+  if (digest.recentlyClosedPRs.length > 0) {
+    console.log('🚫 Recently Closed:');
+    for (const pr of digest.recentlyClosedPRs) {
+      const closedDate = pr.closedAt ? new Date(pr.closedAt).toLocaleDateString() : '';
+      console.log(`  - ${pr.repo}#${pr.number}: ${pr.title}${closedDate ? ` (closed ${closedDate})` : ''}`);
+    }
+    console.log('');
+  }
+
   console.log('Run with --json for structured output');
   console.log('Run "dashboard --open" for browser view');
 }
@@ -313,7 +344,7 @@ function formatBriefSummary(digest: DailyDigest, issueCount: number): string {
  * Collect all actionable issues across PRs for the action-first flow
  * Order: Needs response → CI failing → Merge conflicts → Approaching dormant
  */
-function collectActionableIssues(prs: FetchedPR[]): ActionableIssue[] {
+function collectActionableIssues(prs: FetchedPR[], recentlyClosedPRs: ClosedPR[] = []): ActionableIssue[] {
   const issues: ActionableIssue[] = [];
 
   // 1. Needs Response (highest priority - someone is waiting for you)
@@ -353,6 +384,30 @@ function collectActionableIssues(prs: FetchedPR[]): ActionableIssue[] {
     if (pr.status === 'approaching_dormant') {
       issues.push({ type: 'approaching_dormant', pr, label: '[Approaching Dormant]' });
     }
+  }
+
+  // 6. Recently Closed (informational - PRs closed without merge in last 7 days)
+  for (const closedPR of recentlyClosedPRs) {
+    // Create a minimal FetchedPR-like object for the ActionableIssue interface
+    const pr: FetchedPR = {
+      id: 0,
+      url: closedPR.url,
+      repo: closedPR.repo,
+      number: closedPR.number,
+      title: closedPR.title,
+      status: 'healthy', // placeholder
+      createdAt: '',
+      updatedAt: closedPR.closedAt || '',
+      daysSinceActivity: 0,
+      ciStatus: 'unknown',
+      failingCheckNames: [],
+      hasMergeConflict: false,
+      reviewDecision: 'unknown',
+      hasUnrespondedComment: false,
+      hasIncompleteChecklist: false,
+      maintainerActionHints: [],
+    };
+    issues.push({ type: 'recently_closed', pr, label: '[Recently Closed]' });
   }
 
   return issues;

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -8,7 +8,7 @@ import * as fs from 'fs';
 import { execFile } from 'child_process';
 import { getStateManager, getDashboardPath, PRMonitor, getGitHubToken } from '../core/index.js';
 import { outputJson } from '../formatters/json.js';
-import type { FetchedPR, DailyDigest, AgentState, RepoScore } from '../core/types.js';
+import type { FetchedPR, DailyDigest, AgentState, RepoScore, ClosedPR } from '../core/types.js';
 
 interface DashboardOptions {
   open?: boolean;
@@ -25,13 +25,16 @@ export async function runDashboard(options: DashboardOptions): Promise<void> {
     console.error('Fetching fresh data from GitHub...');
     try {
       const prMonitor = new PRMonitor(token);
-      const { prs, failures } = await prMonitor.fetchUserOpenPRs();
+      const [{ prs, failures }, recentlyClosedPRs] = await Promise.all([
+        prMonitor.fetchUserOpenPRs(),
+        prMonitor.fetchRecentlyClosedPRs(),
+      ]);
 
       if (failures.length > 0) {
         console.error(`Warning: ${failures.length} PR fetch(es) failed`);
       }
 
-      digest = prMonitor.generateDigest(prs);
+      digest = prMonitor.generateDigest(prs, recentlyClosedPRs);
       stateManager.setLastDigest(digest);
       stateManager.save();
       console.error(`Refreshed: ${prs.length} PRs fetched`);
@@ -891,6 +894,37 @@ function generateDashboardHtml(
       </div>
     </section>
     `}
+
+    ${digest.recentlyClosedPRs.length > 0 ? `
+    <section class="health-section" style="opacity: 0; animation-delay: 0.4s;">
+      <div class="health-header">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--text-muted)" stroke-width="2">
+          <circle cx="12" cy="12" r="10"/>
+          <line x1="15" y1="9" x2="9" y2="15"/>
+          <line x1="9" y1="9" x2="15" y2="15"/>
+        </svg>
+        <h2>Recently Closed</h2>
+        <span class="health-badge" style="background: rgba(110, 118, 129, 0.15); color: var(--text-muted);">${digest.recentlyClosedPRs.length} closed</span>
+      </div>
+      <div class="health-items">
+        ${digest.recentlyClosedPRs.map(pr => `
+        <div class="health-item" style="border-left-color: var(--text-muted); opacity: 0.7;">
+          <div class="health-icon" style="background: rgba(110, 118, 129, 0.15); color: var(--text-muted);">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <circle cx="12" cy="12" r="10"/>
+              <line x1="15" y1="9" x2="9" y2="15"/>
+              <line x1="9" y1="9" x2="15" y2="15"/>
+            </svg>
+          </div>
+          <div class="health-content">
+            <div class="health-title"><a href="${pr.url}" target="_blank">${pr.repo}#${pr.number}</a> - Closed</div>
+            <div class="health-meta">${pr.title.slice(0, 50)}${pr.title.length > 50 ? '...' : ''}${pr.closedAt ? ` · ${new Date(pr.closedAt).toLocaleDateString()}` : ''}</div>
+          </div>
+        </div>
+        `).join('')}
+      </div>
+    </section>
+    ` : ''}
 
     <div class="main-grid">
       <div class="card">

--- a/src/core/pr-monitor.ts
+++ b/src/core/pr-monitor.ts
@@ -7,7 +7,7 @@ import { Octokit } from '@octokit/rest';
 import { getOctokit } from './github.js';
 import { getStateManager } from './state.js';
 import { splitRepo, daysBetween } from './utils.js';
-import { FetchedPR, FetchedPRStatus, CIStatus, ReviewDecision, DailyDigest, MaintainerActionHint } from './types.js';
+import { FetchedPR, FetchedPRStatus, CIStatus, ReviewDecision, DailyDigest, MaintainerActionHint, ClosedPR } from './types.js';
 
 // Concurrency limit for parallel API calls
 const MAX_CONCURRENT_REQUESTS = 5;
@@ -660,9 +660,121 @@ export class PRMonitor {
   }
 
   /**
+   * Fetch closed-without-merge PR counts per repository for the configured user.
+   * Used to populate closedWithoutMergeCount in repo scores for accurate merge rate.
+   */
+  async fetchUserClosedPRCounts(): Promise<Map<string, number>> {
+    const config = this.stateManager.getState().config;
+
+    if (!config.githubUsername) {
+      return new Map();
+    }
+
+    console.error(`Fetching closed PR counts for @${config.githubUsername}...`);
+
+    const repos = new Map<string, number>();
+    let page = 1;
+    let fetched = 0;
+
+    while (true) {
+      const { data } = await this.octokit.search.issuesAndPullRequests({
+        q: `is:pr is:closed is:unmerged author:${config.githubUsername}`,
+        sort: 'updated',
+        order: 'desc',
+        per_page: 100,
+        page,
+      });
+
+      for (const item of data.items) {
+        const repoMatch = item.html_url.match(/github\.com\/([^/]+\/[^/]+)\//);
+        if (!repoMatch) continue;
+
+        const repo = repoMatch[1];
+        const owner = repo.split('/')[0];
+
+        // Skip own repos
+        if (owner.toLowerCase() === config.githubUsername.toLowerCase()) continue;
+
+        // Skip excluded repos and orgs
+        if (config.excludeRepos.includes(repo)) continue;
+        if (config.excludeOrgs?.some(org => owner.toLowerCase() === org.toLowerCase())) continue;
+
+        repos.set(repo, (repos.get(repo) || 0) + 1);
+      }
+
+      fetched += data.items.length;
+
+      if (fetched >= data.total_count || fetched >= 1000 || data.items.length === 0) {
+        break;
+      }
+
+      page++;
+    }
+
+    console.error(`Found ${fetched} closed (unmerged) PRs across ${repos.size} repos`);
+    return repos;
+  }
+
+  /**
+   * Fetch PRs closed without merge in the last N days.
+   * Returns lightweight ClosedPR objects for surfacing in the daily digest.
+   */
+  async fetchRecentlyClosedPRs(days: number = 7): Promise<ClosedPR[]> {
+    const config = this.stateManager.getState().config;
+
+    if (!config.githubUsername) {
+      return [];
+    }
+
+    const sinceDate = new Date();
+    sinceDate.setDate(sinceDate.getDate() - days);
+    const since = sinceDate.toISOString().split('T')[0]; // YYYY-MM-DD
+
+    console.error(`Fetching recently closed PRs for @${config.githubUsername} (since ${since})...`);
+
+    const { data } = await this.octokit.search.issuesAndPullRequests({
+      q: `is:pr is:closed is:unmerged author:${config.githubUsername} closed:>=${since}`,
+      sort: 'updated',
+      order: 'desc',
+      per_page: 100,
+    });
+
+    const closedPRs: ClosedPR[] = [];
+
+    for (const item of data.items) {
+      const repoMatch = item.html_url.match(/github\.com\/([^/]+\/[^/]+)\//);
+      if (!repoMatch) continue;
+
+      const repo = repoMatch[1];
+      const owner = repo.split('/')[0];
+
+      // Skip own repos
+      if (owner.toLowerCase() === config.githubUsername.toLowerCase()) continue;
+
+      // Skip excluded repos and orgs
+      if (config.excludeRepos.includes(repo)) continue;
+      if (config.excludeOrgs?.some(org => owner.toLowerCase() === org.toLowerCase())) continue;
+
+      const numberMatch = item.html_url.match(/\/pull\/(\d+)/);
+      const number = numberMatch ? parseInt(numberMatch[1], 10) : 0;
+
+      closedPRs.push({
+        url: item.html_url,
+        repo,
+        number,
+        title: item.title,
+        closedAt: item.closed_at || '',
+      });
+    }
+
+    console.error(`Found ${closedPRs.length} recently closed PRs`);
+    return closedPRs;
+  }
+
+  /**
    * Generate a daily digest from fetched PRs
    */
-  generateDigest(prs: FetchedPR[]): DailyDigest {
+  generateDigest(prs: FetchedPR[], recentlyClosedPRs: ClosedPR[] = []): DailyDigest {
     const now = new Date().toISOString();
 
     // Categorize PRs
@@ -698,6 +810,7 @@ export class PRMonitor {
       approachingDormant,
       dormantPRs,
       healthyPRs,
+      recentlyClosedPRs,
       summary: {
         totalActivePRs: prs.length,
         totalNeedingAttention: prsNeedingResponse.length + ciFailingPRs.length + mergeConflictPRs.length + needsRebasePRs.length + missingRequiredFilesPRs.length + incompleteChecklistPRs.length,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -244,6 +244,15 @@ export interface StateEvent {
   data: Record<string, unknown>;
 }
 
+export interface ClosedPR {
+  url: string;
+  repo: string; // "owner/repo"
+  number: number;
+  title: string;
+  closedAt: string;
+  closedBy?: string;
+}
+
 export interface DailyDigest {
   generatedAt: string;
 
@@ -263,6 +272,9 @@ export interface DailyDigest {
   approachingDormant: FetchedPR[]; // 25+ days
   dormantPRs: FetchedPR[];
   healthyPRs: FetchedPR[];
+
+  // Recently closed PRs (closed without merge in last 7 days)
+  recentlyClosedPRs: ClosedPR[];
 
   // Summary
   summary: {

--- a/src/formatters/json.ts
+++ b/src/formatters/json.ts
@@ -21,7 +21,7 @@ export interface CapacityAssessment {
   reason: string;
 }
 
-export type ActionableIssueType = 'ci_failing' | 'merge_conflict' | 'needs_response' | 'incomplete_checklist' | 'approaching_dormant';
+export type ActionableIssueType = 'ci_failing' | 'merge_conflict' | 'needs_response' | 'incomplete_checklist' | 'approaching_dormant' | 'recently_closed';
 
 export interface ActionableIssue {
   type: ActionableIssueType;


### PR DESCRIPTION
## Summary

- Query GitHub for `is:pr is:closed is:unmerged` to populate `closedWithoutMergeCount` in repo scores — fixes merge rate always showing 100%
- Add `fetchRecentlyClosedPRs()` to surface PRs closed without merge in the last 7 days in the daily digest and dashboard
- Add "Recently Closed" section to daily summary, console output, dashboard HTML, and JSON actionable issues

## Changes

| File | Change |
|------|--------|
| `src/core/types.ts` | Add `ClosedPR` type, `recentlyClosedPRs` field to `DailyDigest` |
| `src/core/pr-monitor.ts` | Add `fetchUserClosedPRCounts()`, `fetchRecentlyClosedPRs()`, update `generateDigest()` |
| `src/commands/daily.ts` | Parallel fetch of closed data, update formatters and actionable issues |
| `src/commands/dashboard.ts` | Add "Recently Closed" section with muted grey styling |
| `src/formatters/json.ts` | Add `recently_closed` to `ActionableIssueType` |
| `package.json`, `plugin.json` | Bump to 0.5.0 |
| `CHANGELOG.md` | Add 0.5.0 entry |

## Test plan

- [x] `npm run bundle` builds successfully (494kb)
- [x] `npm test` — 60 tests pass, no regressions
- [ ] `daily --json` shows `recentlyClosedPRs` array and accurate merge rate
- [ ] `dashboard --open` renders "Recently Closed" section