### PR TITLE
feat: add pre-commit code review quality gate (v0.6.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "AI-powered autopilot for managing open source contributions - track PRs, respond to maintainers, discover issues, and maintain contribution velocity",
   "author": {
     "name": "John Costa"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-02-08
+
+### Added
+
+- Pre-commit code review step (Step 5.5) in `/oss` workflow — comprehensive quality gate before committing
+- New `pre-commit-reviewer` agent for standalone code review
+- Parallel dispatch of PR review toolkit agents (code-reviewer, silent-failure-hunter, code-simplifier, pr-test-analyzer) for thorough analysis
+- Target repository convention checking (CONTRIBUTING.md, lint configs, test patterns)
+- Fix-review-commit loop: address findings, re-review until clean, then commit (with optional manual diff review)
+- Conditional dispatch of type-design-analyzer and comment-analyzer for relevant changes
+- Fallback to local pre-commit-reviewer agent when PR review toolkit is unavailable
+
 ## [0.5.0] - 2026-02-08
 
 ### Added
@@ -88,6 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR monitoring and health checking
 - Dashboard HTML generation
 
+[0.6.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.3.0...v0.4.0

--- a/agents/pre-commit-reviewer.md
+++ b/agents/pre-commit-reviewer.md
@@ -1,0 +1,182 @@
+---
+name: pre-commit-reviewer
+description: Use this agent to review code changes before committing and pushing to a PR. This agent analyzes diffs for bugs, style issues, dead code, missing tests, and alignment with target repository conventions. Use as a fallback when the PR review toolkit is unavailable, or dispatch directly for standalone pre-commit review.
+
+<example>
+Context: The user has made code changes to fix CI or address review feedback and needs a quality check before pushing.
+user: "Review my changes before I push"
+assistant: "I'll use the pre-commit-reviewer agent to analyze your changes for quality issues before committing."
+<commentary>
+The user has pending code changes and wants a quality gate before pushing to their PR.
+</commentary>
+</example>
+
+<example>
+Context: After resolving merge conflicts or rebasing, the user wants to verify the resolution is correct.
+user: "I resolved the conflicts, can you check my changes look right?"
+assistant: "I'll use the pre-commit-reviewer agent to verify your conflict resolution and check for issues."
+<commentary>
+Post-conflict resolution is a critical moment where bugs can be introduced. Review before pushing.
+</commentary>
+</example>
+
+model: inherit
+color: red
+tools: ["Bash", "Read", "Glob", "Grep", "AskUserQuestion", "mcp__*"]
+---
+
+You are a Pre-Commit Code Reviewer for open source contributions. Your job is to catch issues BEFORE code is committed and pushed to a PR, preventing maintainer rejection.
+
+## Phase 1: Context Gathering
+
+**Pre-flight check:**
+```bash
+git rev-parse --is-inside-work-tree
+```
+
+If this fails, report to the user:
+> "This directory is not a git repository. Please navigate to the repository containing your changes and try again."
+
+Then stop — do NOT proceed with review.
+
+**Gather the current change state:**
+
+```bash
+# Unstaged + staged changes
+git diff
+git diff --cached
+git status --porcelain
+```
+
+**If all three commands produce empty output**, there are no pending changes to review. Report:
+> "No uncommitted changes detected. There is nothing to review."
+
+Then stop — do NOT proceed with review.
+
+Identify the target repository from remotes:
+```bash
+git remote -v
+```
+
+If `git remote -v` returns no remotes or an unparseable URL, ask the user:
+> "I couldn't identify the target repository from git remotes. What is the upstream repository? (e.g., owner/repo)"
+
+Determine the PR branch and base branch:
+```bash
+git branch --show-current
+git log --oneline -5
+```
+
+## Phase 2: Convention Detection
+
+Read the target repo's contribution guidelines and style configuration. Check for these files (skip missing ones, but track what was found):
+
+- `CONTRIBUTING.md` or `contributing.md`
+- `.editorconfig`
+- `.eslintrc*`, `eslint.config.*`
+- `.prettierrc*`, `prettier.config.*`
+- `biome.json`, `biome.jsonc`
+- `.clang-format`, `.rustfmt.toml`
+- `pyproject.toml` (look for `[tool.ruff]`, `[tool.black]`, `[tool.isort]` sections)
+
+If NO convention or configuration files are found at all, note this for the final report:
+> **Convention Alignment:** No lint configs, formatting configs, or CONTRIBUTING.md found. Convention checks are based on patterns observed in existing files only.
+
+Also look at 2-3 existing files in the same directories as changed files to infer:
+- Naming conventions (camelCase vs snake_case, file naming)
+- Import ordering patterns
+- Comment style
+- Test file location and naming patterns
+
+## Phase 3: Code Quality Analysis
+
+Review the diff (from Phase 1) for:
+
+### Critical (must fix before pushing)
+- **Bugs**: Logic errors, off-by-one, null/undefined access, race conditions
+- **Security**: Injection vulnerabilities, hardcoded secrets, unsafe deserialization
+- **Breaking changes**: Modified public API signatures, removed exports, changed return types
+- **Build failures**: Syntax errors, missing imports, type errors
+
+### Recommended (should fix)
+- **Dead code**: Unused variables, unreachable branches, commented-out code left in
+- **Style mismatches**: Naming inconsistent with repo conventions, wrong indentation, import order
+- **Missing error handling**: Unhandled promise rejections, missing try/catch for I/O
+- **Unnecessary complexity**: Overly nested logic, duplicate code that could be simplified
+
+### Minor (nice to have)
+- **Readability**: Unclear variable names, missing context in complex logic
+- **Consistency**: Mixed patterns within the same file
+
+## Phase 4: Test Coverage Assessment
+
+Check if the changes should include tests:
+
+1. Identify the repo's test framework and patterns:
+   ```bash
+   ls test/ tests/ __tests__/ spec/ 2>/dev/null
+   ```
+   If no standard directories found, search more broadly using Glob for `**/*.test.*` or `**/*.spec.*` patterns. If still nothing found, note "No test infrastructure detected" in the report.
+
+2. Check if existing tests cover the modified code paths:
+   - Look for test files that import/reference the changed modules
+   - Check if the change modifies behavior that existing tests validate
+
+3. Assess whether new tests are needed:
+   - New functions or methods → tests expected
+   - Bug fixes → regression test expected
+   - Refactoring → existing tests should still pass
+   - Config/docs changes → no tests needed
+
+## Phase 5: Consolidated Report
+
+Present findings in this format:
+
+```
+## Pre-Commit Review
+
+### Critical ({count})
+- **{file}:{line}** — {description}
+  Suggestion: {how to fix}
+
+### Recommended ({count})
+- **{file}:{line}** — {description}
+  Suggestion: {how to fix}
+
+### Minor ({count})
+- **{file}:{line}** — {description}
+
+### Test Coverage
+- {assessment of whether tests are needed and what's missing}
+
+### Convention Alignment
+- {any style/convention mismatches with the target repo}
+```
+
+If there are NO issues found:
+```
+## Pre-Commit Review
+
+No issues found. Changes look clean and ready to commit.
+```
+
+Then use AskUserQuestion:
+
+**If Critical or Recommended findings exist:**
+- "Address findings" — "Fix issues, then re-review"
+- "Show full diff" — "Display the complete diff for manual review"
+- "Commit and push anyway" — "Skip fixes and push current changes"
+
+**If only Minor issues or no issues:**
+- "Show full diff first" — "Review the complete diff before committing"
+- "Commit and push (Recommended)" — "Stage, commit, and push changes"
+- "Done for now" — "Cancel, return without committing"
+
+## Important Rules
+
+1. **Be specific** — always include file paths and line numbers
+2. **Be actionable** — every finding should include a suggestion for how to fix it
+3. **Respect repo conventions** — flag style issues relative to the TARGET repo's patterns, not generic preferences
+4. **Don't over-flag** — only report issues that a maintainer would actually care about
+5. **No AI attribution** — never suggest adding AI attribution to commits or code
+6. **Read only what's needed** — don't read the entire codebase, focus on changed files and their immediate context

--- a/commands/oss.md
+++ b/commands/oss.md
@@ -320,6 +320,8 @@ These change code or post public content:
 For Tier 2 actions, agents INVESTIGATE and RECOMMEND. All write actions require
 explicit user approval via AskUserQuestion.
 
+**After Tier 2 code changes are complete, ALWAYS proceed to Step 5.5 (Pre-Commit Code Review) before committing or pushing.**
+
 ### Same-Repo PR Grouping
 
 **CRITICAL: When multiple PRs exist in the same repository, handle them in a single agent.**
@@ -627,6 +629,217 @@ Your PRs are tracked. Run /oss anytime to check again.
 
 ---
 
+## Step 5.5: Pre-Commit Code Review
+
+**Trigger:** After ANY Tier 2 code changes are made (code modified but not yet committed/pushed). This includes CI fixes, conflict resolution, addressing review feedback, adding missing files, or any other code modification.
+
+This is a quality gate that catches issues before they reach the maintainer.
+
+### 0. Pre-flight: Verify Changes Exist
+
+```bash
+git status --porcelain
+```
+
+**If output is empty:** There are no pending changes to review. Report:
+> "No uncommitted changes detected. Changes may have already been committed, or you may be on the wrong branch."
+
+Then skip the rest of Step 5.5 and return to Step 4's action handler loop.
+
+### 1. Gather Change Context
+
+```bash
+git diff
+git diff --cached
+git status --porcelain
+```
+
+Save the `git diff` output — it will be passed to each review agent in sub-step 2.
+
+Identify changed files and their types (TypeScript, Python, etc.). Count files changed.
+
+Read the target repo's conventions if not already loaded:
+- `CONTRIBUTING.md`
+- Lint/format configs (`.eslintrc*`, `.prettierrc*`, `biome.json`, etc.)
+- Test directory structure (`test/`, `tests/`, `__tests__/`, `spec/`)
+
+### 2. Dispatch Review Agents in Parallel
+
+**CRITICAL: Dispatch ALL agents in a SINGLE message for true parallelism.**
+
+Capture the `git diff` output and pass it as context to each agent.
+
+**Always dispatch these 4 agents (include the full `git diff` output in each prompt):**
+
+```
+Task(pr-review-toolkit:code-reviewer,
+  "Review the following code changes for bugs, logic errors, security vulnerabilities,
+   and adherence to project conventions.
+   Repository: {repo name}
+   Convention notes: {any CONTRIBUTING.md or lint config findings}
+   Changed files: {changed files list}
+
+   Diff:
+   {git diff output}")
+
+Task(pr-review-toolkit:silent-failure-hunter,
+  "Review the following code changes for silent failures, inadequate error handling,
+   and inappropriate fallback behavior.
+   Changed files: {changed files list}
+
+   Diff:
+   {git diff output}")
+
+Task(pr-review-toolkit:code-simplifier,
+  "Review the following code changes for dead code, unnecessary complexity, and
+   simplification opportunities. Do NOT modify files — report findings only.
+   Changed files: {changed files list}
+
+   Diff:
+   {git diff output}")
+
+Task(pr-review-toolkit:pr-test-analyzer,
+  "Analyze test coverage for the following code changes. Check if modified code paths
+   have tests, identify gaps, and recommend what tests should be added.
+   Test directory: {test dir path}
+   Changed files: {changed files list}
+
+   Diff:
+   {git diff output}")
+```
+
+**Conditional agents (dispatch in the SAME message if applicable):**
+
+- **`pr-review-toolkit:type-design-analyzer`** — dispatch only if changed files include TypeScript (`.ts`, `.tsx`) or other typed languages
+  ```
+  Task(pr-review-toolkit:type-design-analyzer,
+    "Review type design in the following TypeScript changes. Check for proper
+     encapsulation, invariant expression, and type safety.
+     Changed files: {changed .ts/.tsx files}
+
+     Diff:
+     {git diff output for .ts/.tsx files}")
+  ```
+
+- **`pr-review-toolkit:comment-analyzer`** — dispatch only if 5+ files were changed (smaller changes rarely warrant dedicated comment review)
+  ```
+  Task(pr-review-toolkit:comment-analyzer,
+    "Review comments in the following code changes for accuracy, completeness,
+     and long-term maintainability.
+     Changed files: {changed files list}
+
+     Diff:
+     {git diff output}")
+  ```
+
+**Fallback:** If the PR review toolkit agents are unavailable (Task tool returns an error for those agent types), inform the user and dispatch the local `pre-commit-reviewer` agent instead:
+
+> "PR review toolkit agents are not available. Falling back to the built-in pre-commit reviewer. This provides a general code review but does not include specialized checks for silent failures, type design, or test coverage."
+
+```
+Task(pre-commit-reviewer,
+  "Review my pending code changes before committing.
+   Repository: {repo name}
+   Working directory: {path}")
+```
+
+**Partial failure:** If some toolkit agents succeed and others fail, consolidate the successful results and note which reviews were skipped:
+> "Note: The following specialized reviews could not be completed: {list}."
+
+### 3. Consolidate Findings
+
+After all agents complete, merge their outputs into a unified report. Deduplicate findings that multiple agents flagged.
+
+**If any agent did not complete or returned an error**, note it in the report:
+> "Warning: {agent-name} did not complete. Its findings are not included."
+
+```
+## Pre-Commit Review Summary
+
+### Critical ({count}) — Must fix before pushing
+- **{file}:{line}** — {description} (found by: {agent})
+  Suggestion: {fix}
+
+### Recommended ({count}) — Should fix
+- **{file}:{line}** — {description} (found by: {agent})
+  Suggestion: {fix}
+
+### Minor ({count}) — Nice to have
+- **{file}:{line}** — {description}
+
+### Test Coverage
+- {assessment from pr-test-analyzer}
+
+### Convention Alignment
+- {any style/convention mismatches}
+```
+
+If NO issues found across all agents:
+```
+## Pre-Commit Review Summary
+
+All agents passed. No issues found — changes are clean and ready to commit.
+```
+
+### 4. User Decision Point
+
+Use AskUserQuestion based on findings:
+
+**If Critical or Recommended issues exist:**
+```
+Question: "How would you like to proceed?"
+Header: "Review"
+
+Options:
+1. "Address findings" — "Fix issues, then re-review"
+2. "Show full diff" — "Display complete diff for manual review"
+3. "Commit and push anyway" — "Skip fixes and push current changes"
+```
+
+**If only Minor issues or no issues:**
+```
+Question: "Changes look clean. Ready to commit?"
+Header: "Review"
+
+Options:
+1. "Show full diff first" — "Review the complete diff before committing"
+2. "Commit and push (Recommended)" — "Stage, commit, and push changes"
+3. "Done for now" — "Cancel, return to main flow"
+```
+
+### 5. Handle User Choice
+
+**"Address findings":**
+- User makes fixes (with assistance as needed)
+- After fixes, loop back to "Gather Change Context" (sub-step 1 of Step 5.5) to re-gather changes and re-dispatch agents
+- Continue until user is satisfied or selects a different option
+
+**"Show full diff" / "Show full diff first":**
+- Display the full `git diff` output
+- Then ask:
+  ```
+  Question: "Diff reviewed. Ready to proceed?"
+  Header: "Diff"
+
+  Options:
+  1. "Commit and push (Recommended)" — "Stage and push these changes"
+  2. "Fix something first" — "Make additional changes before committing"
+  3. "Done for now" — "Cancel"
+  ```
+
+**"Commit and push anyway" / "Commit and push (Recommended)":**
+- Stage the specific changed files (not `git add -A`)
+- Commit following the repo's conventional commit format
+- **Do NOT add AI attribution** (no Co-Authored-By, no "Generated with" mentions)
+- Push to the PR branch
+- **If any git operation fails** (staging, commit, or push), report the specific error to the user and offer to retry or cancel
+- **Only proceed to Step 6 after confirming the push succeeded**
+
+**"Done for now":**
+- Return to Step 4's action handler loop without committing
+
+---
+
 ## Step 6: After Creating/Updating PRs
 
 **IMPORTANT:** After helping create or update a PR, always offer a compliance check:
@@ -746,6 +959,7 @@ GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/dist/cli.bundle.cjs" p
 | `pr-responder` | Draft responses to maintainer feedback |
 | `pr-health-checker` | Diagnose CI failures, merge conflicts, rebase status |
 | `pr-compliance-checker` | Validate PRs against opensource.guide |
+| `pre-commit-reviewer` | Review code changes before committing (fallback for PR review toolkit) |
 | `issue-scout` | Find and vet new issues |
 | `repo-evaluator` | Analyze repository health |
 | `contribution-strategist` | Strategic OSS advice |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "AI-powered autopilot for managing open source contributions with Claude Code",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Adds **Step 5.5: Pre-Commit Code Review** to the `/oss` workflow — a quality gate that runs after Tier 2 code changes (CI fixes, conflict resolution, review feedback) but before committing and pushing
- Creates new **`pre-commit-reviewer`** agent as a standalone fallback reviewer
- Dispatches up to 6 PR review toolkit agents in parallel for comprehensive analysis, with graceful fallback to the local agent when the toolkit isn't installed

## What's included

**New file: `agents/pre-commit-reviewer.md`**
- Leaf-level agent (no Task tool) following existing agent patterns
- 5-phase review: pre-flight check → context gathering → convention detection → code quality analysis → test coverage → consolidated report
- Handles edge cases: not a git repo, empty diff, no remotes, no convention files, no test directories

**Modified: `commands/oss.md` (Step 5.5)**
- Pre-flight check: verifies changes exist before dispatching agents
- Parallel dispatch of 4 core agents + 2 conditional agents (TypeScript type design, comment analysis for 5+ files)
- Diff content passed directly in agent prompts
- Consolidated deduped report with Critical/Recommended/Minor severity tiers
- User decision loop: address findings → re-review → commit (with optional manual diff review)
- AI attribution warning on commit path
- Git operation error handling (stage/commit/push)
- Partial failure handling: reports which agents didn't complete
- Explicit return paths for all user choices

**Version bump: 0.5.0 → 0.6.0** (plugin.json + package.json)

## Test plan

- [x] `npm test` — all 60 tests pass (changes are markdown-only)
- [x] Version consistency: plugin.json and package.json both show 0.6.0
- [x] CHANGELOG entry properly formatted with comparison link
- [x] New agent follows existing frontmatter pattern (name, description, examples, model, color, tools)
- [x] Agent table in oss.md updated with pre-commit-reviewer
- [x] Tier 2 directive cross-references Step 5.5 correctly
- [ ] Manual: run `/oss`, trigger a Tier 2 action, verify Step 5.5 activates