### PR TITLE
feat: seamless plugin upgrade experience

### DIFF
--- a/.claude-plugin/hooks/SessionStart.md
+++ b/.claude-plugin/hooks/SessionStart.md
@@ -1,0 +1,35 @@
+---
+name: oss-autopilot-session-start
+description: Auto-rebuild stale CLI bundles and check for updates
+tools: ["Bash"]
+---
+
+Perform two startup checks silently. Only output something if there's a user-relevant message.
+
+**Step 1: Rebuild stale bundle (if needed)**
+
+```bash
+if [ -f "${CLAUDE_PLUGIN_ROOT}/dist/cli.bundle.cjs" ] && [ "${CLAUDE_PLUGIN_ROOT}/package.json" -nt "${CLAUDE_PLUGIN_ROOT}/dist/cli.bundle.cjs" ]; then
+  echo "Rebuilding CLI after plugin update..."
+  (cd "${CLAUDE_PLUGIN_ROOT}" && npm install --silent 2>&1 && npm run bundle --silent 2>&1) >/dev/null
+  echo "CLI rebuilt successfully."
+fi
+```
+
+**Step 2: Check for updates (once per day)**
+
+```bash
+LAST_CHECK="${HOME}/.oss-autopilot/.last-update-check"
+CURRENT=$(node -e "console.log(require('${CLAUDE_PLUGIN_ROOT}/package.json').version)" 2>/dev/null)
+
+if [ ! -f "$LAST_CHECK" ] || [ -n "$(find "$LAST_CHECK" -mmin +1440 2>/dev/null)" ]; then
+  mkdir -p "${HOME}/.oss-autopilot"
+  touch "$LAST_CHECK"
+  LATEST=$(gh api repos/costajohnt/oss-autopilot/releases/latest --jq '.tag_name' 2>/dev/null | sed 's/^v//')
+  if [ -n "$LATEST" ] && [ "$LATEST" != "$CURRENT" ]; then
+    echo "OSS Autopilot v${LATEST} available (you have v${CURRENT}). Run: /plugin update oss-autopilot"
+  fi
+fi
+```
+
+If neither check triggers output, the hook is silent — no noise for the user.

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "AI-powered autopilot for managing open source contributions - track PRs, respond to maintainers, discover issues, and maintain contribution velocity",
   "author": {
     "name": "John Costa"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-02-08
+
+### Added
+
+- SessionStart hook for automatic stale bundle rebuild after plugin updates
+- Daily update notification — shows when a newer version is available on GitHub
+- Version display in `/oss` summary output (e.g., "v0.6.1")
+
+### Fixed
+
+- CLI bundle not rebuilt after `/plugin update` — Step 0.5 only checked file existence, not staleness
+- CLI VERSION constant hardcoded at 0.1.0 — now reads from package.json at runtime
+
 ## [0.6.0] - 2026-02-08
 
 ### Added
@@ -100,6 +113,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR monitoring and health checking
 - Dashboard HTML generation
 
+[0.6.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.4.0...v0.4.1

--- a/commands/oss.md
+++ b/commands/oss.md
@@ -13,7 +13,10 @@ This command checks your open source PRs and provides a summary of what needs at
 Before running any CLI commands, ensure the bundle exists (auto-builds on first run):
 
 ```bash
-[ -f "${CLAUDE_PLUGIN_ROOT}/dist/cli.bundle.cjs" ] || (cd "${CLAUDE_PLUGIN_ROOT}" && npm install --silent 2>&1 && npm run bundle --silent 2>&1) >/dev/null
+# Rebuild if bundle missing OR package.json is newer (post-upgrade)
+if [ ! -f "${CLAUDE_PLUGIN_ROOT}/dist/cli.bundle.cjs" ] || [ "${CLAUDE_PLUGIN_ROOT}/package.json" -nt "${CLAUDE_PLUGIN_ROOT}/dist/cli.bundle.cjs" ]; then
+  (cd "${CLAUDE_PLUGIN_ROOT}" && npm install --silent 2>&1 && npm run bundle --silent 2>&1) >/dev/null
+fi
 ```
 
 If this fails, fall back to the gh CLI workflow (Step 1b).
@@ -95,13 +98,20 @@ The CLI returns structured data with new fields for the action-first flow:
 }
 ```
 
-**Display ONLY the `briefSummary` field:**
+**Display the `briefSummary` field with the plugin version appended:**
+
+Get the current version:
+```bash
+node -e "console.log(require('${CLAUDE_PLUGIN_ROOT}/package.json').version)" 2>/dev/null
 ```
-data.briefSummary
+
+Then display:
+```
+data.briefSummary + " | v{version}"
 ```
 
 Example output:
-> 16 Active PRs | 3 need attention | Dashboard opened in browser
+> 16 Active PRs | 3 need attention | Dashboard opened in browser | v0.6.1
 
 Then proceed to Step 3 (Present Action Choices).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "AI-powered autopilot for managing open source contributions with Claude Code",
   "type": "module",
   "main": "dist/index.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,7 +21,16 @@ import { runInit } from './commands/init.js';
 import { runRead } from './commands/read.js';
 import { runDashboard } from './commands/dashboard.js';
 
-const VERSION = '0.1.0';
+const VERSION = (() => {
+  try {
+    const fs = require('fs');
+    const path = require('path');
+    const pkgPath = path.join(path.dirname(process.argv[1]), '..', 'package.json');
+    return JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).version;
+  } catch {
+    return '0.0.0';
+  }
+})();
 
 // Commands that don't require GitHub API access
 const LOCAL_ONLY_COMMANDS = ['help', 'status', 'config', 'read', 'untrack', 'version', 'setup', 'checkSetup', 'dashboard'];

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,16 @@ import { IssueDiscovery } from './core/issue-discovery.js';
 import { parseGitHubUrl, getDashboardPath, getGitHubToken } from './core/utils.js';
 import { DailyDigest, TrackedPR } from './core/types.js';
 
-const VERSION = '0.1.0';
+const VERSION = (() => {
+  try {
+    const fs = require('fs');
+    const path = require('path');
+    const pkgPath = path.join(path.dirname(process.argv[1]), '..', 'package.json');
+    return JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).version;
+  } catch {
+    return '0.0.0';
+  }
+})();
 const GITHUB_TOKEN = getGitHubToken();
 
 /**


### PR DESCRIPTION
## Summary

- **Stale bundle detection**: Step 0.5 and a new SessionStart hook use `-nt` (newer-than) to detect when `package.json` is newer than the bundle, triggering an automatic rebuild after `/plugin update`
- **Runtime VERSION**: CLI reads version from `package.json` at runtime instead of hardcoding `0.1.0`
- **Update notifications**: SessionStart hook checks GitHub releases once/day and notifies when a newer version is available
- **Version in `/oss` output**: Brief summary now shows the plugin version (e.g., `v0.6.1`)

## Test plan

- [x] `npm test` — 60/60 tests pass
- [x] `node dist/cli.bundle.cjs --version` prints `0.6.1` (not `0.1.0`)
- [x] `touch package.json` then `-nt` check correctly detects staleness
- [x] Version synced in both `package.json` and `plugin.json`
- [ ] Manual: run `/plugin update oss-autopilot` and verify bundle auto-rebuilds
- [ ] Manual: verify SessionStart hook runs silently when no update available