### PR TITLE
fix: detect changes_addressed status when contributor pushes after maintainer review

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "AI-powered autopilot for managing open source contributions - track PRs, respond to maintainers, discover issues, and maintain contribution velocity",
   "author": {
     "name": "John Costa"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2] - 2026-02-08
+
+### Fixed
+
+- Stale `needs_response` status when contributor has already pushed changes addressing maintainer feedback
+  - GitHub's `reviewDecision` stays `changes_requested` until maintainer re-approves, causing false positives
+  - Now compares latest commit timestamp against last maintainer comment — if the commit is newer, shows `changes_addressed` instead of `needs_response`
+  - New `changes_addressed` status shown in daily digest, dashboard, and JSON output
+  - Not counted in `totalNeedingAttention` (not actionable by contributor)
+
 ## [0.7.1] - 2026-02-08
 
 ### Removed
@@ -142,6 +152,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR monitoring and health checking
 - Dashboard HTML generation
 
+[0.7.2]: https://github.com/costajohnt/oss-autopilot/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.6.0...v0.6.1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Discover issues worth contributing to, track your PRs across repos, and draft responses to maintainer feedback. An AI copilot for your open source journey.
 
-![Version](https://img.shields.io/badge/version-0.7.1-blue)
+![Version](https://img.shields.io/badge/version-0.7.2-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)
 

--- a/commands/oss.md
+++ b/commands/oss.md
@@ -287,6 +287,7 @@ For each PR, categorize as (checked in priority order):
 - **CI Not Running**: No CI checks have been reported at all
 - **Merge Conflict**: mergeable is false
 - **Needs Response**: has new comments from maintainers (changes_requested or unresponded comments)
+- **Changes Addressed**: maintainer commented but contributor pushed newer commits (awaiting re-review)
 - **Needs Rebase**: branch is significantly behind upstream (check via `gh pr view --json baseRefName,headRefName` and compare)
 - **Missing Required Files**: changeset bot or CLA bot has flagged missing files
 - **Approaching Dormant**: no activity past `approachingDormantDays`
@@ -393,6 +394,7 @@ For each issue in `actionableIssues`, include a Task tool call:
 | Merge Conflict | Tier 2 | Identify conflicting files, recommend resolution strategy. DO NOT push. |
 | Needs Response | Tier 2 | Analyze maintainer feedback, draft a response. DO NOT post — return for approval. |
 | Changes Requested | Tier 2 | Analyze requested changes, investigate what needs to change, recommend approach. |
+| Changes Addressed | Info | Note that changes were pushed after maintainer review — no contributor action needed, awaiting re-review. |
 | Missing Required Files | Tier 2 | Identify what's missing (changeset, CLA, etc.), draft the file. DO NOT push. |
 | Approaching Dormant | Tier 2 | Assess if still relevant, recommend follow-up action. |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oss-autopilot",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oss-autopilot",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "@octokit/plugin-throttling": "^11.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "AI-powered autopilot for managing open source contributions with Claude Code",
   "type": "module",
   "main": "dist/cli.js",

--- a/src/commands/daily.ts
+++ b/src/commands/daily.ts
@@ -148,6 +148,17 @@ function formatSummary(digest: DailyDigest, capacity: CapacityAssessment): strin
     lines.push('');
   }
 
+  // Changes Addressed (waiting for maintainer re-review)
+  if (digest.changesAddressedPRs.length > 0) {
+    lines.push('### 📤 Changes Addressed');
+    for (const pr of digest.changesAddressedPRs) {
+      const maintainer = pr.lastMaintainerComment?.author || 'maintainer';
+      lines.push(`- [${pr.repo}#${pr.number}](${pr.url}): ${pr.title}`);
+      lines.push(`  └─ Waiting for @${maintainer} to re-review`);
+    }
+    lines.push('');
+  }
+
   // Approaching Dormant
   if (digest.approachingDormant.length > 0) {
     lines.push('### ⏰ Approaching Dormant');
@@ -250,6 +261,16 @@ function printDigest(digest: DailyDigest, capacity: CapacityAssessment): void {
     for (const pr of digest.incompleteChecklistPRs) {
       const stats = pr.checklistStats ? ` (${pr.checklistStats.checked}/${pr.checklistStats.total} checked)` : '';
       console.log(`  - ${pr.repo}#${pr.number}: ${pr.title}${stats}`);
+    }
+    console.log('');
+  }
+
+  if (digest.changesAddressedPRs.length > 0) {
+    console.log('📤 Changes Addressed:');
+    for (const pr of digest.changesAddressedPRs) {
+      const maintainer = pr.lastMaintainerComment?.author || 'maintainer';
+      console.log(`  - ${pr.repo}#${pr.number}: ${pr.title}`);
+      console.log(`    Waiting for @${maintainer} to re-review`);
     }
     console.log('');
   }

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -426,6 +426,11 @@ function generateDashboardHtml(
       background: var(--accent-warning-dim);
     }
 
+    .health-item.changes-addressed {
+      border-left-color: var(--accent-info);
+      background: var(--accent-info-dim);
+    }
+
     .health-icon {
       width: 32px;
       height: 32px;
@@ -441,6 +446,7 @@ function generateDashboardHtml(
     .health-item.conflict .health-icon { background: rgba(218, 54, 51, 0.15); color: var(--accent-conflict); }
     .health-item.incomplete-checklist .health-icon { background: var(--accent-info-dim); color: var(--accent-info); }
     .health-item.needs-response .health-icon { background: var(--accent-warning-dim); color: var(--accent-warning); }
+    .health-item.changes-addressed .health-icon { background: var(--accent-info-dim); color: var(--accent-info); }
 
     .health-content { flex: 1; min-width: 0; }
 
@@ -650,6 +656,7 @@ function generateDashboardHtml(
     .badge-pending { background: var(--accent-info-dim); color: var(--accent-info); }
     .badge-days { background: var(--bg-elevated); color: var(--text-muted); }
     .badge-changes-requested { background: var(--accent-warning-dim); color: var(--accent-warning); }
+    .badge-changes-addressed { background: var(--accent-info-dim); color: var(--accent-info); }
 
     .pr-activity {
       font-family: 'Geist Mono', monospace;
@@ -865,6 +872,20 @@ function generateDashboardHtml(
           </div>
         </div>
         `).join('')}
+        ${digest.changesAddressedPRs.map(pr => `
+        <div class="health-item changes-addressed">
+          <div class="health-icon">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/>
+              <polyline points="22 4 12 14.01 9 11.01"/>
+            </svg>
+          </div>
+          <div class="health-content">
+            <div class="health-title"><a href="${pr.url}" target="_blank">${pr.repo}#${pr.number}</a> - Changes Addressed</div>
+            <div class="health-meta">Awaiting re-review${pr.lastMaintainerComment ? ` from @${pr.lastMaintainerComment.author}` : ''}</div>
+          </div>
+        </div>
+        `).join('')}
         ${digest.prsNeedingResponse.map(pr => `
         <div class="health-item needs-response">
           <div class="health-icon">
@@ -969,7 +990,7 @@ function generateDashboardHtml(
       </div>
       <div class="pr-list">
         ${digest.openPRs.map(pr => {
-          const hasIssues = pr.ciStatus === 'failing' || pr.hasMergeConflict || pr.hasUnrespondedComment;
+          const hasIssues = pr.ciStatus === 'failing' || pr.hasMergeConflict || (pr.hasUnrespondedComment && pr.status !== 'changes_addressed');
           const isStale = pr.daysSinceActivity >= approachingDormantDays;
           const itemClass = hasIssues ? 'has-issues' : (isStale ? 'stale' : '');
 
@@ -1000,7 +1021,8 @@ function generateDashboardHtml(
               ${pr.ciStatus === 'passing' ? '<span class="badge badge-passing">CI Passing</span>' : ''}
               ${pr.ciStatus === 'pending' ? '<span class="badge badge-pending">CI Pending</span>' : ''}
               ${pr.hasMergeConflict ? '<span class="badge badge-conflict">Merge Conflict</span>' : ''}
-              ${pr.hasUnrespondedComment ? '<span class="badge badge-needs-response">Needs Response</span>' : ''}
+              ${pr.hasUnrespondedComment && pr.status === 'changes_addressed' ? '<span class="badge badge-changes-addressed">Changes Addressed</span>' : ''}
+              ${pr.hasUnrespondedComment && pr.status !== 'changes_addressed' ? '<span class="badge badge-needs-response">Needs Response</span>' : ''}
               ${pr.reviewDecision === 'changes_requested' ? '<span class="badge badge-changes-requested">Changes Requested</span>' : ''}
               ${isStale ? `<span class="badge badge-stale">${pr.daysSinceActivity}d inactive</span>` : ''}
             </div>

--- a/src/core/pr-monitor.test.ts
+++ b/src/core/pr-monitor.test.ts
@@ -151,7 +151,7 @@ describe('PRMonitor CI status deduplication', () => {
     expect(result.failingCheckNames).toEqual([]);
   });
 
-  it('should report failing when one check passes but another still fails', async () => {
+  it('should report failing when one check passes but another still fails (multi-check)', async () => {
     mockOctokitInstance = {
       repos: {
         getCombinedStatusForRef: vi.fn().mockResolvedValue(emptyCombinedStatus),
@@ -183,5 +183,85 @@ describe('PRMonitor CI status deduplication', () => {
 
     expect(result.status).toBe('failing');
     expect(result.failingCheckNames).toEqual(['Test']);
+  });
+});
+
+describe('PRMonitor changes_addressed detection', () => {
+  beforeEach(() => {
+    mockOctokitInstance = {};
+  });
+
+  it('should return changes_addressed when commit is newer than maintainer comment', () => {
+    const monitor = new PRMonitor('fake-token');
+    const result = (monitor as any).determineStatus(
+      'passing',        // ciStatus
+      false,            // hasMergeConflict
+      true,             // hasUnrespondedComment
+      false,            // hasIncompleteChecklist
+      'changes_requested', // reviewDecision
+      2,                // daysSinceActivity
+      30,               // dormantThreshold
+      25,               // approachingThreshold
+      '2026-02-08T12:00:00Z',  // latestCommitDate (newer)
+      '2026-02-07T10:00:00Z'   // lastMaintainerCommentDate (older)
+    );
+
+    expect(result).toBe('changes_addressed');
+  });
+
+  it('should return needs_response when commit is older than maintainer comment', () => {
+    const monitor = new PRMonitor('fake-token');
+    const result = (monitor as any).determineStatus(
+      'passing',
+      false,
+      true,             // hasUnrespondedComment
+      false,
+      'changes_requested',
+      2,
+      30,
+      25,
+      '2026-02-06T10:00:00Z',  // latestCommitDate (older)
+      '2026-02-07T10:00:00Z'   // lastMaintainerCommentDate (newer)
+    );
+
+    expect(result).toBe('needs_response');
+  });
+
+  it('should fall back to needs_response when commit date is unavailable', () => {
+    const monitor = new PRMonitor('fake-token');
+    const result = (monitor as any).determineStatus(
+      'passing',
+      false,
+      true,             // hasUnrespondedComment
+      false,
+      'changes_requested',
+      2,
+      30,
+      25,
+      undefined,               // latestCommitDate (missing)
+      '2026-02-07T10:00:00Z'  // lastMaintainerCommentDate
+    );
+
+    expect(result).toBe('needs_response');
+  });
+
+  it('should not check commit date when hasUnrespondedComment is false', () => {
+    const monitor = new PRMonitor('fake-token');
+    const result = (monitor as any).determineStatus(
+      'passing',
+      false,
+      false,            // hasUnrespondedComment = false
+      false,
+      'approved',
+      2,
+      30,
+      25,
+      '2026-02-08T12:00:00Z',  // latestCommitDate (irrelevant)
+      '2026-02-07T10:00:00Z'   // lastMaintainerCommentDate (irrelevant)
+    );
+
+    // Should be healthy (not changes_addressed) since there's no unresponded comment
+    expect(result).not.toBe('changes_addressed');
+    expect(result).not.toBe('needs_response');
   });
 });

--- a/src/core/pr-monitor.ts
+++ b/src/core/pr-monitor.ts
@@ -129,11 +129,12 @@ export class PRMonitor {
         'needs_rebase': 5,
         'missing_required_files': 6,
         'incomplete_checklist': 7,
-        'approaching_dormant': 8,
-        'dormant': 9,
-        'waiting': 10,
-        'waiting_on_maintainer': 11,
-        'healthy': 12,
+        'changes_addressed': 8,
+        'approaching_dormant': 9,
+        'dormant': 10,
+        'waiting': 11,
+        'waiting_on_maintainer': 12,
+        'healthy': 13,
       };
       return statusPriority[a.status] - statusPriority[b.status];
     });
@@ -166,21 +167,33 @@ export class PRMonitor {
     const comments = commentsResponse.data;
     const reviews = reviewsResponse.data;
 
-    // Get CI status with the actual SHA (must be done after fetching PR data)
-    const { status: ciStatus, failingCheckNames } = await this.getCIStatus(owner, repo, ghPR.head.sha);
-
     // Determine review decision
     const reviewDecision = this.determineReviewDecision(reviews);
 
     // Check for merge conflict
     const hasMergeConflict = this.hasMergeConflict(ghPR.mergeable, ghPR.mergeable_state);
 
-    // Check if there's an unresponded maintainer comment
+    // Check if there's an unresponded maintainer comment (pure computation, no API call)
     const { hasUnrespondedComment, lastMaintainerComment } = this.checkUnrespondedComments(
       comments,
       reviews,
       config.githubUsername
     );
+
+    // Fetch CI status and (conditionally) latest commit date in parallel
+    // We only need the commit date when hasUnrespondedComment is true, to distinguish
+    // "needs_response" from "changes_addressed" (contributor pushed after maintainer commented)
+    const ciPromise = this.getCIStatus(owner, repo, ghPR.head.sha);
+    const commitDatePromise = hasUnrespondedComment
+      ? this.octokit.repos.getCommit({ owner, repo, ref: ghPR.head.sha })
+          .then(res => res.data.commit.author?.date)
+          .catch(() => undefined)
+      : Promise.resolve(undefined);
+
+    const [{ status: ciStatus, failingCheckNames }, latestCommitDate] = await Promise.all([
+      ciPromise,
+      commitDatePromise,
+    ]);
 
     // Analyze PR body for incomplete checklists
     const { hasIncompleteChecklist, checklistStats } = this.analyzeChecklist(ghPR.body || '');
@@ -203,7 +216,9 @@ export class PRMonitor {
       reviewDecision,
       daysSinceActivity,
       config.dormantThresholdDays,
-      config.approachingDormantDays
+      config.approachingDormantDays,
+      latestCommitDate,
+      lastMaintainerComment?.createdAt
     );
 
     return {
@@ -222,6 +237,7 @@ export class PRMonitor {
       reviewDecision,
       hasUnrespondedComment,
       lastMaintainerComment,
+      latestCommitDate,
       hasIncompleteChecklist,
       checklistStats,
       maintainerActionHints,
@@ -309,11 +325,18 @@ export class PRMonitor {
     reviewDecision: ReviewDecision,
     daysSinceActivity: number,
     dormantThreshold: number,
-    approachingThreshold: number
+    approachingThreshold: number,
+    latestCommitDate?: string,
+    lastMaintainerCommentDate?: string
   ): FetchedPRStatus {
-    // Priority order: needs_response > failing_ci > merge_conflict > incomplete_checklist > dormant > approaching_dormant > waiting_on_maintainer > waiting/healthy
+    // Priority order: needs_response/changes_addressed > failing_ci > merge_conflict > incomplete_checklist > dormant > approaching_dormant > waiting_on_maintainer > waiting/healthy
 
     if (hasUnrespondedComment) {
+      // If the contributor pushed a commit after the maintainer's comment,
+      // the changes have been addressed — waiting for maintainer re-review
+      if (latestCommitDate && lastMaintainerCommentDate && latestCommitDate > lastMaintainerCommentDate) {
+        return 'changes_addressed';
+      }
       return 'needs_response';
     }
 
@@ -793,6 +816,7 @@ export class PRMonitor {
     const needsRebasePRs = prs.filter(pr => pr.status === 'needs_rebase');
     const missingRequiredFilesPRs = prs.filter(pr => pr.status === 'missing_required_files');
     const incompleteChecklistPRs = prs.filter(pr => pr.status === 'incomplete_checklist');
+    const changesAddressedPRs = prs.filter(pr => pr.status === 'changes_addressed');
     const waitingOnMaintainerPRs = prs.filter(pr => pr.status === 'waiting_on_maintainer');
 
     return {
@@ -806,6 +830,7 @@ export class PRMonitor {
       needsRebasePRs,
       missingRequiredFilesPRs,
       incompleteChecklistPRs,
+      changesAddressedPRs,
       waitingOnMaintainerPRs,
       approachingDormant,
       dormantPRs,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -22,6 +22,7 @@ export type FetchedPRStatus =
   | 'needs_rebase'
   | 'missing_required_files'
   | 'incomplete_checklist'
+  | 'changes_addressed'
   | 'waiting'
   | 'waiting_on_maintainer'
   | 'healthy'
@@ -81,6 +82,9 @@ export interface FetchedPR {
     body: string;
     createdAt: string;
   };
+
+  // Latest commit timestamp (fetched when hasUnrespondedComment is true)
+  latestCommitDate?: string;
 
   // PR body analysis
   hasIncompleteChecklist: boolean; // PR body has unchecked required checkboxes
@@ -268,6 +272,7 @@ export interface DailyDigest {
   needsRebasePRs: FetchedPR[];
   missingRequiredFilesPRs: FetchedPR[];
   incompleteChecklistPRs: FetchedPR[];
+  changesAddressedPRs: FetchedPR[];
   waitingOnMaintainerPRs: FetchedPR[];
   approachingDormant: FetchedPR[]; // 25+ days
   dormantPRs: FetchedPR[];


### PR DESCRIPTION
## Summary

- Fixes stale `needs_response` status when a contributor has already pushed commits addressing maintainer feedback
- GitHub's `reviewDecision` stays `changes_requested` until the maintainer re-approves, creating a false positive
- Compares latest commit timestamp against last maintainer comment date — if the commit is newer, shows `changes_addressed` instead of `needs_response`
- New status is informational only (not counted in `totalNeedingAttention`)

Closes https://github.com/anthropics/claude-plugins-official/issues/359

## Changes

| File | Change |
|------|--------|
| `src/core/types.ts` | New `changes_addressed` status, `latestCommitDate` field, `changesAddressedPRs` digest array |
| `src/core/pr-monitor.ts` | Conditional commit date fetch, status detection logic, priority ordering, digest generation |
| `src/core/pr-monitor.test.ts` | 4 new test cases for `changes_addressed` detection |
| `src/commands/daily.ts` | Display sections in summary and console output |
| `src/commands/dashboard.ts` | CSS, health section, badge rendering |
| `commands/oss.md` | Documentation update |
| Version files | 0.7.1 → 0.7.2 |

## Test plan

- [x] All 64 tests pass (`npm test`)
- [x] Bundle builds cleanly (`npm run bundle`)
- [ ] Manual: Run `npm start -- daily --json` and verify `changesAddressedPRs` array in output
- [ ] Manual: Verify dashboard shows "Changes Addressed" badge (info-blue) instead of "Needs Response" for qualifying PRs