### PR TITLE
fix: move health check to .cjs file for Node.js 18-24+ compatibility

### DIFF
--- a/.claude-plugin/hooks/SessionStart.md
+++ b/.claude-plugin/hooks/SessionStart.md
@@ -35,32 +35,8 @@ fi
 **Step 3: Quick PR health check (from cached data)**
 
 ```bash
-STATE_FILE="${HOME}/.oss-autopilot/state.json"
-if [ -f "$STATE_FILE" ]; then
-  HEALTH=$(node -e "
-    try {
-      const s = require('fs').readFileSync('${HOME}/.oss-autopilot/state.json', 'utf8');
-      const state = JSON.parse(s);
-      if (state.config && state.config.showHealthCheck === false) process.exit(0);
-      const lastRun = state.lastDigestAt || state.lastRunAt;
-      if (!lastRun || !state.lastDigest) process.exit(0);
-      const ageMs = Date.now() - new Date(lastRun).getTime();
-      const ageDays = Math.floor(ageMs / 86400000);
-      const ageHours = Math.floor(ageMs / 3600000);
-      const ageLabel = ageDays >= 1 ? ageDays + 'd ago' : ageHours + 'h ago';
-      if (ageDays > 7) {
-        console.log('OSS: Haven\\'t checked your PRs in ' + ageDays + ' days. Run /oss to catch up.');
-      } else {
-        const need = state.lastDigest.summary.totalNeedingAttention || 0;
-        const total = state.lastDigest.summary.totalActivePRs || 0;
-        if (need > 0) {
-          console.log('OSS: ' + need + ' of ' + total + ' PRs need attention (' + ageLabel + '). Run /oss to address.');
-        }
-      }
-    } catch(e) {}
-  " 2>/dev/null)
-  [ -n "$HEALTH" ] && echo "$HEALTH"
-fi
+HEALTH=$(node "${CLAUDE_PLUGIN_ROOT}/scripts/health-check.cjs" 2>/dev/null)
+[ -n "$HEALTH" ] && echo "$HEALTH"
 ```
 
 If no checks trigger output, the hook is silent — no noise for the user.

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "AI-powered autopilot for managing open source contributions - track PRs, respond to maintainers, discover issues, and maintain contribution velocity",
   "author": {
     "name": "John Costa"

--- a/.claude-plugin/scripts/health-check.cjs
+++ b/.claude-plugin/scripts/health-check.cjs
@@ -1,0 +1,27 @@
+// Quick PR health check — reads cached state, outputs a one-liner if PRs need attention.
+// Called by SessionStart hook. Exits silently when nothing actionable.
+try {
+  const s = require('fs').readFileSync(
+    require('path').join(require('os').homedir(), '.oss-autopilot', 'state.json'),
+    'utf8'
+  );
+  const state = JSON.parse(s);
+  if (state.config && state.config.showHealthCheck === false) process.exit(0);
+  const lastRun = state.lastDigestAt || state.lastRunAt;
+  if (!lastRun || !state.lastDigest) process.exit(0);
+  const ageMs = Date.now() - new Date(lastRun).getTime();
+  const ageDays = Math.floor(ageMs / 86400000);
+  const ageHours = Math.floor(ageMs / 3600000);
+  const ageLabel = ageDays >= 1 ? ageDays + 'd ago' : ageHours + 'h ago';
+  if (ageDays > 7) {
+    console.log("OSS: Haven't checked your PRs in " + ageDays + ' days. Run /oss to catch up.');
+  } else {
+    const need = state.lastDigest.summary.totalNeedingAttention || 0;
+    const total = state.lastDigest.summary.totalActivePRs || 0;
+    if (need > 0) {
+      console.log('OSS: ' + need + ' of ' + total + ' PRs need attention (' + ageLabel + '). Run /oss to address.');
+    }
+  }
+} catch (e) {
+  // Silent — don't disrupt session start
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2026-02-08
+
+### Fixed
+
+- SessionStart health check silently failing on Node.js 24 — `node -e` inline scripts break because the Bash tool escapes `!` to `\!`, which is invalid in Node 24's TypeScript parser. Moved health check logic to a `.cjs` script file that works on Node 18 through 24+.
+
 ## [0.8.0] - 2026-02-08
 
 ### Added
@@ -159,6 +165,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR monitoring and health checking
 - Dashboard HTML generation
 
+[0.8.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.7.2...v0.8.0
 [0.7.2]: https://github.com/costajohnt/oss-autopilot/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.7.0...v0.7.1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Discover issues worth contributing to, track your PRs across repos, and draft responses to maintainer feedback. An AI copilot for your open source journey.
 
-![Version](https://img.shields.io/badge/version-0.8.0-blue)
+![Version](https://img.shields.io/badge/version-0.8.1-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "AI-powered autopilot for managing open source contributions with Claude Code",
   "type": "module",
   "main": "dist/cli.js",


### PR DESCRIPTION
## Summary

- **SessionStart health check silently failing on Node.js 24** — the `node -e` inline script in the hook breaks because the Bash tool escapes `!` to `\!`, which Node 24's TypeScript parser rejects. The `catch(e) {}` and `2>/dev/null` swallow the error, so the notification never appears.
- **Fix:** Move the health check logic from an inline `node -e` script to a `.cjs` file (`scripts/health-check.cjs`). The `.cjs` extension forces CommonJS parsing and avoids all shell quoting/escaping issues. Works on Node 18 through 24+.

## Test plan

- [ ] `node .claude-plugin/scripts/health-check.cjs` outputs notification when state has PRs needing attention
- [ ] Script is silent when no state file exists
- [ ] Script is silent when `showHealthCheck` is `false` in config
- [ ] Script shows staleness warning when data is > 7 days old
- [ ] `npm test` passes (64 tests)
- [ ] `npm run bundle` succeeds
- [ ] Version 0.8.1 consistent across `package.json`, `plugin.json`, README badge