### PR TITLE
fix: correct health check script path

### DIFF
--- a/.claude-plugin/hooks/SessionStart.md
+++ b/.claude-plugin/hooks/SessionStart.md
@@ -35,7 +35,7 @@ fi
 **Step 3: Quick PR health check (from cached data)**
 
 ```bash
-HEALTH=$(node "${CLAUDE_PLUGIN_ROOT}/scripts/health-check.cjs" 2>/dev/null)
+HEALTH=$(node "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/scripts/health-check.cjs" 2>/dev/null)
 [ -n "$HEALTH" ] && echo "$HEALTH"
 ```
 

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "AI-powered autopilot for managing open source contributions - track PRs, respond to maintainers, discover issues, and maintain contribution velocity",
   "author": {
     "name": "John Costa"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] - 2026-02-08
+
+### Fixed
+
+- SessionStart health check script not found — path was `${CLAUDE_PLUGIN_ROOT}/scripts/` but the file lives at `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/scripts/`
+
 ## [0.8.1] - 2026-02-08
 
 ### Fixed
@@ -165,6 +171,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR monitoring and health checking
 - Dashboard HTML generation
 
+[0.8.2]: https://github.com/costajohnt/oss-autopilot/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.7.2...v0.8.0
 [0.7.2]: https://github.com/costajohnt/oss-autopilot/compare/v0.7.1...v0.7.2

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Discover issues worth contributing to, track your PRs across repos, and draft responses to maintainer feedback. An AI copilot for your open source journey.
 
-![Version](https://img.shields.io/badge/version-0.8.1-blue)
+![Version](https://img.shields.io/badge/version-0.8.2-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "AI-powered autopilot for managing open source contributions with Claude Code",
   "type": "module",
   "main": "dist/cli.js",


### PR DESCRIPTION
## Summary

- Health check script was never found because the hook referenced `${CLAUDE_PLUGIN_ROOT}/scripts/health-check.cjs` but the file lives at `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/scripts/health-check.cjs`. `CLAUDE_PLUGIN_ROOT` points to the repo root, not the `.claude-plugin/` directory.

## Test plan

- [ ] Simulate `CLAUDE_PLUGIN_ROOT` pointing at installed plugin and verify `node "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/scripts/health-check.cjs"` finds the file
- [ ] Version 0.8.2 consistent across all three files
- [ ] `npm test` passes