### PR TITLE
fix: classify PRs with changes_requested review as needs_changes instead of healthy

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "AI-powered autopilot for managing open source contributions - track PRs, respond to maintainers, discover issues, and maintain contribution velocity",
   "author": {
     "name": "John Costa"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.3] - 2026-02-08
+
+### Fixed
+
+- PRs with `changes_requested` review decision but no new commits incorrectly classified as 'healthy' — added `needs_changes` status that detects when a maintainer requests changes via inline review comments (empty review body) and the contributor hasn't pushed new commits yet. Also adds `changes_addressed` detection when commits are pushed after the review. Fixes #48.
+
 ## [0.8.2] - 2026-02-08
 
 ### Fixed
@@ -171,6 +177,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR monitoring and health checking
 - Dashboard HTML generation
 
+[0.8.3]: https://github.com/costajohnt/oss-autopilot/compare/v0.8.2...v0.8.3
 [0.8.2]: https://github.com/costajohnt/oss-autopilot/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.7.2...v0.8.0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Discover issues worth contributing to, track your PRs across repos, and draft responses to maintainer feedback. An AI copilot for your open source journey.
 
-![Version](https://img.shields.io/badge/version-0.8.2-blue)
+![Version](https://img.shields.io/badge/version-0.8.3-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "AI-powered autopilot for managing open source contributions with Claude Code",
   "type": "module",
   "main": "dist/cli.js",

--- a/src/commands/daily.ts
+++ b/src/commands/daily.ts
@@ -138,6 +138,16 @@ function formatSummary(digest: DailyDigest, capacity: CapacityAssessment): strin
     lines.push('');
   }
 
+  // Needs Changes (review requested changes, no new commits yet)
+  if (digest.needsChangesPRs.length > 0) {
+    lines.push('### 🔧 Needs Changes');
+    for (const pr of digest.needsChangesPRs) {
+      lines.push(`- [${pr.repo}#${pr.number}](${pr.url}): ${pr.title}`);
+      lines.push(`  └─ Review requested changes — push commits to address`);
+    }
+    lines.push('');
+  }
+
   // Incomplete Checklist
   if (digest.incompleteChecklistPRs.length > 0) {
     lines.push('### 📋 Incomplete Checklist');
@@ -256,6 +266,15 @@ function printDigest(digest: DailyDigest, capacity: CapacityAssessment): void {
     console.log('');
   }
 
+  if (digest.needsChangesPRs.length > 0) {
+    console.log('🔧 Needs Changes:');
+    for (const pr of digest.needsChangesPRs) {
+      console.log(`  - ${pr.repo}#${pr.number}: ${pr.title}`);
+      console.log(`    Review requested changes — push commits to address`);
+    }
+    console.log('');
+  }
+
   if (digest.incompleteChecklistPRs.length > 0) {
     console.log('📋 Incomplete Checklist:');
     for (const pr of digest.incompleteChecklistPRs) {
@@ -319,7 +338,7 @@ function assessCapacity(prs: FetchedPR[], maxActivePRs: number): CapacityAssessm
   const activePRCount = prs.length;
 
   // Count critical issues
-  const criticalStatuses = new Set(['needs_response', 'failing_ci', 'merge_conflict']);
+  const criticalStatuses = new Set(['needs_response', 'needs_changes', 'failing_ci', 'merge_conflict']);
   const criticalIssueCount = prs.filter(pr => criticalStatuses.has(pr.status)).length;
 
   // Has capacity if: under PR limit AND no critical issues
@@ -375,7 +394,14 @@ function collectActionableIssues(prs: FetchedPR[], recentlyClosedPRs: ClosedPR[]
     }
   }
 
-  // 2. CI Failing (include check names so user can distinguish real CI from validation bots)
+  // 2. Needs Changes (review requested changes, contributor hasn't pushed new code)
+  for (const pr of prs) {
+    if (pr.status === 'needs_changes') {
+      issues.push({ type: 'needs_changes', pr, label: '[Needs Changes]' });
+    }
+  }
+
+  // 3. CI Failing (include check names so user can distinguish real CI from validation bots)
   for (const pr of prs) {
     if (pr.status === 'failing_ci') {
       const checkInfo = pr.failingCheckNames.length > 0
@@ -385,14 +411,14 @@ function collectActionableIssues(prs: FetchedPR[], recentlyClosedPRs: ClosedPR[]
     }
   }
 
-  // 3. Merge Conflicts
+  // 4. Merge Conflicts
   for (const pr of prs) {
     if (pr.status === 'merge_conflict') {
       issues.push({ type: 'merge_conflict', pr, label: '[Merge Conflict]' });
     }
   }
 
-  // 4. Incomplete Checklist
+  // 5. Incomplete Checklist
   for (const pr of prs) {
     if (pr.status === 'incomplete_checklist') {
       const stats = pr.checklistStats ? ` (${pr.checklistStats.checked}/${pr.checklistStats.total})` : '';
@@ -400,14 +426,14 @@ function collectActionableIssues(prs: FetchedPR[], recentlyClosedPRs: ClosedPR[]
     }
   }
 
-  // 5. Approaching Dormant
+  // 6. Approaching Dormant
   for (const pr of prs) {
     if (pr.status === 'approaching_dormant') {
       issues.push({ type: 'approaching_dormant', pr, label: '[Approaching Dormant]' });
     }
   }
 
-  // 6. Recently Closed (informational - PRs closed without merge in last 7 days)
+  // 7. Recently Closed (informational - PRs closed without merge in last 7 days)
   for (const closedPR of recentlyClosedPRs) {
     // Create a minimal FetchedPR-like object for the ActionableIssue interface
     const pr: FetchedPR = {

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -990,7 +990,7 @@ function generateDashboardHtml(
       </div>
       <div class="pr-list">
         ${digest.openPRs.map(pr => {
-          const hasIssues = pr.ciStatus === 'failing' || pr.hasMergeConflict || (pr.hasUnrespondedComment && pr.status !== 'changes_addressed');
+          const hasIssues = pr.ciStatus === 'failing' || pr.hasMergeConflict || (pr.hasUnrespondedComment && pr.status !== 'changes_addressed') || pr.status === 'needs_changes';
           const isStale = pr.daysSinceActivity >= approachingDormantDays;
           const itemClass = hasIssues ? 'has-issues' : (isStale ? 'stale' : '');
 

--- a/src/core/pr-monitor.test.ts
+++ b/src/core/pr-monitor.test.ts
@@ -245,7 +245,7 @@ describe('PRMonitor changes_addressed detection', () => {
     expect(result).toBe('needs_response');
   });
 
-  it('should not check commit date when hasUnrespondedComment is false', () => {
+  it('should not check commit date when hasUnrespondedComment is false and review is approved', () => {
     const monitor = new PRMonitor('fake-token');
     const result = (monitor as any).determineStatus(
       'passing',
@@ -256,12 +256,94 @@ describe('PRMonitor changes_addressed detection', () => {
       2,
       30,
       25,
-      '2026-02-08T12:00:00Z',  // latestCommitDate (irrelevant)
-      '2026-02-07T10:00:00Z'   // lastMaintainerCommentDate (irrelevant)
+      '2026-02-08T12:00:00Z',  // latestCommitDate
+      '2026-02-07T10:00:00Z',  // lastMaintainerCommentDate
+      undefined                 // latestChangesRequestedDate
     );
 
-    // Should be healthy (not changes_addressed) since there's no unresponded comment
-    expect(result).not.toBe('changes_addressed');
-    expect(result).not.toBe('needs_response');
+    expect(result).toBe('waiting_on_maintainer');
+  });
+});
+
+describe('PRMonitor needs_changes detection', () => {
+  beforeEach(() => {
+    mockOctokitInstance = {};
+  });
+
+  it('should return needs_changes when changes_requested and no new commits', () => {
+    const monitor = new PRMonitor('fake-token');
+    const result = (monitor as any).determineStatus(
+      'passing',
+      false,
+      false,            // hasUnrespondedComment = false (inline review comments)
+      false,
+      'changes_requested',
+      2,
+      30,
+      25,
+      '2026-02-08T06:50:38Z',   // latestCommitDate (before review)
+      undefined,                  // lastMaintainerCommentDate
+      '2026-02-08T11:52:22Z'    // latestChangesRequestedDate (after commit)
+    );
+
+    expect(result).toBe('needs_changes');
+  });
+
+  it('should return changes_addressed when commits pushed after changes_requested review', () => {
+    const monitor = new PRMonitor('fake-token');
+    const result = (monitor as any).determineStatus(
+      'passing',
+      false,
+      false,
+      false,
+      'changes_requested',
+      2,
+      30,
+      25,
+      '2026-02-09T10:00:00Z',   // latestCommitDate (after review)
+      undefined,
+      '2026-02-08T11:52:22Z'    // latestChangesRequestedDate (before commit)
+    );
+
+    expect(result).toBe('changes_addressed');
+  });
+
+  it('should return needs_changes when no commit date available', () => {
+    const monitor = new PRMonitor('fake-token');
+    const result = (monitor as any).determineStatus(
+      'passing',
+      false,
+      false,
+      false,
+      'changes_requested',
+      2,
+      30,
+      25,
+      undefined,                  // latestCommitDate (missing)
+      undefined,
+      '2026-02-08T11:52:22Z'    // latestChangesRequestedDate
+    );
+
+    expect(result).toBe('needs_changes');
+  });
+
+  it('should return healthy when changes_requested but no review date available', () => {
+    const monitor = new PRMonitor('fake-token');
+    const result = (monitor as any).determineStatus(
+      'passing',
+      false,
+      false,
+      false,
+      'changes_requested',
+      2,
+      30,
+      25,
+      '2026-02-08T06:50:38Z',
+      undefined,
+      undefined                   // latestChangesRequestedDate (missing)
+    );
+
+    // No review date to compare against — fall through to healthy
+    expect(result).toBe('healthy');
   });
 });

--- a/src/core/pr-monitor.ts
+++ b/src/core/pr-monitor.ts
@@ -122,19 +122,20 @@ export class PRMonitor {
       // Priority: needs_response > failing_ci > merge_conflict > approaching_dormant > dormant > waiting > healthy
       const statusPriority: Record<FetchedPRStatus, number> = {
         'needs_response': 0,
-        'failing_ci': 1,
-        'ci_blocked': 2,
-        'ci_not_running': 3,
-        'merge_conflict': 4,
-        'needs_rebase': 5,
-        'missing_required_files': 6,
-        'incomplete_checklist': 7,
-        'changes_addressed': 8,
-        'approaching_dormant': 9,
-        'dormant': 10,
-        'waiting': 11,
-        'waiting_on_maintainer': 12,
-        'healthy': 13,
+        'needs_changes': 1,
+        'failing_ci': 2,
+        'ci_blocked': 3,
+        'ci_not_running': 4,
+        'merge_conflict': 5,
+        'needs_rebase': 6,
+        'missing_required_files': 7,
+        'incomplete_checklist': 8,
+        'changes_addressed': 9,
+        'approaching_dormant': 10,
+        'dormant': 11,
+        'waiting': 12,
+        'waiting_on_maintainer': 13,
+        'healthy': 14,
       };
       return statusPriority[a.status] - statusPriority[b.status];
     });
@@ -181,10 +182,12 @@ export class PRMonitor {
     );
 
     // Fetch CI status and (conditionally) latest commit date in parallel
-    // We only need the commit date when hasUnrespondedComment is true, to distinguish
-    // "needs_response" from "changes_addressed" (contributor pushed after maintainer commented)
+    // We need the commit date when hasUnrespondedComment is true (to distinguish
+    // "needs_response" from "changes_addressed") OR when reviewDecision is "changes_requested"
+    // (to detect needs_changes: review requested changes but no new commits pushed)
     const ciPromise = this.getCIStatus(owner, repo, ghPR.head.sha);
-    const commitDatePromise = hasUnrespondedComment
+    const needCommitDate = hasUnrespondedComment || reviewDecision === 'changes_requested';
+    const commitDatePromise = needCommitDate
       ? this.octokit.repos.getCommit({ owner, repo, ref: ghPR.head.sha })
           .then(res => res.data.commit.author?.date)
           .catch(() => undefined)
@@ -207,6 +210,9 @@ export class PRMonitor {
     // Calculate days since activity
     const daysSinceActivity = daysBetween(new Date(ghPR.updated_at), new Date());
 
+    // Find the date of the latest changes_requested review (for needs_changes detection)
+    const latestChangesRequestedDate = this.getLatestChangesRequestedDate(reviews);
+
     // Determine status
     const status = this.determineStatus(
       ciStatus,
@@ -218,7 +224,8 @@ export class PRMonitor {
       config.dormantThresholdDays,
       config.approachingDormantDays,
       latestCommitDate,
-      lastMaintainerComment?.createdAt
+      lastMaintainerComment?.createdAt,
+      latestChangesRequestedDate
     );
 
     return {
@@ -327,9 +334,10 @@ export class PRMonitor {
     dormantThreshold: number,
     approachingThreshold: number,
     latestCommitDate?: string,
-    lastMaintainerCommentDate?: string
+    lastMaintainerCommentDate?: string,
+    latestChangesRequestedDate?: string
   ): FetchedPRStatus {
-    // Priority order: needs_response/changes_addressed > failing_ci > merge_conflict > incomplete_checklist > dormant > approaching_dormant > waiting_on_maintainer > waiting/healthy
+    // Priority order: needs_response/needs_changes/changes_addressed > failing_ci > merge_conflict > incomplete_checklist > dormant > approaching_dormant > waiting_on_maintainer > waiting/healthy
 
     if (hasUnrespondedComment) {
       // If the contributor pushed a commit after the maintainer's comment,
@@ -338,6 +346,17 @@ export class PRMonitor {
         return 'changes_addressed';
       }
       return 'needs_response';
+    }
+
+    // Review requested changes but no unresponded comment (feedback was in inline
+    // review comments with empty body, so checkUnrespondedComments didn't catch it).
+    // If the latest commit is before the review, the contributor hasn't addressed it yet.
+    if (reviewDecision === 'changes_requested' && latestChangesRequestedDate) {
+      if (!latestCommitDate || latestCommitDate < latestChangesRequestedDate) {
+        return 'needs_changes';
+      }
+      // Commit is after review — changes have been addressed
+      return 'changes_addressed';
     }
 
     if (ciStatus === 'failing') {
@@ -596,6 +615,24 @@ export class PRMonitor {
   }
 
   /**
+   * Get the date of the latest CHANGES_REQUESTED review (from any reviewer).
+   * Used to detect needs_changes status when review feedback is in inline comments.
+   */
+  private getLatestChangesRequestedDate(
+    reviews: Array<{ state?: string | null; submitted_at?: string | null }>
+  ): string | undefined {
+    let latest: string | undefined;
+    for (const review of reviews) {
+      if (review.state === 'CHANGES_REQUESTED' && review.submitted_at) {
+        if (!latest || review.submitted_at > latest) {
+          latest = review.submitted_at;
+        }
+      }
+    }
+    return latest;
+  }
+
+  /**
    * Check if PR has merge conflict
    */
   private hasMergeConflict(mergeable: boolean | null, mergeableState: string | null): boolean {
@@ -816,6 +853,7 @@ export class PRMonitor {
     const needsRebasePRs = prs.filter(pr => pr.status === 'needs_rebase');
     const missingRequiredFilesPRs = prs.filter(pr => pr.status === 'missing_required_files');
     const incompleteChecklistPRs = prs.filter(pr => pr.status === 'incomplete_checklist');
+    const needsChangesPRs = prs.filter(pr => pr.status === 'needs_changes');
     const changesAddressedPRs = prs.filter(pr => pr.status === 'changes_addressed');
     const waitingOnMaintainerPRs = prs.filter(pr => pr.status === 'waiting_on_maintainer');
 
@@ -830,6 +868,7 @@ export class PRMonitor {
       needsRebasePRs,
       missingRequiredFilesPRs,
       incompleteChecklistPRs,
+      needsChangesPRs,
       changesAddressedPRs,
       waitingOnMaintainerPRs,
       approachingDormant,
@@ -838,7 +877,7 @@ export class PRMonitor {
       recentlyClosedPRs,
       summary: {
         totalActivePRs: prs.length,
-        totalNeedingAttention: prsNeedingResponse.length + ciFailingPRs.length + mergeConflictPRs.length + needsRebasePRs.length + missingRequiredFilesPRs.length + incompleteChecklistPRs.length,
+        totalNeedingAttention: prsNeedingResponse.length + needsChangesPRs.length + ciFailingPRs.length + mergeConflictPRs.length + needsRebasePRs.length + missingRequiredFilesPRs.length + incompleteChecklistPRs.length,
         totalMergedAllTime: stats.mergedPRs,
         mergeRate: parseFloat(stats.mergeRate),
       },

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -22,6 +22,7 @@ export type FetchedPRStatus =
   | 'needs_rebase'
   | 'missing_required_files'
   | 'incomplete_checklist'
+  | 'needs_changes'
   | 'changes_addressed'
   | 'waiting'
   | 'waiting_on_maintainer'
@@ -272,6 +273,7 @@ export interface DailyDigest {
   needsRebasePRs: FetchedPR[];
   missingRequiredFilesPRs: FetchedPR[];
   incompleteChecklistPRs: FetchedPR[];
+  needsChangesPRs: FetchedPR[];
   changesAddressedPRs: FetchedPR[];
   waitingOnMaintainerPRs: FetchedPR[];
   approachingDormant: FetchedPR[]; // 25+ days


### PR DESCRIPTION
## Summary

- Adds `needs_changes` status for PRs where a maintainer submitted a `changes_requested` review but the contributor hasn't pushed new commits yet
- Adds `changes_addressed` detection when commits are pushed after the `changes_requested` review
- Fixes the root cause: when maintainers put feedback in inline code review comments (empty review body), `checkUnrespondedComments` skipped the review entirely, causing the PR to fall through to 'healthy'
- Fetches `latestCommitDate` when `reviewDecision === 'changes_requested'` (previously only fetched when `hasUnrespondedComment` was true)

Fixes #48

## Files changed

| File | Change |
|------|--------|
| `src/core/types.ts` | Add `needs_changes` to `FetchedPRStatus`, `needsChangesPRs` to `DailyDigest` |
| `src/core/pr-monitor.ts` | New `getLatestChangesRequestedDate()` helper, updated `determineStatus()` logic, fetch commit date for `changes_requested` PRs |
| `src/core/pr-monitor.test.ts` | 4 new tests for `needs_changes` detection + 1 updated existing test |
| `src/commands/daily.ts` | Display sections for `needs_changes` PRs in markdown and text output |
| `src/commands/dashboard.ts` | Include `needs_changes` in `hasIssues` check |

## Test plan

- [x] All 68 tests pass (`npm test`)
- [x] Bundle builds clean (`npm run bundle`)
- [ ] Manual: run `/oss` on a repo with a `changes_requested` review and no new commits — should show as "Needs Changes"
- [ ] Manual: push a commit after `changes_requested` review — should show as "Changes Addressed"