### PR TITLE
fix: health check always shows PR status on session start

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "AI-powered autopilot for managing open source contributions - track PRs, respond to maintainers, discover issues, and maintain contribution velocity",
   "author": {
     "name": "John Costa"

--- a/.claude-plugin/scripts/health-check.cjs
+++ b/.claude-plugin/scripts/health-check.cjs
@@ -1,5 +1,5 @@
-// Quick PR health check — reads cached state, outputs a one-liner if PRs need attention.
-// Called by SessionStart hook. Exits silently when nothing actionable.
+// Quick PR health check — reads cached state, outputs a one-liner summary.
+// Called by SessionStart hook. Exits silently only when no PRs are tracked.
 try {
   const s = require('fs').readFileSync(
     require('path').join(require('os').homedir(), '.oss-autopilot', 'state.json'),
@@ -16,10 +16,29 @@ try {
   if (ageDays > 7) {
     console.log("OSS: Haven't checked your PRs in " + ageDays + ' days. Run /oss to catch up.');
   } else {
-    const need = state.lastDigest.summary.totalNeedingAttention || 0;
-    const total = state.lastDigest.summary.totalActivePRs || 0;
-    if (need > 0) {
-      console.log('OSS: ' + need + ' of ' + total + ' PRs need attention (' + ageLabel + '). Run /oss to address.');
+    const d = state.lastDigest;
+    const total = d.summary.totalActivePRs || 0;
+    if (total === 0) process.exit(0);
+    // Build status segments for a compact one-liner
+    const segments = [];
+    const needResponse = (d.prsNeedingResponse || []).length;
+    const ciFailing = (d.ciFailingPRs || []).length;
+    const conflicts = (d.mergeConflictPRs || []).length;
+    const needsChanges = (d.needsChangesPRs || []).length;
+    const addressed = (d.changesAddressedPRs || []).length;
+    const waitMaintainer = (d.waitingOnMaintainerPRs || []).length;
+    // Actionable items first (you need to do something)
+    if (needResponse > 0) segments.push(needResponse + ' need response');
+    if (needsChanges > 0) segments.push(needsChanges + ' need changes');
+    if (ciFailing > 0) segments.push(ciFailing + ' CI failing');
+    if (conflicts > 0) segments.push(conflicts + ' conflicts');
+    // Informational items (waiting on others)
+    if (addressed > 0) segments.push(addressed + ' awaiting re-review');
+    if (waitMaintainer > 0) segments.push(waitMaintainer + ' waiting on maintainer');
+    if (segments.length > 0) {
+      console.log('OSS: ' + total + ' active PRs — ' + segments.join(', ') + ' (' + ageLabel + ')');
+    } else {
+      console.log('OSS: ' + total + ' active PRs, all healthy (' + ageLabel + ')');
     }
   }
 } catch (e) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.7] - 2026-02-08
+
+### Fixed
+
+- SessionStart health check was silent even with active PRs — only reported when `totalNeedingAttention > 0`, which excluded `changesAddressedPRs` and `waitingOnMaintainerPRs`. Now always shows a one-liner summary with PR portfolio breakdown (e.g., "OSS: 16 active PRs — 2 awaiting re-review, 1 waiting on maintainer").
+
 ## [0.8.6] - 2026-02-08
 
 ### Fixed
@@ -208,6 +214,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR monitoring and health checking
 - Dashboard HTML generation
 
+[0.8.7]: https://github.com/costajohnt/oss-autopilot/compare/v0.8.6...v0.8.7
 [0.8.6]: https://github.com/costajohnt/oss-autopilot/compare/v0.8.5...v0.8.6
 [0.8.5]: https://github.com/costajohnt/oss-autopilot/compare/v0.8.4...v0.8.5
 [0.8.4]: https://github.com/costajohnt/oss-autopilot/compare/v0.8.3...v0.8.4

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Discover issues worth contributing to, track your PRs across repos, and draft responses to maintainer feedback. An AI copilot for your open source journey.
 
-![Version](https://img.shields.io/badge/version-0.8.6-blue)
+![Version](https://img.shields.io/badge/version-0.8.7-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oss-autopilot",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oss-autopilot",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "license": "MIT",
       "dependencies": {
         "@octokit/plugin-throttling": "^11.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "AI-powered autopilot for managing open source contributions with Claude Code",
   "type": "module",
   "main": "dist/cli.js",


### PR DESCRIPTION
## Summary

- **Root cause**: `health-check.cjs` only produced output when `totalNeedingAttention > 0`, but that counter excluded `changesAddressedPRs` and `waitingOnMaintainerPRs`. With 16 active PRs (2 awaiting re-review, 1 waiting on maintainer), the health check was completely silent.
- **Fix**: Rewrote health-check to always show a one-liner when there are active PRs, with a compact breakdown of status categories. Actionable items (need response, need changes, CI failing, conflicts) listed first, then informational items (awaiting re-review, waiting on maintainer). Falls back to "all healthy" when nothing is notable.

**Before**: `SessionStart:startup hook success: Success` (no useful content)
**After**: `OSS: 16 active PRs — 2 awaiting re-review, 1 waiting on maintainer (0h ago)`

## Test plan

- [x] `npm test` — 214 tests pass
- [x] `health-check.cjs` produces correct output against real state data
- [x] Full `session-start.sh` produces JSON with `additionalContext` containing the status line
- [ ] Manual: Start a new Claude Code session and verify `system-reminder` shows the PR summary
- [ ] Manual: Verify output with 0 active PRs (should be silent)
- [ ] Manual: Verify output with all-healthy PRs shows "all healthy" message
- [ ] Manual: Verify actionable categories (need response, CI failing, etc.) appear when present