### PR TITLE
fix: show SessionStart status to user via systemMessage

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "AI-powered autopilot for managing open source contributions - track PRs, respond to maintainers, discover issues, and maintain contribution velocity",
   "author": {
     "name": "John Costa"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.8] - 2026-02-08
+
+### Fixed
+
+- SessionStart hook status not visible to user — `additionalContext` only injects into the AI's system context, never displayed to the user. Added `systemMessage` field to hook JSON output so the PR status summary (e.g., "OSS: 16 active PRs — 2 awaiting re-review") is shown as a visible notification on session start.
+
 ## [0.8.7] - 2026-02-08
 
 ### Fixed
@@ -214,6 +220,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR monitoring and health checking
 - Dashboard HTML generation
 
+[0.8.8]: https://github.com/costajohnt/oss-autopilot/compare/v0.8.7...v0.8.8
 [0.8.7]: https://github.com/costajohnt/oss-autopilot/compare/v0.8.6...v0.8.7
 [0.8.6]: https://github.com/costajohnt/oss-autopilot/compare/v0.8.5...v0.8.6
 [0.8.5]: https://github.com/costajohnt/oss-autopilot/compare/v0.8.4...v0.8.5

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Discover issues worth contributing to, track your PRs across repos, and draft responses to maintainer feedback. An AI copilot for your open source journey.
 
-![Version](https://img.shields.io/badge/version-0.8.7-blue)
+![Version](https://img.shields.io/badge/version-0.8.8-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)
 

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -60,6 +60,7 @@ if [ -n "$messages" ]; then
   escaped=$(printf '%s' "$messages" | sed 's/\\/\\\\/g; s/"/\\"/g')
   cat <<EOF
 {
+  "systemMessage": "${escaped}",
   "hookSpecificOutput": {
     "hookEventName": "SessionStart",
     "additionalContext": "${escaped}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oss-autopilot",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oss-autopilot",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "license": "MIT",
       "dependencies": {
         "@octokit/plugin-throttling": "^11.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "AI-powered autopilot for managing open source contributions with Claude Code",
   "type": "module",
   "main": "dist/cli.js",


### PR DESCRIPTION
## Summary
- `additionalContext` in hook output only injects into the AI's system context — it was never displayed to the user
- Added `systemMessage` field to the SessionStart hook JSON output so the PR status summary (e.g., "OSS: 16 active PRs — 2 awaiting re-review") is shown as a visible notification when Claude Code starts
- Both fields are now set: `systemMessage` for the user, `additionalContext` for the AI

## Test plan
- [ ] Start a new Claude Code session with the plugin installed
- [ ] Verify the OSS PR status line appears as a visible notification (not just in system context)
- [ ] Verify the AI still receives the status in its system-reminder context
- [ ] Run `bash hooks/session-start.sh` and confirm output includes both `systemMessage` and `additionalContext`