### PR TITLE
feat: smarter issue search strategy with merged-PR prioritization

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "description": "AI-powered autopilot for managing open source contributions - track PRs, respond to maintainers, discover issues, and maintain contribution velocity",
   "author": {
     "name": "John Costa"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-02-08
+
+### Added
+
+- Smarter issue search strategy — new Phase 0 prioritizes repos where user has merged PRs (highest merge probability), replacing the generic "high-score" phase
+- `getReposWithMergedPRs()` method on `StateManager` — returns repos sorted by merged PR count for search prioritization
+- Closed/rejected PR history check in issue vetting — repos where all user PRs were closed without merge get a -15 viability penalty and "rejected PR(s)" skip reason; mixed history (some merged, some closed) shown as informational note
+- `searchPriority` and `viabilityScore` fields in search JSON output — agents can see why each issue was ranked
+- `excludedRepos` array in search JSON output — agents can see which repos were filtered out
+- Exclusion awareness for issue-scout agent — fallback `gh` searches now respect the exclusion list
+- Issue list depletion detection — when curated list reaches 0 available issues, offers "Replenish your issue list" instead of empty state
+- Auto-exclude prompt for recently closed PRs — offers to exclude repos where PRs were rejected
+- 8 new tests (222 total): `getReposWithMergedPRs` sorting/filtering (4), closed-PR viability penalty (4)
+
+### Changed
+
+- Search phases reordered: merged-PR repos → starred repos → general (was: starred → high-score → general)
+- `SearchPriority` type: `'merged_pr' | 'starred' | 'normal'` (was: `'starred' | 'high_score' | 'normal'`)
+
 ## [0.8.8] - 2026-02-08
 
 ### Fixed
@@ -220,6 +239,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR monitoring and health checking
 - Dashboard HTML generation
 
+[0.9.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.8.8...v0.9.0
 [0.8.8]: https://github.com/costajohnt/oss-autopilot/compare/v0.8.7...v0.8.8
 [0.8.7]: https://github.com/costajohnt/oss-autopilot/compare/v0.8.6...v0.8.7
 [0.8.6]: https://github.com/costajohnt/oss-autopilot/compare/v0.8.5...v0.8.6

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Discover issues worth contributing to, track your PRs across repos, and draft responses to maintainer feedback. An AI copilot for your open source journey.
 
-![Version](https://img.shields.io/badge/version-0.8.8-blue)
+![Version](https://img.shields.io/badge/version-0.9.0-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)
 

--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -124,6 +124,19 @@ When dispatched with an issue from the user's curated list (indicated by `Source
 
 ---
 
+**Excluded Repos Awareness:**
+
+The CLI search command now includes `excludedRepos` in its JSON output. These repos have been explicitly excluded by the user (via config or auto-exclude after rejected PRs).
+
+When performing **fallback manual searches** (using `gh` directly instead of the CLI):
+1. First load the exclusion list from `excludedRepos` in the CLI search output or from the config
+2. **Skip any repos in the exclusion list** when doing `gh search issues` results filtering
+3. When presenting results, note if any were filtered: "Skipped {count} results from excluded repos ({repo1}, {repo2})"
+
+The CLI handles exclusions automatically when using the `search` command — this guidance is only needed for manual `gh` fallback searches.
+
+---
+
 **Search Process:**
 
 1. **Use CLI Search (Primary Method)**

--- a/commands/oss.md
+++ b/commands/oss.md
@@ -126,11 +126,19 @@ When `data.actionableIssues` is empty, display:
 All PRs are healthy! No issues need attention.
 ```
 
+If `hasIssueList && availableCount === 0`:
+```
+Your curated issue list is depleted ({completedCount} done). Time to find new issues!
+```
+
 Then use AskUserQuestion with:
 - "Pick an issue from your list" (if `hasIssueList` and `availableCount > 0` and `hasCapacity`) — "{availableCount} vetted issues available"
-- "Search for new issues" (if `hasCapacity`)
+- "Replenish your issue list" (if `hasIssueList` and `availableCount === 0` and `hasCapacity`) — "All {completedCount} issues done — search for fresh ones"
+- "Search for new issues" (if `hasCapacity` and NOT showing replenish option)
 - "View PR status details"
 - "Done for now"
+
+**"Replenish your issue list"** routes to **Handle "Find New Issues"** (same as search), but agents should be told to suggest issues suitable for adding to the curated list.
 
 ### Display All PRs First (Information Before Prompt)
 
@@ -448,6 +456,27 @@ After all agents complete, present a consolidated summary table:
 | #863 | ink | CI green, awaiting review |
 | #2857 | eslint-plugin-unicorn | CI green, awaiting review |
 ```
+
+### Auto-Exclude Prompt for Rejected PRs
+
+When the daily digest includes `[Recently Closed]` entries (PRs closed without merge), offer to exclude those repos from future searches:
+
+For each recently closed PR where the repo is NOT already excluded and the user has no merged PRs in that repo:
+
+```
+Your PR in {repo} was closed without merge. Exclude this repo from future issue searches?
+```
+
+Use AskUserQuestion with multiSelect:
+- "{repo} — exclude from searches" (for each qualifying repo)
+- "Keep all repos" — "Don't exclude any"
+
+If the user selects repos to exclude, update config:
+```bash
+GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/dist/cli.bundle.cjs" config --exclude-repo {repo} --json
+```
+
+Or update the config file directly to add repos to `excludeRepos`.
 
 ### Ask User About Remaining Issues
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "description": "AI-powered autopilot for managing open source contributions with Claude Code",
   "type": "module",
   "main": "dist/cli.js",

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -3,7 +3,7 @@
  * Searches for new issues to work on
  */
 
-import { IssueDiscovery, getGitHubToken } from '../core/index.js';
+import { IssueDiscovery, getGitHubToken, getStateManager } from '../core/index.js';
 import { outputJson, outputJsonError, type SearchOutput } from '../formatters/json.js';
 
 interface SearchOptions {
@@ -35,6 +35,8 @@ export async function runSearch(options: SearchOptions): Promise<void> {
   const candidates = await discovery.searchIssues({ maxResults: options.maxResults });
 
   if (options.json) {
+    const stateManager = getStateManager();
+    const excludedRepos = stateManager.getState().config.excludeRepos || [];
     outputJson<SearchOutput>({
       candidates: candidates.map(c => ({
         issue: {
@@ -47,7 +49,10 @@ export async function runSearch(options: SearchOptions): Promise<void> {
         recommendation: c.recommendation,
         reasonsToApprove: c.reasonsToApprove,
         reasonsToSkip: c.reasonsToSkip,
+        searchPriority: c.searchPriority,
+        viabilityScore: c.viabilityScore,
       })),
+      excludedRepos,
     });
   } else {
     if (candidates.length === 0) {

--- a/src/core/issue-discovery.test.ts
+++ b/src/core/issue-discovery.test.ts
@@ -148,6 +148,45 @@ describe('IssueDiscovery.calculateViabilityScore', () => {
     // 50 + 10 + 15 + 15 + 10 - 20 = 80
     expect(score).toBe(80);
   });
+
+  it('should subtract -15 for closed-without-merge history with no merges', () => {
+    const score = discovery.calculateViabilityScore({
+      ...baseParams,
+      closedWithoutMergeCount: 2,
+      mergedPRCount: 0,
+    });
+    expect(score).toBe(50 - 15);
+  });
+
+  it('should NOT subtract penalty when closed PRs exist but merges also exist', () => {
+    const score = discovery.calculateViabilityScore({
+      ...baseParams,
+      closedWithoutMergeCount: 1,
+      mergedPRCount: 2,
+    });
+    // No -15 penalty because mergedPRCount > 0
+    expect(score).toBe(50);
+  });
+
+  it('should NOT subtract penalty when closedWithoutMergeCount is 0', () => {
+    const score = discovery.calculateViabilityScore({
+      ...baseParams,
+      closedWithoutMergeCount: 0,
+      mergedPRCount: 0,
+    });
+    expect(score).toBe(50);
+  });
+
+  it('should apply closed-PR penalty alongside other penalties', () => {
+    const score = discovery.calculateViabilityScore({
+      ...baseParams,
+      hasExistingPR: true, // -30
+      closedWithoutMergeCount: 1, // -15
+      mergedPRCount: 0,
+    });
+    // 50 - 30 - 15 = 5
+    expect(score).toBe(5);
+  });
 });
 
 describe('IssueDiscovery.analyzeRequirements (via vetIssue internals)', () => {

--- a/src/core/issue-discovery.ts
+++ b/src/core/issue-discovery.ts
@@ -28,7 +28,7 @@ interface GitHubSearchItem {
   [key: string]: unknown;
 }
 
-type SearchPriority = 'starred' | 'high_score' | 'normal';
+type SearchPriority = 'merged_pr' | 'starred' | 'normal';
 
 export interface IssueCandidate {
   issue: TrackedIssue;
@@ -170,13 +170,15 @@ export class IssueDiscovery {
 
     const allCandidates: IssueCandidate[] = [];
 
+    // Get merged-PR repos (highest merge probability)
+    const mergedPRRepos = this.stateManager.getReposWithMergedPRs();
+    const mergedPRRepoSet = new Set(mergedPRRepos);
+
     // Get starred repos (with refresh if stale)
     const starredRepos = await this.getStarredReposWithRefresh();
     const starredRepoSet = new Set(starredRepos);
 
-    // Get high-scoring and low-scoring repos from state
-    const highScoringRepos = this.stateManager.getHighScoringRepos();
-    const highScoringRepoSet = new Set(highScoringRepos);
+    // Get low-scoring repos from state
     const lowScoringRepos = new Set(this.stateManager.getLowScoringRepos(3)); // Score <= 3 is low
 
     // Common filters
@@ -206,45 +208,46 @@ export class IssueDiscovery {
       });
     };
 
-    // Phase 1: Search starred repos first
-    if (starredRepos.length > 0) {
-      console.log(`Phase 1: Searching issues in ${starredRepos.length} starred repos...`);
+    // Phase 0: Search repos where user has merged PRs (highest merge probability)
+    if (mergedPRRepos.length > 0) {
+      console.log(`Phase 0: Searching issues in ${mergedPRRepos.length} repos with merged PRs...`);
       const remainingNeeded = maxResults - allCandidates.length;
       if (remainingNeeded > 0) {
-        const starredCandidates = await this.searchInRepos(
-          starredRepos.slice(0, 10), // Limit to first 10 starred repos
+        const mergedPRCandidates = await this.searchInRepos(
+          mergedPRRepos.slice(0, 10),
           baseQuery,
           remainingNeeded,
-          'starred',
+          'merged_pr',
           filterIssues
         );
-        allCandidates.push(...starredCandidates);
-        console.log(`Found ${starredCandidates.length} candidates from starred repos`);
+        allCandidates.push(...mergedPRCandidates);
+        console.log(`Found ${mergedPRCandidates.length} candidates from merged-PR repos`);
       }
     }
 
-    // Phase 2: Search high-scoring repos
-    if (allCandidates.length < maxResults && highScoringRepos.length > 0) {
-      console.log(`Phase 2: Searching issues in ${highScoringRepos.length} high-scoring repos...`);
-      // Filter out repos already searched (starred)
-      const reposToSearch = highScoringRepos.filter(r => !starredRepoSet.has(r));
-      const remainingNeeded = maxResults - allCandidates.length;
-      if (remainingNeeded > 0 && reposToSearch.length > 0) {
-        const highScoreCandidates = await this.searchInRepos(
-          reposToSearch.slice(0, 10), // Limit to first 10 high-scoring repos
-          baseQuery,
-          remainingNeeded,
-          'high_score',
-          filterIssues
-        );
-        allCandidates.push(...highScoreCandidates);
-        console.log(`Found ${highScoreCandidates.length} candidates from high-scoring repos`);
+    // Phase 1: Search starred repos (filter out already-searched merged-PR repos)
+    if (allCandidates.length < maxResults && starredRepos.length > 0) {
+      const reposToSearch = starredRepos.filter(r => !mergedPRRepoSet.has(r));
+      if (reposToSearch.length > 0) {
+        console.log(`Phase 1: Searching issues in ${reposToSearch.length} starred repos...`);
+        const remainingNeeded = maxResults - allCandidates.length;
+        if (remainingNeeded > 0) {
+          const starredCandidates = await this.searchInRepos(
+            reposToSearch.slice(0, 10),
+            baseQuery,
+            remainingNeeded,
+            'starred',
+            filterIssues
+          );
+          allCandidates.push(...starredCandidates);
+          console.log(`Found ${starredCandidates.length} candidates from starred repos`);
+        }
       }
     }
 
-    // Phase 3: General search (if still need more)
+    // Phase 2: General search (if still need more)
     if (allCandidates.length < maxResults) {
-      console.log('Phase 3: General issue search...');
+      console.log('Phase 2: General issue search...');
       const remainingNeeded = maxResults - allCandidates.length;
       try {
         const { data } = await this.octokit.search.issuesAndPullRequests({
@@ -261,8 +264,8 @@ export class IssueDiscovery {
         const itemsToVet = filterIssues(data.items)
           .filter(item => {
             const repoFullName = item.repository_url.split('/').slice(-2).join('/');
-            // Skip if already searched in starred or high-score phases
-            return !starredRepoSet.has(repoFullName) && !highScoringRepoSet.has(repoFullName) && !seenRepos.has(repoFullName);
+            // Skip if already searched in earlier phases
+            return !mergedPRRepoSet.has(repoFullName) && !starredRepoSet.has(repoFullName) && !seenRepos.has(repoFullName);
           })
           .slice(0, remainingNeeded * 2);
 
@@ -275,7 +278,7 @@ export class IssueDiscovery {
         console.log(`Found ${results.length} candidates from general search`);
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
-        console.error(`[SEARCH_PHASE_3_FAILED] Error in general issue search: ${errorMessage}`);
+        console.error(`[SEARCH_PHASE_2_FAILED] Error in general issue search: ${errorMessage}`);
       }
     }
 
@@ -288,8 +291,8 @@ export class IssueDiscovery {
 
     // Sort by priority first, then by recommendation
     allCandidates.sort((a, b) => {
-      // Priority order: starred > high_score > normal
-      const priorityOrder: Record<SearchPriority, number> = { starred: 0, high_score: 1, normal: 2 };
+      // Priority order: merged_pr > starred > normal
+      const priorityOrder: Record<SearchPriority, number> = { merged_pr: 0, starred: 1, normal: 2 };
       const priorityDiff = priorityOrder[a.searchPriority] - priorityOrder[b.searchPriority];
       if (priorityDiff !== 0) return priorityDiff;
 
@@ -507,6 +510,16 @@ export class IssueDiscovery {
       reasonsToApprove.push('Trusted project (previous PR merged)');
     }
 
+    // Check for closed/rejected PR history in this repo
+    const repoScoreRecord = this.stateManager.getRepoScore(repoFullName);
+    if (repoScoreRecord) {
+      if (repoScoreRecord.closedWithoutMergeCount > 0 && repoScoreRecord.mergedPRCount === 0) {
+        reasonsToSkip.push('User has rejected PR(s) in this repo with no successful merges');
+      } else if (repoScoreRecord.closedWithoutMergeCount > 0 && repoScoreRecord.mergedPRCount > 0) {
+        vettingResult.notes.push(`Mixed history: ${repoScoreRecord.mergedPRCount} merged, ${repoScoreRecord.closedWithoutMergeCount} closed without merge`);
+      }
+    }
+
     let recommendation: 'approve' | 'skip' | 'needs_review';
     if (vettingResult.passedAllChecks) {
       recommendation = 'approve';
@@ -524,16 +537,17 @@ export class IssueDiscovery {
       clearRequirements,
       hasContributionGuidelines: !!contributionGuidelines,
       issueUpdatedAt: ghIssue.updated_at,
+      closedWithoutMergeCount: repoScoreRecord?.closedWithoutMergeCount ?? 0,
+      mergedPRCount: repoScoreRecord?.mergedPRCount ?? 0,
     });
 
     // Determine search priority
     const starredRepos = this.stateManager.getStarredRepos();
-    const repoScore = this.getRepoScore(repoFullName);
     let searchPriority: SearchPriority = 'normal';
-    if (starredRepos.includes(repoFullName)) {
+    if (repoScoreRecord && repoScoreRecord.mergedPRCount > 0) {
+      searchPriority = 'merged_pr';
+    } else if (starredRepos.includes(repoFullName)) {
       searchPriority = 'starred';
-    } else if (repoScore !== null && repoScore >= 7) {
-      searchPriority = 'high_score';
     }
 
     return {
@@ -829,6 +843,8 @@ export class IssueDiscovery {
     clearRequirements: boolean;
     hasContributionGuidelines: boolean;
     issueUpdatedAt: string;
+    closedWithoutMergeCount?: number;
+    mergedPRCount?: number;
   }): number {
     let score = 50; // Base score
 
@@ -865,6 +881,11 @@ export class IssueDiscovery {
     // Penalty for claimed issue (-20)
     if (params.isClaimed) {
       score -= 20;
+    }
+
+    // Penalty for closed-without-merge history with no successful merges (-15)
+    if ((params.closedWithoutMergeCount ?? 0) > 0 && (params.mergedPRCount ?? 0) === 0) {
+      score -= 15;
     }
 
     // Clamp to 0-100

--- a/src/core/state.test.ts
+++ b/src/core/state.test.ts
@@ -346,6 +346,47 @@ describe('StateManager calculateScore (via updateRepoScore)', () => {
   });
 });
 
+describe('StateManager getReposWithMergedPRs', () => {
+  let stateManager: StateManager;
+
+  beforeEach(() => {
+    stateManager = new StateManager(true);
+  });
+
+  it('should return empty array when no repos have merged PRs', () => {
+    expect(stateManager.getReposWithMergedPRs()).toEqual([]);
+  });
+
+  it('should return repos with mergedPRCount > 0', () => {
+    stateManager.updateRepoScore('owner/merged-repo', { mergedPRCount: 2 });
+    stateManager.updateRepoScore('owner/no-merges', { mergedPRCount: 0 });
+    stateManager.updateRepoScore('owner/also-merged', { mergedPRCount: 1 });
+
+    const repos = stateManager.getReposWithMergedPRs();
+    expect(repos).toHaveLength(2);
+    expect(repos).toContain('owner/merged-repo');
+    expect(repos).toContain('owner/also-merged');
+    expect(repos).not.toContain('owner/no-merges');
+  });
+
+  it('should sort by merged count descending', () => {
+    stateManager.updateRepoScore('owner/few', { mergedPRCount: 1 });
+    stateManager.updateRepoScore('owner/many', { mergedPRCount: 5 });
+    stateManager.updateRepoScore('owner/some', { mergedPRCount: 3 });
+
+    const repos = stateManager.getReposWithMergedPRs();
+    expect(repos).toEqual(['owner/many', 'owner/some', 'owner/few']);
+  });
+
+  it('should not include repos that only have closed PRs', () => {
+    stateManager.updateRepoScore('owner/rejected', { closedWithoutMergeCount: 3, mergedPRCount: 0 });
+    stateManager.updateRepoScore('owner/merged', { mergedPRCount: 1 });
+
+    const repos = stateManager.getReposWithMergedPRs();
+    expect(repos).toEqual(['owner/merged']);
+  });
+});
+
 describe('StateManager state validity', () => {
   let stateManager: StateManager;
 

--- a/src/core/state.ts
+++ b/src/core/state.ts
@@ -1044,6 +1044,18 @@ export class StateManager {
   }
 
   /**
+   * Get repositories where the user has at least one merged PR, sorted by merged count descending.
+   * These repos represent proven relationships with high merge probability.
+   * @returns Array of "owner/repo" strings for repos with mergedPRCount > 0.
+   */
+  getReposWithMergedPRs(): string[] {
+    return Object.values(this.state.repoScores)
+      .filter(rs => rs.mergedPRCount > 0)
+      .sort((a, b) => b.mergedPRCount - a.mergedPRCount)
+      .map(rs => rs.repo);
+  }
+
+  /**
    * Get repositories with a score at or above the given threshold, sorted highest first.
    * @param minScore - Minimum score (inclusive). Defaults to `config.minRepoScoreThreshold`.
    * @returns Array of "owner/repo" strings for repos meeting the threshold.

--- a/src/formatters/json.ts
+++ b/src/formatters/json.ts
@@ -67,7 +67,10 @@ export interface SearchOutput {
     recommendation: 'approve' | 'skip' | 'needs_review';
     reasonsToApprove: string[];
     reasonsToSkip: string[];
+    searchPriority: string;
+    viabilityScore: number;
   }>;
+  excludedRepos: string[];
 }
 
 export interface TrackOutput {


### PR DESCRIPTION
## Summary

- **Merged-PR repo tier**: New Phase 0 searches repos where user has merged PRs first (highest merge probability), replacing the generic "high-score" phase
- **Closed-PR penalty**: Issues in repos where all user PRs were rejected get a -15 viability penalty and skip reason; mixed history shown as informational note
- **Exclusion surfacing**: Search JSON output now includes `excludedRepos`, `searchPriority`, and `viabilityScore` so agents can see filtering decisions
- **Depletion detection**: When curated issue list reaches 0 available issues, offers "Replenish your issue list" instead of empty state
- **Auto-exclude prompt**: Offers to exclude repos after PRs are closed without merge
- **Agent awareness**: Issue-scout agent now respects exclusion list during fallback `gh` searches

## Test plan

- [x] `npm test` — 222 tests pass (8 new: 4 for `getReposWithMergedPRs`, 4 for closed-PR penalty)
- [x] `npm run bundle` — builds successfully (492kb)
- [ ] Manual: `npm start -- search --json` — verify JSON output includes `excludedRepos` and `searchPriority` fields
- [ ] Manual: repos with only closed PRs should show lower viability scores and "rejected PR(s)" skip reason