### PR TITLE
feat: smarter issue search, enhanced repo scoring, and hardened type safety

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "description": "AI-powered autopilot for managing open source contributions - track PRs, respond to maintainers, discover issues, and maintain contribution velocity",
   "author": {
     "name": "John Costa"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-02-08
+
+### Added
+
+- Smarter issue search strategy — new Phase 0 prioritizes repos where user has merged PRs (highest merge probability), replacing the generic "high-score" phase. Phase 0 uses a broader search query without `good first issue`/`help wanted` labels — established contributors can handle any open issue
+- `getReposWithMergedPRs()` method on `StateManager` — returns repos sorted by merged PR count for search prioritization
+- Logarithmic repo scoring formula — merge bonus now scales from +2 (1 PR) to +5 (5+ PRs), replacing the linear formula. Full formula: base 5, log merge bonus (max +5), -1 per closed (max -3), +1 recency, +1 responsive, -2 hostile, clamped [1-10]
+- Recency bonus in repo scoring — +1 for repos with a merge within the last 90 days, so stale relationships decay over time
+- Responsiveness signal from open PR data — daily check now observes maintainer behavior (comments, review states) and updates `isResponsive` signal on repo scores
+- Active maintainer detection — repos with open PRs in healthy/review states get `hasActiveMaintainers: true` from real data instead of defaults
+- Auto-sync `trustedProjects` from merged PR history — repos with mergedPRCount > 0 are automatically added to trustedProjects during daily check
+- Org-level affinity scoring — +5 viability bonus for issues in repos under an org where user has merged PRs elsewhere (e.g., merged in `facebook/react` boosts `facebook/react-dom` issues)
+- Closed/rejected PR history check in issue vetting — repos where all user PRs were closed without merge get a -15 viability penalty; mixed history shown as informational note
+- `searchPriority`, `viabilityScore`, `repoScore`, and `excludedRepos` fields in search JSON output — agents can see why each issue was ranked and which repos were filtered
+- Exclusion awareness for issue-scout agent — fallback `gh` searches now respect the exclusion list
+- Issue list depletion detection — when curated list reaches 0 available issues, offers "Replenish your issue list" instead of empty state
+- Auto-exclude prompt for recently closed PRs — offers to exclude repos where PRs were rejected
+- `CheckResult` type for vetting checks that may be inconclusive — `checkNoExistingPR` and `checkNotClaimed` now return `{ passed, inconclusive?, reason? }` instead of bare `boolean`, surfacing API failures to the user
+- Aggregate failure detection in daily signal/trust sync loops — `[DAILY_ALL_SIGNAL_UPDATES_FAILED]` and `[DAILY_ALL_TRUST_SYNCS_FAILED]` tags logged when all updates fail, matching the pattern already used in `searchInRepos` and `vetIssuesParallel`
+- Per-phase error tracking in `searchIssues` — phases 0, 1, and 2 errors are now all included in the final "No issue candidates found" error message
+- 32 new tests (254 total): logarithmic scoring, recency bonus, org affinity, computeRepoSignals, partial signal preservation, closed-PR viability penalty, `markRepoHostile` signal preservation, and `incrementMergedCount`/`incrementClosedCount` routing
+
+### Changed
+
+- Search phases reordered: merged-PR repos → starred repos → general (was: starred → high-score → general)
+- `SearchPriority` type: `'merged_pr' | 'starred' | 'normal'` union replacing raw `string`
+- `vetIssue()` now uses `repoScores` directly for trusted project detection, showing merge count (e.g., "Trusted project (3 PRs merged)")
+
+### Fixed
+
+- `RepoScoreUpdate` type introduced replacing `Partial<RepoScore>` in `updateRepoScore()` — prevents callers from setting `score`, `repo`, or `lastEvaluatedAt` fields that should never be set externally
+- `RepoSignals` interface extracted from inline `RepoScore.signals` type — enables type-safe partial signal updates
+- `ComputedRepoSignals` type moved to `src/core/types.ts` so core domain types are defined in the core module, not in command modules
+- `incrementMergedCount()` and `incrementClosedCount()` now route through `updateRepoScore()` for a single mutation path — all repo score changes flow through one typed interface with diagnostic log messages
+- `vetIssue()` now checks `projectHealth.checkFailed` — repos are no longer penalized as "inactive" when the health check itself failed due to API errors; uses a neutral default instead
+- Recommendation downgraded to `needs_review` when any vetting check was inconclusive — `approve` now requires all checks to actually pass, not just optimistically default
+- `checkNoExistingPR` and `checkNotClaimed` inconclusive results surfaced as vetting notes — previously silent on API failure, users can now see "Could not verify absence of existing PRs" or "Could not verify claim status"
+- `searchInRepos` and `vetIssuesParallel` now return failure metadata (`allBatchesFailed`, `allFailed`) to callers — failures propagate to the final error message instead of being absorbed
+- Silent batch-failure absorption in `searchInRepos` — now tracks failed batch count and logs `[SEARCH_PHASE_ALL_BATCHES_FAILED]` when all batches fail
+- Silent vetting-failure absorption in `vetIssuesParallel` — now logs `[VET_ISSUES_ALL_FAILED]` when all issues fail vetting
+- `computeRepoSignals` now skips PRs with empty/missing `repo` field with a warning, preventing corrupted state entries
+- Daily check signal/trusted-project sync loops wrapped in try-catch with aggregate failure detection so a single corrupted repo score cannot crash the entire daily digest
+- Misleading org affinity guard `orgName !== repoFullName` replaced with `repoFullName.includes('/')` to clearly express intent
+- Hardcoded status comparisons in `computeRepoSignals` replaced with named `Set<FetchedPRStatus>` constants for exhaustiveness tracking
+
 ## [0.8.8] - 2026-02-08
 
 ### Fixed
@@ -220,6 +265,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR monitoring and health checking
 - Dashboard HTML generation
 
+[0.9.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.8.8...v0.9.0
 [0.8.8]: https://github.com/costajohnt/oss-autopilot/compare/v0.8.7...v0.8.8
 [0.8.7]: https://github.com/costajohnt/oss-autopilot/compare/v0.8.6...v0.8.7
 [0.8.6]: https://github.com/costajohnt/oss-autopilot/compare/v0.8.5...v0.8.6

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Discover issues worth contributing to, track your PRs across repos, and draft responses to maintainer feedback. An AI copilot for your open source journey.
 
-![Version](https://img.shields.io/badge/version-0.8.8-blue)
+![Version](https://img.shields.io/badge/version-0.9.0-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)
 

--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -124,6 +124,19 @@ When dispatched with an issue from the user's curated list (indicated by `Source
 
 ---
 
+**Excluded Repos Awareness:**
+
+The CLI search command now includes `excludedRepos` in its JSON output. These repos have been explicitly excluded by the user (via config or auto-exclude after rejected PRs).
+
+When performing **fallback manual searches** (using `gh` directly instead of the CLI):
+1. First load the exclusion list from `excludedRepos` in the CLI search output or from the config
+2. **Skip any repos in the exclusion list** when doing `gh search issues` results filtering
+3. When presenting results, note if any were filtered: "Skipped {count} results from excluded repos ({repo1}, {repo2})"
+
+The CLI handles exclusions automatically when using the `search` command — this guidance is only needed for manual `gh` fallback searches.
+
+---
+
 **Search Process:**
 
 1. **Use CLI Search (Primary Method)**

--- a/commands/oss.md
+++ b/commands/oss.md
@@ -126,11 +126,19 @@ When `data.actionableIssues` is empty, display:
 All PRs are healthy! No issues need attention.
 ```
 
+If `hasIssueList && availableCount === 0`:
+```
+Your curated issue list is depleted ({completedCount} done). Time to find new issues!
+```
+
 Then use AskUserQuestion with:
 - "Pick an issue from your list" (if `hasIssueList` and `availableCount > 0` and `hasCapacity`) — "{availableCount} vetted issues available"
-- "Search for new issues" (if `hasCapacity`)
+- "Replenish your issue list" (if `hasIssueList` and `availableCount === 0` and `hasCapacity`) — "All {completedCount} issues done — search for fresh ones"
+- "Search for new issues" (if `hasCapacity` and NOT showing replenish option)
 - "View PR status details"
 - "Done for now"
+
+**"Replenish your issue list"** routes to **Handle "Find New Issues"** (same as search), but agents should be told to suggest issues suitable for adding to the curated list.
 
 ### Display All PRs First (Information Before Prompt)
 
@@ -448,6 +456,27 @@ After all agents complete, present a consolidated summary table:
 | #863 | ink | CI green, awaiting review |
 | #2857 | eslint-plugin-unicorn | CI green, awaiting review |
 ```
+
+### Auto-Exclude Prompt for Rejected PRs
+
+When the daily digest includes `[Recently Closed]` entries (PRs closed without merge), offer to exclude those repos from future searches:
+
+For each recently closed PR where the repo is NOT already excluded and the user has no merged PRs in that repo:
+
+```
+Your PR in {repo} was closed without merge. Exclude this repo from future issue searches?
+```
+
+Use AskUserQuestion with multiSelect:
+- "{repo} — exclude from searches" (for each qualifying repo)
+- "Keep all repos" — "Don't exclude any"
+
+If the user selects repos to exclude, update config:
+```bash
+GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/dist/cli.bundle.cjs" config --exclude-repo {repo} --json
+```
+
+Or update the config file directly to add repos to `excludeRepos`.
 
 ### Ask User About Remaining Issues
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "description": "AI-powered autopilot for managing open source contributions with Claude Code",
   "type": "module",
   "main": "dist/cli.js",

--- a/src/commands/daily.test.ts
+++ b/src/commands/daily.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for daily command helper functions
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeRepoSignals } from './daily.js';
+import type { FetchedPR } from '../core/types.js';
+
+/** Create a minimal FetchedPR for testing signal computation */
+function makePR(overrides: Partial<FetchedPR> & { repo: string }): FetchedPR {
+  return {
+    id: 1,
+    url: `https://github.com/${overrides.repo}/pull/1`,
+    number: 1,
+    title: 'Test PR',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-15T00:00:00Z',
+    daysSinceActivity: 5,
+    ciStatus: 'passing',
+    failingCheckNames: [],
+    hasMergeConflict: false,
+    reviewDecision: 'approved',
+    hasUnrespondedComment: false,
+    hasIncompleteChecklist: false,
+    maintainerActionHints: [],
+    status: 'healthy',
+    ...overrides,
+  };
+}
+
+describe('computeRepoSignals', () => {
+  it('should return empty map for empty PR list', () => {
+    const result = computeRepoSignals([]);
+    expect(result.size).toBe(0);
+  });
+
+  it('should mark repo as responsive when PR has maintainer comment and is not dormant', () => {
+    const prs = [
+      makePR({
+        repo: 'owner/responsive',
+        status: 'healthy',
+        lastMaintainerComment: { author: 'maintainer', body: 'LGTM', createdAt: '2026-01-15T00:00:00Z' },
+      }),
+    ];
+    const result = computeRepoSignals(prs);
+    expect(result.get('owner/responsive')!.isResponsive).toBe(true);
+  });
+
+  it('should NOT mark repo as responsive when PR is dormant despite having comment', () => {
+    const prs = [
+      makePR({
+        repo: 'owner/dormant-repo',
+        status: 'dormant',
+        lastMaintainerComment: { author: 'maintainer', body: 'Will review', createdAt: '2025-06-01T00:00:00Z' },
+      }),
+    ];
+    const result = computeRepoSignals(prs);
+    expect(result.get('owner/dormant-repo')!.isResponsive).toBe(false);
+  });
+
+  it('should NOT mark repo as responsive when PR is approaching_dormant', () => {
+    const prs = [
+      makePR({
+        repo: 'owner/stale-repo',
+        status: 'approaching_dormant',
+        lastMaintainerComment: { author: 'maintainer', body: 'Old comment', createdAt: '2025-11-01T00:00:00Z' },
+      }),
+    ];
+    const result = computeRepoSignals(prs);
+    expect(result.get('owner/stale-repo')!.isResponsive).toBe(false);
+  });
+
+  it('should NOT mark repo as responsive when PR has no maintainer comment', () => {
+    const prs = [
+      makePR({
+        repo: 'owner/no-comment',
+        status: 'healthy',
+        lastMaintainerComment: undefined,
+      }),
+    ];
+    const result = computeRepoSignals(prs);
+    expect(result.get('owner/no-comment')!.isResponsive).toBe(false);
+  });
+
+  it('should mark repo as having active maintainers for healthy status', () => {
+    const prs = [makePR({ repo: 'owner/active', status: 'healthy' })];
+    const result = computeRepoSignals(prs);
+    expect(result.get('owner/active')!.hasActiveMaintainers).toBe(true);
+  });
+
+  it('should mark repo as having active maintainers for review-related statuses', () => {
+    const statuses = ['waiting_on_maintainer', 'changes_addressed', 'needs_response', 'needs_changes'] as const;
+    for (const status of statuses) {
+      const prs = [makePR({ repo: `owner/${status}`, status })];
+      const result = computeRepoSignals(prs);
+      expect(result.get(`owner/${status}`)!.hasActiveMaintainers).toBe(true);
+    }
+  });
+
+  it('should NOT mark repo as having active maintainers for non-review statuses', () => {
+    const inactiveStatuses = ['failing_ci', 'merge_conflict', 'dormant', 'approaching_dormant', 'incomplete_checklist'] as const;
+    for (const status of inactiveStatuses) {
+      const prs = [makePR({ repo: `owner/${status}`, status })];
+      const result = computeRepoSignals(prs);
+      expect(result.get(`owner/${status}`)!.hasActiveMaintainers).toBe(false);
+    }
+  });
+
+  it('should aggregate signals across multiple PRs in the same repo', () => {
+    const prs = [
+      makePR({
+        repo: 'owner/multi',
+        status: 'dormant',
+        lastMaintainerComment: undefined,
+      }),
+      makePR({
+        repo: 'owner/multi',
+        number: 2,
+        status: 'healthy',
+        lastMaintainerComment: { author: 'maintainer', body: 'Looks good', createdAt: '2026-01-15T00:00:00Z' },
+      }),
+    ];
+    const result = computeRepoSignals(prs);
+    // Second PR is healthy with comment → responsive. Second PR is healthy → active maintainers.
+    expect(result.get('owner/multi')!.isResponsive).toBe(true);
+    expect(result.get('owner/multi')!.hasActiveMaintainers).toBe(true);
+  });
+
+  it('should skip PRs with empty repo field', () => {
+    const prs = [
+      makePR({
+        repo: '' as any,
+        status: 'healthy',
+      }),
+      makePR({
+        repo: 'owner/valid',
+        status: 'healthy',
+      }),
+    ];
+    const result = computeRepoSignals(prs);
+    expect(result.has('')).toBe(false);
+    expect(result.has('owner/valid')).toBe(true);
+  });
+
+  it('should handle multiple repos independently', () => {
+    const prs = [
+      makePR({
+        repo: 'owner/active-repo',
+        status: 'healthy',
+        lastMaintainerComment: { author: 'maintainer', body: 'LGTM', createdAt: '2026-01-15T00:00:00Z' },
+      }),
+      makePR({
+        repo: 'owner/dead-repo',
+        status: 'dormant',
+        lastMaintainerComment: undefined,
+      }),
+    ];
+    const result = computeRepoSignals(prs);
+    expect(result.get('owner/active-repo')!.isResponsive).toBe(true);
+    expect(result.get('owner/active-repo')!.hasActiveMaintainers).toBe(true);
+    expect(result.get('owner/dead-repo')!.isResponsive).toBe(false);
+    expect(result.get('owner/dead-repo')!.hasActiveMaintainers).toBe(false);
+  });
+});

--- a/src/commands/daily.ts
+++ b/src/commands/daily.ts
@@ -4,7 +4,7 @@
  * v2: No local state tracking - everything is fetched fresh
  */
 
-import { getStateManager, PRMonitor, getGitHubToken, type DailyDigest, type FetchedPR, type PRCheckFailure, type MaintainerActionHint, type ClosedPR } from '../core/index.js';
+import { getStateManager, PRMonitor, getGitHubToken, type DailyDigest, type FetchedPR, type FetchedPRStatus, type PRCheckFailure, type MaintainerActionHint, type ClosedPR, type ComputedRepoSignals } from '../core/index.js';
 import { outputJson, outputJsonError, type DailyOutput, type CapacityAssessment, type ActionableIssue } from '../formatters/json.js';
 
 interface DailyOptions {
@@ -46,19 +46,80 @@ export async function runDaily(options: DailyOptions): Promise<void> {
 
   const { repos: mergedCounts, monthlyCounts } = mergedResult;
 
-  // Reset stale repos first (so excluded/removed repos get zeroed)
-  for (const score of Object.values(stateManager.getState().repoScores)) {
-    if (!mergedCounts.has(score.repo)) {
-      stateManager.updateRepoScore(score.repo, { mergedPRCount: 0 });
+  // Reset stale repos first (so excluded/removed repos get zeroed).
+  // Guard: if the API returned zero results but we have existing repos with merged PRs,
+  // skip the reset to avoid wiping scores due to transient API failures.
+  const existingReposWithMerges = Object.values(stateManager.getState().repoScores)
+    .filter(s => s.mergedPRCount > 0);
+  if (mergedCounts.size === 0 && existingReposWithMerges.length > 0) {
+    console.error(`[DAILY] Skipping stale repo reset: API returned 0 merged PR results but state has ${existingReposWithMerges.length} repo(s) with merges. Possible API issue.`);
+  } else {
+    for (const score of Object.values(stateManager.getState().repoScores)) {
+      if (!mergedCounts.has(score.repo)) {
+        stateManager.updateRepoScore(score.repo, { mergedPRCount: 0 });
+      }
     }
   }
+
+  // Update merged/closed counts with per-repo error isolation (matches signal/trust loops below)
+  let mergedCountFailures = 0;
   for (const [repo, { count, lastMergedAt }] of mergedCounts) {
-    stateManager.updateRepoScore(repo, { mergedPRCount: count, lastMergedAt: lastMergedAt || undefined });
+    try {
+      stateManager.updateRepoScore(repo, { mergedPRCount: count, lastMergedAt: lastMergedAt || undefined });
+    } catch (error) {
+      mergedCountFailures++;
+      console.error(`[DAILY] Failed to update merged count for ${repo}:`, error instanceof Error ? error.message : error);
+    }
+  }
+  if (mergedCountFailures === mergedCounts.size && mergedCounts.size > 0) {
+    console.error(`[DAILY_ALL_MERGED_COUNT_UPDATES_FAILED] All ${mergedCounts.size} merged count update(s) failed.`);
   }
 
   // Populate closedWithoutMergeCount in repo scores
+  let closedCountFailures = 0;
   for (const [repo, count] of closedCounts) {
-    stateManager.updateRepoScore(repo, { closedWithoutMergeCount: count });
+    try {
+      stateManager.updateRepoScore(repo, { closedWithoutMergeCount: count });
+    } catch (error) {
+      closedCountFailures++;
+      console.error(`[DAILY] Failed to update closed count for ${repo}:`, error instanceof Error ? error.message : error);
+    }
+  }
+  if (closedCountFailures === closedCounts.size && closedCounts.size > 0) {
+    console.error(`[DAILY_ALL_CLOSED_COUNT_UPDATES_FAILED] All ${closedCounts.size} closed count update(s) failed.`);
+  }
+
+  // Update repo signals from observed open PR data (responsiveness, active maintainers).
+  // Only repos with current open PRs get signal updates — repos with no open PRs
+  // preserve their existing signals to avoid degrading scores when PRs are merged.
+  // Per-repo try-catch: signal/trust syncing is secondary to the daily digest —
+  // a single corrupted repo score should not prevent updates to other repos.
+  const repoSignals = computeRepoSignals(prs);
+  let signalUpdateFailures = 0;
+  for (const [repo, signals] of repoSignals) {
+    try {
+      stateManager.updateRepoScore(repo, { signals });
+    } catch (error) {
+      signalUpdateFailures++;
+      console.error(`[DAILY] Failed to update signals for ${repo}:`, error instanceof Error ? error.message : error);
+    }
+  }
+  if (signalUpdateFailures === repoSignals.size && repoSignals.size > 0) {
+    console.error(`[DAILY_ALL_SIGNAL_UPDATES_FAILED] All ${repoSignals.size} signal update(s) failed. This may indicate corrupted state.`);
+  }
+
+  // Auto-sync trustedProjects from repos with merged PRs
+  let trustSyncFailures = 0;
+  for (const [repo] of mergedCounts) {
+    try {
+      stateManager.addTrustedProject(repo);
+    } catch (error) {
+      trustSyncFailures++;
+      console.error(`[DAILY] Failed to sync trusted project ${repo}:`, error instanceof Error ? error.message : error);
+    }
+  }
+  if (trustSyncFailures === mergedCounts.size && mergedCounts.size > 0) {
+    console.error(`[DAILY_ALL_TRUST_SYNCS_FAILED] All ${mergedCounts.size} trusted project sync(s) failed. This may indicate corrupted state.`);
   }
 
   // Store monthly merged counts for the contribution timeline chart
@@ -471,4 +532,46 @@ function formatActionHint(hint: MaintainerActionHint): string {
     case 'docs_requested': return 'documentation requested';
     case 'rebase_requested': return 'rebase requested';
   }
+}
+
+/** Statuses indicating active maintainer engagement (reviews, feedback, merges). */
+const ACTIVE_MAINTAINER_STATUSES: Set<FetchedPRStatus> = new Set([
+  'healthy', 'waiting_on_maintainer', 'changes_addressed', 'needs_response', 'needs_changes',
+]);
+
+/** Statuses indicating staleness — maintainer comments during these statuses don't count as responsive. */
+const STALE_STATUSES: Set<FetchedPRStatus> = new Set([
+  'dormant', 'approaching_dormant',
+]);
+
+/**
+ * Compute per-repo maintainer signals from observed open PR data.
+ * - isResponsive: true if any PR in the repo has a maintainer comment and status
+ *   is not in STALE_STATUSES
+ * - hasActiveMaintainers: true if any PR in the repo has a status in ACTIVE_MAINTAINER_STATUSES
+ */
+export function computeRepoSignals(prs: FetchedPR[]): Map<string, ComputedRepoSignals> {
+  const repoMap = new Map<string, FetchedPR[]>();
+  for (const pr of prs) {
+    if (!pr.repo) {
+      console.warn(`[COMPUTE_SIGNALS] Skipping PR #${pr.number} (${pr.url}) with empty repo field`);
+      continue;
+    }
+    const existing = repoMap.get(pr.repo) || [];
+    existing.push(pr);
+    repoMap.set(pr.repo, existing);
+  }
+
+  const result = new Map<string, ComputedRepoSignals>();
+  for (const [repo, repoPRs] of repoMap) {
+    const isResponsive = repoPRs.some(pr =>
+      pr.lastMaintainerComment && !STALE_STATUSES.has(pr.status)
+    );
+    const hasActiveMaintainers = repoPRs.some(pr =>
+      ACTIVE_MAINTAINER_STATUSES.has(pr.status)
+    );
+    result.set(repo, { isResponsive, hasActiveMaintainers });
+  }
+
+  return result;
 }

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -3,7 +3,7 @@
  * Searches for new issues to work on
  */
 
-import { IssueDiscovery, getGitHubToken } from '../core/index.js';
+import { IssueDiscovery, getGitHubToken, getStateManager } from '../core/index.js';
 import { outputJson, outputJsonError, type SearchOutput } from '../formatters/json.js';
 
 interface SearchOptions {
@@ -35,19 +35,34 @@ export async function runSearch(options: SearchOptions): Promise<void> {
   const candidates = await discovery.searchIssues({ maxResults: options.maxResults });
 
   if (options.json) {
+    const stateManager = getStateManager();
+    const excludedRepos = stateManager.getState().config.excludeRepos || [];
     outputJson<SearchOutput>({
-      candidates: candidates.map(c => ({
-        issue: {
-          repo: c.issue.repo,
-          number: c.issue.number,
-          title: c.issue.title,
-          url: c.issue.url,
-          labels: c.issue.labels,
-        },
-        recommendation: c.recommendation,
-        reasonsToApprove: c.reasonsToApprove,
-        reasonsToSkip: c.reasonsToSkip,
-      })),
+      candidates: candidates.map(c => {
+        const repoScoreRecord = stateManager.getRepoScore(c.issue.repo);
+        return {
+          issue: {
+            repo: c.issue.repo,
+            number: c.issue.number,
+            title: c.issue.title,
+            url: c.issue.url,
+            labels: c.issue.labels,
+          },
+          recommendation: c.recommendation,
+          reasonsToApprove: c.reasonsToApprove,
+          reasonsToSkip: c.reasonsToSkip,
+          searchPriority: c.searchPriority,
+          viabilityScore: c.viabilityScore,
+          repoScore: repoScoreRecord ? {
+            score: repoScoreRecord.score,
+            mergedPRCount: repoScoreRecord.mergedPRCount,
+            closedWithoutMergeCount: repoScoreRecord.closedWithoutMergeCount,
+            isResponsive: repoScoreRecord.signals?.isResponsive ?? false,
+            lastMergedAt: repoScoreRecord.lastMergedAt,
+          } : undefined,
+        };
+      }),
+      excludedRepos,
     });
   } else {
     if (candidates.length === 0) {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -5,7 +5,7 @@
 
 export { StateManager, getStateManager, resetStateManager } from './state.js';
 export { PRMonitor, type PRCheckFailure, type FetchPRsResult, type PRUpdate, type CheckAllPRsResult } from './pr-monitor.js';
-export { IssueDiscovery, type IssueCandidate } from './issue-discovery.js';
+export { IssueDiscovery, type IssueCandidate, type SearchPriority } from './issue-discovery.js';
 export { getOctokit } from './github.js';
 export {
   parseGitHubUrl,

--- a/src/core/issue-discovery.test.ts
+++ b/src/core/issue-discovery.test.ts
@@ -17,8 +17,9 @@ vi.mock('./state.js', () => ({
       repoScores: {},
     }),
     getStarredRepos: () => [],
-    getHighScoringRepos: () => [],
+    getReposWithMergedPRs: () => [],
     getLowScoringRepos: () => [],
+    getRepoScore: () => undefined,
   })),
 }));
 
@@ -39,6 +40,9 @@ describe('IssueDiscovery.calculateViabilityScore', () => {
     clearRequirements: false,
     hasContributionGuidelines: false,
     issueUpdatedAt: '2020-01-01T00:00:00Z', // Very old, no freshness bonus
+    closedWithoutMergeCount: 0,
+    mergedPRCount: 0,
+    orgHasMergedPRs: false,
   };
 
   it('should return base score of 50 with no bonuses or penalties', () => {
@@ -129,6 +133,9 @@ describe('IssueDiscovery.calculateViabilityScore', () => {
       clearRequirements: true,
       hasContributionGuidelines: true,
       issueUpdatedAt: recent.toISOString(),
+      closedWithoutMergeCount: 0,
+      mergedPRCount: 0,
+      orgHasMergedPRs: false,
     });
     // 50 + 20 + 15 + 15 + 10 = 110, clamped to 100
     expect(score).toBe(100);
@@ -144,9 +151,81 @@ describe('IssueDiscovery.calculateViabilityScore', () => {
       clearRequirements: true, // +15
       hasContributionGuidelines: true, // +10
       issueUpdatedAt: recent.toISOString(), // +15
+      closedWithoutMergeCount: 0,
+      mergedPRCount: 0,
+      orgHasMergedPRs: false,
     });
     // 50 + 10 + 15 + 15 + 10 - 20 = 80
     expect(score).toBe(80);
+  });
+
+  it('should subtract -15 for closed-without-merge history with no merges', () => {
+    const score = discovery.calculateViabilityScore({
+      ...baseParams,
+      closedWithoutMergeCount: 2,
+      mergedPRCount: 0,
+    });
+    expect(score).toBe(50 - 15);
+  });
+
+  it('should NOT subtract penalty when closed PRs exist but merges also exist', () => {
+    const score = discovery.calculateViabilityScore({
+      ...baseParams,
+      closedWithoutMergeCount: 1,
+      mergedPRCount: 2,
+    });
+    // No -15 penalty because mergedPRCount > 0
+    expect(score).toBe(50);
+  });
+
+  it('should NOT subtract penalty when closedWithoutMergeCount is 0', () => {
+    const score = discovery.calculateViabilityScore({
+      ...baseParams,
+      closedWithoutMergeCount: 0,
+      mergedPRCount: 0,
+    });
+    expect(score).toBe(50);
+  });
+
+  it('should apply closed-PR penalty alongside other penalties', () => {
+    const score = discovery.calculateViabilityScore({
+      ...baseParams,
+      hasExistingPR: true, // -30
+      closedWithoutMergeCount: 1, // -15
+      mergedPRCount: 0,
+    });
+    // 50 - 30 - 15 = 5
+    expect(score).toBe(5);
+  });
+
+  it('should add +5 for org affinity', () => {
+    const score = discovery.calculateViabilityScore({
+      ...baseParams,
+      orgHasMergedPRs: true,
+    });
+    expect(score).toBe(55);
+  });
+
+  it('should NOT add org affinity bonus when false', () => {
+    const score = discovery.calculateViabilityScore({
+      ...baseParams,
+      orgHasMergedPRs: false,
+    });
+    expect(score).toBe(50);
+  });
+
+  it('should combine org affinity with other bonuses', () => {
+    const recent = new Date();
+    recent.setDate(recent.getDate() - 3);
+    const score = discovery.calculateViabilityScore({
+      ...baseParams,
+      repoScore: 8, // +16
+      clearRequirements: true, // +15
+      issueUpdatedAt: recent.toISOString(), // +15
+      orgHasMergedPRs: true, // +5
+    });
+    // 50 + 16 + 15 + 15 + 5 = 101, clamped to 100
+    expect(score).toBe(100);
   });
 });
 
@@ -217,5 +296,101 @@ describe('IssueDiscovery.analyzeRequirements (via vetIssue internals)', () => {
       We want to improve user experience by providing clear feedback.
     `;
     expect(discovery.analyzeRequirements(body)).toBe(true);
+  });
+});
+
+describe('IssueDiscovery.vetIssue inconclusive downgrade', () => {
+  let discovery: InstanceType<typeof IssueDiscovery>;
+
+  const makeGhIssue = () => ({
+    id: 1,
+    html_url: 'https://github.com/owner/repo/issues/42',
+    title: 'Test issue with clear requirements',
+    labels: [{ name: 'good first issue' }],
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-02-01T00:00:00Z',
+    comments: 0,
+    body: `
+      This feature should add pagination to the API.
+      1. Add page parameter to GET /items
+      2. Return 20 items per page
+      The API should return a 400 error for invalid page numbers.
+    `,
+  });
+
+  beforeEach(() => {
+    mockOctokitInstance = {
+      issues: {
+        get: vi.fn().mockResolvedValue({ data: makeGhIssue() }),
+        listEventsForTimeline: vi.fn().mockResolvedValue({ data: [] }),
+      },
+      search: {
+        issuesAndPullRequests: vi.fn().mockResolvedValue({ data: { total_count: 0, items: [] } }),
+      },
+      repos: {
+        get: vi.fn().mockResolvedValue({
+          data: { open_issues_count: 5, pushed_at: '2026-02-01T00:00:00Z' },
+        }),
+        listCommits: vi.fn().mockResolvedValue({
+          data: [{ commit: { author: { date: '2026-02-01T00:00:00Z' } } }],
+        }),
+        getContent: vi.fn().mockRejectedValue(new Error('404 Not Found')),
+      },
+      actions: {
+        listRepoWorkflows: vi.fn().mockResolvedValue({ data: { total_count: 1 } }),
+      },
+    };
+    discovery = new IssueDiscovery('fake-token');
+  });
+
+  it('should approve when all checks pass definitively', async () => {
+    const candidate = await discovery.vetIssue('https://github.com/owner/repo/issues/42');
+    expect(candidate.recommendation).toBe('approve');
+  });
+
+  it('should downgrade to needs_review when checkNoExistingPR is inconclusive', async () => {
+    // Make the search call throw (simulating rate limit / API error)
+    mockOctokitInstance.search.issuesAndPullRequests.mockRejectedValue(
+      new Error('API rate limit exceeded')
+    );
+
+    const candidate = await discovery.vetIssue('https://github.com/owner/repo/issues/42');
+    expect(candidate.recommendation).toBe('needs_review');
+    expect(candidate.vettingResult.notes).toContainEqual(
+      expect.stringContaining('Could not verify absence of existing PRs')
+    );
+    expect(candidate.vettingResult.notes).toContainEqual(
+      expect.stringContaining('Recommendation downgraded')
+    );
+  });
+
+  it('should downgrade to needs_review when checkNotClaimed is inconclusive', async () => {
+    // Issue has comments, so checkNotClaimed will try to fetch them
+    mockOctokitInstance.issues.get.mockResolvedValue({
+      data: { ...makeGhIssue(), comments: 3 },
+    });
+    // Make paginate throw (simulating API error)
+    mockOctokitInstance.paginate = vi.fn().mockRejectedValue(
+      new Error('Server error')
+    );
+
+    const candidate = await discovery.vetIssue('https://github.com/owner/repo/issues/42');
+    expect(candidate.recommendation).toBe('needs_review');
+    expect(candidate.vettingResult.notes).toContainEqual(
+      expect.stringContaining('Could not verify claim status')
+    );
+  });
+
+  it('should downgrade to needs_review when project health check fails', async () => {
+    // Make repos.get throw (simulating API error)
+    mockOctokitInstance.repos.get.mockRejectedValue(
+      new Error('Not Found')
+    );
+
+    const candidate = await discovery.vetIssue('https://github.com/owner/repo/issues/42');
+    expect(candidate.recommendation).toBe('needs_review');
+    expect(candidate.vettingResult.notes).toContainEqual(
+      expect.stringContaining('Could not verify project activity')
+    );
   });
 });

--- a/src/core/issue-discovery.ts
+++ b/src/core/issue-discovery.ts
@@ -28,7 +28,14 @@ interface GitHubSearchItem {
   [key: string]: unknown;
 }
 
-type SearchPriority = 'starred' | 'high_score' | 'normal';
+export type SearchPriority = 'merged_pr' | 'starred' | 'normal';
+
+/** Result of a vetting check that may be inconclusive due to API errors. */
+interface CheckResult {
+  passed: boolean;
+  inconclusive?: boolean;
+  reason?: string;
+}
 
 export interface IssueCandidate {
   issue: TrackedIssue;
@@ -155,8 +162,8 @@ export class IssueDiscovery {
 
   /**
    * Search for issues matching our criteria.
-   * Searches in priority order: starred repos first, then high-scoring repos, then general.
-   * Filters out issues from low-scoring repos.
+   * Searches in priority order: merged-PR repos first (no label filter), then starred repos, then general.
+   * Filters out issues from low-scoring and excluded repos.
    */
   async searchIssues(options: {
     languages?: string[];
@@ -169,14 +176,18 @@ export class IssueDiscovery {
     const maxResults = options.maxResults || 10;
 
     const allCandidates: IssueCandidate[] = [];
+    let phase0Error: string | null = null;
+    let phase1Error: string | null = null;
+
+    // Get merged-PR repos (highest merge probability)
+    const mergedPRRepos = this.stateManager.getReposWithMergedPRs();
+    const mergedPRRepoSet = new Set(mergedPRRepos);
 
     // Get starred repos (with refresh if stale)
     const starredRepos = await this.getStarredReposWithRefresh();
     const starredRepoSet = new Set(starredRepos);
 
-    // Get high-scoring and low-scoring repos from state
-    const highScoringRepos = this.stateManager.getHighScoringRepos();
-    const highScoringRepoSet = new Set(highScoringRepos);
+    // Get low-scoring repos from state
     const lowScoringRepos = new Set(this.stateManager.getLowScoringRepos(3)); // Score <= 3 is low
 
     // Common filters
@@ -185,9 +196,12 @@ export class IssueDiscovery {
     const maxAgeDays = config.maxIssueAgeDays || 90;
     const now = new Date();
 
-    // Build base query parts
+    // Build query parts
     const labelQuery = labels.map(l => `label:"${l}"`).join(' ');
     const langQuery = languages.map(l => `language:${l}`).join(' ');
+    // Phase 0 uses a broader query — established contributors don't need beginner labels
+    const establishedQuery = `is:issue is:open ${langQuery} no:assignee`;
+    // Phases 1+ use label-filtered query for discovery in unfamiliar repos
     const baseQuery = `is:issue is:open ${labelQuery} ${langQuery} no:assignee`;
 
     // Helper to filter issues
@@ -206,45 +220,54 @@ export class IssueDiscovery {
       });
     };
 
-    // Phase 1: Search starred repos first
-    if (starredRepos.length > 0) {
-      console.log(`Phase 1: Searching issues in ${starredRepos.length} starred repos...`);
+    // Phase 0: Search repos where user has merged PRs (highest merge probability)
+    // Uses broader query — established contributors don't need "good first issue" labels
+    if (mergedPRRepos.length > 0) {
+      console.log(`Phase 0: Searching issues in ${mergedPRRepos.length} repos with merged PRs (no label filter)...`);
       const remainingNeeded = maxResults - allCandidates.length;
       if (remainingNeeded > 0) {
-        const starredCandidates = await this.searchInRepos(
-          starredRepos.slice(0, 10), // Limit to first 10 starred repos
-          baseQuery,
+        const { candidates: mergedPRCandidates, allBatchesFailed } = await this.searchInRepos(
+          mergedPRRepos.slice(0, 10),
+          establishedQuery,
           remainingNeeded,
-          'starred',
+          'merged_pr',
           filterIssues
         );
-        allCandidates.push(...starredCandidates);
-        console.log(`Found ${starredCandidates.length} candidates from starred repos`);
+        allCandidates.push(...mergedPRCandidates);
+        if (allBatchesFailed) {
+          phase0Error = 'All merged-PR repo batches failed';
+        }
+        console.log(`Found ${mergedPRCandidates.length} candidates from merged-PR repos`);
       }
     }
 
-    // Phase 2: Search high-scoring repos
-    if (allCandidates.length < maxResults && highScoringRepos.length > 0) {
-      console.log(`Phase 2: Searching issues in ${highScoringRepos.length} high-scoring repos...`);
-      // Filter out repos already searched (starred)
-      const reposToSearch = highScoringRepos.filter(r => !starredRepoSet.has(r));
-      const remainingNeeded = maxResults - allCandidates.length;
-      if (remainingNeeded > 0 && reposToSearch.length > 0) {
-        const highScoreCandidates = await this.searchInRepos(
-          reposToSearch.slice(0, 10), // Limit to first 10 high-scoring repos
-          baseQuery,
-          remainingNeeded,
-          'high_score',
-          filterIssues
-        );
-        allCandidates.push(...highScoreCandidates);
-        console.log(`Found ${highScoreCandidates.length} candidates from high-scoring repos`);
+    // Phase 1: Search starred repos (filter out already-searched merged-PR repos)
+    if (allCandidates.length < maxResults && starredRepos.length > 0) {
+      const reposToSearch = starredRepos.filter(r => !mergedPRRepoSet.has(r));
+      if (reposToSearch.length > 0) {
+        console.log(`Phase 1: Searching issues in ${reposToSearch.length} starred repos...`);
+        const remainingNeeded = maxResults - allCandidates.length;
+        if (remainingNeeded > 0) {
+          const { candidates: starredCandidates, allBatchesFailed } = await this.searchInRepos(
+            reposToSearch.slice(0, 10),
+            baseQuery,
+            remainingNeeded,
+            'starred',
+            filterIssues
+          );
+          allCandidates.push(...starredCandidates);
+          if (allBatchesFailed) {
+            phase1Error = 'All starred repo batches failed';
+          }
+          console.log(`Found ${starredCandidates.length} candidates from starred repos`);
+        }
       }
     }
 
-    // Phase 3: General search (if still need more)
+    // Phase 2: General search (if still need more)
+    let phase2Error: string | null = null;
     if (allCandidates.length < maxResults) {
-      console.log('Phase 3: General issue search...');
+      console.log('Phase 2: General issue search...');
       const remainingNeeded = maxResults - allCandidates.length;
       try {
         const { data } = await this.octokit.search.issuesAndPullRequests({
@@ -261,35 +284,47 @@ export class IssueDiscovery {
         const itemsToVet = filterIssues(data.items)
           .filter(item => {
             const repoFullName = item.repository_url.split('/').slice(-2).join('/');
-            // Skip if already searched in starred or high-score phases
-            return !starredRepoSet.has(repoFullName) && !highScoringRepoSet.has(repoFullName) && !seenRepos.has(repoFullName);
+            // Skip if already searched in earlier phases
+            return !mergedPRRepoSet.has(repoFullName) && !starredRepoSet.has(repoFullName) && !seenRepos.has(repoFullName);
           })
           .slice(0, remainingNeeded * 2);
 
-        const results = await this.vetIssuesParallel(
+        const { candidates: results, allFailed: allVetFailed } = await this.vetIssuesParallel(
           itemsToVet.map(i => i.html_url),
           remainingNeeded,
           'normal'
         );
         allCandidates.push(...results);
+        if (allVetFailed) {
+          phase2Error = (phase2Error ? phase2Error + '; ' : '') + 'all vetting failed';
+        }
         console.log(`Found ${results.length} candidates from general search`);
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
-        console.error(`[SEARCH_PHASE_3_FAILED] Error in general issue search: ${errorMessage}`);
+        phase2Error = errorMessage;
+        console.error(`[SEARCH_PHASE_2_FAILED] Error in general issue search: ${errorMessage}`);
       }
     }
 
     if (allCandidates.length === 0) {
+      const phaseErrors = [
+        phase0Error ? `Phase 0 (merged-PR repos): ${phase0Error}` : null,
+        phase1Error ? `Phase 1 (starred repos): ${phase1Error}` : null,
+        phase2Error ? `Phase 2 (general): ${phase2Error}` : null,
+      ].filter(Boolean);
+      const details = phaseErrors.length > 0
+        ? ` ${phaseErrors.join('. ')}.`
+        : '';
       throw new Error(
-        'No issue candidates found across all search phases. ' +
+        `No issue candidates found across all search phases.${details} ` +
         'Try adjusting your search criteria (languages, labels) or check your network connection.'
       );
     }
 
     // Sort by priority first, then by recommendation
     allCandidates.sort((a, b) => {
-      // Priority order: starred > high_score > normal
-      const priorityOrder: Record<SearchPriority, number> = { starred: 0, high_score: 1, normal: 2 };
+      // Priority order: merged_pr > starred > normal
+      const priorityOrder: Record<SearchPriority, number> = { merged_pr: 0, starred: 1, normal: 2 };
       const priorityDiff = priorityOrder[a.searchPriority] - priorityOrder[b.searchPriority];
       if (priorityDiff !== 0) return priorityDiff;
 
@@ -316,7 +351,7 @@ export class IssueDiscovery {
     maxResults: number,
     priority: SearchPriority,
     filterFn: (items: GitHubSearchItem[]) => GitHubSearchItem[]
-  ): Promise<IssueCandidate[]> {
+  ): Promise<{ candidates: IssueCandidate[]; allBatchesFailed: boolean }> {
     const candidates: IssueCandidate[] = [];
 
     // Batch repos to reduce API calls.
@@ -325,6 +360,7 @@ export class IssueDiscovery {
     // Using 5 repos per batch stays well under the limit.
     const BATCH_SIZE = 5;
     const batches = this.batchRepos(repos, BATCH_SIZE);
+    let failedBatches = 0;
 
     for (const batch of batches) {
       if (candidates.length >= maxResults) break;
@@ -344,21 +380,29 @@ export class IssueDiscovery {
         if (data.items.length > 0) {
           const filtered = filterFn(data.items);
           const remainingNeeded = maxResults - candidates.length;
-          const results = await this.vetIssuesParallel(
+          const { candidates: vetted } = await this.vetIssuesParallel(
             filtered.slice(0, remainingNeeded * 2).map(i => i.html_url),
             remainingNeeded,
             priority
           );
-          candidates.push(...results);
+          candidates.push(...vetted);
         }
       } catch (error) {
-        // Log but continue with other batches
+        failedBatches++;
         const batchRepos = batch.join(', ');
         console.error(`Error searching issues in batch [${batchRepos}]:`, error instanceof Error ? error.message : error);
       }
     }
 
-    return candidates;
+    const allBatchesFailed = failedBatches === batches.length && batches.length > 0;
+    if (allBatchesFailed) {
+      console.error(
+        `[SEARCH_PHASE_ALL_BATCHES_FAILED] All ${batches.length} batch(es) failed for ${priority} phase. ` +
+        `This may indicate a systemic issue (rate limit, auth, network).`
+      );
+    }
+
+    return { candidates, allBatchesFailed };
   }
 
   /**
@@ -382,12 +426,15 @@ export class IssueDiscovery {
     urls: string[],
     maxResults: number,
     priority?: SearchPriority
-  ): Promise<IssueCandidate[]> {
+  ): Promise<{ candidates: IssueCandidate[]; allFailed: boolean }> {
     const candidates: IssueCandidate[] = [];
     const pending: Promise<void>[] = [];
+    let failedVettingCount = 0;
+    let attemptedCount = 0;
 
     for (const url of urls) {
       if (candidates.length >= maxResults) break;
+      attemptedCount++;
 
       const task = this.vetIssue(url)
         .then(candidate => {
@@ -400,6 +447,7 @@ export class IssueDiscovery {
           }
         })
         .catch(error => {
+          failedVettingCount++;
           console.error(`Error vetting issue ${url}:`, error instanceof Error ? error.message : error);
         });
 
@@ -417,7 +465,16 @@ export class IssueDiscovery {
 
     // Wait for remaining
     await Promise.allSettled(pending);
-    return candidates.slice(0, maxResults);
+
+    const allFailed = failedVettingCount === attemptedCount && attemptedCount > 0;
+    if (allFailed) {
+      console.error(
+        `[VET_ISSUES_ALL_FAILED] All ${attemptedCount} issue(s) failed vetting. ` +
+        `This may indicate a systemic issue (rate limit, auth, network).`
+      );
+    }
+
+    return { candidates: candidates.slice(0, maxResults), allFailed };
   }
 
   /**
@@ -441,22 +498,29 @@ export class IssueDiscovery {
     });
 
     // Run all vetting checks in parallel
-    const [noExistingPR, notClaimed, projectHealth, contributionGuidelines] = await Promise.all([
+    const [existingPRCheck, claimCheck, projectHealth, contributionGuidelines] = await Promise.all([
       this.checkNoExistingPR(owner, repo, number),
       this.checkNotClaimed(owner, repo, number, ghIssue.comments),
       this.checkProjectHealth(owner, repo),
       this.fetchContributionGuidelines(owner, repo),
     ]);
 
+    const noExistingPR = existingPRCheck.passed;
+    const notClaimed = claimCheck.passed;
+
     // Analyze issue quality
     const clearRequirements = this.analyzeRequirements(ghIssue.body || '');
 
+    // When the health check itself failed (API error), use a neutral default:
+    // don't penalize the repo as inactive, but don't credit it as active either.
+    const projectActive = projectHealth.checkFailed ? true : projectHealth.isActive;
+
     const vettingResult: IssueVettingResult = {
-      passedAllChecks: noExistingPR && notClaimed && projectHealth.isActive && clearRequirements,
+      passedAllChecks: noExistingPR && notClaimed && projectActive && clearRequirements,
       checks: {
         noExistingPR,
         notClaimed,
-        projectActive: projectHealth.isActive,
+        projectActive,
         clearRequirements,
         contributionGuidelinesFound: !!contributionGuidelines,
       },
@@ -467,7 +531,17 @@ export class IssueDiscovery {
     // Build notes
     if (!noExistingPR) vettingResult.notes.push('Existing PR found for this issue');
     if (!notClaimed) vettingResult.notes.push('Issue appears to be claimed by someone');
-    if (!projectHealth.isActive) vettingResult.notes.push('Project may be inactive');
+    if (existingPRCheck.inconclusive) {
+      vettingResult.notes.push(`Could not verify absence of existing PRs: ${existingPRCheck.reason || 'API error'}`);
+    }
+    if (claimCheck.inconclusive) {
+      vettingResult.notes.push(`Could not verify claim status: ${claimCheck.reason || 'API error'}`);
+    }
+    if (projectHealth.checkFailed) {
+      vettingResult.notes.push(`Could not verify project activity: ${projectHealth.failureReason || 'API error'}`);
+    } else if (!projectHealth.isActive) {
+      vettingResult.notes.push('Project may be inactive');
+    }
     if (!clearRequirements) vettingResult.notes.push('Issue requirements are unclear');
     if (!contributionGuidelines) vettingResult.notes.push('No CONTRIBUTING.md found');
 
@@ -492,19 +566,42 @@ export class IssueDiscovery {
 
     if (!noExistingPR) reasonsToSkip.push('Has existing PR');
     if (!notClaimed) reasonsToSkip.push('Already claimed');
-    if (!projectHealth.isActive) reasonsToSkip.push('Inactive project');
+    if (!projectHealth.isActive && !projectHealth.checkFailed) reasonsToSkip.push('Inactive project');
     if (!clearRequirements) reasonsToSkip.push('Unclear requirements');
 
     if (noExistingPR) reasonsToApprove.push('No existing PR');
     if (notClaimed) reasonsToApprove.push('Not claimed');
-    if (projectHealth.isActive) reasonsToApprove.push('Active project');
+    if (projectHealth.isActive && !projectHealth.checkFailed) reasonsToApprove.push('Active project');
     if (clearRequirements) reasonsToApprove.push('Clear requirements');
     if (contributionGuidelines) reasonsToApprove.push('Has contribution guidelines');
 
-    // Check if it's a trusted project
+    // Check if it's a trusted project (via repoScores or legacy trustedProjects list)
     const config = this.stateManager.getState().config;
-    if (config.trustedProjects.includes(repoFullName)) {
+    const repoScoreRecord = this.stateManager.getRepoScore(repoFullName);
+    if (repoScoreRecord && repoScoreRecord.mergedPRCount > 0) {
+      reasonsToApprove.push(`Trusted project (${repoScoreRecord.mergedPRCount} PR${repoScoreRecord.mergedPRCount > 1 ? 's' : ''} merged)`);
+    } else if (config.trustedProjects.includes(repoFullName)) {
       reasonsToApprove.push('Trusted project (previous PR merged)');
+    }
+
+    // Check for closed/rejected PR history in this repo
+    if (repoScoreRecord) {
+      if (repoScoreRecord.closedWithoutMergeCount > 0 && repoScoreRecord.mergedPRCount === 0) {
+        reasonsToSkip.push('User has rejected PR(s) in this repo with no successful merges');
+      } else if (repoScoreRecord.closedWithoutMergeCount > 0 && repoScoreRecord.mergedPRCount > 0) {
+        vettingResult.notes.push(`Mixed history: ${repoScoreRecord.mergedPRCount} merged, ${repoScoreRecord.closedWithoutMergeCount} closed without merge`);
+      }
+    }
+
+    // Check for org-level affinity (user has merged PRs in another repo under same org)
+    const orgName = repoFullName.split('/')[0];
+    let orgHasMergedPRs = false;
+    if (orgName && repoFullName.includes('/')) {
+      orgHasMergedPRs = Object.values(this.stateManager.getState().repoScores)
+        .some(rs => rs.repo && rs.mergedPRCount > 0 && rs.repo.startsWith(orgName + '/') && rs.repo !== repoFullName);
+    }
+    if (orgHasMergedPRs) {
+      reasonsToApprove.push(`Org affinity (merged PRs in other ${orgName} repos)`);
     }
 
     let recommendation: 'approve' | 'skip' | 'needs_review';
@@ -516,6 +613,14 @@ export class IssueDiscovery {
       recommendation = 'needs_review';
     }
 
+    // Downgrade to needs_review if any check was inconclusive —
+    // "approve" should only be given when all checks actually passed, not when they were skipped.
+    const hasInconclusiveChecks = projectHealth.checkFailed || existingPRCheck.inconclusive || claimCheck.inconclusive;
+    if (recommendation === 'approve' && hasInconclusiveChecks) {
+      recommendation = 'needs_review';
+      vettingResult.notes.push('Recommendation downgraded: one or more checks were inconclusive');
+    }
+
     // Calculate viability score
     const viabilityScore = this.calculateViabilityScore({
       repoScore: this.getRepoScore(repoFullName),
@@ -524,16 +629,18 @@ export class IssueDiscovery {
       clearRequirements,
       hasContributionGuidelines: !!contributionGuidelines,
       issueUpdatedAt: ghIssue.updated_at,
+      closedWithoutMergeCount: repoScoreRecord?.closedWithoutMergeCount ?? 0,
+      mergedPRCount: repoScoreRecord?.mergedPRCount ?? 0,
+      orgHasMergedPRs,
     });
 
     // Determine search priority
     const starredRepos = this.stateManager.getStarredRepos();
-    const repoScore = this.getRepoScore(repoFullName);
     let searchPriority: SearchPriority = 'normal';
-    if (starredRepos.includes(repoFullName)) {
+    if (repoScoreRecord && repoScoreRecord.mergedPRCount > 0) {
+      searchPriority = 'merged_pr';
+    } else if (starredRepos.includes(repoFullName)) {
       searchPriority = 'starred';
-    } else if (repoScore !== null && repoScore >= 7) {
-      searchPriority = 'high_score';
     }
 
     return {
@@ -548,7 +655,7 @@ export class IssueDiscovery {
     };
   }
 
-  private async checkNoExistingPR(owner: string, repo: string, issueNumber: number): Promise<boolean> {
+  private async checkNoExistingPR(owner: string, repo: string, issueNumber: number): Promise<CheckResult> {
     try {
       // Search for PRs that mention this issue
       const { data } = await this.octokit.search.issuesAndPullRequests({
@@ -571,11 +678,11 @@ export class IssueDiscovery {
         }
       );
 
-      return data.total_count === 0 && linkedPRs.length === 0;
+      return { passed: data.total_count === 0 && linkedPRs.length === 0 };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       console.warn(`[CHECK_NO_EXISTING_PR] Failed to check for existing PRs on ${owner}/${repo}#${issueNumber}: ${errorMessage}. Assuming no existing PR.`);
-      return true;
+      return { passed: true, inconclusive: true, reason: errorMessage };
     }
   }
 
@@ -584,8 +691,8 @@ export class IssueDiscovery {
     repo: string,
     issueNumber: number,
     commentCount: number
-  ): Promise<boolean> {
-    if (commentCount === 0) return true;
+  ): Promise<CheckResult> {
+    if (commentCount === 0) return { passed: true };
 
     try {
       // Paginate through all comments (up to 100)
@@ -625,15 +732,15 @@ export class IssueDiscovery {
       for (const comment of recentComments) {
         const body = (comment.body || '').toLowerCase();
         if (claimPhrases.some(phrase => body.includes(phrase))) {
-          return false;
+          return { passed: false };
         }
       }
 
-      return true;
+      return { passed: true };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       console.warn(`[CHECK_NOT_CLAIMED] Failed to check claim status on ${owner}/${repo}#${issueNumber}: ${errorMessage}. Assuming not claimed.`);
-      return true;
+      return { passed: true, inconclusive: true, reason: errorMessage };
     }
   }
 
@@ -819,8 +926,10 @@ export class IssueDiscovery {
    * - +15 for clear requirements (clarity)
    * - +15 for freshness (recently updated)
    * - +10 for contribution guidelines
+   * - +5 for org affinity (merged PRs in same org)
    * - -30 if existing PR
    * - -20 if claimed
+   * - -15 if closed-without-merge history with no merges
    */
   calculateViabilityScore(params: {
     repoScore: number | null;
@@ -829,6 +938,9 @@ export class IssueDiscovery {
     clearRequirements: boolean;
     hasContributionGuidelines: boolean;
     issueUpdatedAt: string;
+    closedWithoutMergeCount: number;
+    mergedPRCount: number;
+    orgHasMergedPRs: boolean;
   }): number {
     let score = 50; // Base score
 
@@ -857,6 +969,11 @@ export class IssueDiscovery {
       score += 10;
     }
 
+    // Org affinity bonus (+5) — user has merged PRs in another repo under same org
+    if (params.orgHasMergedPRs) {
+      score += 5;
+    }
+
     // Penalty for existing PR (-30)
     if (params.hasExistingPR) {
       score -= 30;
@@ -865,6 +982,11 @@ export class IssueDiscovery {
     // Penalty for claimed issue (-20)
     if (params.isClaimed) {
       score -= 20;
+    }
+
+    // Penalty for closed-without-merge history with no successful merges (-15)
+    if (params.closedWithoutMergeCount > 0 && params.mergedPRCount === 0) {
+      score -= 15;
     }
 
     // Clamp to 0-100
@@ -934,7 +1056,7 @@ ${Object.entries(vettingResult.checks)
   .join('\n')}
 
 ### Project Health
-- Last commit: ${projectHealth.daysSinceLastCommit} days ago
+- Last commit: ${projectHealth.checkFailed ? 'unknown (API error)' : `${projectHealth.daysSinceLastCommit} days ago`}
 - Open issues: ${projectHealth.openIssuesCount}
 - CI status: ${projectHealth.ciStatus}
 

--- a/src/core/state.test.ts
+++ b/src/core/state.test.ts
@@ -299,30 +299,82 @@ describe('StateManager calculateScore (via updateRepoScore)', () => {
     expect(score!.score).toBe(5);
   });
 
-  it('should add +2 per merged PR, capped at +4', () => {
-    // 3 merged PRs => bonus would be 6, but capped at +4 => score = 9
+  it('should apply logarithmic merge bonus (1 merge → +2)', () => {
+    // log2(1+1)*2 = log2(2)*2 = 1*2 = 2, score = 5+2 = 7
+    stateManager.updateRepoScore('owner/repo', { mergedPRCount: 1 });
+    expect(stateManager.getRepoScore('owner/repo')!.score).toBe(7);
+  });
+
+  it('should apply logarithmic merge bonus (3 merges → +4)', () => {
+    // log2(3+1)*2 = log2(4)*2 = 2*2 = 4, score = 5+4 = 9
     stateManager.updateRepoScore('owner/repo', { mergedPRCount: 3 });
-    const score = stateManager.getRepoScore('owner/repo');
-    expect(score!.score).toBe(9);
+    expect(stateManager.getRepoScore('owner/repo')!.score).toBe(9);
+  });
+
+  it('should cap logarithmic merge bonus at +5 (5+ merges)', () => {
+    // log2(5+1)*2 = log2(6)*2 = 2.585*2 = 5.17, rounded to 5, score = 5+5 = 10
+    stateManager.updateRepoScore('owner/repo', { mergedPRCount: 5 });
+    expect(stateManager.getRepoScore('owner/repo')!.score).toBe(10);
+  });
+
+  it('should also cap at +5 for 7+ merges', () => {
+    // log2(7+1)*2 = log2(8)*2 = 3*2 = 6, capped at 5, score = 5+5 = 10
+    stateManager.updateRepoScore('owner/repo', { mergedPRCount: 7 });
+    expect(stateManager.getRepoScore('owner/repo')!.score).toBe(10);
+  });
+
+  it('should differentiate 2 merges from 7 merges', () => {
+    stateManager.updateRepoScore('owner/few', { mergedPRCount: 2 });
+    stateManager.updateRepoScore('owner/many', { mergedPRCount: 7 });
+    const fewScore = stateManager.getRepoScore('owner/few')!.score;
+    const manyScore = stateManager.getRepoScore('owner/many')!.score;
+    expect(manyScore).toBeGreaterThan(fewScore);
   });
 
   it('should subtract -1 per closed without merge, capped at -3', () => {
     // 5 closed without merge => penalty would be 5, but capped at -3 => score = 2
     stateManager.updateRepoScore('owner/repo', { closedWithoutMergeCount: 5 });
-    const score = stateManager.getRepoScore('owner/repo');
-    expect(score!.score).toBe(2);
+    expect(stateManager.getRepoScore('owner/repo')!.score).toBe(2);
+  });
+
+  it('should add +1 for recency (last merge within 90 days)', () => {
+    const recentDate = new Date();
+    recentDate.setDate(recentDate.getDate() - 30);
+    stateManager.updateRepoScore('owner/repo', { mergedPRCount: 1, lastMergedAt: recentDate.toISOString() });
+    // 5 + 2 (1 merge) + 1 (recency) = 8
+    expect(stateManager.getRepoScore('owner/repo')!.score).toBe(8);
+  });
+
+  it('should add recency bonus at exactly 90 days', () => {
+    const boundaryDate = new Date();
+    boundaryDate.setDate(boundaryDate.getDate() - 90);
+    stateManager.updateRepoScore('owner/repo', { mergedPRCount: 1, lastMergedAt: boundaryDate.toISOString() });
+    // 5 + 2 (1 merge) + 1 (recency, daysSince <= 90) = 8
+    expect(stateManager.getRepoScore('owner/repo')!.score).toBe(8);
+  });
+
+  it('should NOT add recency bonus for merges older than 90 days', () => {
+    const oldDate = new Date();
+    oldDate.setDate(oldDate.getDate() - 120);
+    stateManager.updateRepoScore('owner/repo', { mergedPRCount: 1, lastMergedAt: oldDate.toISOString() });
+    // 5 + 2 (1 merge) + 0 (no recency) = 7
+    expect(stateManager.getRepoScore('owner/repo')!.score).toBe(7);
+  });
+
+  it('should skip recency bonus for invalid lastMergedAt date', () => {
+    stateManager.updateRepoScore('owner/repo', { mergedPRCount: 1, lastMergedAt: 'invalid-date' });
+    // 5 + 2 (1 merge) + 0 (invalid date, no recency) = 7
+    expect(stateManager.getRepoScore('owner/repo')!.score).toBe(7);
   });
 
   it('should add +1 for responsive signal', () => {
     stateManager.updateRepoScore('owner/repo', { signals: { isResponsive: true, hasActiveMaintainers: true, hasHostileComments: false } });
-    const score = stateManager.getRepoScore('owner/repo');
-    expect(score!.score).toBe(6);
+    expect(stateManager.getRepoScore('owner/repo')!.score).toBe(6);
   });
 
   it('should subtract -2 for hostile signal', () => {
     stateManager.updateRepoScore('owner/repo', { signals: { hasHostileComments: true, hasActiveMaintainers: true, isResponsive: false } });
-    const score = stateManager.getRepoScore('owner/repo');
-    expect(score!.score).toBe(3);
+    expect(stateManager.getRepoScore('owner/repo')!.score).toBe(3);
   });
 
   it('should clamp score to minimum of 1', () => {
@@ -331,18 +383,94 @@ describe('StateManager calculateScore (via updateRepoScore)', () => {
       closedWithoutMergeCount: 10,
       signals: { hasHostileComments: true, hasActiveMaintainers: true, isResponsive: false },
     });
-    const score = stateManager.getRepoScore('owner/repo');
-    expect(score!.score).toBe(1);
+    expect(stateManager.getRepoScore('owner/repo')!.score).toBe(1);
   });
 
   it('should clamp score to maximum of 10', () => {
-    // Base 5, +4 (merged cap), +1 (responsive) = 10
+    // Base 5, +5 (merged cap), +1 (responsive) = 11 => clamped to 10
     stateManager.updateRepoScore('owner/repo', {
       mergedPRCount: 100,
       signals: { isResponsive: true, hasActiveMaintainers: true, hasHostileComments: false },
     });
-    const score = stateManager.getRepoScore('owner/repo');
-    expect(score!.score).toBe(10);
+    expect(stateManager.getRepoScore('owner/repo')!.score).toBe(10);
+  });
+});
+
+describe('StateManager updateRepoScore partial signals', () => {
+  let stateManager: StateManager;
+
+  beforeEach(() => {
+    stateManager = new StateManager(true);
+  });
+
+  it('should preserve hasHostileComments when updating with partial signals', () => {
+    // First set hostile to true
+    stateManager.updateRepoScore('owner/repo', {
+      signals: { hasHostileComments: true, hasActiveMaintainers: true, isResponsive: false },
+    });
+    expect(stateManager.getRepoScore('owner/repo')!.signals.hasHostileComments).toBe(true);
+
+    // Now update only isResponsive — hasHostileComments should be preserved
+    stateManager.updateRepoScore('owner/repo', {
+      signals: { isResponsive: true, hasActiveMaintainers: true },
+    });
+    const score = stateManager.getRepoScore('owner/repo')!;
+    expect(score.signals.hasHostileComments).toBe(true);
+    expect(score.signals.isResponsive).toBe(true);
+  });
+
+  it('should preserve isResponsive when updating only hasHostileComments', () => {
+    stateManager.updateRepoScore('owner/repo', {
+      signals: { isResponsive: true, hasActiveMaintainers: false, hasHostileComments: false },
+    });
+
+    stateManager.updateRepoScore('owner/repo', {
+      signals: { hasHostileComments: true },
+    });
+    const score = stateManager.getRepoScore('owner/repo')!;
+    expect(score.signals.isResponsive).toBe(true);
+    expect(score.signals.hasHostileComments).toBe(true);
+  });
+});
+
+describe('StateManager getReposWithMergedPRs', () => {
+  let stateManager: StateManager;
+
+  beforeEach(() => {
+    stateManager = new StateManager(true);
+  });
+
+  it('should return empty array when no repos have merged PRs', () => {
+    expect(stateManager.getReposWithMergedPRs()).toEqual([]);
+  });
+
+  it('should return repos with mergedPRCount > 0', () => {
+    stateManager.updateRepoScore('owner/merged-repo', { mergedPRCount: 2 });
+    stateManager.updateRepoScore('owner/no-merges', { mergedPRCount: 0 });
+    stateManager.updateRepoScore('owner/also-merged', { mergedPRCount: 1 });
+
+    const repos = stateManager.getReposWithMergedPRs();
+    expect(repos).toHaveLength(2);
+    expect(repos).toContain('owner/merged-repo');
+    expect(repos).toContain('owner/also-merged');
+    expect(repos).not.toContain('owner/no-merges');
+  });
+
+  it('should sort by merged count descending', () => {
+    stateManager.updateRepoScore('owner/few', { mergedPRCount: 1 });
+    stateManager.updateRepoScore('owner/many', { mergedPRCount: 5 });
+    stateManager.updateRepoScore('owner/some', { mergedPRCount: 3 });
+
+    const repos = stateManager.getReposWithMergedPRs();
+    expect(repos).toEqual(['owner/many', 'owner/some', 'owner/few']);
+  });
+
+  it('should not include repos that only have closed PRs', () => {
+    stateManager.updateRepoScore('owner/rejected', { closedWithoutMergeCount: 3, mergedPRCount: 0 });
+    stateManager.updateRepoScore('owner/merged', { mergedPRCount: 1 });
+
+    const repos = stateManager.getReposWithMergedPRs();
+    expect(repos).toEqual(['owner/merged']);
   });
 });
 
@@ -412,6 +540,90 @@ describe('StateManager state validity', () => {
     expect(stats.totalTracked).toBe(2);
     // mergeRate = 5 / (5+1) * 100 = 83.3%
     expect(stats.mergeRate).toBe('83.3%');
+  });
+});
+
+describe('StateManager markRepoHostile signal preservation', () => {
+  let stateManager: StateManager;
+
+  beforeEach(() => {
+    stateManager = new StateManager(true);
+  });
+
+  it('should preserve isResponsive when marking repo as hostile', () => {
+    stateManager.updateRepoScore('owner/repo', {
+      signals: { isResponsive: true, hasActiveMaintainers: true, hasHostileComments: false },
+    });
+    stateManager.markRepoHostile('owner/repo');
+    const score = stateManager.getRepoScore('owner/repo')!;
+    expect(score.signals.hasHostileComments).toBe(true);
+    expect(score.signals.isResponsive).toBe(true);
+    expect(score.signals.hasActiveMaintainers).toBe(true);
+  });
+
+  it('should apply -2 hostile penalty to score', () => {
+    stateManager.updateRepoScore('owner/repo', { mergedPRCount: 1 });
+    const scoreBefore = stateManager.getRepoScore('owner/repo')!.score;
+    stateManager.markRepoHostile('owner/repo');
+    const scoreAfter = stateManager.getRepoScore('owner/repo')!.score;
+    expect(scoreAfter).toBe(scoreBefore - 2);
+  });
+
+  it('should create default score record if repo not yet scored', () => {
+    stateManager.markRepoHostile('owner/new-repo');
+    const score = stateManager.getRepoScore('owner/new-repo')!;
+    expect(score).toBeDefined();
+    expect(score.signals.hasHostileComments).toBe(true);
+    // Base 5 - 2 hostile = 3
+    expect(score.score).toBe(3);
+  });
+});
+
+describe('StateManager incrementMergedCount / incrementClosedCount routing', () => {
+  let stateManager: StateManager;
+
+  beforeEach(() => {
+    stateManager = new StateManager(true);
+  });
+
+  it('should create record and set count to 1 for new repo', () => {
+    stateManager.incrementMergedCount('owner/new-repo');
+    const score = stateManager.getRepoScore('owner/new-repo')!;
+    expect(score).toBeDefined();
+    expect(score.mergedPRCount).toBe(1);
+    expect(score.lastMergedAt).toBeDefined();
+  });
+
+  it('should increment correctly on multiple calls', () => {
+    stateManager.incrementMergedCount('owner/repo');
+    stateManager.incrementMergedCount('owner/repo');
+    expect(stateManager.getRepoScore('owner/repo')!.mergedPRCount).toBe(2);
+  });
+
+  it('should preserve existing signals when incrementing merged count', () => {
+    stateManager.updateRepoScore('owner/repo', {
+      signals: { isResponsive: true, hasActiveMaintainers: true, hasHostileComments: false },
+    });
+    stateManager.incrementMergedCount('owner/repo');
+    const score = stateManager.getRepoScore('owner/repo')!;
+    expect(score.signals.isResponsive).toBe(true);
+    expect(score.signals.hasActiveMaintainers).toBe(true);
+    expect(score.mergedPRCount).toBe(1);
+  });
+
+  it('should create record and set count to 1 for new repo on incrementClosedCount', () => {
+    stateManager.incrementClosedCount('owner/new-repo');
+    const score = stateManager.getRepoScore('owner/new-repo')!;
+    expect(score).toBeDefined();
+    expect(score.closedWithoutMergeCount).toBe(1);
+  });
+
+  it('should handle mixed increment and closed operations on same repo', () => {
+    stateManager.incrementMergedCount('owner/repo');
+    stateManager.incrementClosedCount('owner/repo');
+    const score = stateManager.getRepoScore('owner/repo')!;
+    expect(score.mergedPRCount).toBe(1);
+    expect(score.closedWithoutMergeCount).toBe(1);
   });
 });
 

--- a/src/core/state.ts
+++ b/src/core/state.ts
@@ -5,7 +5,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { AgentState, INITIAL_STATE, TrackedPR, TrackedIssue, RepoScore, StateEvent, StateEventType, DailyDigest } from './types.js';
+import { AgentState, INITIAL_STATE, TrackedPR, TrackedIssue, RepoScore, RepoScoreUpdate, StateEvent, StateEventType, DailyDigest } from './types.js';
 import { getStatePath, getBackupDir, getDataDir } from './utils.js';
 
 // Current state version
@@ -919,20 +919,36 @@ export class StateManager {
   }
 
   /**
-   * Calculate the score based on the repo's metrics
-   * Base 5, +2 per merged (max +4), -1 per closed without merge (max -3),
-   * +1 if responsive, -2 if hostile. Clamp 1-10.
+   * Calculate the score based on the repo's metrics.
+   * Base 5, logarithmic merge bonus (max +5), -1 per closed without merge (max -3),
+   * +1 if recently merged (within 90 days), +1 if responsive, -2 if hostile. Clamp 1-10.
    */
   private calculateScore(repoScore: RepoScore): number {
     let score = 5; // Base score
 
-    // +2 per merged PR (max +4)
-    const mergedBonus = Math.min(repoScore.mergedPRCount * 2, 4);
-    score += mergedBonus;
+    // Logarithmic merge bonus (max +5): 1→+2, 2→+3, 3→+4, 5+→+5
+    if (repoScore.mergedPRCount > 0) {
+      const mergedBonus = Math.min(Math.round(Math.log2(repoScore.mergedPRCount + 1) * 2), 5);
+      score += mergedBonus;
+    }
 
     // -1 per closed without merge (max -3)
     const closedPenalty = Math.min(repoScore.closedWithoutMergeCount, 3);
     score -= closedPenalty;
+
+    // +1 if lastMergedAt is set and within 90 days (recency)
+    if (repoScore.lastMergedAt) {
+      const lastMergedDate = new Date(repoScore.lastMergedAt);
+      if (isNaN(lastMergedDate.getTime())) {
+        console.error(`[SCORE_CALC] Invalid lastMergedAt date for ${repoScore.repo}: "${repoScore.lastMergedAt}". Skipping recency bonus.`);
+      } else {
+        const msPerDay = 1000 * 60 * 60 * 24;
+        const daysSince = Math.floor((Date.now() - lastMergedDate.getTime()) / msPerDay);
+        if (daysSince <= 90) {
+          score += 1;
+        }
+      }
+    }
 
     // +1 if responsive
     if (repoScore.signals.isResponsive) {
@@ -951,13 +967,14 @@ export class StateManager {
   /**
    * Update a repository's score with partial updates. If the repo has no existing score,
    * a default score record is created first (base score 5). After applying updates, the
-   * numeric score is recalculated using the formula: base 5, +2 per merged PR (max +4),
-   * -1 per closed-without-merge (max -3), +1 if responsive, -2 if hostile, clamped to [1, 10].
+   * numeric score is recalculated using the formula: base 5, logarithmic merge bonus (max +5),
+   * -1 per closed-without-merge (max -3), +1 if recently merged, +1 if responsive, -2 if hostile, clamped to [1, 10].
    * @param repo - Repository in "owner/repo" format.
-   * @param updates - Partial RepoScore fields to merge. The `score` field is ignored
-   *   since it is always recalculated.
+   * @param updates - Updatable RepoScore fields to merge. The `score`, `repo`, and
+   *   `lastEvaluatedAt` fields are not accepted — score is always derived via
+   *   calculateScore(), and repo/lastEvaluatedAt are managed internally.
    */
-  updateRepoScore(repo: string, updates: Partial<RepoScore>): void {
+  updateRepoScore(repo: string, updates: RepoScoreUpdate): void {
     if (!this.state.repoScores[repo]) {
       this.state.repoScores[repo] = this.createDefaultRepoScore(repo);
     }
@@ -990,39 +1007,31 @@ export class StateManager {
 
   /**
    * Increment the merged PR count for a repository and recalculate its score.
-   * Creates a default score record if the repo has not been scored yet.
+   * Routes through {@link updateRepoScore} for a single mutation path.
    * @param repo - Repository in "owner/repo" format.
    */
   incrementMergedCount(repo: string): void {
-    if (!this.state.repoScores[repo]) {
-      this.state.repoScores[repo] = this.createDefaultRepoScore(repo);
-    }
-
-    const repoScore = this.state.repoScores[repo];
-    repoScore.mergedPRCount += 1;
-    repoScore.lastMergedAt = new Date().toISOString();
-    repoScore.score = this.calculateScore(repoScore);
-    repoScore.lastEvaluatedAt = new Date().toISOString();
-
-    console.error(`Incremented merged count for ${repo}: ${repoScore.mergedPRCount} merged, score: ${repoScore.score}/10`);
+    const current = this.state.repoScores[repo];
+    const newCount = (current?.mergedPRCount ?? 0) + 1;
+    this.updateRepoScore(repo, {
+      mergedPRCount: newCount,
+      lastMergedAt: new Date().toISOString(),
+    });
+    console.error(`  └─ incremented merged count for ${repo}: ${newCount}`);
   }
 
   /**
    * Increment the closed-without-merge count for a repository and recalculate its score.
-   * Creates a default score record if the repo has not been scored yet.
+   * Routes through {@link updateRepoScore} for a single mutation path.
    * @param repo - Repository in "owner/repo" format.
    */
   incrementClosedCount(repo: string): void {
-    if (!this.state.repoScores[repo]) {
-      this.state.repoScores[repo] = this.createDefaultRepoScore(repo);
-    }
-
-    const repoScore = this.state.repoScores[repo];
-    repoScore.closedWithoutMergeCount += 1;
-    repoScore.score = this.calculateScore(repoScore);
-    repoScore.lastEvaluatedAt = new Date().toISOString();
-
-    console.error(`Incremented closed count for ${repo}: ${repoScore.closedWithoutMergeCount} closed, score: ${repoScore.score}/10`);
+    const current = this.state.repoScores[repo];
+    const newCount = (current?.closedWithoutMergeCount ?? 0) + 1;
+    this.updateRepoScore(repo, {
+      closedWithoutMergeCount: newCount,
+    });
+    console.error(`  └─ incremented closed count for ${repo}: ${newCount}`);
   }
 
   /**
@@ -1031,16 +1040,20 @@ export class StateManager {
    * @param repo - Repository in "owner/repo" format.
    */
   markRepoHostile(repo: string): void {
-    if (!this.state.repoScores[repo]) {
-      this.state.repoScores[repo] = this.createDefaultRepoScore(repo);
-    }
+    this.updateRepoScore(repo, { signals: { hasHostileComments: true } });
+    console.error(`Marked ${repo} as hostile, score: ${this.state.repoScores[repo].score}/10`);
+  }
 
-    const repoScore = this.state.repoScores[repo];
-    repoScore.signals.hasHostileComments = true;
-    repoScore.score = this.calculateScore(repoScore);
-    repoScore.lastEvaluatedAt = new Date().toISOString();
-
-    console.error(`Marked ${repo} as hostile, score: ${repoScore.score}/10`);
+  /**
+   * Get repositories where the user has at least one merged PR, sorted by merged count descending.
+   * These repos represent proven relationships with high merge probability.
+   * @returns Array of "owner/repo" strings for repos with mergedPRCount > 0.
+   */
+  getReposWithMergedPRs(): string[] {
+    return Object.values(this.state.repoScores)
+      .filter(rs => rs.mergedPRCount > 0)
+      .sort((a, b) => b.mergedPRCount - a.mergedPRCount)
+      .map(rs => rs.repo);
   }
 
   /**

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -300,7 +300,9 @@ export interface ProjectHealth {
 
 /**
  * Quality score for a repository, used to prioritize issue search results.
- * Score is on a 1-10 scale: base 5, +2 per merged PR (max +4), -1 per closed-without-merge (max -3).
+ * Score is on a 1-10 scale: base 5, logarithmic merge bonus (max +5: 1→+2, 2→+3, 3→+4, 5+→+5),
+ * -1 per closed-without-merge (max -3), +1 if lastMergedAt is set and within 90 days,
+ * +1 if responsive, -2 if hostile.
  * Repos below `AgentConfig.minRepoScoreThreshold` are deprioritized.
  */
 export interface RepoScore {
@@ -316,11 +318,30 @@ export interface RepoScore {
   lastMergedAt?: string;
   lastEvaluatedAt: string;
   /** Qualitative signals about the repo's maintainer culture. */
-  signals: {
-    hasActiveMaintainers: boolean;
-    isResponsive: boolean;
-    hasHostileComments: boolean;
-  };
+  signals: RepoSignals;
+}
+
+/** Full set of qualitative signals about a repo's maintainer culture. */
+export interface RepoSignals {
+  hasActiveMaintainers: boolean;
+  isResponsive: boolean;
+  hasHostileComments: boolean;
+}
+
+/** Signals computed from observed open PR data, suitable for merging into RepoScore.signals. */
+export type ComputedRepoSignals = Pick<RepoSignals, 'isResponsive' | 'hasActiveMaintainers'>;
+
+/**
+ * Subset of RepoScore fields that callers may update via `updateRepoScore()`.
+ * Excludes `score` (always derived), `repo` (immutable key), and `lastEvaluatedAt` (auto-set).
+ * The `signals` field accepts a partial update — only provided fields are merged.
+ */
+export interface RepoScoreUpdate {
+  mergedPRCount?: number;
+  closedWithoutMergeCount?: number;
+  avgResponseDays?: number | null;
+  lastMergedAt?: string;
+  signals?: Partial<RepoSignals>;
 }
 
 /**

--- a/src/formatters/json.ts
+++ b/src/formatters/json.ts
@@ -5,6 +5,7 @@
 
 import type { TrackedPR, FetchedPR, DailyDigest, AgentState } from '../core/types.js';
 import type { PRCheckFailure } from '../core/pr-monitor.js';
+import type { SearchPriority } from '../core/issue-discovery.js';
 
 export interface JsonOutput<T = unknown> {
   success: boolean;
@@ -67,7 +68,19 @@ export interface SearchOutput {
     recommendation: 'approve' | 'skip' | 'needs_review';
     reasonsToApprove: string[];
     reasonsToSkip: string[];
+    searchPriority: SearchPriority;
+    /** 0-100 scale composite viability score */
+    viabilityScore: number;
+    repoScore?: {
+      /** 1-10 scale repository quality score */
+      score: number;
+      mergedPRCount: number;
+      closedWithoutMergeCount: number;
+      isResponsive: boolean;
+      lastMergedAt?: string;
+    };
   }>;
+  excludedRepos: string[];
 }
 
 export interface TrackOutput {


### PR DESCRIPTION
## Summary

**Search strategy** (0.9.0):
- New Phase 0 searches repos where user has merged PRs first (highest merge probability), replacing the generic "high-score" phase
- Closed-PR penalty: issues in repos where all user PRs were rejected get -15 viability penalty
- Search JSON output now includes `excludedRepos`, `searchPriority`, and `viabilityScore`
- Issue-scout agent now respects exclusion list during fallback `gh` searches

**Scoring & signals** (0.10.0):
- Logarithmic scoring formula: merge bonus scales from +2 (1 PR) to +5 (7+ PRs), replacing linear formula
- Recency bonus (+1) for repos with merges within 90 days
- Responsiveness signals wired up from open PR data (comments, review states)
- Auto-sync trustedProjects from merged PR history
- Org-level affinity: +5 viability bonus for issues under orgs where user has merged PRs elsewhere
- Repo score details in search JSON output per candidate
- Typed `SearchPriority` union replacing raw `string`

**Hardening** (0.10.1):
- `RepoScoreUpdate` type replacing `Partial<RepoScore>` — prevents callers from setting `score`/`repo`/`lastEvaluatedAt`
- `RepoSignals` and `ComputedRepoSignals` named types replacing anonymous inline types
- Batch/vetting failure tracking with `[SEARCH_PHASE_ALL_BATCHES_FAILED]` and `[VET_ISSUES_ALL_FAILED]` log tags
- `markRepoHostile` routed through `updateRepoScore`, completing single-mutation-path consolidation
- Per-repo error isolation in daily signal/trust sync loops (one failure no longer skips remaining repos)
- Fixed org affinity guard, empty-repo defense, named status constant sets
- Fixed 2 pre-existing test TS errors, added 3 new tests

## Test plan

- [x] `npm test` — 246 tests pass (24 new across 4 commits)
- [x] `npx tsc --noEmit` — 0 TypeScript errors
- [x] `npm run bundle` — builds successfully (496kb)
- [ ] Manual: `npm start -- search --json` — verify `repoScore` and `excludedRepos` in output
- [ ] Manual: verify repos with 2 vs 7 merges produce different scores