### PR TITLE
fix: CI failure priority over changes_addressed + acknowledgment filtering

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "AI-powered autopilot for managing open source contributions - track PRs, respond to maintainers, discover issues, and maintain contribution velocity",
   "author": {
     "name": "John Costa"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.1] - 2026-02-09
+
+### Fixed
+
+- **CI failures hidden behind `changes_addressed` status (#68)** — When a PR had addressed maintainer feedback but CI was failing, the status showed `changes_addressed` (informational) instead of `failing_ci` (actionable). CI failures now take precedence over `changes_addressed` since they block maintainer re-review and require contributor action. Priority hierarchy preserved: `needs_response` > `needs_changes` > `failing_ci` > `changes_addressed`.
+- **False `needs_response` for acknowledgment comments (#69)** — Simple maintainer acknowledgments ("thanks", "LGTM", "will review soon") no longer trigger `needs_response` status. New `isAcknowledgmentComment()` detection uses conservative heuristics: keyword match + no question mark + under 100 chars. Actionable comments after an acknowledgment still correctly trigger `needs_response`.
+- **Spurious "Needs Response" badge in dashboard** — When a PR's status is upgraded from `changes_addressed` to `failing_ci`, the dashboard no longer shows a misleading "Needs Response" badge alongside the CI failure status.
+
 ## [0.12.0] - 2026-02-09
 
 ### Fixed
@@ -341,6 +349,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR monitoring and health checking
 - Dashboard HTML generation
 
+[0.12.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.10.1...v0.11.0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Discover issues worth contributing to, track your PRs across repos, and draft responses to maintainer feedback. An AI copilot for your open source journey.
 
-![Version](https://img.shields.io/badge/version-0.12.0-blue)
+![Version](https://img.shields.io/badge/version-0.12.1-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)
 ![Node Version](https://img.shields.io/badge/node-%3E%3D18-brightgreen)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "AI-powered autopilot for managing open source contributions with Claude Code",
   "type": "module",
   "main": "dist/cli.js",

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -1081,7 +1081,7 @@ function generateDashboardHtml(
               ${pr.ciStatus === 'pending' ? '<span class="badge badge-pending">CI Pending</span>' : ''}
               ${pr.hasMergeConflict ? '<span class="badge badge-conflict">Merge Conflict</span>' : ''}
               ${pr.hasUnrespondedComment && pr.status === 'changes_addressed' ? '<span class="badge badge-changes-addressed">Changes Addressed</span>' : ''}
-              ${pr.hasUnrespondedComment && pr.status !== 'changes_addressed' ? '<span class="badge badge-needs-response">Needs Response</span>' : ''}
+              ${pr.hasUnrespondedComment && pr.status !== 'changes_addressed' && pr.status !== 'failing_ci' ? '<span class="badge badge-needs-response">Needs Response</span>' : ''}
               ${pr.reviewDecision === 'changes_requested' ? '<span class="badge badge-changes-requested">Changes Requested</span>' : ''}
               ${isStale ? `<span class="badge badge-stale">${pr.daysSinceActivity}d inactive</span>` : ''}
             </div>

--- a/src/core/pr-monitor.test.ts
+++ b/src/core/pr-monitor.test.ts
@@ -1065,3 +1065,185 @@ describe('PRMonitor generateDigest', () => {
     expect(digest.recentlyClosedPRs[1].number).toBe(101);
   });
 });
+
+describe('PRMonitor CI failure overrides changes_addressed (Issue #68)', () => {
+  beforeEach(() => {
+    mockOctokitInstance = {};
+  });
+
+  // Helper to call determineStatus with defaults
+  function callDetermineStatus(overrides: Partial<{
+    ciStatus: string;
+    hasMergeConflict: boolean;
+    hasUnrespondedComment: boolean;
+    hasIncompleteChecklist: boolean;
+    reviewDecision: string;
+    daysSinceActivity: number;
+    dormantThreshold: number;
+    approachingThreshold: number;
+    latestCommitDate: string | undefined;
+    lastMaintainerCommentDate: string | undefined;
+    latestChangesRequestedDate: string | undefined;
+  }> = {}) {
+    const monitor = new PRMonitor('fake-token');
+    const defaults = {
+      ciStatus: 'passing',
+      hasMergeConflict: false,
+      hasUnrespondedComment: false,
+      hasIncompleteChecklist: false,
+      reviewDecision: 'review_required',
+      daysSinceActivity: 2,
+      dormantThreshold: 30,
+      approachingThreshold: 25,
+      latestCommitDate: undefined as string | undefined,
+      lastMaintainerCommentDate: undefined as string | undefined,
+      latestChangesRequestedDate: undefined as string | undefined,
+    };
+    const p = { ...defaults, ...overrides };
+    return (monitor as any).determineStatus(
+      p.ciStatus, p.hasMergeConflict, p.hasUnrespondedComment,
+      p.hasIncompleteChecklist, p.reviewDecision, p.daysSinceActivity,
+      p.dormantThreshold, p.approachingThreshold, p.latestCommitDate,
+      p.lastMaintainerCommentDate, p.latestChangesRequestedDate
+    );
+  }
+
+  it('should return failing_ci when changes_addressed (comment path) and CI is failing', () => {
+    expect(callDetermineStatus({
+      ciStatus: 'failing',
+      hasUnrespondedComment: true,
+      latestCommitDate: '2026-02-08T12:00:00Z',
+      lastMaintainerCommentDate: '2026-02-07T10:00:00Z',
+    })).toBe('failing_ci');
+  });
+
+  it('should return failing_ci when changes_addressed (review path) and CI is failing', () => {
+    expect(callDetermineStatus({
+      ciStatus: 'failing',
+      reviewDecision: 'changes_requested',
+      latestCommitDate: '2026-02-09T10:00:00Z',
+      latestChangesRequestedDate: '2026-02-08T11:52:22Z',
+    })).toBe('failing_ci');
+  });
+
+  it('should still return changes_addressed when CI is passing (comment path regression)', () => {
+    expect(callDetermineStatus({
+      ciStatus: 'passing',
+      hasUnrespondedComment: true,
+      latestCommitDate: '2026-02-08T12:00:00Z',
+      lastMaintainerCommentDate: '2026-02-07T10:00:00Z',
+    })).toBe('changes_addressed');
+  });
+
+  it('should still return changes_addressed when CI is passing (review path regression)', () => {
+    expect(callDetermineStatus({
+      ciStatus: 'passing',
+      reviewDecision: 'changes_requested',
+      latestCommitDate: '2026-02-09T10:00:00Z',
+      latestChangesRequestedDate: '2026-02-08T11:52:22Z',
+    })).toBe('changes_addressed');
+  });
+
+  it('should still prioritize needs_response over failing_ci', () => {
+    expect(callDetermineStatus({
+      ciStatus: 'failing',
+      hasUnrespondedComment: true,
+      // No commit after maintainer comment → needs_response, not changes_addressed
+    })).toBe('needs_response');
+  });
+
+  it('should still prioritize needs_changes over failing_ci', () => {
+    expect(callDetermineStatus({
+      ciStatus: 'failing',
+      reviewDecision: 'changes_requested',
+      latestCommitDate: '2026-02-07T06:50:38Z',
+      latestChangesRequestedDate: '2026-02-08T11:52:22Z',
+    })).toBe('needs_changes');
+  });
+});
+
+describe('PRMonitor acknowledgment comment detection (Issue #69)', () => {
+  beforeEach(() => {
+    mockOctokitInstance = {};
+  });
+
+  it('should detect "thanks" as acknowledgment', () => {
+    const monitor = new PRMonitor('fake-token');
+    expect((monitor as any).isAcknowledgmentComment('thanks')).toBe(true);
+  });
+
+  it('should detect "Thank you!" as acknowledgment', () => {
+    const monitor = new PRMonitor('fake-token');
+    expect((monitor as any).isAcknowledgmentComment('Thank you!')).toBe(true);
+  });
+
+  it('should detect "LGTM" as acknowledgment', () => {
+    const monitor = new PRMonitor('fake-token');
+    expect((monitor as any).isAcknowledgmentComment('LGTM')).toBe(true);
+  });
+
+  it('should detect "Looks good, will review soon" as acknowledgment', () => {
+    const monitor = new PRMonitor('fake-token');
+    expect((monitor as any).isAcknowledgmentComment('Looks good, will review soon')).toBe(true);
+  });
+
+  it('should detect "we\'ll get to this shortly" as acknowledgment', () => {
+    const monitor = new PRMonitor('fake-token');
+    expect((monitor as any).isAcknowledgmentComment("we'll get to this shortly")).toBe(true);
+  });
+
+  it('should detect "noted" as acknowledgment', () => {
+    const monitor = new PRMonitor('fake-token');
+    expect((monitor as any).isAcknowledgmentComment('noted')).toBe(true);
+  });
+
+  it('should NOT detect actionable comment as acknowledgment', () => {
+    const monitor = new PRMonitor('fake-token');
+    expect((monitor as any).isAcknowledgmentComment('Please fix linting errors')).toBe(false);
+  });
+
+  it('should NOT detect empty string as acknowledgment', () => {
+    const monitor = new PRMonitor('fake-token');
+    expect((monitor as any).isAcknowledgmentComment('')).toBe(false);
+  });
+
+  it('should NOT detect comment with question mark as acknowledgment', () => {
+    const monitor = new PRMonitor('fake-token');
+    expect((monitor as any).isAcknowledgmentComment('Thanks, can you add tests?')).toBe(false);
+  });
+
+  it('should NOT detect long comment with keyword as acknowledgment', () => {
+    const monitor = new PRMonitor('fake-token');
+    const longComment = 'Thanks for this PR! ' + 'x'.repeat(100);
+    expect((monitor as any).isAcknowledgmentComment(longComment)).toBe(false);
+  });
+
+  it('should not trigger hasUnrespondedComment for acknowledgment comments', () => {
+    const monitor = new PRMonitor('fake-token');
+    const result = (monitor as any).checkUnrespondedComments(
+      [
+        { user: { login: 'testuser' }, body: 'My PR description', created_at: '2026-02-07T10:00:00Z' },
+        { user: { login: 'maintainer' }, body: 'Thanks, will review soon', created_at: '2026-02-07T12:00:00Z' },
+      ],
+      [],
+      'testuser'
+    );
+    expect(result.hasUnrespondedComment).toBe(false);
+    expect(result.lastMaintainerComment).toBeUndefined();
+  });
+
+  it('should still trigger hasUnrespondedComment for actionable comment after acknowledgment', () => {
+    const monitor = new PRMonitor('fake-token');
+    const result = (monitor as any).checkUnrespondedComments(
+      [
+        { user: { login: 'testuser' }, body: 'My PR', created_at: '2026-02-07T10:00:00Z' },
+        { user: { login: 'maintainer' }, body: 'Thanks, will look at this', created_at: '2026-02-07T11:00:00Z' },
+        { user: { login: 'maintainer' }, body: 'Please fix the linting errors in src/main.ts', created_at: '2026-02-07T12:00:00Z' },
+      ],
+      [],
+      'testuser'
+    );
+    expect(result.hasUnrespondedComment).toBe(true);
+    expect(result.lastMaintainerComment?.author).toBe('maintainer');
+  });
+});

--- a/src/core/pr-monitor.ts
+++ b/src/core/pr-monitor.ts
@@ -313,10 +313,34 @@ export class PRMonitor {
       }
     }
 
+    // Filter out pure acknowledgment comments that don't require a response
+    if (lastMaintainerComment && this.isAcknowledgmentComment(lastMaintainerComment.body)) {
+      lastMaintainerComment = undefined;
+    }
+
     return {
       hasUnrespondedComment: !!lastMaintainerComment,
       lastMaintainerComment,
     };
+  }
+
+  /**
+   * Detect acknowledgment comments that don't require a response.
+   * Returns true only when: no question mark, matches an acknowledgment keyword, and under 100 chars.
+   * Conservative — false negatives (flagging an acknowledgment) are safer than false positives.
+   */
+  private isAcknowledgmentComment(body: string): boolean {
+    if (!body || body.length > 100) return false;
+    if (body.includes('?')) return false;
+
+    const lower = body.toLowerCase();
+    const ackKeywords = [
+      'thanks', 'thank you', 'lgtm', 'looks good',
+      'will review', "we'll review", "we'll get to this",
+      'noted', 'got it', 'will look', 'will check',
+    ];
+
+    return ackKeywords.some(kw => lower.includes(kw));
   }
 
   /**
@@ -341,6 +365,7 @@ export class PRMonitor {
       // If the contributor pushed a commit after the maintainer's comment,
       // the changes have been addressed — waiting for maintainer re-review
       if (latestCommitDate && lastMaintainerCommentDate && latestCommitDate > lastMaintainerCommentDate) {
+        if (ciStatus === 'failing') return 'failing_ci';
         return 'changes_addressed';
       }
       return 'needs_response';
@@ -354,6 +379,7 @@ export class PRMonitor {
         return 'needs_changes';
       }
       // Commit is after review — changes have been addressed
+      if (ciStatus === 'failing') return 'failing_ci';
       return 'changes_addressed';
     }
 


### PR DESCRIPTION
## Summary

- **CI failures override `changes_addressed` (#68)**: When a PR has addressed maintainer feedback but CI is failing, status now shows `failing_ci` (actionable) instead of `changes_addressed` (informational). Priority hierarchy preserved: `needs_response` > `needs_changes` > `failing_ci` > `changes_addressed`.
- **Acknowledgment comment filtering (#69)**: Simple maintainer acknowledgments ("thanks", "LGTM", "will review soon") no longer trigger `needs_response`. Conservative heuristic: keyword match + no question mark + under 100 chars.
- **Dashboard badge fix**: Suppresses spurious "Needs Response" badge when PR status is upgraded from `changes_addressed` to `failing_ci`.

## Test plan

- [x] 276 tests pass (258 existing + 18 new)
- [x] Bundle builds cleanly (507KB)
- [ ] Verify with live PRs: a `changes_addressed` PR with failing CI now shows as `failing_ci`
- [ ] Verify acknowledgment comments ("thanks, will review") don't trigger `needs_response`

Closes #68, closes #69