### PR TITLE
feat: pre-compute action menu in daily --json output

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "AI-powered autopilot for managing open source contributions - track PRs, respond to maintainers, discover issues, and maintain contribution velocity",
   "author": {
     "name": "John Costa"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.1] - 2026-02-09
+
+### Added
+
+- **Pre-computed action menu in `daily --json`** — The CLI now outputs an `actionMenu` field with ready-to-use menu items (`key`, `label`, `description`) and context flags (`hasActionableIssues`, `actionableCount`, `hasCapacity`). The orchestration layer uses these directly in AskUserQuestion instead of manually deriving options from raw data. Closes #78.
+
 ## [0.13.0] - 2026-02-09
 
 ### Added
@@ -375,6 +381,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR monitoring and health checking
 - Dashboard HTML generation
 
+[0.13.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.12.2...v0.13.0
 [0.12.2]: https://github.com/costajohnt/oss-autopilot/compare/v0.12.1...v0.12.2
 [0.12.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.12.0...v0.12.1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Discover issues worth contributing to, track your PRs across repos, and draft responses to maintainer feedback. An AI copilot for your open source journey.
 
-![Version](https://img.shields.io/badge/version-0.13.0-blue)
+![Version](https://img.shields.io/badge/version-0.13.1-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)
 ![Node Version](https://img.shields.io/badge/node-%3E%3D18-brightgreen)

--- a/commands/oss.md
+++ b/commands/oss.md
@@ -113,6 +113,14 @@ The CLI returns structured data with new fields for the action-first flow:
         "pr": { "repo": "owner/repo", "number": 123, "title": "...", "url": "..." }
       }
     ],
+    "actionMenu": {
+      "items": [
+        { "key": "address_all", "label": "Address all 3 issues in parallel (Recommended)", "description": "Launch agents simultaneously..." },
+        { "key": "search", "label": "Search for new issues", "description": "Look for new contribution opportunities" },
+        { "key": "done", "label": "Done for now", "description": "End session with summary" }
+      ],
+      "context": { "hasActionableIssues": true, "actionableCount": 3, "hasCapacity": true }
+    },
     "capacity": { "hasCapacity": true, ... },
     "digest": { ... },
     "updates": [...]
@@ -141,9 +149,13 @@ Then proceed to Step 3 (Present Action Choices).
 
 ## Step 3: Present Action Choices
 
+The CLI pre-computes the action menu in `data.actionMenu`. Use these items directly in AskUserQuestion instead of manually deriving options.
+
+**Fallback:** If `data.actionMenu` is missing (e.g., older CLI version), tell the user: "Action menu not found in CLI output — you may need to rebuild the CLI: `cd ${CLAUDE_PLUGIN_ROOT} && npm run bundle`". Then derive options manually: always include "Done for now"; add "Address all N issues in parallel (Recommended)" if `data.actionableIssues.length > 0`; add "Search for new issues" if `data.capacity.hasCapacity`; add "View healthy PRs" if not `data.capacity.hasCapacity` and `data.actionableIssues.length > 0`; otherwise add "View PR status details".
+
 ### If No Actionable Issues
 
-When `data.actionableIssues` is empty, display:
+When `data.actionMenu` is present and `data.actionMenu.context.hasActionableIssues` is `false` (or when `data.actionMenu` is absent and `data.actionableIssues` is empty), display:
 ```
 All PRs are healthy! No issues need attention.
 ```
@@ -153,80 +165,40 @@ If `hasIssueList && availableCount === 0`:
 Your curated issue list is depleted ({completedCount} done). Time to find new issues!
 ```
 
-Then use AskUserQuestion with:
-- "Pick an issue from your list" (if `hasIssueList` and `availableCount > 0` and `hasCapacity`) — "{availableCount} vetted issues available"
-- "Replenish your issue list" (if `hasIssueList` and `availableCount === 0` and `hasCapacity`) — "All {completedCount} issues done — search for fresh ones"
-- "Search for new issues" (if `hasCapacity` and NOT showing replenish option)
-- "View PR status details"
-- "Done for now"
-
-**"Replenish your issue list"** routes to **Handle "Find New Issues"** (same as search), but agents should be told to suggest issues suitable for adding to the curated list.
-
 ### Display All PRs First (Information Before Prompt)
 
-**Before asking the user anything**, display all actionable issues as formatted text:
+When there are actionable issues, display them **before asking the user anything**:
 
 ```
 {count} PRs Need Attention:
 
 1. {issue.label} {issue.pr.repo}#{issue.pr.number}
-   {issue.pr.title} ({daysSinceActivity}d inactive)
+   {issue.pr.title} ({issue.pr.daysSinceActivity}d inactive)
 
 2. {issue.label} {issue.pr.repo}#{issue.pr.number}
-   {issue.pr.title} ({daysSinceActivity}d inactive)
+   {issue.pr.title} ({issue.pr.daysSinceActivity}d inactive)
 
 ... (list ALL actionable issues, no limit)
 
 ---
 ```
 
-Calculate `daysSinceActivity` from the PR's `updatedAt` field.
+Use `issue.pr.daysSinceActivity` from the CLI output (already computed).
 
-Example output:
-```
-7 PRs Need Attention:
+### Ask for Action (Using Pre-Computed Menu)
 
-1. [Needs Rebase] shadcn-ui/ui#9263 (160 behind)
-   fix(docs): use yarn dlx for npx command (35d inactive)
+Use `data.actionMenu.items` directly as AskUserQuestion options. Each item has `key`, `label`, and `description` fields ready for display.
 
-2. [Needs Rebase] shadcn-ui/ui#9262 (160 behind)
-   fix(cli): use 'bun x' instead of 'bunx' (35d inactive)
+**Issue list integration:** If the user has a curated issue list (detected in Step 0.7), insert an issue-list option **after `address_all`** (index 1) or **at the start** (index 0) when no actionable issues exist — i.e., always before the `search`/`view_details`/`view_healthy` item:
 
-3. [Needs Rebase] oven-sh/bun#25791 (233 behind)
-   fix(console): route console.trace() to stderr (14d inactive)
+| Condition | Insert Item |
+|-----------|-------------|
+| `hasIssueList && availableCount > 0 && context.hasCapacity` | Key: `pick_from_list`, Label: `"Pick from your issue list ({availableCount} available)"`, Description: `"Choose from your curated list of vetted issues"` |
+| `hasIssueList && availableCount === 0 && context.hasCapacity` | Key: `replenish_list`, Label: `"Replenish your issue list"`, Description: `"All {completedCount} issues done — search for fresh ones"`. Also **remove** the `search` item (replenish replaces it). |
 
-4. [CI Blocked] oven-sh/bun#25791
-   CI needs maintainer to trigger Buildkite
+When inserting issue-list items, keep within the 4-option limit (the 5th is the auto "Other").
 
-5. [Changes Requested] ghostfolio/ghostfolio#6223
-   feat(api): add groupBy=year support (2d inactive)
-
-6. [Merge Conflict] cline/cline#8362
-   fix: update button text after deleting history item (10d inactive)
-
-7. [Needs Response] vadimdemedes/ink#858
-   Remove create-ink-app from README (10d inactive)
-
----
-```
-
-### Ask for Action (4-Option Limit)
-
-Use AskUserQuestion with **action-focused options**, not PR-specific options.
-
-**Options to present:**
-
-| Option | Condition | Label | Description |
-|--------|-----------|-------|-------------|
-| 1 | Always (if actionable issues exist) | "Address all {count} issues in parallel (Recommended)" | "Launch agents simultaneously to check status, rebase, fix CI, and respond" |
-| 2 | If `hasIssueList` and `availableCount > 0` and `hasCapacity` | "Pick from your issue list ({availableCount} available)" | "Choose from your curated list of vetted issues" |
-| 2/3 | If `capacity.hasCapacity === true` | "Search for new issues" | "Look for new contribution opportunities" |
-| 2/3 | If `capacity.hasCapacity === false` | "View healthy PRs" | "See status of PRs not needing attention" |
-| 3/4 | Always | "Done for now" | "End session with summary" |
-
-**Note:** Option numbers shift based on whether the issue list option is shown. Keep within the 4-option limit (the 4th is auto "Other").
-
-**Note:** The 4th option is the automatic "Other" - user can type specific PR selections.
+**"Replenish your issue list"** routes to **Handle "Find New Issues"** (same as search), but agents should be told to suggest issues suitable for adding to the curated list.
 
 ### Example AskUserQuestion
 
@@ -234,7 +206,7 @@ Use AskUserQuestion with **action-focused options**, not PR-specific options.
 Question: "What would you like to do?"
 Header: "Action"
 
-Options:
+Options (from data.actionMenu.items):
 1. Label: "Address all 7 issues in parallel (Recommended)"
    Description: "Launch agents simultaneously to check status, rebase, fix CI, and respond"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "AI-powered autopilot for managing open source contributions with Claude Code",
   "type": "module",
   "main": "dist/cli.js",

--- a/src/commands/daily.test.ts
+++ b/src/commands/daily.test.ts
@@ -3,8 +3,9 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { computeRepoSignals } from './daily.js';
+import { computeRepoSignals, computeActionMenu } from './daily.js';
 import type { FetchedPR } from '../core/types.js';
+import type { ActionableIssue, CapacityAssessment } from '../formatters/json.js';
 
 /** Create a minimal FetchedPR for testing signal computation */
 function makePR(overrides: Partial<FetchedPR> & { repo: string }): FetchedPR {
@@ -27,6 +28,128 @@ function makePR(overrides: Partial<FetchedPR> & { repo: string }): FetchedPR {
     ...overrides,
   };
 }
+
+/** Create a minimal CapacityAssessment for testing */
+function makeCapacity(overrides: Partial<CapacityAssessment> = {}): CapacityAssessment {
+  return {
+    hasCapacity: true,
+    activePRCount: 3,
+    maxActivePRs: 10,
+    criticalIssueCount: 0,
+    reason: 'You have capacity: 3/10 active PRs, no critical issues',
+    ...overrides,
+  };
+}
+
+/** Create a minimal ActionableIssue for testing */
+function makeActionableIssue(type: ActionableIssue['type'] = 'ci_failing'): ActionableIssue {
+  return {
+    type,
+    pr: makePR({ repo: 'owner/repo' }),
+    label: '[CI Failing]',
+  };
+}
+
+describe('computeActionMenu', () => {
+  it('should include address_all when there are actionable issues', () => {
+    const issues = [makeActionableIssue(), makeActionableIssue('needs_response')];
+    const menu = computeActionMenu(issues, makeCapacity());
+
+    expect(menu.items[0].key).toBe('address_all');
+    expect(menu.items[0].label).toContain('2 issues');
+    expect(menu.context.hasActionableIssues).toBe(true);
+    expect(menu.context.actionableCount).toBe(2);
+  });
+
+  it('should use singular "issue" for count of 1', () => {
+    const issues = [makeActionableIssue()];
+    const menu = computeActionMenu(issues, makeCapacity());
+
+    expect(menu.items[0].label).toContain('1 issue ');
+    expect(menu.items[0].label).not.toContain('1 issues');
+  });
+
+  it('should not include address_all when there are no actionable issues', () => {
+    const menu = computeActionMenu([], makeCapacity());
+
+    expect(menu.items.find(i => i.key === 'address_all')).toBeUndefined();
+    expect(menu.context.hasActionableIssues).toBe(false);
+    expect(menu.context.actionableCount).toBe(0);
+  });
+
+  it('should include search when user has capacity', () => {
+    const menu = computeActionMenu([], makeCapacity({ hasCapacity: true }));
+
+    expect(menu.items.find(i => i.key === 'search')).toBeDefined();
+    expect(menu.items.find(i => i.key === 'view_healthy')).toBeUndefined();
+  });
+
+  it('should include view_healthy (not search) when no capacity and has actionable issues', () => {
+    const issues = [makeActionableIssue()];
+    const menu = computeActionMenu(issues, makeCapacity({ hasCapacity: false }));
+
+    expect(menu.items.find(i => i.key === 'view_healthy')).toBeDefined();
+    expect(menu.items.find(i => i.key === 'search')).toBeUndefined();
+  });
+
+  it('should include view_details when no capacity and no actionable issues', () => {
+    const menu = computeActionMenu([], makeCapacity({ hasCapacity: false }));
+
+    expect(menu.items.find(i => i.key === 'view_details')).toBeDefined();
+    expect(menu.items.find(i => i.key === 'search')).toBeUndefined();
+    expect(menu.items.find(i => i.key === 'view_healthy')).toBeUndefined();
+  });
+
+  it('should always include done as the last item', () => {
+    const menu1 = computeActionMenu([], makeCapacity());
+    const menu2 = computeActionMenu([makeActionableIssue()], makeCapacity({ hasCapacity: false }));
+
+    expect(menu1.items[menu1.items.length - 1].key).toBe('done');
+    expect(menu2.items[menu2.items.length - 1].key).toBe('done');
+  });
+
+  it('should have correct context flags', () => {
+    const menu = computeActionMenu(
+      [makeActionableIssue()],
+      makeCapacity({ hasCapacity: true }),
+    );
+
+    expect(menu.context).toEqual({
+      hasActionableIssues: true,
+      actionableCount: 1,
+      hasCapacity: true,
+    });
+  });
+
+  it('should produce 3 items when actionable issues exist and has capacity', () => {
+    const menu = computeActionMenu([makeActionableIssue()], makeCapacity());
+
+    expect(menu.items).toHaveLength(3);
+    expect(menu.items.map(i => i.key)).toEqual(['address_all', 'search', 'done']);
+  });
+
+  it('should produce 2 items when no actionable issues and has capacity', () => {
+    const menu = computeActionMenu([], makeCapacity());
+
+    expect(menu.items).toHaveLength(2);
+    expect(menu.items.map(i => i.key)).toEqual(['search', 'done']);
+  });
+
+  it('should produce 2 items when no actionable issues and no capacity', () => {
+    const menu = computeActionMenu([], makeCapacity({ hasCapacity: false }));
+
+    expect(menu.items).toHaveLength(2);
+    expect(menu.items.map(i => i.key)).toEqual(['view_details', 'done']);
+  });
+
+  it('should produce 3 items when actionable issues exist and no capacity', () => {
+    const issues = [makeActionableIssue(), makeActionableIssue('needs_response')];
+    const menu = computeActionMenu(issues, makeCapacity({ hasCapacity: false }));
+
+    expect(menu.items).toHaveLength(3);
+    expect(menu.items.map(i => i.key)).toEqual(['address_all', 'view_healthy', 'done']);
+  });
+});
 
 describe('computeRepoSignals', () => {
   it('should return empty map for empty PR list', () => {

--- a/src/commands/daily.ts
+++ b/src/commands/daily.ts
@@ -5,7 +5,7 @@
  */
 
 import { getStateManager, PRMonitor, getGitHubToken, type DailyDigest, type FetchedPR, type FetchedPRStatus, type PRCheckFailure, type MaintainerActionHint, type ClosedPR, type ComputedRepoSignals } from '../core/index.js';
-import { outputJson, outputJsonError, type DailyOutput, type CapacityAssessment, type ActionableIssue } from '../formatters/json.js';
+import { outputJson, outputJsonError, type DailyOutput, type CapacityAssessment, type ActionableIssue, type ActionMenu, type ActionMenuItem } from '../formatters/json.js';
 
 interface DailyOptions {
   json?: boolean;
@@ -199,7 +199,8 @@ async function runDailyInner(token: string, options: DailyOptions): Promise<void
     // New action-first flow fields
     const actionableIssues = collectActionableIssues(prs, recentlyClosedPRs);
     const briefSummary = formatBriefSummary(digest, actionableIssues.length);
-    outputJson<DailyOutput>({ digest, updates: [], capacity, summary, briefSummary, actionableIssues, failures });
+    const actionMenu = computeActionMenu(actionableIssues, capacity);
+    outputJson<DailyOutput>({ digest, updates: [], capacity, summary, briefSummary, actionableIssues, actionMenu, failures });
   } else {
     // Simple console output for non-JSON mode
     printDigest(digest, capacity);
@@ -588,6 +589,67 @@ function formatActionHint(hint: MaintainerActionHint): string {
     case 'docs_requested': return 'documentation requested';
     case 'rebase_requested': return 'rebase requested';
   }
+}
+
+/**
+ * Compute the action menu from PR data and capacity.
+ * The orchestration layer can insert issue-list options (e.g., "Pick from list")
+ * using the context flags.
+ */
+export function computeActionMenu(
+  actionableIssues: ActionableIssue[],
+  capacity: CapacityAssessment,
+): ActionMenu {
+  const items: ActionMenuItem[] = [];
+  const hasActionableIssues = actionableIssues.length > 0;
+
+  if (hasActionableIssues) {
+    items.push({
+      key: 'address_all',
+      label: `Address all ${actionableIssues.length} issue${actionableIssues.length === 1 ? '' : 's'} in parallel (Recommended)`,
+      description: 'Launch agents simultaneously to check status, rebase, fix CI, and respond',
+    });
+  }
+
+  // Slot for issue-list options — the orchestration layer may insert items here
+  // (index 1 when address_all is present, index 0 otherwise).
+  // See commands/oss.md Step 3 for the insertion logic.
+
+  if (capacity.hasCapacity) {
+    items.push({
+      key: 'search',
+      label: 'Search for new issues',
+      description: 'Look for new contribution opportunities',
+    });
+  } else if (!hasActionableIssues) {
+    // When no actionable issues and no capacity, offer status details
+    items.push({
+      key: 'view_details',
+      label: 'View PR status details',
+      description: 'See full status of all tracked PRs',
+    });
+  } else {
+    items.push({
+      key: 'view_healthy',
+      label: 'View healthy PRs',
+      description: 'See status of PRs not needing attention',
+    });
+  }
+
+  items.push({
+    key: 'done',
+    label: 'Done for now',
+    description: 'End session with summary',
+  });
+
+  return {
+    items,
+    context: {
+      hasActionableIssues,
+      actionableCount: actionableIssues.length,
+      hasCapacity: capacity.hasCapacity,
+    },
+  };
 }
 
 /** Statuses indicating active maintainer engagement (reviews, feedback, merges). */

--- a/src/formatters/json.ts
+++ b/src/formatters/json.ts
@@ -30,6 +30,35 @@ export interface ActionableIssue {
   label: string; // e.g., "[CI Failing]"
 }
 
+/**
+ * A single action menu item pre-computed by the CLI.
+ * The orchestration layer can use these directly in AskUserQuestion prompts.
+ */
+export interface ActionMenuItem {
+  /** Stable identifier for routing (e.g., "address_all", "search", "done"). */
+  key: string;
+  /** Display text for the option (e.g., "Address all 3 issues in parallel (Recommended)"). */
+  label: string;
+  /** Explanation shown below the label. */
+  description: string;
+}
+
+/**
+ * Pre-computed action menu for the orchestration layer.
+ * Contains the menu items the CLI can determine from PR data and capacity,
+ * plus context flags so the orchestration can insert issue-list options.
+ */
+export interface ActionMenu {
+  /** Ordered list of menu items. The orchestration may insert issue-list items after `address_all` (index 1) or at the start (index 0) when no actionable issues exist. */
+  items: ActionMenuItem[];
+  /** Context flags for the orchestration layer to decide on issue-list options. */
+  context: {
+    hasActionableIssues: boolean;
+    actionableCount: number;
+    hasCapacity: boolean;
+  };
+}
+
 export interface DailyOutput {
   digest: DailyDigest;
   updates: unknown[]; // Legacy field, always empty in v2
@@ -37,6 +66,7 @@ export interface DailyOutput {
   summary: string; // Pre-formatted markdown for Claude to display verbatim
   briefSummary: string; // One-liner for action-first flow
   actionableIssues: ActionableIssue[]; // Structured list for AskUserQuestion
+  actionMenu: ActionMenu; // Pre-computed action menu for Step 3
   failures: PRCheckFailure[]; // PRs that failed to fetch (e.g., rate limits, network errors)
 }
 


### PR DESCRIPTION
## Summary

- Adds `ActionMenu` and `ActionMenuItem` types to the CLI's `daily --json` output with ready-to-use menu items (`key`, `label`, `description`) and context flags (`hasActionableIssues`, `actionableCount`, `hasCapacity`)
- The orchestration layer (`oss.md` Step 3) now uses pre-computed items directly in AskUserQuestion instead of manually deriving options from raw data
- Includes fallback instructions with user warning for older CLI versions that don't produce the field
- 12 new tests covering all 4 state combinations (actionable/not × capacity/not), singular/plural labels, item ordering, and context flags

Closes #78

## Test plan

- [x] All 288 tests pass (12 new + 276 existing)
- [x] Bundle builds cleanly (508KB)
- [x] Version bumped to 0.13.1 in all 3 places (package.json, plugin.json, README badge)
- [x] CHANGELOG updated with comparison link
- [x] 3 rounds of PR review toolkit (code-reviewer, silent-failure-hunter, pr-test-analyzer, comment-analyzer) — all findings addressed