### PR TITLE
feat: pre-commit gate and conditional daily re-run

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "AI-powered autopilot for managing open source contributions - track PRs, respond to maintainers, discover issues, and maintain contribution velocity",
   "author": {
     "name": "John Costa"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2026-02-10
+
+### Changed
+
+- **Pre-commit review gate at decision point** — Added a mandatory "Pre-Commit Gate" checkpoint in Step 4 (Execute Approved Actions Only) that routes to Step 5.5 before presenting commit/push options. Previously, the instruction to run pre-commit review was in the Action Tiers preamble, far from the decision point where agents present commit options, causing them to skip it. Now the gate is at the exact point where the agent is about to offer commit options. Closes #86.
+- **Conditional daily re-run after actions** — The "After Each Action" section now distinguishes between Tier 1 (rebases, force pushes) and Tier 2 (comment responses, code fixes) actions. Tier 1 triggers a full daily re-run to refresh PR state; Tier 2 skips the re-run since the data is still valid, saving ~10-15s of API calls between sequential PR responses. Closes #87.
+
 ## [0.15.1] - 2026-02-10
 
 ### Removed
@@ -407,6 +414,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR monitoring and health checking
 - Dashboard HTML generation
 
+[0.16.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.15.1...v0.16.0
+[0.15.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.13.1...v0.14.0
 [0.13.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.13.0...v0.13.1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Discover issues worth contributing to, track your PRs across repos, and draft responses to maintainer feedback. An AI copilot for your open source journey.
 
-![Version](https://img.shields.io/badge/version-0.15.1-blue)
+![Version](https://img.shields.io/badge/version-0.16.0-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)
 ![Node Version](https://img.shields.io/badge/node-%3E%3D18-brightgreen)

--- a/commands/oss.md
+++ b/commands/oss.md
@@ -497,6 +497,10 @@ Only after user explicitly approves Tier 2 actions:
 - Post comments
 - Add missing files
 
+#### Pre-Commit Gate (MANDATORY)
+
+**STOP. Before presenting commit/push options to the user, you MUST complete Step 5.5 (Pre-Commit Code Review).** Do not skip this step. Do not offer to commit first. Run the review agents, present findings, THEN offer commit options. The only exception is if `git status --porcelain` confirms there are no uncommitted changes (e.g., only a comment was posted, or the action was investigation-only). Always verify with git status — do not assume based on which actions were dispatched.
+
 ### CRITICAL: Continue the Flow
 
 **After EVERY action completes (investigation, approval, execution), ALWAYS ask what to do next.**
@@ -657,9 +661,16 @@ After implementation, the flow proceeds through the **draft-first workflow**:
 
 ### After Each Action
 
-1. Re-run the daily check to refresh state
-2. If `hasIssueList`, re-read the list file to get updated available/completed counts
-3. Return to Step 3 with updated action choices (including updated list counts)
+1. **If ANY Tier 1 actions were taken** (rebases, force pushes), regardless of whether Tier 2 actions also occurred:
+   - Re-run the daily check to refresh state
+   - Return to Step 3 with updated action choices
+2. **If ONLY Tier 2 actions were taken** (comment responses, code fixes, missing file additions) with no Tier 1 actions in this round:
+   - Skip the daily re-run — the existing data is still valid
+   - Remove completed items from the current action list
+   - Inform the user: "Skipping full refresh — showing locally updated action list. Select 'Check for more PR updates' for a fresh check."
+   - Return to Step 3 with current action choices
+   - **Exception:** If any completed action involved merge conflict resolution (issue type `merge_conflict` from the actionableIssues list), treat the entire batch as Tier 1 and re-run the daily check
+3. If `hasIssueList`, re-read the list file to get updated available/completed counts
 4. Continue until user selects "Done for now"
 
 ---
@@ -762,6 +773,8 @@ Generate the PR title and body following the target repo's conventions (check `C
 ---
 
 ### Standard Path (existing PR updates)
+
+**This path is triggered automatically by the Pre-Commit Gate in Step 4 whenever Tier 2 code changes have been made to an existing PR.** You should already be here before any commit/push options are presented.
 
 #### 1. Pre-flight: Verify Changes Exist
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "AI-powered autopilot for managing open source contributions with Claude Code",
   "type": "module",
   "main": "dist/cli.js",


### PR DESCRIPTION
## Summary

- **Pre-Commit Gate (#86)**: Adds a mandatory checkpoint in Step 4 (Execute Approved Actions Only) that routes to Step 5.5 before presenting commit/push options. The instruction existed at line 336 but was buried in the Action Tiers preamble — agents consistently skipped it. Now the gate is at the exact decision point.

- **Conditional daily re-run (#87)**: Changes the "After Each Action" section to distinguish between Tier 1 (rebases, force pushes) and Tier 2 (comment responses, code fixes). Tier 1 triggers a full daily re-run; Tier 2 skips it since the data is still valid, saving ~10-15s of API calls between sequential PR responses.

Both changes are markdown-only (`commands/oss.md`). No TypeScript code changes.

Closes #86, closes #87

## Test plan

- [ ] Verify all 358 tests pass
- [ ] Verify bundle builds successfully
- [ ] Manual test: After Tier 2 action (e.g., posting a comment response), verify the daily check is NOT re-run
- [ ] Manual test: After Tier 1 action (e.g., rebase), verify the daily check IS re-run
- [ ] Manual test: After code changes to an existing PR, verify Step 5.5 review is triggered before commit/push options