### PR TITLE
feat: add label-farming spam filter and repo quality signals to issue search

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "AI-powered autopilot for managing open source contributions - track PRs, respond to maintainers, discover issues, and maintain contribution velocity",
   "author": {
     "name": "John Costa"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] - 2026-02-10
+
+### Changed
+
+- **Label-farming spam filter for issue search** — Phase 2 (general search) now detects and filters label-farming repositories that mass-create beginner-labeled issues. Uses two signals: single issues with 5+ beginner labels (strong signal) and repos with 3+ templated titles like "Add Trivia Question 61" (batch signal). Phases 0/1 (user's own repos) are unaffected. Closes #97.
+- **Repo quality bonus in viability scoring** — Issue viability scores now include a quality bonus based on repository star and fork counts. Stars: <50 → +0, 50-499 → +3, 500-4999 → +5, 5000+ → +8. Forks: 50+ → +2, 500+ → +4. This means a 30k-star repo's issues score up to +12 higher than a 10-star spam repo. `ProjectHealth` now includes `stargazersCount` and `forksCount`. Closes #98.
+
 ## [0.16.0] - 2026-02-10
 
 ### Changed
@@ -414,6 +421,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR monitoring and health checking
 - Dashboard HTML generation
 
+[0.17.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.15.1...v0.16.0
 [0.15.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.14.0...v0.15.0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Discover issues worth contributing to, track your PRs across repos, and draft responses to maintainer feedback. An AI copilot for your open source journey.
 
-![Version](https://img.shields.io/badge/version-0.16.0-blue)
+![Version](https://img.shields.io/badge/version-0.17.0-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)
 ![Node Version](https://img.shields.io/badge/node-%3E%3D18-brightgreen)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "AI-powered autopilot for managing open source contributions with Claude Code",
   "type": "module",
   "main": "dist/cli.js",

--- a/src/core/issue-discovery.test.ts
+++ b/src/core/issue-discovery.test.ts
@@ -23,7 +23,14 @@ vi.mock('./state.js', () => ({
   })),
 }));
 
-const { IssueDiscovery } = await import('./issue-discovery.js');
+const {
+  IssueDiscovery,
+  isLabelFarming,
+  hasTemplatedTitle,
+  detectLabelFarmingRepos,
+  calculateRepoQualityBonus,
+  BEGINNER_LABELS,
+} = await import('./issue-discovery.js');
 
 describe('IssueDiscovery.calculateViabilityScore', () => {
   let discovery: InstanceType<typeof IssueDiscovery>;
@@ -329,7 +336,7 @@ describe('IssueDiscovery.vetIssue inconclusive downgrade', () => {
       },
       repos: {
         get: vi.fn().mockResolvedValue({
-          data: { open_issues_count: 5, pushed_at: '2026-02-01T00:00:00Z' },
+          data: { open_issues_count: 5, pushed_at: '2026-02-01T00:00:00Z', stargazers_count: 100, forks_count: 20 },
         }),
         listCommits: vi.fn().mockResolvedValue({
           data: [{ commit: { author: { date: '2026-02-01T00:00:00Z' } } }],
@@ -392,5 +399,301 @@ describe('IssueDiscovery.vetIssue inconclusive downgrade', () => {
     expect(candidate.vettingResult.notes).toContainEqual(
       expect.stringContaining('Could not verify project activity')
     );
+  });
+
+  it('should note unavailable quality bonus when health check fails', async () => {
+    mockOctokitInstance.repos.get.mockRejectedValue(new Error('Not Found'));
+
+    const candidate = await discovery.vetIssue('https://github.com/owner/repo/issues/42');
+    expect(candidate.vettingResult.notes).toContainEqual(
+      expect.stringContaining('Repo quality bonus unavailable')
+    );
+  });
+
+  it('should populate stargazersCount and forksCount from checkProjectHealth', async () => {
+    mockOctokitInstance.repos.get.mockResolvedValue({
+      data: { open_issues_count: 5, pushed_at: '2026-02-01T00:00:00Z', stargazers_count: 5000, forks_count: 800 },
+    });
+
+    const candidate = await discovery.vetIssue('https://github.com/owner/repo/issues/42');
+    expect(candidate.projectHealth.stargazersCount).toBe(5000);
+    expect(candidate.projectHealth.forksCount).toBe(800);
+  });
+});
+
+describe('isLabelFarming', () => {
+  const makeItem = (labels: string[]) => ({
+    html_url: 'https://github.com/spam/repo/issues/1',
+    repository_url: 'https://api.github.com/repos/spam/repo',
+    updated_at: '2026-01-01T00:00:00Z',
+    labels: labels.map(name => ({ name })),
+  });
+
+  it('should return false with 4 beginner labels', () => {
+    expect(isLabelFarming(makeItem([
+      'good first issue', 'hacktoberfest', 'easy', 'beginner',
+    ]))).toBe(false);
+  });
+
+  it('should return true with 5 beginner labels', () => {
+    expect(isLabelFarming(makeItem([
+      'good first issue', 'hacktoberfest', 'easy', 'beginner', 'starter',
+    ]))).toBe(true);
+  });
+
+  it('should count only beginner labels, ignoring non-beginner labels', () => {
+    expect(isLabelFarming(makeItem([
+      'good first issue', 'hacktoberfest', 'bug', 'enhancement', 'easy', 'documentation',
+    ]))).toBe(false); // Only 3 beginner labels
+  });
+
+  it('should handle string labels', () => {
+    const item = {
+      html_url: 'https://github.com/spam/repo/issues/1',
+      repository_url: 'https://api.github.com/repos/spam/repo',
+      updated_at: '2026-01-01T00:00:00Z',
+      labels: ['good first issue', 'hacktoberfest', 'easy', 'beginner', 'newbie'] as any,
+    };
+    expect(isLabelFarming(item)).toBe(true);
+  });
+
+  it('should return false when no labels present', () => {
+    const item = {
+      html_url: 'https://github.com/spam/repo/issues/1',
+      repository_url: 'https://api.github.com/repos/spam/repo',
+      updated_at: '2026-01-01T00:00:00Z',
+    };
+    expect(isLabelFarming(item)).toBe(false);
+  });
+
+  it('should be case-insensitive', () => {
+    expect(isLabelFarming(makeItem([
+      'Good First Issue', 'HACKTOBERFEST', 'Easy', 'Beginner', 'Starter',
+    ]))).toBe(true);
+  });
+});
+
+describe('hasTemplatedTitle', () => {
+  it('should detect "Add Trivia Question 61"', () => {
+    expect(hasTemplatedTitle('Add Trivia Question 61')).toBe(true);
+  });
+
+  it('should detect "Create Entry #5"', () => {
+    expect(hasTemplatedTitle('Create Entry #5')).toBe(true);
+  });
+
+  it('should detect "Update Documentation Item 12"', () => {
+    expect(hasTemplatedTitle('Update Documentation Item 12')).toBe(true);
+  });
+
+  it('should detect "Write Blog Post #42"', () => {
+    expect(hasTemplatedTitle('Write Blog Post #42')).toBe(true);
+  });
+
+  it('should detect "Implement Feature Task 7"', () => {
+    expect(hasTemplatedTitle('Implement Feature Task 7')).toBe(true);
+  });
+
+  it('should NOT detect "Fix authentication bug"', () => {
+    expect(hasTemplatedTitle('Fix authentication bug')).toBe(false);
+  });
+
+  it('should NOT detect "Add dark mode support"', () => {
+    expect(hasTemplatedTitle('Add dark mode support')).toBe(false);
+  });
+
+  it('should NOT detect empty string', () => {
+    expect(hasTemplatedTitle('')).toBe(false);
+  });
+
+  it('should NOT detect "Update the README with installation instructions"', () => {
+    expect(hasTemplatedTitle('Update the README with installation instructions')).toBe(false);
+  });
+
+  // False-positive resistance: legitimate titles ending in numbers
+  it('should NOT detect "Add support for Python 3.12"', () => {
+    expect(hasTemplatedTitle('Add support for Python 3.12')).toBe(false);
+  });
+
+  it('should NOT detect "Implement RFC 7231"', () => {
+    expect(hasTemplatedTitle('Implement RFC 7231')).toBe(false);
+  });
+
+  it('should NOT detect "Update CI pipeline to use Node 22"', () => {
+    expect(hasTemplatedTitle('Update CI pipeline to use Node 22')).toBe(false);
+  });
+});
+
+describe('detectLabelFarmingRepos', () => {
+  const makeItem = (repo: string, opts: { labels?: string[]; title?: string } = {}) => ({
+    html_url: `https://github.com/${repo}/issues/1`,
+    repository_url: `https://api.github.com/repos/${repo}`,
+    updated_at: '2026-01-01T00:00:00Z',
+    title: opts.title || 'Some issue',
+    labels: (opts.labels || []).map(name => ({ name })),
+  });
+
+  it('should flag repo with single issue having 5+ beginner labels', () => {
+    const items = [
+      makeItem('spam/repo', {
+        labels: ['good first issue', 'hacktoberfest', 'easy', 'beginner', 'starter'],
+      }),
+      makeItem('legit/project', { labels: ['bug'] }),
+    ];
+    const spamRepos = detectLabelFarmingRepos(items);
+    expect(spamRepos.has('spam/repo')).toBe(true);
+    expect(spamRepos.has('legit/project')).toBe(false);
+  });
+
+  it('should flag repo with 3+ templated title issues', () => {
+    const items = [
+      makeItem('spam/trivia', { title: 'Add Trivia Question 1' }),
+      makeItem('spam/trivia', { title: 'Add Trivia Question 2' }),
+      makeItem('spam/trivia', { title: 'Add Trivia Question 3' }),
+      makeItem('legit/project', { title: 'Fix login redirect' }),
+    ];
+    const spamRepos = detectLabelFarmingRepos(items);
+    expect(spamRepos.has('spam/trivia')).toBe(true);
+    expect(spamRepos.has('legit/project')).toBe(false);
+  });
+
+  it('should NOT flag repo with only 2 templated title issues', () => {
+    const items = [
+      makeItem('borderline/repo', { title: 'Add Question 1' }),
+      makeItem('borderline/repo', { title: 'Add Question 2' }),
+    ];
+    const spamRepos = detectLabelFarmingRepos(items);
+    expect(spamRepos.has('borderline/repo')).toBe(false);
+  });
+
+  it('should return empty set for clean items', () => {
+    const items = [
+      makeItem('legit/a', { title: 'Fix memory leak', labels: ['bug'] }),
+      makeItem('legit/b', { title: 'Add feature X', labels: ['good first issue'] }),
+    ];
+    const spamRepos = detectLabelFarmingRepos(items);
+    expect(spamRepos.size).toBe(0);
+  });
+
+  it('should handle mixed spam signals across repos', () => {
+    const items = [
+      // Spam repo via labels
+      makeItem('spam/labels', {
+        labels: ['good first issue', 'hacktoberfest', 'easy', 'beginner', 'community'],
+      }),
+      // Spam repo via templated titles (need 3)
+      makeItem('spam/titles', { title: 'Create Entry 1' }),
+      makeItem('spam/titles', { title: 'Create Entry 2' }),
+      makeItem('spam/titles', { title: 'Create Entry 3' }),
+      // Legit
+      makeItem('legit/project', { title: 'Improve error handling' }),
+    ];
+    const spamRepos = detectLabelFarmingRepos(items);
+    expect(spamRepos.has('spam/labels')).toBe(true);
+    expect(spamRepos.has('spam/titles')).toBe(true);
+    expect(spamRepos.has('legit/project')).toBe(false);
+  });
+});
+
+describe('calculateRepoQualityBonus', () => {
+  it('should return 0 for tiny repo (< 50 stars, < 50 forks)', () => {
+    expect(calculateRepoQualityBonus(10, 5)).toBe(0);
+  });
+
+  it('should return 3 for small repo (50-499 stars)', () => {
+    expect(calculateRepoQualityBonus(100, 20)).toBe(3);
+  });
+
+  it('should return 7 for medium repo (500-4999 stars, 50+ forks)', () => {
+    expect(calculateRepoQualityBonus(1000, 100)).toBe(7); // 5 stars + 2 forks
+  });
+
+  it('should return 12 for large repo (5000+ stars, 500+ forks)', () => {
+    expect(calculateRepoQualityBonus(30000, 5000)).toBe(12); // 8 stars + 4 forks
+  });
+
+  it('should return 12 for very large repo (natural max)', () => {
+    expect(calculateRepoQualityBonus(50000, 10000)).toBe(12); // 8 + 4
+  });
+
+  it('should return 8 for high-star low-fork repo', () => {
+    expect(calculateRepoQualityBonus(10000, 30)).toBe(8); // 8 stars + 0 forks
+  });
+
+  it('should return 4 for low-star high-fork repo', () => {
+    expect(calculateRepoQualityBonus(10, 1000)).toBe(4); // 0 stars + 4 forks
+  });
+
+  it('should handle exact boundary values', () => {
+    expect(calculateRepoQualityBonus(50, 0)).toBe(3);    // exactly 50 stars
+    expect(calculateRepoQualityBonus(500, 0)).toBe(5);   // exactly 500 stars
+    expect(calculateRepoQualityBonus(5000, 0)).toBe(8);  // exactly 5000 stars
+    expect(calculateRepoQualityBonus(0, 50)).toBe(2);    // exactly 50 forks
+    expect(calculateRepoQualityBonus(0, 500)).toBe(4);   // exactly 500 forks
+  });
+
+  it('should return 0 for zero stars and forks', () => {
+    expect(calculateRepoQualityBonus(0, 0)).toBe(0);
+  });
+});
+
+describe('calculateViabilityScore with repoQualityBonus', () => {
+  let discovery: InstanceType<typeof IssueDiscovery>;
+
+  beforeEach(() => {
+    mockOctokitInstance = {};
+    discovery = new IssueDiscovery('fake-token');
+  });
+
+  const baseParams = {
+    repoScore: null as number | null,
+    hasExistingPR: false,
+    isClaimed: false,
+    clearRequirements: false,
+    hasContributionGuidelines: false,
+    issueUpdatedAt: '2020-01-01T00:00:00Z',
+    closedWithoutMergeCount: 0,
+    mergedPRCount: 0,
+    orgHasMergedPRs: false,
+  };
+
+  it('should add repoQualityBonus to base score', () => {
+    const score = discovery.calculateViabilityScore({ ...baseParams, repoQualityBonus: 8 });
+    expect(score).toBe(58); // 50 + 8
+  });
+
+  it('should default to 0 when repoQualityBonus is undefined', () => {
+    const score = discovery.calculateViabilityScore(baseParams);
+    expect(score).toBe(50);
+  });
+
+  it('should still clamp to 100 with quality bonus', () => {
+    const recent = new Date();
+    recent.setDate(recent.getDate() - 1);
+    const score = discovery.calculateViabilityScore({
+      repoScore: 10,            // +20
+      hasExistingPR: false,
+      isClaimed: false,
+      clearRequirements: true,   // +15
+      hasContributionGuidelines: true, // +10
+      issueUpdatedAt: recent.toISOString(), // +15
+      closedWithoutMergeCount: 0,
+      mergedPRCount: 0,
+      orgHasMergedPRs: true,     // +5
+      repoQualityBonus: 12,      // +12
+    });
+    // 50 + 20 + 12 + 15 + 15 + 10 + 5 = 127, clamped to 100
+    expect(score).toBe(100);
+  });
+
+  it('should combine quality bonus with other bonuses and penalties', () => {
+    const score = discovery.calculateViabilityScore({
+      ...baseParams,
+      repoQualityBonus: 7,       // +7
+      clearRequirements: true,    // +15
+      isClaimed: true,            // -20
+    });
+    // 50 + 7 + 15 - 20 = 52
+    expect(score).toBe(52);
   });
 });

--- a/src/core/issue-discovery.ts
+++ b/src/core/issue-discovery.ts
@@ -25,6 +25,8 @@ interface GitHubSearchItem {
   html_url: string;
   repository_url: string;
   updated_at: string;
+  title?: string;
+  labels?: Array<{ name?: string } | string>;
   [key: string]: unknown;
 }
 
@@ -73,6 +75,98 @@ function pruneCache(): void {
       guidelinesCache.delete(key);
     }
   }
+}
+
+/** Known beginner-type label names used to detect label-farming repos (#97). */
+export const BEGINNER_LABELS = new Set([
+  'good first issue',
+  'hacktoberfest',
+  'easy',
+  'up-for-grabs',
+  'first-timers-only',
+  'beginner-friendly',
+  'beginner',
+  'starter',
+  'newbie',
+  'low-hanging-fruit',
+  'community',
+]);
+
+/** Check if a single issue has an excessive number of beginner labels (>= 5). */
+export function isLabelFarming(item: GitHubSearchItem): boolean {
+  if (!item.labels || !Array.isArray(item.labels)) return false;
+  const labelNames = item.labels.map(l =>
+    (typeof l === 'string' ? l : l.name || '').toLowerCase()
+  );
+  const beginnerCount = labelNames.filter(n => BEGINNER_LABELS.has(n)).length;
+  return beginnerCount >= 5;
+}
+
+/** Detect mass-created issue titles like "Add Trivia Question 61" or "Create Entry #5". */
+export function hasTemplatedTitle(title: string): boolean {
+  if (!title) return false;
+  // Matches "<anything> <category-noun> <number>" where category nouns are typical
+  // of mass-created templated issues. This avoids false positives on legitimate titles
+  // like "Add support for Python 3" or "Implement RFC 7231" which lack category nouns.
+  return /^.+\s+(question|fact|point|item|task|entry|post|challenge|exercise|example|problem|tip|recipe|snippet)\s+#?\d+$/i.test(title);
+}
+
+/**
+ * Batch-analyze search items to detect label-farming repositories (#97).
+ * Returns a Set of repo full names (owner/repo) that appear to be spam.
+ *
+ * A repo is flagged if:
+ * - ANY single issue has >= 5 beginner labels (strong individual signal), OR
+ * - It has >= 3 issues with templated titles (batch signal)
+ */
+export function detectLabelFarmingRepos(items: GitHubSearchItem[]): Set<string> {
+  const spamRepos = new Set<string>();
+  const repoSpamCounts = new Map<string, number>();
+
+  for (const item of items) {
+    const repoFullName = item.repository_url.split('/').slice(-2).join('/');
+
+    // Strong signal: single issue with 5+ beginner labels
+    if (isLabelFarming(item)) {
+      spamRepos.add(repoFullName);
+      continue;
+    }
+
+    // Weaker signal: templated title
+    if (item.title && hasTemplatedTitle(item.title)) {
+      repoSpamCounts.set(repoFullName, (repoSpamCounts.get(repoFullName) || 0) + 1);
+    }
+  }
+
+  // Flag repos with 3+ templated-title issues
+  for (const [repo, count] of repoSpamCounts) {
+    if (count >= 3) {
+      spamRepos.add(repo);
+    }
+  }
+
+  return spamRepos;
+}
+
+/**
+ * Calculate a quality bonus based on repo star and fork counts (#98).
+ * Stars: <50 → 0, 50-499 → +3, 500-4999 → +5, 5000+ → +8
+ * Forks: 50+ → +2, 500+ → +4
+ * Natural max is 12 (8 stars + 4 forks).
+ */
+export function calculateRepoQualityBonus(stargazersCount: number, forksCount: number): number {
+  let bonus = 0;
+
+  // Star tiers
+  if (stargazersCount >= 5000) bonus += 8;
+  else if (stargazersCount >= 500) bonus += 5;
+  else if (stargazersCount >= 50) bonus += 3;
+
+  // Fork tiers
+  if (forksCount >= 500) bonus += 4;
+  else if (forksCount >= 50) bonus += 2;
+
+  return bonus;
 }
 
 export class IssueDiscovery {
@@ -279,9 +373,24 @@ export class IssueDiscovery {
 
         console.log(`Found ${data.total_count} issues in general search, processing top ${data.items.length}...`);
 
+        // Detect and filter label-farming repos (#97)
+        const spamRepos = detectLabelFarmingRepos(data.items);
+        if (spamRepos.size > 0) {
+          const spamCount = data.items.filter(i =>
+            spamRepos.has(i.repository_url.split('/').slice(-2).join('/'))
+          ).length;
+          console.log(
+            `[SPAM_FILTER] Filtered ${spamCount} issues from ${spamRepos.size} label-farming repos: ${[...spamRepos].join(', ')}`
+          );
+        }
+
         // Filter and exclude already-found repos
         const seenRepos = new Set(allCandidates.map(c => c.issue.repo));
         const itemsToVet = filterIssues(data.items)
+          .filter(item => {
+            const repoFullName = item.repository_url.split('/').slice(-2).join('/');
+            return !spamRepos.has(repoFullName);
+          })
           .filter(item => {
             const repoFullName = item.repository_url.split('/').slice(-2).join('/');
             // Skip if already searched in earlier phases
@@ -621,6 +730,15 @@ export class IssueDiscovery {
       vettingResult.notes.push('Recommendation downgraded: one or more checks were inconclusive');
     }
 
+    // Calculate repo quality bonus from star/fork counts (#98)
+    const repoQualityBonus = calculateRepoQualityBonus(
+      projectHealth.stargazersCount ?? 0,
+      projectHealth.forksCount ?? 0,
+    );
+    if (projectHealth.checkFailed && repoQualityBonus === 0) {
+      vettingResult.notes.push('Repo quality bonus unavailable: could not fetch star/fork counts due to API error');
+    }
+
     // Calculate viability score
     const viabilityScore = this.calculateViabilityScore({
       repoScore: this.getRepoScore(repoFullName),
@@ -632,6 +750,7 @@ export class IssueDiscovery {
       closedWithoutMergeCount: repoScoreRecord?.closedWithoutMergeCount ?? 0,
       mergedPRCount: repoScoreRecord?.mergedPRCount ?? 0,
       orgHasMergedPRs,
+      repoQualityBonus,
     });
 
     // Determine search priority
@@ -784,6 +903,8 @@ export class IssueDiscovery {
         avgIssueResponseDays: 0, // Would need more API calls to calculate
         ciStatus,
         isActive: daysSinceLastCommit < 30,
+        stargazersCount: repoData.stargazers_count,
+        forksCount: repoData.forks_count,
       };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
@@ -923,6 +1044,7 @@ export class IssueDiscovery {
    * Scoring:
    * - Base: 50 points
    * - +repoScore*2 (up to +20 for score of 10)
+   * - +repoQualityBonus (up to +12 for established repos, from star/fork counts) (#98)
    * - +15 for clear requirements (clarity)
    * - +15 for freshness (recently updated)
    * - +10 for contribution guidelines
@@ -941,6 +1063,7 @@ export class IssueDiscovery {
     closedWithoutMergeCount: number;
     mergedPRCount: number;
     orgHasMergedPRs: boolean;
+    repoQualityBonus?: number;
   }): number {
     let score = 50; // Base score
 
@@ -948,6 +1071,9 @@ export class IssueDiscovery {
     if (params.repoScore !== null) {
       score += params.repoScore * 2;
     }
+
+    // Repo quality bonus from star/fork counts (#98, up to +12)
+    score += params.repoQualityBonus ?? 0;
 
     // Clarity bonus (+15)
     if (params.clearRequirements) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -323,6 +323,10 @@ export interface ProjectHealth {
   ciStatus: 'passing' | 'failing' | 'unknown';
   /** Whether the project is considered active based on recent commit history. */
   isActive: boolean;
+  /** GitHub star count, used for repo quality scoring (#98). */
+  stargazersCount?: number;
+  /** GitHub fork count, used for repo quality scoring (#98). */
+  forksCount?: number;
   /** True if the health check itself failed (e.g., API error). */
   checkFailed?: boolean;
   failureReason?: string;


### PR DESCRIPTION
## Summary

- **Label-farming spam filter (#97)** — Phase 2 (general search) now detects and filters repos that mass-create beginner-labeled issues. Two signals: single issues with 5+ beginner labels (strong), and repos with 3+ templated titles like "Add Trivia Question 61" (batch). Phases 0/1 (user's own repos) are unaffected.
- **Repo quality bonus (#98)** — Viability scores now include a quality bonus based on star/fork counts. Stars: <50 → +0, 50-499 → +3, 500-4999 → +5, 5000+ → +8. Forks: 50+ → +2, 500+ → +4. A 30k-star repo's issues score up to +12 higher than a 10-star spam repo.
- `ProjectHealth` now includes `stargazersCount` and `forksCount`

## Test plan

- [x] All 396 tests pass (38 new: spam detection, quality bonus, viability score integration)
- [x] Bundle builds at 530KB
- [x] Version bumped to 0.17.0 in all 3 locations
- [x] CHANGELOG updated with comparison link

Closes #97, closes #98