### PR TITLE
feat: add merged-PR prioritization and rate limit handling to issue search

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "AI-powered autopilot for managing open source contributions - track PRs, respond to maintainers, discover issues, and maintain contribution velocity",
   "author": {
     "name": "John Costa"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0] - 2026-02-10
+
+### Added
+
+- **Merged-PR viability bonus** — Issues in repos where the user has merged PRs now receive a +15 viability score bonus, stacking with the existing org affinity (+5) for up to +20 total relationship bonus. This makes proven repos surface higher in search results. Closes #99.
+- **Phase 0 open-PR repo expansion** — Phase 0 search now includes repos where the user has interacted (score data exists) but hasn't merged yet. These open-PR repos fill remaining Phase 0 slots after merged-PR repos, capped at 10 total. New `getReposWithOpenPRs()` method on StateManager. Closes #99.
+- **Viability score as tertiary sort key** — Within the same priority tier and recommendation level, candidates are now sorted by viability score (highest first), preventing arbitrary ordering among equally-recommended issues. Closes #99.
+- **Pre-flight rate limit check** — `searchIssues()` now calls `checkRateLimit()` before starting search phases. When remaining quota < 5, logs a warning with quota info and reset time. The warning is also surfaced in `--json` output via the new `rateLimitWarning` field on `SearchOutput`. Closes #100.
+- **`checkRateLimit()` utility** — New exported function in `github.ts` that queries the GitHub Search API rate limit endpoint and returns `{ remaining, limit, resetAt }`. Closes #100.
+- **Enhanced rate limit retry logging** — `onRateLimit` and `onSecondaryRateLimit` callbacks now log retry count, wait duration, and reset time (e.g., "Rate limit hit (retry 1/2, waiting 30s, resets at 14:52:00)") instead of bare "Retrying after N seconds...". Closes #100.
+- **Graceful partial result context** — When no candidates are found and rate limits were hit during search, the error message now includes "GitHub API rate limits may have affected results" to help users understand the failure. Closes #100.
+
 ## [0.17.0] - 2026-02-10
 
 ### Changed
@@ -421,6 +433,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR monitoring and health checking
 - Dashboard HTML generation
 
+[0.18.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.15.1...v0.16.0
 [0.15.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.15.0...v0.15.1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Discover issues worth contributing to, track your PRs across repos, and draft responses to maintainer feedback. An AI copilot for your open source journey.
 
-![Version](https://img.shields.io/badge/version-0.17.0-blue)
+![Version](https://img.shields.io/badge/version-0.18.0-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)
 ![Node Version](https://img.shields.io/badge/node-%3E%3D18-brightgreen)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "AI-powered autopilot for managing open source contributions with Claude Code",
   "type": "module",
   "main": "dist/cli.js",

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -37,7 +37,7 @@ export async function runSearch(options: SearchOptions): Promise<void> {
   if (options.json) {
     const stateManager = getStateManager();
     const excludedRepos = stateManager.getState().config.excludeRepos || [];
-    outputJson<SearchOutput>({
+    const searchOutput: SearchOutput = {
       candidates: candidates.map(c => {
         const repoScoreRecord = stateManager.getRepoScore(c.issue.repo);
         return {
@@ -63,11 +63,19 @@ export async function runSearch(options: SearchOptions): Promise<void> {
         };
       }),
       excludedRepos,
-    });
+    };
+    if (discovery.rateLimitWarning) {
+      searchOutput.rateLimitWarning = discovery.rateLimitWarning;
+    }
+    outputJson<SearchOutput>(searchOutput);
   } else {
     if (candidates.length === 0) {
       console.log('No matching issues found.');
       return;
+    }
+
+    if (discovery.rateLimitWarning) {
+      console.warn(`\n⚠ ${discovery.rateLimitWarning}\n`);
     }
 
     console.log(`Found ${candidates.length} candidates:\n`);

--- a/src/core/github.test.ts
+++ b/src/core/github.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for github.ts — checkRateLimit utility
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+let mockOctokitInstance: any;
+
+vi.mock('@octokit/rest', () => ({
+  Octokit: {
+    plugin: () =>
+      class MockOctokit {
+        constructor() {
+          return mockOctokitInstance;
+        }
+      },
+  },
+}));
+
+vi.mock('@octokit/plugin-throttling', () => ({
+  throttling: {},
+}));
+
+// Must import after mocks are set up
+const { checkRateLimit } = await import('./github.js');
+
+describe('checkRateLimit', () => {
+  beforeEach(() => {
+    // Reset cached octokit instance by providing a new token each test
+    mockOctokitInstance = {
+      rateLimit: {
+        get: vi.fn(),
+      },
+    };
+  });
+
+  it('should return search rate limit info', async () => {
+    const resetTimestamp = Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
+    mockOctokitInstance.rateLimit.get.mockResolvedValue({
+      data: {
+        resources: {
+          search: {
+            remaining: 25,
+            limit: 30,
+            reset: resetTimestamp,
+          },
+        },
+      },
+    });
+
+    const result = await checkRateLimit('test-token-1');
+    expect(result.remaining).toBe(25);
+    expect(result.limit).toBe(30);
+    expect(result.resetAt).toBe(new Date(resetTimestamp * 1000).toISOString());
+  });
+
+  it('should return low remaining when quota is nearly exhausted', async () => {
+    const resetTimestamp = Math.floor(Date.now() / 1000) + 600;
+    mockOctokitInstance.rateLimit.get.mockResolvedValue({
+      data: {
+        resources: {
+          search: {
+            remaining: 2,
+            limit: 30,
+            reset: resetTimestamp,
+          },
+        },
+      },
+    });
+
+    const result = await checkRateLimit('test-token-2');
+    expect(result.remaining).toBe(2);
+    expect(result.limit).toBe(30);
+  });
+
+  it('should propagate API errors', async () => {
+    mockOctokitInstance.rateLimit.get.mockRejectedValue(new Error('Bad credentials'));
+    await expect(checkRateLimit('test-token-3')).rejects.toThrow('Bad credentials');
+  });
+});

--- a/src/core/github.ts
+++ b/src/core/github.ts
@@ -7,8 +7,23 @@ import { throttling } from '@octokit/plugin-throttling';
 
 const ThrottledOctokit = Octokit.plugin(throttling);
 
+/** Rate limit info returned by {@link checkRateLimit}. */
+export interface RateLimitInfo {
+  /** Remaining search API requests in current window. */
+  remaining: number;
+  /** Total search API request limit per window. */
+  limit: number;
+  /** ISO timestamp when the rate limit window resets. */
+  resetAt: string;
+}
+
 let _octokit: Octokit | null = null;
 let _currentToken: string | null = null;
+
+/** Format a Date as HH:MM:SS for log messages. */
+function formatResetTime(date: Date): string {
+  return date.toLocaleTimeString('en-US', { hour12: false });
+}
 
 export function getOctokit(token: string): Octokit {
   // Return cached instance only if token matches
@@ -19,21 +34,30 @@ export function getOctokit(token: string): Octokit {
     throttle: {
       onRateLimit: (retryAfter, options, octokit, retryCount) => {
         const opts = options as { method: string; url: string };
-        console.warn(`Rate limit hit for ${opts.method} ${opts.url}`);
+        const resetAt = new Date(Date.now() + retryAfter * 1000);
         if (retryCount < 2) {
-          console.log(`Retrying after ${retryAfter} seconds...`);
+          console.warn(
+            `Rate limit hit (retry ${retryCount + 1}/2, waiting ${retryAfter}s, resets at ${formatResetTime(resetAt)}) — ${opts.method} ${opts.url}`
+          );
           return true;
         }
-        console.error('Rate limit exceeded, not retrying');
+        console.error(
+          `Rate limit exceeded, not retrying — ${opts.method} ${opts.url} (resets at ${formatResetTime(resetAt)})`
+        );
         return false;
       },
       onSecondaryRateLimit: (retryAfter, options, octokit, retryCount) => {
         const opts = options as { method: string; url: string };
-        console.warn(`Secondary rate limit hit for ${opts.method} ${opts.url}`);
+        const resetAt = new Date(Date.now() + retryAfter * 1000);
         if (retryCount < 1) {
-          console.log(`Retrying after ${retryAfter} seconds...`);
+          console.warn(
+            `Secondary rate limit hit (retry ${retryCount + 1}/1, waiting ${retryAfter}s, resets at ${formatResetTime(resetAt)}) — ${opts.method} ${opts.url}`
+          );
           return true;
         }
+        console.error(
+          `Secondary rate limit exceeded, not retrying — ${opts.method} ${opts.url} (resets at ${formatResetTime(resetAt)})`
+        );
         return false;
       },
     },
@@ -41,4 +65,19 @@ export function getOctokit(token: string): Octokit {
 
   _currentToken = token;
   return _octokit;
+}
+
+/**
+ * Check the GitHub Search API rate limit quota.
+ * Returns the remaining requests, total limit, and reset time for the search endpoint.
+ */
+export async function checkRateLimit(token: string): Promise<RateLimitInfo> {
+  const octokit = getOctokit(token);
+  const { data } = await octokit.rateLimit.get();
+  const search = data.resources.search;
+  return {
+    remaining: search.remaining,
+    limit: search.limit,
+    resetAt: new Date(search.reset * 1000).toISOString(),
+  };
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -6,7 +6,7 @@
 export { StateManager, getStateManager, resetStateManager } from './state.js';
 export { PRMonitor, type PRCheckFailure, type FetchPRsResult, computeDisplayLabel, classifyCICheck, classifyFailingChecks } from './pr-monitor.js';
 export { IssueDiscovery, type IssueCandidate, type SearchPriority } from './issue-discovery.js';
-export { getOctokit } from './github.js';
+export { getOctokit, checkRateLimit, type RateLimitInfo } from './github.js';
 export {
   parseGitHubUrl,
   daysBetween,

--- a/src/core/issue-discovery.test.ts
+++ b/src/core/issue-discovery.test.ts
@@ -8,6 +8,7 @@ let mockOctokitInstance: any;
 
 vi.mock('./github.js', () => ({
   getOctokit: vi.fn(() => mockOctokitInstance),
+  checkRateLimit: vi.fn().mockResolvedValue({ remaining: 30, limit: 30, resetAt: new Date().toISOString() }),
 }));
 
 vi.mock('./state.js', () => ({
@@ -18,6 +19,7 @@ vi.mock('./state.js', () => ({
     }),
     getStarredRepos: () => [],
     getReposWithMergedPRs: () => [],
+    getReposWithOpenPRs: () => [],
     getLowScoringRepos: () => [],
     getRepoScore: () => undefined,
   })),
@@ -166,6 +168,40 @@ describe('IssueDiscovery.calculateViabilityScore', () => {
     expect(score).toBe(80);
   });
 
+  it('should add +15 for merged PR in this repo (#99)', () => {
+    const score = discovery.calculateViabilityScore({
+      ...baseParams,
+      mergedPRCount: 1,
+    });
+    expect(score).toBe(50 + 15);
+  });
+
+  it('should add +15 for merged PR even with multiple merges (#99)', () => {
+    const score = discovery.calculateViabilityScore({
+      ...baseParams,
+      mergedPRCount: 5,
+    });
+    expect(score).toBe(50 + 15);
+  });
+
+  it('should NOT add merged PR bonus when mergedPRCount is 0', () => {
+    const score = discovery.calculateViabilityScore({
+      ...baseParams,
+      mergedPRCount: 0,
+    });
+    expect(score).toBe(50);
+  });
+
+  it('should stack merged PR bonus (+15) with org affinity (+5) for +20 total relationship bonus', () => {
+    const score = discovery.calculateViabilityScore({
+      ...baseParams,
+      mergedPRCount: 2,
+      orgHasMergedPRs: true,
+    });
+    // 50 + 15 (merged PR) + 5 (org affinity) = 70
+    expect(score).toBe(70);
+  });
+
   it('should subtract -15 for closed-without-merge history with no merges', () => {
     const score = discovery.calculateViabilityScore({
       ...baseParams,
@@ -181,8 +217,8 @@ describe('IssueDiscovery.calculateViabilityScore', () => {
       closedWithoutMergeCount: 1,
       mergedPRCount: 2,
     });
-    // No -15 penalty because mergedPRCount > 0
-    expect(score).toBe(50);
+    // No -15 penalty because mergedPRCount > 0, but +15 merged PR bonus applies
+    expect(score).toBe(50 + 15);
   });
 
   it('should NOT subtract penalty when closedWithoutMergeCount is 0', () => {
@@ -695,5 +731,38 @@ describe('calculateViabilityScore with repoQualityBonus', () => {
     });
     // 50 + 7 + 15 - 20 = 52
     expect(score).toBe(52);
+  });
+});
+
+describe('IssueDiscovery.isRateLimitError', () => {
+  const isRateLimitError = (IssueDiscovery as any).isRateLimitError;
+
+  it('should return true for HTTP 429', () => {
+    const error = Object.assign(new Error('Too Many Requests'), { status: 429 });
+    expect(isRateLimitError(error)).toBe(true);
+  });
+
+  it('should return true for HTTP 403 with "rate limit" in message', () => {
+    const error = Object.assign(new Error('API rate limit exceeded'), { status: 403 });
+    expect(isRateLimitError(error)).toBe(true);
+  });
+
+  it('should return false for HTTP 403 without rate limit message', () => {
+    const error = Object.assign(new Error('Resource not accessible by integration'), { status: 403 });
+    expect(isRateLimitError(error)).toBe(false);
+  });
+
+  it('should return false for HTTP 500', () => {
+    const error = Object.assign(new Error('Internal Server Error'), { status: 500 });
+    expect(isRateLimitError(error)).toBe(false);
+  });
+
+  it('should return false for errors without status', () => {
+    expect(isRateLimitError(new Error('Network timeout'))).toBe(false);
+  });
+
+  it('should return false for null/undefined', () => {
+    expect(isRateLimitError(null)).toBe(false);
+    expect(isRateLimitError(undefined)).toBe(false);
   });
 });

--- a/src/core/issue-discovery.ts
+++ b/src/core/issue-discovery.ts
@@ -6,7 +6,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { Octokit } from '@octokit/rest';
-import { getOctokit } from './github.js';
+import { getOctokit, checkRateLimit } from './github.js';
 import { getStateManager } from './state.js';
 import { parseGitHubUrl, daysBetween, getDataDir } from './utils.js';
 import {
@@ -172,8 +172,13 @@ export function calculateRepoQualityBonus(stargazersCount: number, forksCount: n
 export class IssueDiscovery {
   private octokit: Octokit;
   private stateManager: ReturnType<typeof getStateManager>;
+  private githubToken: string;
+
+  /** Set after searchIssues() runs if rate limits affected the search (low pre-flight quota or mid-search rate limit hits). */
+  rateLimitWarning: string | null = null;
 
   constructor(githubToken: string) {
+    this.githubToken = githubToken;
     this.octokit = getOctokit(githubToken);
     this.stateManager = getStateManager();
   }
@@ -272,10 +277,33 @@ export class IssueDiscovery {
     const allCandidates: IssueCandidate[] = [];
     let phase0Error: string | null = null;
     let phase1Error: string | null = null;
+    let rateLimitHitDuringSearch = false;
+
+    // Pre-flight rate limit check (#100)
+    this.rateLimitWarning = null;
+    try {
+      const rateLimit = await checkRateLimit(this.githubToken);
+      if (rateLimit.remaining < 5) {
+        const resetTime = new Date(rateLimit.resetAt).toLocaleTimeString('en-US', { hour12: false });
+        this.rateLimitWarning =
+          `GitHub search API quota low (${rateLimit.remaining}/${rateLimit.limit} remaining, resets at ${resetTime}). Search may be slow.`;
+        console.warn(this.rateLimitWarning);
+      }
+    } catch (error) {
+      // Fail fast on auth errors — no point searching with a bad token
+      if ((error as any)?.status === 401) {
+        throw error;
+      }
+      // Non-fatal: proceed with search for transient/network errors
+      console.warn('[RATE_LIMIT_CHECK] Could not check rate limit:', error instanceof Error ? error.message : error);
+    }
 
     // Get merged-PR repos (highest merge probability)
     const mergedPRRepos = this.stateManager.getReposWithMergedPRs();
     const mergedPRRepoSet = new Set(mergedPRRepos);
+
+    // Get open-PR repos (repos with score data but no merges yet)
+    const openPRRepos = this.stateManager.getReposWithOpenPRs();
 
     // Get starred repos (with refresh if stale)
     const starredRepos = await this.getStarredReposWithRefresh();
@@ -314,35 +342,76 @@ export class IssueDiscovery {
       });
     };
 
-    // Phase 0: Search repos where user has merged PRs (highest merge probability)
+    // Phase 0: Search repos where user has merged PRs + open-PR repos (highest merge probability)
     // Uses broader query — established contributors don't need "good first issue" labels
-    if (mergedPRRepos.length > 0) {
-      console.log(`Phase 0: Searching issues in ${mergedPRRepos.length} repos with merged PRs (no label filter)...`);
-      const remainingNeeded = maxResults - allCandidates.length;
-      if (remainingNeeded > 0) {
-        const { candidates: mergedPRCandidates, allBatchesFailed } = await this.searchInRepos(
-          mergedPRRepos.slice(0, 10),
-          establishedQuery,
-          remainingNeeded,
-          'merged_pr',
-          filterIssues
-        );
-        allCandidates.push(...mergedPRCandidates);
-        if (allBatchesFailed) {
-          phase0Error = 'All merged-PR repo batches failed';
+    // Merged-PR repos come first, then open-PR repos fill remaining slots (capped at 10 total)
+    const phase0Repos = [
+      ...mergedPRRepos,
+      ...openPRRepos.filter(r => !mergedPRRepoSet.has(r)),
+    ].slice(0, 10);
+    const phase0RepoSet = new Set(phase0Repos);
+
+    if (phase0Repos.length > 0) {
+      const mergedInPhase0 = Math.min(mergedPRRepos.length, phase0Repos.length);
+      const openInPhase0 = phase0Repos.length - mergedInPhase0;
+      console.log(`Phase 0: Searching issues in ${phase0Repos.length} repos (${mergedInPhase0} merged-PR, ${openInPhase0} open-PR, no label filter)...`);
+
+      // Phase 0a: merged-PR repos (priority: merged_pr)
+      const mergedPhase0Repos = phase0Repos.slice(0, mergedInPhase0);
+      if (mergedPhase0Repos.length > 0) {
+        const remainingNeeded = maxResults - allCandidates.length;
+        if (remainingNeeded > 0) {
+          const { candidates: mergedCandidates, allBatchesFailed, rateLimitHit } = await this.searchInRepos(
+            mergedPhase0Repos,
+            establishedQuery,
+            remainingNeeded,
+            'merged_pr',
+            filterIssues
+          );
+          allCandidates.push(...mergedCandidates);
+          if (allBatchesFailed) {
+            phase0Error = 'All merged-PR repo batches failed';
+          }
+          if (rateLimitHit) {
+            rateLimitHitDuringSearch = true;
+          }
+          console.log(`Found ${mergedCandidates.length} candidates from merged-PR repos`);
         }
-        console.log(`Found ${mergedPRCandidates.length} candidates from merged-PR repos`);
+      }
+
+      // Phase 0b: open-PR repos (priority: starred — intermediate tier)
+      const openPhase0Repos = phase0Repos.slice(mergedInPhase0);
+      if (openPhase0Repos.length > 0 && allCandidates.length < maxResults) {
+        const remainingNeeded = maxResults - allCandidates.length;
+        if (remainingNeeded > 0) {
+          const { candidates: openCandidates, allBatchesFailed, rateLimitHit } = await this.searchInRepos(
+            openPhase0Repos,
+            establishedQuery,
+            remainingNeeded,
+            'starred',
+            filterIssues
+          );
+          allCandidates.push(...openCandidates);
+          if (allBatchesFailed) {
+            const msg = 'All open-PR repo batches failed';
+            phase0Error = phase0Error ? `${phase0Error}; ${msg}` : msg;
+          }
+          if (rateLimitHit) {
+            rateLimitHitDuringSearch = true;
+          }
+          console.log(`Found ${openCandidates.length} candidates from open-PR repos`);
+        }
       }
     }
 
-    // Phase 1: Search starred repos (filter out already-searched merged-PR repos)
+    // Phase 1: Search starred repos (filter out already-searched Phase 0 repos)
     if (allCandidates.length < maxResults && starredRepos.length > 0) {
-      const reposToSearch = starredRepos.filter(r => !mergedPRRepoSet.has(r));
+      const reposToSearch = starredRepos.filter(r => !phase0RepoSet.has(r));
       if (reposToSearch.length > 0) {
         console.log(`Phase 1: Searching issues in ${reposToSearch.length} starred repos...`);
         const remainingNeeded = maxResults - allCandidates.length;
         if (remainingNeeded > 0) {
-          const { candidates: starredCandidates, allBatchesFailed } = await this.searchInRepos(
+          const { candidates: starredCandidates, allBatchesFailed, rateLimitHit } = await this.searchInRepos(
             reposToSearch.slice(0, 10),
             baseQuery,
             remainingNeeded,
@@ -352,6 +421,9 @@ export class IssueDiscovery {
           allCandidates.push(...starredCandidates);
           if (allBatchesFailed) {
             phase1Error = 'All starred repo batches failed';
+          }
+          if (rateLimitHit) {
+            rateLimitHitDuringSearch = true;
           }
           console.log(`Found ${starredCandidates.length} candidates from starred repos`);
         }
@@ -394,11 +466,11 @@ export class IssueDiscovery {
           .filter(item => {
             const repoFullName = item.repository_url.split('/').slice(-2).join('/');
             // Skip if already searched in earlier phases
-            return !mergedPRRepoSet.has(repoFullName) && !starredRepoSet.has(repoFullName) && !seenRepos.has(repoFullName);
+            return !phase0RepoSet.has(repoFullName) && !starredRepoSet.has(repoFullName) && !seenRepos.has(repoFullName);
           })
           .slice(0, remainingNeeded * 2);
 
-        const { candidates: results, allFailed: allVetFailed } = await this.vetIssuesParallel(
+        const { candidates: results, allFailed: allVetFailed, rateLimitHit: vetRateLimitHit } = await this.vetIssuesParallel(
           itemsToVet.map(i => i.html_url),
           remainingNeeded,
           'normal'
@@ -407,10 +479,16 @@ export class IssueDiscovery {
         if (allVetFailed) {
           phase2Error = (phase2Error ? phase2Error + '; ' : '') + 'all vetting failed';
         }
+        if (vetRateLimitHit) {
+          rateLimitHitDuringSearch = true;
+        }
         console.log(`Found ${results.length} candidates from general search`);
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
         phase2Error = errorMessage;
+        if (IssueDiscovery.isRateLimitError(error)) {
+          rateLimitHitDuringSearch = true;
+        }
         console.error(`[SEARCH_PHASE_2_FAILED] Error in general issue search: ${errorMessage}`);
       }
     }
@@ -424,13 +502,26 @@ export class IssueDiscovery {
       const details = phaseErrors.length > 0
         ? ` ${phaseErrors.join('. ')}.`
         : '';
+      const rateLimitContext = rateLimitHitDuringSearch
+        ? ' GitHub API rate limits may have affected results — try again after the rate limit resets.'
+        : '';
       throw new Error(
-        `No issue candidates found across all search phases.${details} ` +
+        `No issue candidates found across all search phases.${details}${rateLimitContext} ` +
         'Try adjusting your search criteria (languages, labels) or check your network connection.'
       );
     }
 
-    // Sort by priority first, then by recommendation
+    // Surface rate limit warning even with partial results (#100)
+    // This overwrites the pre-flight "quota low" warning (speculative) with a more
+    // informative "results incomplete" warning (factual) when rate limits actually hit.
+    if (rateLimitHitDuringSearch) {
+      this.rateLimitWarning =
+        `Search results may be incomplete: GitHub API rate limits were hit during search. ` +
+        `Found ${allCandidates.length} candidate${allCandidates.length === 1 ? '' : 's'} but some search phases failed. ` +
+        `Try again after the rate limit resets for complete results.`;
+    }
+
+    // Sort by priority first, then by recommendation, then by viability score
     allCandidates.sort((a, b) => {
       // Priority order: merged_pr > starred > normal
       const priorityOrder: Record<SearchPriority, number> = { merged_pr: 0, starred: 1, normal: 2 };
@@ -439,10 +530,25 @@ export class IssueDiscovery {
 
       // Then by recommendation
       const recommendationOrder = { approve: 0, needs_review: 1, skip: 2 };
-      return recommendationOrder[a.recommendation] - recommendationOrder[b.recommendation];
+      const recDiff = recommendationOrder[a.recommendation] - recommendationOrder[b.recommendation];
+      if (recDiff !== 0) return recDiff;
+
+      // Then by viability score (highest first)
+      return b.viabilityScore - a.viabilityScore;
     });
 
     return allCandidates.slice(0, maxResults);
+  }
+
+  /** Check if an error is a GitHub rate limit error (429 or rate-limit 403). */
+  private static isRateLimitError(error: unknown): boolean {
+    const status = (error as any)?.status;
+    if (status === 429) return true;
+    if (status === 403) {
+      const msg = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+      return msg.includes('rate limit');
+    }
+    return false;
   }
 
   /**
@@ -460,7 +566,7 @@ export class IssueDiscovery {
     maxResults: number,
     priority: SearchPriority,
     filterFn: (items: GitHubSearchItem[]) => GitHubSearchItem[]
-  ): Promise<{ candidates: IssueCandidate[]; allBatchesFailed: boolean }> {
+  ): Promise<{ candidates: IssueCandidate[]; allBatchesFailed: boolean; rateLimitHit: boolean }> {
     const candidates: IssueCandidate[] = [];
 
     // Batch repos to reduce API calls.
@@ -470,6 +576,7 @@ export class IssueDiscovery {
     const BATCH_SIZE = 5;
     const batches = this.batchRepos(repos, BATCH_SIZE);
     let failedBatches = 0;
+    let rateLimitFailures = 0;
 
     for (const batch of batches) {
       if (candidates.length >= maxResults) break;
@@ -498,12 +605,16 @@ export class IssueDiscovery {
         }
       } catch (error) {
         failedBatches++;
+        if (IssueDiscovery.isRateLimitError(error)) {
+          rateLimitFailures++;
+        }
         const batchRepos = batch.join(', ');
         console.error(`Error searching issues in batch [${batchRepos}]:`, error instanceof Error ? error.message : error);
       }
     }
 
     const allBatchesFailed = failedBatches === batches.length && batches.length > 0;
+    const rateLimitHit = rateLimitFailures > 0;
     if (allBatchesFailed) {
       console.error(
         `[SEARCH_PHASE_ALL_BATCHES_FAILED] All ${batches.length} batch(es) failed for ${priority} phase. ` +
@@ -511,7 +622,7 @@ export class IssueDiscovery {
       );
     }
 
-    return { candidates, allBatchesFailed };
+    return { candidates, allBatchesFailed, rateLimitHit };
   }
 
   /**
@@ -535,10 +646,11 @@ export class IssueDiscovery {
     urls: string[],
     maxResults: number,
     priority?: SearchPriority
-  ): Promise<{ candidates: IssueCandidate[]; allFailed: boolean }> {
+  ): Promise<{ candidates: IssueCandidate[]; allFailed: boolean; rateLimitHit: boolean }> {
     const candidates: IssueCandidate[] = [];
     const pending: Promise<void>[] = [];
     let failedVettingCount = 0;
+    let rateLimitFailures = 0;
     let attemptedCount = 0;
 
     for (const url of urls) {
@@ -557,6 +669,9 @@ export class IssueDiscovery {
         })
         .catch(error => {
           failedVettingCount++;
+          if (IssueDiscovery.isRateLimitError(error)) {
+            rateLimitFailures++;
+          }
           console.error(`Error vetting issue ${url}:`, error instanceof Error ? error.message : error);
         });
 
@@ -583,7 +698,7 @@ export class IssueDiscovery {
       );
     }
 
-    return { candidates: candidates.slice(0, maxResults), allFailed };
+    return { candidates: candidates.slice(0, maxResults), allFailed, rateLimitHit: rateLimitFailures > 0 };
   }
 
   /**
@@ -1045,6 +1160,7 @@ export class IssueDiscovery {
    * - Base: 50 points
    * - +repoScore*2 (up to +20 for score of 10)
    * - +repoQualityBonus (up to +12 for established repos, from star/fork counts) (#98)
+   * - +15 for merged PR in this repo (direct proven relationship) (#99)
    * - +15 for clear requirements (clarity)
    * - +15 for freshness (recently updated)
    * - +10 for contribution guidelines
@@ -1074,6 +1190,11 @@ export class IssueDiscovery {
 
     // Repo quality bonus from star/fork counts (#98, up to +12)
     score += params.repoQualityBonus ?? 0;
+
+    // Merged PR bonus (+15) — direct proven relationship with this repo (#99)
+    if (params.mergedPRCount > 0) {
+      score += 15;
+    }
 
     // Clarity bonus (+15)
     if (params.clearRequirements) {

--- a/src/core/state.test.ts
+++ b/src/core/state.test.ts
@@ -474,6 +474,54 @@ describe('StateManager getReposWithMergedPRs', () => {
   });
 });
 
+describe('StateManager getReposWithOpenPRs', () => {
+  let stateManager: StateManager;
+
+  beforeEach(() => {
+    stateManager = new StateManager(true);
+  });
+
+  it('should return empty array when no repos have score data', () => {
+    expect(stateManager.getReposWithOpenPRs()).toEqual([]);
+  });
+
+  it('should return repos with mergedPRCount === 0 and no rejections (interacted but no merges)', () => {
+    stateManager.updateRepoScore('owner/rejected', { mergedPRCount: 0, closedWithoutMergeCount: 1 });
+    stateManager.updateRepoScore('owner/merged-repo', { mergedPRCount: 2 });
+    stateManager.updateRepoScore('owner/open-only', { mergedPRCount: 0 });
+
+    const repos = stateManager.getReposWithOpenPRs();
+    expect(repos).toHaveLength(1);
+    expect(repos).toContain('owner/open-only');
+    expect(repos).not.toContain('owner/rejected');
+    expect(repos).not.toContain('owner/merged-repo');
+  });
+
+  it('should sort by score descending', () => {
+    // Both have no merges and no rejections — differentiate by signals
+    stateManager.updateRepoScore('owner/low-score', {
+      mergedPRCount: 0,
+      // default score (5) with no signals
+    });
+    stateManager.updateRepoScore('owner/high-score', {
+      mergedPRCount: 0,
+      signals: { isResponsive: true, hasActiveMaintainers: true, hasHostileComments: false },
+    });
+
+    const repos = stateManager.getReposWithOpenPRs();
+    expect(repos[0]).toBe('owner/high-score');
+    expect(repos[1]).toBe('owner/low-score');
+  });
+
+  it('should NOT include repos with merged PRs', () => {
+    stateManager.updateRepoScore('owner/merged', { mergedPRCount: 1 });
+    stateManager.updateRepoScore('owner/open', { mergedPRCount: 0 });
+
+    const repos = stateManager.getReposWithOpenPRs();
+    expect(repos).toEqual(['owner/open']);
+  });
+});
+
 describe('StateManager state validity', () => {
   let stateManager: StateManager;
 

--- a/src/core/state.ts
+++ b/src/core/state.ts
@@ -1088,6 +1088,20 @@ export class StateManager {
   }
 
   /**
+   * Get repositories where the user has interacted (has a score record) but has NOT
+   * yet had a PR merged, excluding repos where the only interaction was rejection.
+   * These represent repos with open or in-progress PRs — relationships that benefit
+   * from continued search attention.
+   * @returns Array of "owner/repo" strings, sorted by score descending.
+   */
+  getReposWithOpenPRs(): string[] {
+    return Object.values(this.state.repoScores)
+      .filter(rs => rs.mergedPRCount === 0 && rs.closedWithoutMergeCount === 0)
+      .sort((a, b) => b.score - a.score)
+      .map(rs => rs.repo);
+  }
+
+  /**
    * Get repositories with a score at or above the given threshold, sorted highest first.
    * @param minScore - Minimum score (inclusive). Defaults to `config.minRepoScoreThreshold`.
    * @returns Array of "owner/repo" strings for repos meeting the threshold.

--- a/src/formatters/json.ts
+++ b/src/formatters/json.ts
@@ -112,6 +112,8 @@ export interface SearchOutput {
     };
   }>;
   excludedRepos: string[];
+  /** Present when rate limits affected the search — either low pre-flight quota or mid-search rate limit hits (#100). */
+  rateLimitWarning?: string;
 }
 
 export interface TrackOutput {


### PR DESCRIPTION
## Summary

- **#99 Merged-PR Prioritization**: +15 viability bonus for repos with merged PRs, Phase 0 expanded to include open-PR repos (split into 0a merged-PR / 0b open-PR with correct priority tiers), viability score as tertiary sort tiebreaker
- **#100 Rate Limit Handling**: Pre-flight quota check with warning, enhanced retry logging with reset times, `rateLimitWarning` surfaced in both JSON and console output, `isRateLimitError` helper (429 or rate-limit 403) threaded through `searchInRepos` and `vetIssuesParallel` for precise error discrimination
- **`getReposWithOpenPRs()`** on StateManager — returns repos with score records but no merge/rejection outcomes, filtered to exclude rejection-only repos
- **`checkRateLimit()`** utility — queries GitHub Search API quota, exported from core
- Version bump 0.17.0 → 0.18.0

## Test plan

- [x] All 413 tests pass (17 new tests added)
- [x] Bundle builds at 535.6KB
- [x] `npm start -- search --json` includes `rateLimitWarning` field when applicable
- [x] `npm start -- search --max-results 5` runs with Phase 0 expansion
- [x] 4 rounds of automated code review (code-reviewer, silent-failure-hunter, pr-test-analyzer, type-design-analyzer) — all actionable findings resolved

Closes #99, closes #100