### PR TITLE
feat: CLI search result diversification (#105)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "AI-powered autopilot for managing open source contributions - track PRs, respond to maintainers, discover issues, and maintain contribution velocity",
   "author": {
     "name": "John Costa"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.0] - 2026-02-10
+
+### Added
+
+- **Minimum star threshold for Phase 2 search results** — General discovery (Phase 2) now filters out repos with fewer than `minStars` (default 50) GitHub stars. Phases 0 (merged-PR repos) and 1 (starred repos) are exempt since those repos have a known relationship. Repos where the health check failed are not penalized. Configurable via `setup --set minStars=100`. Closes #105.
+- **Per-repo result cap (max 2 issues per repo)** — After sorting, no more than 2 issues from any single repo appear in search results. Prevents a single active repo from dominating the candidate list. Applied after priority/recommendation/viability sorting to keep the best candidates. Closes #105.
+- **Documentation-only issue filter (opt-in)** — Issues where ALL labels are documentation-related (`documentation`, `docs`, `typo`, `spelling`) can be filtered out via `setup --set includeDocIssues=false`. Included by default since doc issues can have bounties. Issues with mixed labels (e.g., `good first issue` + `documentation`) always pass through. Closes #105.
+- `minStars` and `includeDocIssues` fields on `AgentConfig` with defaults (50 and true)
+- `isDocOnlyIssue()`, `applyPerRepoCap()`, and `DOC_ONLY_LABELS` exported from issue-discovery module
+- 19 new tests for doc-only detection, per-repo capping, and DOC_ONLY_LABELS constant (432 total)
+
 ## [0.20.0] - 2026-02-10
 
 ### Changed
@@ -451,6 +462,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR monitoring and health checking
 - Dashboard HTML generation
 
+[0.21.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.17.0...v0.18.0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Discover issues worth contributing to, track your PRs across repos, and draft responses to maintainer feedback. An AI copilot for your open source journey.
 
-![Version](https://img.shields.io/badge/version-0.20.0-blue)
+![Version](https://img.shields.io/badge/version-0.21.0-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)
 ![Node Version](https://img.shields.io/badge/node-%3E%3D18-brightgreen)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "AI-powered autopilot for managing open source contributions with Claude Code",
   "type": "module",
   "main": "dist/cli.js",

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -66,6 +66,16 @@ export async function runSetup(options: SetupOptions): Promise<void> {
             results[key] = value !== 'false' ? 'true' : 'false';
           }
           break;
+        case 'minStars': {
+          const parsed = parseInt(value);
+          stateManager.updateConfig({ minStars: isNaN(parsed) ? 50 : parsed });
+          results[key] = value;
+          break;
+        }
+        case 'includeDocIssues':
+          stateManager.updateConfig({ includeDocIssues: value === 'true' });
+          results[key] = value === 'true' ? 'true' : 'false';
+          break;
         case 'complete':
           if (value === 'true') {
             stateManager.markSetupComplete();

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -5,7 +5,7 @@
 
 export { StateManager, getStateManager, resetStateManager } from './state.js';
 export { PRMonitor, type PRCheckFailure, type FetchPRsResult, computeDisplayLabel, classifyCICheck, classifyFailingChecks } from './pr-monitor.js';
-export { IssueDiscovery, type IssueCandidate, type SearchPriority } from './issue-discovery.js';
+export { IssueDiscovery, type IssueCandidate, type SearchPriority, isDocOnlyIssue, applyPerRepoCap, DOC_ONLY_LABELS } from './issue-discovery.js';
 export { getOctokit, checkRateLimit, type RateLimitInfo } from './github.js';
 export {
   parseGitHubUrl,

--- a/src/core/issue-discovery.test.ts
+++ b/src/core/issue-discovery.test.ts
@@ -31,6 +31,9 @@ const {
   hasTemplatedTitle,
   detectLabelFarmingRepos,
   calculateRepoQualityBonus,
+  isDocOnlyIssue,
+  applyPerRepoCap,
+  DOC_ONLY_LABELS,
   BEGINNER_LABELS,
 } = await import('./issue-discovery.js');
 
@@ -764,5 +767,176 @@ describe('IssueDiscovery.isRateLimitError', () => {
   it('should return false for null/undefined', () => {
     expect(isRateLimitError(null)).toBe(false);
     expect(isRateLimitError(undefined)).toBe(false);
+  });
+});
+
+describe('isDocOnlyIssue (#105)', () => {
+  const makeItem = (labels: string[]) => ({
+    html_url: 'https://github.com/owner/repo/issues/1',
+    repository_url: 'https://api.github.com/repos/owner/repo',
+    updated_at: '2026-01-01T00:00:00Z',
+    labels: labels.map(name => ({ name })),
+  });
+
+  it('should return true when ALL labels are doc-related', () => {
+    expect(isDocOnlyIssue(makeItem(['documentation', 'typo']))).toBe(true);
+  });
+
+  it('should return true for single doc label', () => {
+    expect(isDocOnlyIssue(makeItem(['docs']))).toBe(true);
+  });
+
+  it('should return true for spelling label', () => {
+    expect(isDocOnlyIssue(makeItem(['spelling']))).toBe(true);
+  });
+
+  it('should return false when mixed labels (doc + non-doc)', () => {
+    expect(isDocOnlyIssue(makeItem(['documentation', 'good first issue']))).toBe(false);
+  });
+
+  it('should return false when no labels', () => {
+    expect(isDocOnlyIssue(makeItem([]))).toBe(false);
+  });
+
+  it('should return false for non-doc labels', () => {
+    expect(isDocOnlyIssue(makeItem(['bug', 'enhancement']))).toBe(false);
+  });
+
+  it('should be case-insensitive', () => {
+    expect(isDocOnlyIssue(makeItem(['Documentation', 'TYPO']))).toBe(true);
+  });
+
+  it('should return false when item has no labels property', () => {
+    const item = {
+      html_url: 'https://github.com/owner/repo/issues/1',
+      repository_url: 'https://api.github.com/repos/owner/repo',
+      updated_at: '2026-01-01T00:00:00Z',
+    };
+    expect(isDocOnlyIssue(item)).toBe(false);
+  });
+
+  it('should handle string labels', () => {
+    const item = {
+      html_url: 'https://github.com/owner/repo/issues/1',
+      repository_url: 'https://api.github.com/repos/owner/repo',
+      updated_at: '2026-01-01T00:00:00Z',
+      labels: ['documentation', 'docs'] as any,
+    };
+    expect(isDocOnlyIssue(item)).toBe(true);
+  });
+
+  it('should return false for mixed string labels', () => {
+    const item = {
+      html_url: 'https://github.com/owner/repo/issues/1',
+      repository_url: 'https://api.github.com/repos/owner/repo',
+      updated_at: '2026-01-01T00:00:00Z',
+      labels: ['documentation', 'bug'] as any,
+    };
+    expect(isDocOnlyIssue(item)).toBe(false);
+  });
+});
+
+describe('applyPerRepoCap (#105)', () => {
+  const makeCandidate = (repo: string, score: number): any => ({
+    issue: { repo, number: Math.random(), title: `Issue in ${repo}` },
+    viabilityScore: score,
+    searchPriority: 'normal',
+    recommendation: 'approve',
+  });
+
+  it('should keep at most 2 issues per repo', () => {
+    const candidates = [
+      makeCandidate('owner/repo-a', 90),
+      makeCandidate('owner/repo-a', 85),
+      makeCandidate('owner/repo-a', 80), // Should be dropped
+      makeCandidate('owner/repo-b', 75),
+    ];
+    const result = applyPerRepoCap(candidates, 2);
+    expect(result).toHaveLength(3);
+    expect(result.filter((c: any) => c.issue.repo === 'owner/repo-a')).toHaveLength(2);
+    expect(result.filter((c: any) => c.issue.repo === 'owner/repo-b')).toHaveLength(1);
+  });
+
+  it('should keep first N per repo based on input order (preserves sort)', () => {
+    const candidates = [
+      makeCandidate('owner/repo-a', 90),
+      makeCandidate('owner/repo-a', 85),
+      makeCandidate('owner/repo-a', 80),
+    ];
+    const result = applyPerRepoCap(candidates, 2);
+    expect(result).toHaveLength(2);
+    expect(result[0].viabilityScore).toBe(90);
+    expect(result[1].viabilityScore).toBe(85);
+  });
+
+  it('should return all candidates when no repo exceeds cap', () => {
+    const candidates = [
+      makeCandidate('owner/repo-a', 90),
+      makeCandidate('owner/repo-b', 85),
+      makeCandidate('owner/repo-c', 80),
+    ];
+    const result = applyPerRepoCap(candidates, 2);
+    expect(result).toHaveLength(3);
+  });
+
+  it('should handle empty input', () => {
+    expect(applyPerRepoCap([], 2)).toHaveLength(0);
+  });
+
+  it('should handle cap of 1', () => {
+    const candidates = [
+      makeCandidate('owner/repo-a', 90),
+      makeCandidate('owner/repo-a', 85),
+      makeCandidate('owner/repo-b', 80),
+      makeCandidate('owner/repo-b', 75),
+    ];
+    const result = applyPerRepoCap(candidates, 1);
+    expect(result).toHaveLength(2);
+    expect(result[0].issue.repo).toBe('owner/repo-a');
+    expect(result[1].issue.repo).toBe('owner/repo-b');
+  });
+
+  it('should handle multiple repos each at exactly the cap', () => {
+    const candidates = [
+      makeCandidate('owner/repo-a', 90),
+      makeCandidate('owner/repo-a', 85),
+      makeCandidate('owner/repo-b', 80),
+      makeCandidate('owner/repo-b', 75),
+      makeCandidate('owner/repo-c', 70),
+    ];
+    const result = applyPerRepoCap(candidates, 2);
+    expect(result).toHaveLength(5); // All kept
+  });
+
+  it('should cap multiple repos simultaneously', () => {
+    const candidates = [
+      makeCandidate('owner/repo-a', 90),
+      makeCandidate('owner/repo-a', 85),
+      makeCandidate('owner/repo-a', 80), // Dropped
+      makeCandidate('owner/repo-b', 75),
+      makeCandidate('owner/repo-b', 70),
+      makeCandidate('owner/repo-b', 65), // Dropped
+      makeCandidate('owner/repo-c', 60),
+    ];
+    const result = applyPerRepoCap(candidates, 2);
+    expect(result).toHaveLength(5);
+    expect(result.filter((c: any) => c.issue.repo === 'owner/repo-a')).toHaveLength(2);
+    expect(result.filter((c: any) => c.issue.repo === 'owner/repo-b')).toHaveLength(2);
+    expect(result.filter((c: any) => c.issue.repo === 'owner/repo-c')).toHaveLength(1);
+  });
+});
+
+describe('DOC_ONLY_LABELS', () => {
+  it('should contain the expected documentation labels', () => {
+    expect(DOC_ONLY_LABELS.has('documentation')).toBe(true);
+    expect(DOC_ONLY_LABELS.has('docs')).toBe(true);
+    expect(DOC_ONLY_LABELS.has('typo')).toBe(true);
+    expect(DOC_ONLY_LABELS.has('spelling')).toBe(true);
+  });
+
+  it('should not contain non-doc labels', () => {
+    expect(DOC_ONLY_LABELS.has('bug')).toBe(false);
+    expect(DOC_ONLY_LABELS.has('good first issue')).toBe(false);
+    expect(DOC_ONLY_LABELS.has('enhancement')).toBe(false);
   });
 });

--- a/src/core/issue-discovery.ts
+++ b/src/core/issue-discovery.ts
@@ -77,6 +77,51 @@ function pruneCache(): void {
   }
 }
 
+/** Labels that indicate documentation-only issues (#105). */
+export const DOC_ONLY_LABELS = new Set([
+  'documentation',
+  'docs',
+  'typo',
+  'spelling',
+]);
+
+/**
+ * Check if an issue's labels are ALL documentation-related (#105).
+ * Issues with mixed labels (e.g., "good first issue" + "documentation") pass through.
+ * Issues with no labels are not considered doc-only.
+ */
+export function isDocOnlyIssue(item: GitHubSearchItem): boolean {
+  if (!item.labels || !Array.isArray(item.labels) || item.labels.length === 0) return false;
+  const labelNames = item.labels.map(l =>
+    (typeof l === 'string' ? l : l.name || '').toLowerCase()
+  );
+  // Filter out empty label names before checking
+  const nonEmptyLabels = labelNames.filter(n => n.length > 0);
+  if (nonEmptyLabels.length === 0) return false;
+  return nonEmptyLabels.every(n => DOC_ONLY_LABELS.has(n));
+}
+
+/**
+ * Apply per-repo cap to candidates (#105).
+ * Keeps at most `maxPerRepo` issues from any single repo.
+ * Maintains the existing sort order — first N from each repo are kept,
+ * excess issues from over-represented repos are dropped.
+ */
+export function applyPerRepoCap(candidates: IssueCandidate[], maxPerRepo: number): IssueCandidate[] {
+  const repoCounts = new Map<string, number>();
+  const kept: IssueCandidate[] = [];
+
+  for (const c of candidates) {
+    const count = repoCounts.get(c.issue.repo) || 0;
+    if (count < maxPerRepo) {
+      kept.push(c);
+      repoCounts.set(c.issue.repo, count + 1);
+    }
+  }
+
+  return kept;
+}
+
 /** Known beginner-type label names used to detect label-farming repos (#97). */
 export const BEGINNER_LABELS = new Set([
   'good first issue',
@@ -327,6 +372,7 @@ export class IssueDiscovery {
     const baseQuery = `is:issue is:open ${labelQuery} ${langQuery} no:assignee`;
 
     // Helper to filter issues
+    const includeDocIssues = config.includeDocIssues ?? true;
     const filterIssues = (items: GitHubSearchItem[]) => {
       return items.filter(item => {
         if (trackedUrls.has(item.html_url)) return false;
@@ -338,6 +384,8 @@ export class IssueDiscovery {
         const updatedAt = new Date(item.updated_at);
         const ageDays = daysBetween(updatedAt, now);
         if (ageDays > maxAgeDays) return false;
+        // Filter out doc-only issues unless opted in (#105)
+        if (!includeDocIssues && isDocOnlyIssue(item)) return false;
         return true;
       });
     };
@@ -475,14 +523,28 @@ export class IssueDiscovery {
           remainingNeeded,
           'normal'
         );
-        allCandidates.push(...results);
+
+        // Apply minStars filter to Phase 2 results (#105)
+        // Phase 0/1 are exempt — if you've already contributed to or starred a repo, star count is irrelevant.
+        const minStars = config.minStars ?? 50;
+        const starFiltered = results.filter(c => {
+          if (c.projectHealth.checkFailed) return true; // Don't penalize repos we couldn't check
+          const stars = c.projectHealth.stargazersCount ?? 0;
+          return stars >= minStars;
+        });
+        const starFilteredCount = results.length - starFiltered.length;
+        if (starFilteredCount > 0) {
+          console.log(`[STAR_FILTER] Filtered ${starFilteredCount} candidates below ${minStars} stars`);
+        }
+
+        allCandidates.push(...starFiltered);
         if (allVetFailed) {
           phase2Error = (phase2Error ? phase2Error + '; ' : '') + 'all vetting failed';
         }
         if (vetRateLimitHit) {
           rateLimitHitDuringSearch = true;
         }
-        console.log(`Found ${results.length} candidates from general search`);
+        console.log(`Found ${starFiltered.length} candidates from general search`);
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
         phase2Error = errorMessage;
@@ -537,7 +599,10 @@ export class IssueDiscovery {
       return b.viabilityScore - a.viabilityScore;
     });
 
-    return allCandidates.slice(0, maxResults);
+    // Apply per-repo cap: max 2 issues from any single repo (#105)
+    const capped = applyPerRepoCap(allCandidates, 2);
+
+    return capped.slice(0, maxResults);
   }
 
   /** Check if an error is a GitHub rate limit error (429 or rate-limit 403). */

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -563,6 +563,12 @@ export interface AgentConfig {
 
   /** Directories to scan for local git clones (#84). Falls back to default paths if not set. */
   localRepoScanPaths?: string[];
+
+  /** Minimum GitHub star count for Phase 2 (general search) results. Default 50. Phases 0/1 are exempt. */
+  minStars?: number;
+
+  /** Whether to include documentation-only issues in search results. Default true. */
+  includeDocIssues?: boolean;
 }
 
 /** Default configuration applied to new state files. All fields can be overridden via `/setup-oss`. */
@@ -580,6 +586,8 @@ export const DEFAULT_CONFIG: AgentConfig = {
   minRepoScoreThreshold: 4,
   starredRepos: [],
   squashByDefault: true,
+  minStars: 50,
+  includeDocIssues: true,
 };
 
 /** Initial state written to `~/.oss-autopilot/state.json` on first run. Uses v2 architecture. */


### PR DESCRIPTION
## Summary

- **Minimum star threshold**: Phase 2 (general search) filters repos below `minStars` (default 50). Phases 0/1 exempt — if you've contributed to or starred a repo, star count is irrelevant. Configurable via `setup --set minStars=100`.
- **Per-repo cap (max 2)**: After sorting by priority/recommendation/viability, no more than 2 issues from any single repo appear in results. Prevents a single active repo from dominating the candidate list.
- **Doc-only issue filter**: Issues where ALL labels are documentation-related (`documentation`, `docs`, `typo`, `spelling`) are filtered by default. Mixed labels (e.g., `good first issue` + `documentation`) pass through. Configurable via `setup --set includeDocIssues=true`.

Closes #105

## Test plan

- [x] 19 new tests for `isDocOnlyIssue`, `applyPerRepoCap`, and `DOC_ONLY_LABELS`
- [x] All 432 tests pass
- [x] Bundle builds successfully (537.5KB)
- [x] Version bumped to 0.21.0 in all three locations