### PR TITLE
feat: AI policy detection with configurable repo blocklist

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.23.2",
+  "version": "0.24.0",
   "description": "AI-powered autopilot for managing open source contributions - track PRs, respond to maintainers, discover issues, and maintain contribution velocity",
   "author": {
     "name": "John Costa"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.24.0] - 2026-02-11
+
+### Added
+
+- **AI policy detection with configurable repo blocklist** — Repos with known anti-AI contribution policies (e.g., `matplotlib/matplotlib`) are now automatically filtered from search results. Ships with a small default blocklist. Configurable via `setup --set aiPolicyBlocklist="owner/repo,owner2/repo2"`. The issue-scout agent is also trained to detect AI policy signals during manual vetting (hidden comments, policy PRs, anti-AI CONTRIBUTING.md language) and recommend blocklist additions. The `aiPolicyBlocklist` field is exposed in CLI search JSON output. Closes #108.
+
 ## [0.23.2] - 2026-02-11
 
 ### Fixed
@@ -494,6 +500,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR monitoring and health checking
 - Dashboard HTML generation
 
+[0.24.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.23.2...v0.24.0
 [0.23.2]: https://github.com/costajohnt/oss-autopilot/compare/v0.23.1...v0.23.2
 [0.23.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.23.0...v0.23.1
 [0.23.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.22.0...v0.23.0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Discover issues worth contributing to, track your PRs across repos, and draft responses to maintainer feedback. An AI copilot for your open source journey.
 
-![Version](https://img.shields.io/badge/version-0.23.2-blue)
+![Version](https://img.shields.io/badge/version-0.24.0-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)
 ![Node Version](https://img.shields.io/badge/node-%3E%3D18-brightgreen)

--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -143,6 +143,23 @@ The CLI handles exclusions automatically when using the `search` command — thi
 
 ---
 
+**AI Policy Awareness (#108):**
+
+Some repositories have anti-AI contribution policies that reject or hide AI-assisted contributions. The CLI automatically filters repos listed in `aiPolicyBlocklist` during search.
+
+When **manually vetting** an issue (outside the CLI search), watch for these signals:
+- Comments hidden as spam (especially claim comments)
+- Policy PRs or issues filed against AI-assisted contributions
+- CONTRIBUTING.md language explicitly prohibiting AI tools
+- Maintainer comments about AI-generated code
+
+The `aiPolicyBlocklist` field is included in CLI search JSON output. If you discover a repo has an anti-AI policy during vetting:
+1. Warn the user immediately — do not proceed with claiming
+2. Recommend adding the repo to their blocklist: `setup --set aiPolicyBlocklist="matplotlib/matplotlib,new-owner/new-repo"` (this **replaces** the entire blocklist — include all existing entries)
+3. Note the discovery in the vetting summary under a "Policy Warning" section
+
+---
+
 **Search Process:**
 
 1. **Use CLI Search (Primary Method)**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.23.2",
+  "version": "0.24.0",
   "description": "AI-powered autopilot for managing open source contributions with Claude Code",
   "type": "module",
   "main": "dist/cli.js",

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -3,7 +3,7 @@
  * Searches for new issues to work on
  */
 
-import { IssueDiscovery, getGitHubToken, getStateManager } from '../core/index.js';
+import { IssueDiscovery, getGitHubToken, getStateManager, DEFAULT_CONFIG } from '../core/index.js';
 import { outputJson, outputJsonError, type SearchOutput } from '../formatters/json.js';
 
 interface SearchOptions {
@@ -36,7 +36,9 @@ export async function runSearch(options: SearchOptions): Promise<void> {
 
   if (options.json) {
     const stateManager = getStateManager();
-    const excludedRepos = stateManager.getState().config.excludeRepos || [];
+    const { config } = stateManager.getState();
+    const excludedRepos = config.excludeRepos || [];
+    const aiPolicyBlocklist = config.aiPolicyBlocklist ?? DEFAULT_CONFIG.aiPolicyBlocklist ?? [];
     const searchOutput: SearchOutput = {
       candidates: candidates.map(c => {
         const repoScoreRecord = stateManager.getRepoScore(c.issue.repo);
@@ -63,6 +65,7 @@ export async function runSearch(options: SearchOptions): Promise<void> {
         };
       }),
       excludedRepos,
+      aiPolicyBlocklist,
     };
     if (discovery.rateLimitWarning) {
       searchOutput.rateLimitWarning = discovery.rateLimitWarning;

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -3,7 +3,7 @@
  * Interactive setup / configuration
  */
 
-import { getStateManager } from '../core/index.js';
+import { getStateManager, DEFAULT_CONFIG } from '../core/index.js';
 import { outputJson } from '../formatters/json.js';
 
 interface SetupOptions {
@@ -76,6 +76,35 @@ export async function runSetup(options: SetupOptions): Promise<void> {
           stateManager.updateConfig({ includeDocIssues: value === 'true' });
           results[key] = value === 'true' ? 'true' : 'false';
           break;
+        case 'aiPolicyBlocklist': {
+          const entries = value.split(',').map(r => r.trim()).filter(Boolean);
+          const valid: string[] = [];
+          const invalid: string[] = [];
+          for (const entry of entries) {
+            const normalized = entry.replace(/\s+/g, '');
+            if (/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/.test(normalized)) {
+              valid.push(normalized);
+            } else {
+              invalid.push(entry);
+            }
+          }
+          if (invalid.length > 0) {
+            if (!options.json) {
+              console.warn(`Warning: Skipping invalid entries (expected "owner/repo" format): ${invalid.join(', ')}`);
+            }
+            results['aiPolicyBlocklist_invalidEntries'] = invalid.join(', ');
+          }
+          if (valid.length === 0 && entries.length > 0) {
+            if (!options.json) {
+              console.warn('Warning: All entries were invalid. Blocklist not updated.');
+            }
+            results[key] = '(all entries invalid)';
+            break;
+          }
+          stateManager.updateConfig({ aiPolicyBlocklist: valid });
+          results[key] = valid.length > 0 ? valid.join(', ') : '(empty)';
+          break;
+        }
         case 'complete':
           if (value === 'true') {
             stateManager.markSetupComplete();
@@ -177,6 +206,13 @@ export async function runSetup(options: SetupOptions): Promise<void> {
           default: ['good first issue', 'help wanted'],
           type: 'list',
         },
+        {
+          setting: 'aiPolicyBlocklist',
+          prompt: 'Repos with anti-AI contribution policies to block (owner/repo, comma-separated)?',
+          current: config.aiPolicyBlocklist ?? DEFAULT_CONFIG.aiPolicyBlocklist,
+          default: ['matplotlib/matplotlib'],
+          type: 'list',
+        },
       ],
     });
   } else {
@@ -223,6 +259,13 @@ export async function runSetup(options: SetupOptions): Promise<void> {
     console.log('PROMPT: What issue labels should we search for? (comma-separated)');
     console.log(`CURRENT: ${config.labels.join(', ')}`);
     console.log('DEFAULT: good first issue, help wanted');
+    console.log('TYPE: list');
+    console.log('');
+
+    console.log('SETTING: aiPolicyBlocklist');
+    console.log('PROMPT: Repos with anti-AI contribution policies to block? (owner/repo, comma-separated)');
+    console.log(`CURRENT: ${(config.aiPolicyBlocklist ?? DEFAULT_CONFIG.aiPolicyBlocklist ?? []).join(', ')}`);
+    console.log('DEFAULT: matplotlib/matplotlib');
     console.log('TYPE: list');
     console.log('');
 

--- a/src/core/issue-discovery.test.ts
+++ b/src/core/issue-discovery.test.ts
@@ -37,6 +37,8 @@ const {
   BEGINNER_LABELS,
 } = await import('./issue-discovery.js');
 
+const { getStateManager } = await import('./state.js');
+
 describe('IssueDiscovery.calculateViabilityScore', () => {
   let discovery: InstanceType<typeof IssueDiscovery>;
 
@@ -923,6 +925,144 @@ describe('applyPerRepoCap (#105)', () => {
     expect(result.filter((c: any) => c.issue.repo === 'owner/repo-a')).toHaveLength(2);
     expect(result.filter((c: any) => c.issue.repo === 'owner/repo-b')).toHaveLength(2);
     expect(result.filter((c: any) => c.issue.repo === 'owner/repo-c')).toHaveLength(1);
+  });
+});
+
+describe('aiPolicyBlocklist filtering in searchIssues (#108)', () => {
+  let discovery: InstanceType<typeof IssueDiscovery>;
+
+  const makeSearchItem = (repo: string, num: number) => ({
+    html_url: `https://github.com/${repo}/issues/${num}`,
+    repository_url: `https://api.github.com/repos/${repo}`,
+    updated_at: new Date().toISOString(),
+    title: `Test issue ${num}`,
+    labels: [{ name: 'good first issue' }],
+    id: num,
+    comments: 0,
+    body: `1. Step one\n2. Step two\nThis should work correctly.\n${'x'.repeat(200)}`,
+    created_at: new Date().toISOString(),
+    number: num,
+  });
+
+  function mockStateWithBlocklist(aiPolicyBlocklist?: string[]): void {
+    const config: Record<string, unknown> = {
+      githubUsername: 'testuser',
+      trustedProjects: [],
+      starredRepos: [],
+      excludeRepos: [],
+      languages: ['typescript'],
+      labels: ['good first issue'],
+      maxIssueAgeDays: 90,
+      includeDocIssues: true,
+      minStars: 0,
+    };
+    if (aiPolicyBlocklist !== undefined) {
+      config.aiPolicyBlocklist = aiPolicyBlocklist;
+    }
+    (getStateManager as any).mockReturnValue({
+      getState: () => ({ config, repoScores: {}, activeIssues: [] }),
+      getStarredRepos: () => [],
+      isStarredReposStale: () => false,
+      getReposWithMergedPRs: () => [],
+      getReposWithOpenPRs: () => [],
+      getLowScoringRepos: () => [],
+      getRepoScore: () => undefined,
+    });
+  }
+
+  beforeEach(() => {
+    mockStateWithBlocklist(['blocked/repo']);
+
+    mockOctokitInstance = {
+      search: {
+        issuesAndPullRequests: vi.fn().mockResolvedValue({
+          data: {
+            total_count: 2,
+            items: [
+              makeSearchItem('blocked/repo', 1),
+              makeSearchItem('allowed/repo', 2),
+            ],
+          },
+        }),
+      },
+      issues: {
+        get: vi.fn().mockImplementation(({ owner, repo, issue_number }: any) => Promise.resolve({
+          data: {
+            id: issue_number,
+            html_url: `https://github.com/${owner}/${repo}/issues/${issue_number}`,
+            title: `Test issue ${issue_number}`,
+            labels: [{ name: 'good first issue' }],
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+            comments: 0,
+            body: `1. Step one\n2. Step two\nThis should work correctly.\n${'x'.repeat(200)}`,
+          },
+        })),
+        listEventsForTimeline: vi.fn().mockResolvedValue({ data: [] }),
+      },
+      repos: {
+        get: vi.fn().mockResolvedValue({
+          data: { open_issues_count: 5, pushed_at: new Date().toISOString(), stargazers_count: 100, forks_count: 20 },
+        }),
+        listCommits: vi.fn().mockResolvedValue({
+          data: [{ commit: { author: { date: new Date().toISOString() } } }],
+        }),
+        getContent: vi.fn().mockRejectedValue(new Error('404 Not Found')),
+      },
+      actions: {
+        listRepoWorkflows: vi.fn().mockResolvedValue({ data: { total_count: 1 } }),
+      },
+    };
+
+    discovery = new IssueDiscovery('fake-token');
+  });
+
+  it('should filter out issues from blocklisted repos', async () => {
+    const candidates = await discovery.searchIssues({ maxResults: 10 });
+    const repos = candidates.map(c => c.issue.repo);
+    expect(repos).not.toContain('blocked/repo');
+    expect(repos).toContain('allowed/repo');
+  });
+
+  it('should pass through all issues when blocklist is empty', async () => {
+    mockStateWithBlocklist([]);
+    discovery = new IssueDiscovery('fake-token');
+
+    const candidates = await discovery.searchIssues({ maxResults: 10 });
+    const repos = candidates.map(c => c.issue.repo);
+    expect(repos).toContain('blocked/repo');
+    expect(repos).toContain('allowed/repo');
+  });
+
+  it('should handle undefined blocklist gracefully', async () => {
+    mockStateWithBlocklist(undefined);
+    discovery = new IssueDiscovery('fake-token');
+
+    const candidates = await discovery.searchIssues({ maxResults: 10 });
+    const repos = candidates.map(c => c.issue.repo);
+    // Neither test repo is in DEFAULT_CONFIG.aiPolicyBlocklist (['matplotlib/matplotlib']), so both pass through
+    expect(repos).toContain('blocked/repo');
+    expect(repos).toContain('allowed/repo');
+  });
+
+  it('should fall back to DEFAULT_CONFIG blocklist when config value is undefined', async () => {
+    mockStateWithBlocklist(undefined);
+    // Include matplotlib/matplotlib (which IS in DEFAULT_CONFIG.aiPolicyBlocklist) in search results
+    mockOctokitInstance.search.issuesAndPullRequests.mockResolvedValue({
+      data: {
+        total_count: 2,
+        items: [
+          makeSearchItem('matplotlib/matplotlib', 1),
+          makeSearchItem('allowed/repo', 2),
+        ],
+      },
+    });
+    discovery = new IssueDiscovery('fake-token');
+
+    const candidates = await discovery.searchIssues({ maxResults: 10 });
+    const repos = candidates.map(c => c.issue.repo);
+    expect(repos).not.toContain('matplotlib/matplotlib');
+    expect(repos).toContain('allowed/repo');
   });
 });
 

--- a/src/core/issue-discovery.ts
+++ b/src/core/issue-discovery.ts
@@ -15,6 +15,7 @@ import {
   ContributionGuidelines,
   ProjectHealth,
   RepoScore,
+  DEFAULT_CONFIG,
 } from './types.js';
 
 // Concurrency limit for parallel API calls
@@ -373,11 +374,17 @@ export class IssueDiscovery {
 
     // Helper to filter issues
     const includeDocIssues = config.includeDocIssues ?? true;
+    const aiBlocklisted = new Set(config.aiPolicyBlocklist ?? DEFAULT_CONFIG.aiPolicyBlocklist ?? []);
+    if (aiBlocklisted.size > 0) {
+      console.log(`[AI_POLICY_FILTER] Filtering issues from ${aiBlocklisted.size} blocklisted repo(s): ${[...aiBlocklisted].join(', ')}`);
+    }
     const filterIssues = (items: GitHubSearchItem[]) => {
       return items.filter(item => {
         if (trackedUrls.has(item.html_url)) return false;
         const repoFullName = item.repository_url.split('/').slice(-2).join('/');
         if (excludedRepos.has(repoFullName)) return false;
+        // Filter repos with known anti-AI contribution policies (#108)
+        if (aiBlocklisted.has(repoFullName)) return false;
         // Filter OUT low-scoring repos
         if (lowScoringRepos.has(repoFullName)) return false;
         // Filter by issue age based on updated_at

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -569,6 +569,9 @@ export interface AgentConfig {
 
   /** Whether to include documentation-only issues in search results. Default true. */
   includeDocIssues?: boolean;
+
+  /** Repos known to have anti-AI contribution policies, in `"owner/repo"` format. Filtered from search results automatically. */
+  aiPolicyBlocklist?: string[];
 }
 
 /** Default configuration applied to new state files. All fields can be overridden via `/setup-oss`. */
@@ -588,6 +591,7 @@ export const DEFAULT_CONFIG: AgentConfig = {
   squashByDefault: true,
   minStars: 50,
   includeDocIssues: true,
+  aiPolicyBlocklist: ['matplotlib/matplotlib'],
 };
 
 /** Initial state written to `~/.oss-autopilot/state.json` on first run. Uses v2 architecture. */

--- a/src/formatters/json.ts
+++ b/src/formatters/json.ts
@@ -112,6 +112,8 @@ export interface SearchOutput {
     };
   }>;
   excludedRepos: string[];
+  /** Repos with known anti-AI contribution policies, filtered from search results (#108). */
+  aiPolicyBlocklist: string[];
   /** Present when rate limits affected the search — either low pre-flight quota or mid-search rate limit hits (#100). */
   rateLimitWarning?: string;
 }


### PR DESCRIPTION
## Summary

- Adds `aiPolicyBlocklist` config field (`string[]`) to automatically filter repos with known anti-AI contribution policies from search results
- Ships with `matplotlib/matplotlib` as default blocklist entry, configurable via `setup --set aiPolicyBlocklist="owner/repo,owner2/repo2"`
- Includes `owner/repo` format validation in setup, consistent `DEFAULT_CONFIG` fallback via nullish coalescing, and issue-scout agent guidance for detecting AI policy signals during manual vetting

Closes #108

## Changes (11 files)

| File | Change |
|------|--------|
| `src/core/types.ts` | `aiPolicyBlocklist` field + default |
| `src/core/issue-discovery.ts` | Blocklist filtering in `searchIssues()` |
| `src/commands/search.ts` | Expose blocklist in JSON output |
| `src/formatters/json.ts` | Extend `SearchOutput` type |
| `src/commands/setup.ts` | Config setter with `owner/repo` validation |
| `agents/issue-scout.md` | AI policy awareness section |
| `src/core/issue-discovery.test.ts` | 3 integration tests |
| `package.json` | 0.23.0 → 0.24.0 |
| `.claude-plugin/plugin.json` | 0.23.0 → 0.24.0 |
| `README.md` | Version badge bump |
| `CHANGELOG.md` | New 0.24.0 section |

## Test plan

- [x] All 435 tests pass including 3 new blocklist tests
- [x] Bundle builds successfully (538.6KB)
- [x] Blocklisted repos filtered from search results
- [x] Empty blocklist passes all issues through
- [x] Undefined blocklist falls back to DEFAULT_CONFIG
- [x] Invalid `owner/repo` format rejected with warning in setup
- [x] `aiPolicyBlocklist` exposed in search JSON output