### PR TITLE
fix: marketplace.json source field validation error

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "oss-autopilot",
-      "source": ".",
+      "source": "./",
       "description": "AI-powered autopilot for managing open source contributions - track PRs, respond to maintainers, discover issues, and maintain contribution velocity"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "description": "AI-powered autopilot for managing open source contributions - track PRs, respond to maintainers, discover issues, and maintain contribution velocity",
   "author": {
     "name": "John Costa"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.2] - 2026-02-11
+
+### Fixed
+
+- **Marketplace install failing with "Invalid input"** — `marketplace.json` source field used `"."` which doesn't match the schema's expected relative path format. Changed to `"./"` to match the pattern used by all official Anthropic plugins (e.g., `"./plugins/name"`). Fixes marketplace install via `/plugin marketplace add costajohnt/oss-autopilot`.
+
 ## [0.23.1] - 2026-02-11
 
 ### Added
@@ -488,6 +494,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR monitoring and health checking
 - Dashboard HTML generation
 
+[0.23.2]: https://github.com/costajohnt/oss-autopilot/compare/v0.23.1...v0.23.2
 [0.23.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.23.0...v0.23.1
 [0.23.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.21.0...v0.22.0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Discover issues worth contributing to, track your PRs across repos, and draft responses to maintainer feedback. An AI copilot for your open source journey.
 
-![Version](https://img.shields.io/badge/version-0.23.1-blue)
+![Version](https://img.shields.io/badge/version-0.23.2-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)
 ![Node Version](https://img.shields.io/badge/node-%3E%3D18-brightgreen)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "description": "AI-powered autopilot for managing open source contributions with Claude Code",
   "type": "module",
   "main": "dist/cli.js",


### PR DESCRIPTION
## Summary

- Fix marketplace install failing with `plugins.0.source: Invalid input` by changing `"source": "."` to `"source": "./"` in `.claude-plugin/marketplace.json`
- The schema validator requires relative paths to use the `./` prefix format (e.g., `"./plugins/name"`), matching all official Anthropic plugins

## Context

After #115 added `marketplace.json`, users installing via `/plugin marketplace add costajohnt/oss-autopilot` got:
```
Error: Invalid schema: .../marketplace.json plugins.0.source: Invalid input
```

## Test plan

- [ ] Run `/plugin marketplace add costajohnt/oss-autopilot` — should succeed without schema error
- [ ] Run `/plugin install oss-autopilot@oss-autopilot` — should install the plugin
- [ ] `npm test` — all 432 tests pass