### PR TITLE
feat: add issue conversation tracking

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "description": "AI-powered autopilot for managing open source contributions - track PRs, respond to maintainers, discover issues, and maintain contribution velocity",
   "author": {
     "name": "John Costa"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.0] - 2026-02-11
+
+### Added
+
+- **Issue conversation tracking** — The `/oss` daily check now monitors GitHub issues the user has commented on (e.g., "Is this still relevant?", "I'd like to work on this") and surfaces maintainer responses. New `IssueConversationMonitor` class follows the `PRMonitor` pattern: stateless GitHub Search API fetch, bounded concurrency worker pool, bot filtering, and acknowledgment detection. Results appear in the daily summary, action menu ("Review N issue replies"), and HTML dashboard. The user can claim issues directly from the replies flow, feeding them into the existing `TrackedIssue` pipeline. Closes #114.
+- `CommentedIssue` and `IssueConversationStatus` types in `src/core/types.ts`
+- `IssueConversationMonitor` class with `fetchCommentedIssues()` in `src/core/issue-conversation.ts`
+- `isAcknowledgmentComment()` exported utility for shared acknowledgment filtering (used by both `IssueConversationMonitor` and `PRMonitor`)
+- `commentedIssues` field on `DailyOutput` for structured issue conversation data
+- `hasIssueResponses`/`issueResponseCount` context flags on `ActionMenu`
+- `issue_replies` action menu item when maintainer responses are detected
+- Issue Conversations section in HTML dashboard with speech bubble icons
+- "Handle Review Issue Replies" orchestration in `commands/oss.md`
+- 30 new tests for issue conversation detection, bot filtering, acknowledgment filtering, and edge cases (27 in `issue-conversation.test.ts`, 3 in `daily.test.ts`)
+
 ## [0.24.1] - 2026-02-11
 
 ### Added
@@ -506,6 +521,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR monitoring and health checking
 - Dashboard HTML generation
 
+[0.25.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.24.1...v0.25.0
 [0.24.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.24.0...v0.24.1
 [0.24.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.23.2...v0.24.0
 [0.23.2]: https://github.com/costajohnt/oss-autopilot/compare/v0.23.1...v0.23.2

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Discover issues worth contributing to, track your PRs across repos, and draft responses to maintainer feedback. An AI copilot for your open source journey.
 
-![Version](https://img.shields.io/badge/version-0.24.1-blue)
+![Version](https://img.shields.io/badge/version-0.25.0-blue)
 ![CI](https://github.com/costajohnt/oss-autopilot/actions/workflows/ci.yml/badge.svg)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)

--- a/commands/oss.md
+++ b/commands/oss.md
@@ -121,7 +121,7 @@ The CLI returns structured data with new fields for the action-first flow:
         { "key": "search", "label": "Search for new issues", "description": "Look for new contribution opportunities" },
         { "key": "done", "label": "Done for now", "description": "End session with summary" }
       ],
-      "context": { "hasActionableIssues": true, "actionableCount": 3, "hasCapacity": true }
+      "context": { "hasActionableIssues": true, "actionableCount": 3, "hasCapacity": true, "hasIssueResponses": false, "issueResponseCount": 0 }
     },
     "capacity": { "hasCapacity": true, ... },
     "digest": { ... },
@@ -621,6 +621,31 @@ Use AskUserQuestion:
 
 When user selects specific PRs (e.g., "1 and 3"), dispatch only those agents in parallel.
 Still group by repo if selected PRs share a repository.
+
+### Handle "Review Issue Replies"
+
+When the user selects "Review issue replies", display each commented issue with a maintainer response from `data.commentedIssues` (filtered to `status === 'new_response'`):
+
+```
+## Issue Replies
+
+Maintainers responded to your comments on these issues:
+
+1. **owner/repo#123** — Issue title
+   └─ @maintainer: "Go for it! Feel free to submit a PR..."
+   └─ Your comment: 5 days ago
+
+2. **owner/repo#456** — Another issue title
+   └─ @maintainer: "Thanks for the interest. Here's what..."
+   └─ Your comment: 2 days ago
+```
+
+For each issue, use AskUserQuestion to offer actions:
+- "Claim this issue" — Run `GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/dist/cli.bundle.cjs" claim ISSUE_URL --json` to add it to the tracked pipeline, then proceed to work on it
+- "View full thread" — Display the issue URL for the user to open in browser
+- "Skip" — Move to the next issue
+
+After processing all issue replies (or user chooses to stop), return to Step 3 to present action choices again.
 
 ### Handle "View Healthy PRs"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "description": "AI-powered autopilot for managing open source contributions with Claude Code",
   "type": "module",
   "main": "dist/cli.js",

--- a/src/commands/daily.test.ts
+++ b/src/commands/daily.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { computeRepoSignals, computeActionMenu, groupPRsByRepo } from './daily.js';
-import type { FetchedPR } from '../core/types.js';
+import type { FetchedPR, CommentedIssue } from '../core/types.js';
 import type { ActionableIssue, CapacityAssessment } from '../formatters/json.js';
 
 /** Create a minimal FetchedPR for testing signal computation */
@@ -121,6 +121,8 @@ describe('computeActionMenu', () => {
       hasActionableIssues: true,
       actionableCount: 1,
       hasCapacity: true,
+      hasIssueResponses: false,
+      issueResponseCount: 0,
     });
   });
 
@@ -151,6 +153,54 @@ describe('computeActionMenu', () => {
 
     expect(menu.items).toHaveLength(3);
     expect(menu.items.map(i => i.key)).toEqual(['address_all', 'view_healthy', 'done']);
+  });
+
+  it('should include issue_replies item and context when issue responses exist', () => {
+    const issueResponses: CommentedIssue[] = [
+      {
+        repo: 'owner/repo',
+        number: 10,
+        title: 'Test issue',
+        url: 'https://github.com/owner/repo/issues/10',
+        status: 'new_response',
+        userLastCommentedAt: '2026-02-01T10:00:00Z',
+        lastResponseAuthor: 'maintainer',
+        lastResponseBody: 'Go for it!',
+        lastResponseAt: '2026-02-02T10:00:00Z',
+        labels: ['bug'],
+        daysSinceUserComment: 3,
+      },
+    ];
+    const menu = computeActionMenu([], makeCapacity(), issueResponses);
+
+    expect(menu.items.map(i => i.key)).toEqual(['issue_replies', 'search', 'done']);
+    expect(menu.items[0].label).toBe('Review 1 issue reply');
+    expect(menu.context).toEqual({
+      hasActionableIssues: false,
+      actionableCount: 0,
+      hasCapacity: true,
+      hasIssueResponses: true,
+      issueResponseCount: 1,
+    });
+  });
+
+  it('should order address_all before issue_replies when both present', () => {
+    const issueResponses: CommentedIssue[] = [
+      { repo: 'a/b', number: 1, title: 'T', url: 'u', status: 'new_response', userLastCommentedAt: '', labels: [], daysSinceUserComment: 0 },
+    ];
+    const menu = computeActionMenu([makeActionableIssue()], makeCapacity(), issueResponses);
+
+    expect(menu.items.map(i => i.key)).toEqual(['address_all', 'issue_replies', 'search', 'done']);
+  });
+
+  it('should use plural label for multiple issue responses', () => {
+    const issueResponses: CommentedIssue[] = [
+      { repo: 'a/b', number: 1, title: 'T', url: 'u', status: 'new_response', userLastCommentedAt: '', labels: [], daysSinceUserComment: 0 },
+      { repo: 'c/d', number: 2, title: 'T', url: 'u', status: 'new_response', userLastCommentedAt: '', labels: [], daysSinceUserComment: 0 },
+    ];
+    const menu = computeActionMenu([], makeCapacity(), issueResponses);
+
+    expect(menu.items[0].label).toBe('Review 2 issue replies');
   });
 });
 

--- a/src/commands/daily.ts
+++ b/src/commands/daily.ts
@@ -4,7 +4,7 @@
  * generates a digest, and updates repo scores and analytics in local state.
  */
 
-import { getStateManager, PRMonitor, getGitHubToken, type DailyDigest, type FetchedPR, type FetchedPRStatus, type PRCheckFailure, type MaintainerActionHint, type ClosedPR, type ComputedRepoSignals, type RepoGroup } from '../core/index.js';
+import { getStateManager, PRMonitor, IssueConversationMonitor, getGitHubToken, formatRelativeTime, type DailyDigest, type FetchedPR, type FetchedPRStatus, type PRCheckFailure, type MaintainerActionHint, type ClosedPR, type ComputedRepoSignals, type RepoGroup, type CommentedIssue } from '../core/index.js';
 import { outputJson, outputJsonError, type DailyOutput, type CapacityAssessment, type ActionableIssue, type ActionMenu, type ActionMenuItem } from '../formatters/json.js';
 
 interface DailyOptions {
@@ -57,12 +57,27 @@ async function runDailyInner(token: string, options: DailyOptions): Promise<void
     console.error(`Warning: ${failures.length} PR fetch(es) failed`);
   }
 
-  // Fetch merged PR counts, closed PR counts, and recently closed PRs in parallel
-  const [mergedResult, closedResult, recentlyClosedPRs] = await Promise.all([
+  // Fetch merged PR counts, closed PR counts, recently closed PRs, and commented issues in parallel
+  const issueMonitor = new IssueConversationMonitor(token);
+  const [mergedResult, closedResult, recentlyClosedPRs, issueConversationResult] = await Promise.all([
     prMonitor.fetchUserMergedPRCounts(),
     prMonitor.fetchUserClosedPRCounts(),
     prMonitor.fetchRecentlyClosedPRs(),
+    issueMonitor.fetchCommentedIssues().catch(error => {
+      const msg = error instanceof Error ? error.message : String(error);
+      if (msg.includes('No GitHub username configured')) {
+        console.error(`[DAILY] Issue conversation tracking requires setup: ${msg}`);
+      } else {
+        console.error(`[DAILY] Issue conversation fetch failed: ${msg}`);
+      }
+      return { issues: [] as CommentedIssue[], failures: [{ issueUrl: 'N/A', error: `Issue conversation fetch failed: ${msg}` }] };
+    }),
   ]);
+
+  const commentedIssues = issueConversationResult.issues;
+  if (issueConversationResult.failures.length > 0) {
+    console.error(`[DAILY] ${issueConversationResult.failures.length} issue conversation check(s) failed`);
+  }
 
   const { repos: mergedCounts, monthlyCounts, monthlyOpenedCounts: openedFromMerged } = mergedResult;
   const { repos: closedCounts, monthlyCounts: monthlyClosedCounts, monthlyOpenedCounts: openedFromClosed } = closedResult;
@@ -195,24 +210,25 @@ async function runDailyInner(token: string, options: DailyOptions): Promise<void
 
   if (options.json) {
     // Include pre-formatted summary for Claude to display verbatim
-    const summary = formatSummary(digest, capacity);
+    const issueResponses = commentedIssues.filter(i => i.status === 'new_response');
+    const summary = formatSummary(digest, capacity, issueResponses);
     // New action-first flow fields
     const actionableIssues = collectActionableIssues(prs, recentlyClosedPRs);
-    const briefSummary = formatBriefSummary(digest, actionableIssues.length);
-    const actionMenu = computeActionMenu(actionableIssues, capacity);
+    const briefSummary = formatBriefSummary(digest, actionableIssues.length, issueResponses.length);
+    const actionMenu = computeActionMenu(actionableIssues, capacity, issueResponses);
     // Group PRs by repo for safe parallel dispatch (#80)
     const repoGroups = groupPRsByRepo(prs);
-    outputJson<DailyOutput>({ digest, updates: [], capacity, summary, briefSummary, actionableIssues, actionMenu, repoGroups, failures });
+    outputJson<DailyOutput>({ digest, updates: [], capacity, summary, briefSummary, actionableIssues, actionMenu, commentedIssues, repoGroups, failures });
   } else {
     // Simple console output for non-JSON mode
-    printDigest(digest, capacity);
+    printDigest(digest, capacity, commentedIssues);
   }
 }
 
 /**
  * Format summary as markdown (used in JSON output for Claude to display verbatim)
  */
-function formatSummary(digest: DailyDigest, capacity: CapacityAssessment): string {
+function formatSummary(digest: DailyDigest, capacity: CapacityAssessment, issueResponses: CommentedIssue[] = []): string {
   const lines: string[] = [];
 
   // Header
@@ -335,6 +351,19 @@ function formatSummary(digest: DailyDigest, capacity: CapacityAssessment): strin
     lines.push('');
   }
 
+  // Issue Replies
+  if (issueResponses.length > 0) {
+    lines.push('### 💬 Issue Replies');
+    for (const issue of issueResponses) {
+      lines.push(`- [${issue.repo}#${issue.number}](${issue.url}): ${issue.title}`);
+      if (issue.lastResponseAuthor && issue.lastResponseBody) {
+        const timeAgo = issue.lastResponseAt ? formatRelativeTime(issue.lastResponseAt) : '';
+        lines.push(`  └─ @${issue.lastResponseAuthor}: "${issue.lastResponseBody.slice(0, 80)}${issue.lastResponseBody.length > 80 ? '...' : ''}"${timeAgo ? ` (${timeAgo})` : ''}`);
+      }
+    }
+    lines.push('');
+  }
+
   // Capacity
   const capacityIcon = capacity.hasCapacity ? '✅' : '⚠️';
   const capacityLabel = capacity.hasCapacity ? 'Ready for new work' : 'Focus on existing PRs';
@@ -346,7 +375,7 @@ function formatSummary(digest: DailyDigest, capacity: CapacityAssessment): strin
 /**
  * Print digest to console (simple text output)
  */
-function printDigest(digest: DailyDigest, capacity: CapacityAssessment): void {
+function printDigest(digest: DailyDigest, capacity: CapacityAssessment, commentedIssues: CommentedIssue[] = []): void {
   console.log('\n📊 OSS Daily Check\n');
   console.log(`Active PRs: ${digest.summary.totalActivePRs}`);
   console.log(`Needing Attention: ${digest.summary.totalNeedingAttention}`);
@@ -447,6 +476,18 @@ function printDigest(digest: DailyDigest, capacity: CapacityAssessment): void {
     console.log('');
   }
 
+  const issueResponses = commentedIssues.filter(i => i.status === 'new_response');
+  if (issueResponses.length > 0) {
+    console.log('💬 Issue Replies:');
+    for (const issue of issueResponses) {
+      console.log(`  - ${issue.repo}#${issue.number}: ${issue.title}`);
+      if (issue.lastResponseAuthor) {
+        console.log(`    @${issue.lastResponseAuthor}: ${(issue.lastResponseBody || '').slice(0, 80)}${(issue.lastResponseBody || '').length > 80 ? '...' : ''}`);
+      }
+    }
+    console.log('');
+  }
+
   console.log('Run with --json for structured output');
   console.log('Run "dashboard --open" for browser view');
 }
@@ -493,11 +534,14 @@ function assessCapacity(prs: FetchedPR[], maxActivePRs: number): CapacityAssessm
 /**
  * Format a brief one-liner summary for the action-first flow
  */
-function formatBriefSummary(digest: DailyDigest, issueCount: number): string {
+function formatBriefSummary(digest: DailyDigest, issueCount: number, issueResponseCount: number = 0): string {
   const attentionText = issueCount > 0
     ? `${issueCount} need${issueCount === 1 ? 's' : ''} attention`
     : 'all healthy';
-  return `📊 ${digest.summary.totalActivePRs} Active PRs | ${attentionText} | Dashboard opened in browser`;
+  const issueReplyText = issueResponseCount > 0
+    ? ` | ${issueResponseCount} issue repl${issueResponseCount === 1 ? 'y' : 'ies'}`
+    : '';
+  return `📊 ${digest.summary.totalActivePRs} Active PRs | ${attentionText}${issueReplyText} | Dashboard opened in browser`;
 }
 
 /**
@@ -604,9 +648,11 @@ function formatActionHint(hint: MaintainerActionHint): string {
 export function computeActionMenu(
   actionableIssues: ActionableIssue[],
   capacity: CapacityAssessment,
+  issueResponses: CommentedIssue[] = [],
 ): ActionMenu {
   const items: ActionMenuItem[] = [];
   const hasActionableIssues = actionableIssues.length > 0;
+  const hasIssueResponses = issueResponses.length > 0;
 
   if (hasActionableIssues) {
     items.push({
@@ -616,8 +662,17 @@ export function computeActionMenu(
     });
   }
 
+  // Issue replies — positioned after address_all but before search
+  if (hasIssueResponses) {
+    items.push({
+      key: 'issue_replies',
+      label: `Review ${issueResponses.length} issue repl${issueResponses.length === 1 ? 'y' : 'ies'}`,
+      description: 'Maintainers responded to your comments on issues',
+    });
+  }
+
   // Slot for issue-list options — the orchestration layer may insert items here
-  // (index 1 when address_all is present, index 0 otherwise).
+  // (index after address_all/issue_replies when present, index 0 otherwise).
   // See commands/oss.md Step 3 for the insertion logic.
 
   if (capacity.hasCapacity) {
@@ -653,6 +708,8 @@ export function computeActionMenu(
       hasActionableIssues,
       actionableCount: actionableIssues.length,
       hasCapacity: capacity.hasCapacity,
+      hasIssueResponses,
+      issueResponseCount: issueResponses.length,
     },
   };
 }
@@ -668,26 +725,33 @@ const STALE_STATUSES: Set<FetchedPRStatus> = new Set([
 ]);
 
 /**
- * Group PRs by repository (#80).
- * Ensures one agent per repo during parallel dispatch, preventing branch checkout conflicts.
+ * Build a map grouping PRs by repository, skipping PRs with empty repo fields.
+ * Shared by groupPRsByRepo and computeRepoSignals.
  */
-export function groupPRsByRepo(prs: FetchedPR[]): RepoGroup[] {
+function buildRepoMap(prs: FetchedPR[], label: string): Map<string, FetchedPR[]> {
   const repoMap = new Map<string, FetchedPR[]>();
   for (const pr of prs) {
     if (!pr.repo) {
-      console.warn(`[GROUP_BY_REPO] Skipping PR #${pr.number} (${pr.url}) with empty repo field`);
+      console.warn(`[${label}] Skipping PR #${pr.number} (${pr.url}) with empty repo field`);
       continue;
     }
     const existing = repoMap.get(pr.repo) || [];
     existing.push(pr);
     repoMap.set(pr.repo, existing);
   }
+  return repoMap;
+}
 
+/**
+ * Group PRs by repository (#80).
+ * Ensures one agent per repo during parallel dispatch, preventing branch checkout conflicts.
+ */
+export function groupPRsByRepo(prs: FetchedPR[]): RepoGroup[] {
+  const repoMap = buildRepoMap(prs, 'GROUP_BY_REPO');
   const groups: RepoGroup[] = [];
   for (const [repo, repoPRs] of repoMap) {
     groups.push({ repo, prs: repoPRs });
   }
-
   return groups;
 }
 
@@ -698,17 +762,7 @@ export function groupPRsByRepo(prs: FetchedPR[]): RepoGroup[] {
  * - hasActiveMaintainers: true if any PR in the repo has a status in ACTIVE_MAINTAINER_STATUSES
  */
 export function computeRepoSignals(prs: FetchedPR[]): Map<string, ComputedRepoSignals> {
-  const repoMap = new Map<string, FetchedPR[]>();
-  for (const pr of prs) {
-    if (!pr.repo) {
-      console.warn(`[COMPUTE_SIGNALS] Skipping PR #${pr.number} (${pr.url}) with empty repo field`);
-      continue;
-    }
-    const existing = repoMap.get(pr.repo) || [];
-    existing.push(pr);
-    repoMap.set(pr.repo, existing);
-  }
-
+  const repoMap = buildRepoMap(prs, 'COMPUTE_SIGNALS');
   const result = new Map<string, ComputedRepoSignals>();
   for (const [repo, repoPRs] of repoMap) {
     const isResponsive = repoPRs.some(pr =>
@@ -719,6 +773,5 @@ export function computeRepoSignals(prs: FetchedPR[]): Map<string, ComputedRepoSi
     );
     result.set(repo, { isResponsive, hasActiveMaintainers });
   }
-
   return result;
 }

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -6,9 +6,9 @@
 
 import * as fs from 'fs';
 import { execFile } from 'child_process';
-import { getStateManager, getDashboardPath, PRMonitor, getGitHubToken } from '../core/index.js';
+import { getStateManager, getDashboardPath, PRMonitor, IssueConversationMonitor, getGitHubToken } from '../core/index.js';
 import { outputJson } from '../formatters/json.js';
-import type { FetchedPR, DailyDigest, AgentState, RepoScore, ClosedPR } from '../core/types.js';
+import type { FetchedPR, DailyDigest, AgentState, RepoScore, ClosedPR, CommentedIssue } from '../core/types.js';
 
 interface DashboardOptions {
   open?: boolean;
@@ -19,18 +19,30 @@ export async function runDashboard(options: DashboardOptions): Promise<void> {
   const stateManager = getStateManager();
   const token = getGitHubToken();
   let digest: DailyDigest | undefined;
+  let commentedIssues: CommentedIssue[] = [];
 
   // If we have a token, fetch fresh data
   if (token) {
     console.error('Fetching fresh data from GitHub...');
     try {
       const prMonitor = new PRMonitor(token);
-      const [{ prs, failures }, recentlyClosedPRs, mergedResult, closedResult] = await Promise.all([
+      const issueMonitor = new IssueConversationMonitor(token);
+      const [{ prs, failures }, recentlyClosedPRs, mergedResult, closedResult, fetchedIssues] = await Promise.all([
         prMonitor.fetchUserOpenPRs(),
         prMonitor.fetchRecentlyClosedPRs(),
         prMonitor.fetchUserMergedPRCounts(),
         prMonitor.fetchUserClosedPRCounts(),
+        issueMonitor.fetchCommentedIssues().catch(error => {
+          const msg = error instanceof Error ? error.message : String(error);
+          if (msg.includes('No GitHub username configured')) {
+            console.error(`[DASHBOARD] Issue conversation tracking requires setup: ${msg}`);
+          } else {
+            console.error(`[DASHBOARD] Issue conversation fetch failed: ${msg}`);
+          }
+          return { issues: [] as CommentedIssue[], failures: [{ issueUrl: 'N/A', error: `Issue conversation fetch failed: ${msg}` }] };
+        }),
       ]);
+      commentedIssues = fetchedIssues.issues;
 
       if (failures.length > 0) {
         console.error(`Warning: ${failures.length} PR fetch(es) failed`);
@@ -40,8 +52,12 @@ export async function runDashboard(options: DashboardOptions): Promise<void> {
       const { monthlyCounts, monthlyOpenedCounts: openedFromMerged } = mergedResult;
       const { monthlyCounts: monthlyClosedCounts, monthlyOpenedCounts: openedFromClosed } = closedResult;
 
-      try { stateManager.setMonthlyMergedCounts(monthlyCounts); } catch { /* non-critical */ }
-      try { stateManager.setMonthlyClosedCounts(monthlyClosedCounts); } catch { /* non-critical */ }
+      try { stateManager.setMonthlyMergedCounts(monthlyCounts); } catch (error) {
+        console.error('[DASHBOARD] Failed to store monthly merged counts:', error instanceof Error ? error.message : error);
+      }
+      try { stateManager.setMonthlyClosedCounts(monthlyClosedCounts); } catch (error) {
+        console.error('[DASHBOARD] Failed to store monthly closed counts:', error instanceof Error ? error.message : error);
+      }
       try {
         const combinedOpenedCounts: Record<string, number> = { ...openedFromMerged };
         for (const [month, count] of Object.entries(openedFromClosed)) {
@@ -54,7 +70,9 @@ export async function runDashboard(options: DashboardOptions): Promise<void> {
           }
         }
         stateManager.setMonthlyOpenedCounts(combinedOpenedCounts);
-      } catch { /* non-critical */ }
+      } catch (error) {
+        console.error('[DASHBOARD] Failed to store monthly opened counts:', error instanceof Error ? error.message : error);
+      }
 
       digest = prMonitor.generateDigest(prs, recentlyClosedPRs);
       stateManager.setLastDigest(digest);
@@ -121,17 +139,21 @@ export async function runDashboard(options: DashboardOptions): Promise<void> {
   };
 
   if (options.json) {
+    const issueResponses = commentedIssues.filter(i => i.status === 'new_response');
     outputJson({
       stats,
       prsByRepo,
       topRepos: topRepos.map(([repo, data]) => ({ repo, ...data })),
       monthlyMerged,
       activePRs: digest.openPRs || [],
+      commentedIssues,
+      issueResponses,
     });
     return;
   }
 
-  const html = generateDashboardHtml(stats, monthlyMerged, monthlyClosed, monthlyOpened, digest, state);
+  const issueResponses = commentedIssues.filter(i => i.status === 'new_response');
+  const html = generateDashboardHtml(stats, monthlyMerged, monthlyClosed, monthlyOpened, digest, state, issueResponses);
 
   // Write to file in ~/.oss-autopilot/
   const dashboardPath = getDashboardPath();
@@ -191,6 +213,7 @@ function generateDashboardHtml(
   monthlyOpened: Record<string, number>,
   digest: DailyDigest,
   state: Readonly<AgentState>,
+  issueResponses: CommentedIssue[] = [],
 ): string {
   const approachingDormantDays = state.config?.approachingDormantDays ?? 25;
   // Action Required: contributor must do something
@@ -999,6 +1022,33 @@ function generateDashboardHtml(
           <div class="health-content">
             <div class="health-title"><a href="${escapeHtml(pr.url)}" target="_blank">${escapeHtml(pr.repo)}#${pr.number}</a> - Closed</div>
             <div class="health-meta">${escapeHtml(pr.title.slice(0, 50))}${pr.title.length > 50 ? '...' : ''}${pr.closedAt ? ` · ${new Date(pr.closedAt).toLocaleDateString()}` : ''}</div>
+          </div>
+        </div>
+        `).join('')}
+      </div>
+    </section>
+    ` : ''}
+
+    ${issueResponses.length > 0 ? `
+    <section class="health-section" style="animation-delay: 0.25s;">
+      <div class="health-header">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--accent-info)" stroke-width="2">
+          ${SVG.comment}
+        </svg>
+        <h2>Issue Conversations</h2>
+        <span class="health-badge" style="background: var(--accent-info-dim); color: var(--accent-info);">${issueResponses.length} repl${issueResponses.length !== 1 ? 'ies' : 'y'}</span>
+      </div>
+      <div class="health-items">
+        ${issueResponses.map(issue => `
+        <div class="health-item changes-addressed">
+          <div class="health-icon" style="background: var(--accent-info-dim); color: var(--accent-info);">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              ${SVG.comment}
+            </svg>
+          </div>
+          <div class="health-content">
+            <div class="health-title"><a href="${escapeHtml(issue.url)}" target="_blank">${escapeHtml(issue.repo)}#${issue.number}</a> - ${escapeHtml(issue.title.slice(0, 50))}${issue.title.length > 50 ? '...' : ''}</div>
+            <div class="health-meta">${issue.lastResponseAuthor ? `@${escapeHtml(issue.lastResponseAuthor)}: ${escapeHtml((issue.lastResponseBody || '').slice(0, 60))}${(issue.lastResponseBody || '').length > 60 ? '...' : ''}` : 'New response'}</div>
           </div>
         </div>
         `).join('')}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -6,6 +6,7 @@
 export { StateManager, getStateManager, resetStateManager } from './state.js';
 export { PRMonitor, type PRCheckFailure, type FetchPRsResult, computeDisplayLabel, classifyCICheck, classifyFailingChecks } from './pr-monitor.js';
 export { IssueDiscovery, type IssueCandidate, type SearchPriority, isDocOnlyIssue, applyPerRepoCap, DOC_ONLY_LABELS } from './issue-discovery.js';
+export { IssueConversationMonitor, isAcknowledgmentComment } from './issue-conversation.js';
 export { getOctokit, checkRateLimit, type RateLimitInfo } from './github.js';
 export {
   parseGitHubUrl,

--- a/src/core/issue-conversation.test.ts
+++ b/src/core/issue-conversation.test.ts
@@ -1,0 +1,586 @@
+/**
+ * Tests for IssueConversationMonitor — comment detection, bot filtering,
+ * acknowledgment filtering, issue exclusion, and edge cases
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+let mockOctokitInstance: any;
+
+// Default state config — reset in beforeEach and overridable per test
+const defaultState = () => ({
+  config: {
+    githubUsername: 'testuser',
+    excludeRepos: [] as string[],
+    excludeOrgs: [] as string[],
+    aiPolicyBlocklist: ['blocked/repo'],
+  },
+  activeIssues: [] as Array<{ repo: string; number: number; status: string }>,
+});
+
+let mockState = defaultState();
+
+vi.mock('./github.js', () => ({
+  getOctokit: vi.fn(() => mockOctokitInstance),
+}));
+
+vi.mock('./state.js', () => ({
+  getStateManager: vi.fn(() => ({
+    getState: () => mockState,
+  })),
+}));
+
+const { IssueConversationMonitor, isAcknowledgmentComment } = await import('./issue-conversation.js');
+
+// Helper to build a search result item
+function makeSearchItem(overrides: Record<string, any> = {}) {
+  return {
+    html_url: 'https://github.com/owner/repo/issues/42',
+    number: 42,
+    title: 'Test issue',
+    labels: [{ name: 'bug' }],
+    pull_request: undefined,
+    user: { login: 'someone-else' },
+    ...overrides,
+  };
+}
+
+// Helper to build a comment
+function makeComment(author: string, body: string, created_at: string) {
+  return {
+    user: { login: author },
+    body,
+    created_at,
+  };
+}
+
+describe('isAcknowledgmentComment', () => {
+  it('should detect "thanks" as acknowledgment', () => {
+    expect(isAcknowledgmentComment('Thanks for the PR!')).toBe(true);
+  });
+
+  it('should detect "LGTM" as acknowledgment', () => {
+    expect(isAcknowledgmentComment('LGTM')).toBe(true);
+  });
+
+  it('should detect "will review" as acknowledgment', () => {
+    expect(isAcknowledgmentComment('Will review this soon')).toBe(true);
+  });
+
+  it('should NOT treat questions as acknowledgments', () => {
+    expect(isAcknowledgmentComment('Thanks, but can you add tests?')).toBe(false);
+  });
+
+  it('should NOT treat long comments as acknowledgments', () => {
+    const longComment = 'Thanks! '.repeat(20); // > 100 chars
+    expect(isAcknowledgmentComment(longComment)).toBe(false);
+  });
+
+  it('should return false for empty string', () => {
+    expect(isAcknowledgmentComment('')).toBe(false);
+  });
+
+  it('should return false for non-acknowledgment comment', () => {
+    expect(isAcknowledgmentComment('Please fix the lint errors')).toBe(false);
+  });
+});
+
+describe('IssueConversationMonitor', () => {
+  beforeEach(() => {
+    mockState = defaultState();
+    mockOctokitInstance = {
+      search: {
+        issuesAndPullRequests: vi.fn().mockResolvedValue({
+          data: { items: [], total_count: 0 },
+        }),
+      },
+      issues: {
+        listComments: vi.fn().mockResolvedValue({
+          data: [],
+        }),
+      },
+    };
+  });
+
+  it('should detect maintainer response after user comment', async () => {
+    mockOctokitInstance.search.issuesAndPullRequests.mockResolvedValue({
+      data: {
+        items: [makeSearchItem()],
+        total_count: 1,
+      },
+    });
+
+    mockOctokitInstance.issues.listComments.mockResolvedValue({
+      data: [
+        makeComment('testuser', 'Is this still relevant?', '2026-02-01T10:00:00Z'),
+        makeComment('maintainer', 'Yes, go for it!', '2026-02-02T10:00:00Z'),
+      ],
+    });
+
+    const monitor = new IssueConversationMonitor('fake-token');
+    const { issues, failures } = await monitor.fetchCommentedIssues();
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0].status).toBe('new_response');
+    expect(issues[0].lastResponseAuthor).toBe('maintainer');
+    expect(issues[0].lastResponseBody).toContain('Yes, go for it!');
+    expect(failures).toHaveLength(0);
+  });
+
+  it('should ignore bot comments', async () => {
+    mockOctokitInstance.search.issuesAndPullRequests.mockResolvedValue({
+      data: {
+        items: [makeSearchItem()],
+        total_count: 1,
+      },
+    });
+
+    mockOctokitInstance.issues.listComments.mockResolvedValue({
+      data: [
+        makeComment('testuser', 'I can work on this', '2026-02-01T10:00:00Z'),
+        makeComment('stale[bot]', 'This issue has been automatically marked as stale.', '2026-02-05T10:00:00Z'),
+      ],
+    });
+
+    const monitor = new IssueConversationMonitor('fake-token');
+    const { issues } = await monitor.fetchCommentedIssues();
+
+    expect(issues).toHaveLength(1);
+    // Bot comment should be ignored, so user is last commenter
+    expect(issues[0].status).toBe('acknowledged');
+  });
+
+  it('should set waiting status when only acknowledgment responses exist', async () => {
+    mockOctokitInstance.search.issuesAndPullRequests.mockResolvedValue({
+      data: {
+        items: [makeSearchItem()],
+        total_count: 1,
+      },
+    });
+
+    mockOctokitInstance.issues.listComments.mockResolvedValue({
+      data: [
+        makeComment('testuser', 'I would like to work on this', '2026-02-01T10:00:00Z'),
+        makeComment('maintainer', 'Thanks!', '2026-02-02T10:00:00Z'),
+      ],
+    });
+
+    const monitor = new IssueConversationMonitor('fake-token');
+    const { issues } = await monitor.fetchCommentedIssues();
+
+    expect(issues).toHaveLength(1);
+    // "Thanks!" is an acknowledgment — filtered from lastResponse, but maintainer
+    // is the last non-bot commenter, so status is 'waiting' not 'new_response'
+    expect(issues[0].status).toBe('waiting');
+  });
+
+  it('should filter out user-authored issues', async () => {
+    mockOctokitInstance.search.issuesAndPullRequests.mockResolvedValue({
+      data: {
+        items: [
+          makeSearchItem({ user: { login: 'testuser' } }), // authored by user
+        ],
+        total_count: 1,
+      },
+    });
+
+    const monitor = new IssueConversationMonitor('fake-token');
+    const { issues } = await monitor.fetchCommentedIssues();
+
+    expect(issues).toHaveLength(0);
+  });
+
+  it('should filter out already-tracked issues', async () => {
+    mockState = {
+      ...defaultState(),
+      config: {
+        ...defaultState().config,
+        aiPolicyBlocklist: [],
+      },
+      activeIssues: [{
+        repo: 'owner/repo',
+        number: 42,
+        status: 'claimed',
+      }],
+    };
+
+    mockOctokitInstance.search.issuesAndPullRequests.mockResolvedValue({
+      data: {
+        items: [makeSearchItem()],
+        total_count: 1,
+      },
+    });
+
+    const monitor = new IssueConversationMonitor('fake-token');
+    const { issues } = await monitor.fetchCommentedIssues();
+
+    expect(issues).toHaveLength(0);
+  });
+
+  it('should handle empty comment threads', async () => {
+    mockOctokitInstance.search.issuesAndPullRequests.mockResolvedValue({
+      data: {
+        items: [makeSearchItem({
+          html_url: 'https://github.com/owner/repo/issues/99',
+          number: 99,
+        })],
+        total_count: 1,
+      },
+    });
+
+    mockOctokitInstance.issues.listComments.mockResolvedValue({
+      data: [], // no comments
+    });
+
+    const monitor = new IssueConversationMonitor('fake-token');
+    const { issues } = await monitor.fetchCommentedIssues();
+
+    // No user comment found in timeline, analyzeIssueConversation returns null
+    expect(issues).toHaveLength(0);
+  });
+
+  it('should use case-insensitive username matching', async () => {
+    mockOctokitInstance.search.issuesAndPullRequests.mockResolvedValue({
+      data: {
+        items: [makeSearchItem()],
+        total_count: 1,
+      },
+    });
+
+    mockOctokitInstance.issues.listComments.mockResolvedValue({
+      data: [
+        makeComment('TestUser', 'Can I work on this?', '2026-02-01T10:00:00Z'),  // Different case
+        makeComment('maintainer', 'Sure, go ahead!', '2026-02-02T10:00:00Z'),
+      ],
+    });
+
+    const monitor = new IssueConversationMonitor('fake-token');
+    const { issues } = await monitor.fetchCommentedIssues();
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0].status).toBe('new_response');
+  });
+
+  it('should filter out pull requests from search results', async () => {
+    mockOctokitInstance.search.issuesAndPullRequests.mockResolvedValue({
+      data: {
+        items: [
+          makeSearchItem({ pull_request: { url: 'https://api.github.com/...' } }), // is a PR
+        ],
+        total_count: 1,
+      },
+    });
+
+    const monitor = new IssueConversationMonitor('fake-token');
+    const { issues } = await monitor.fetchCommentedIssues();
+
+    expect(issues).toHaveLength(0);
+  });
+
+  it('should filter out blocklisted repos', async () => {
+    mockOctokitInstance.search.issuesAndPullRequests.mockResolvedValue({
+      data: {
+        items: [
+          makeSearchItem({
+            html_url: 'https://github.com/blocked/repo/issues/1',
+            number: 1,
+          }),
+        ],
+        total_count: 1,
+      },
+    });
+
+    const monitor = new IssueConversationMonitor('fake-token');
+    const { issues } = await monitor.fetchCommentedIssues();
+
+    expect(issues).toHaveLength(0);
+  });
+
+  it('should set acknowledged status when user is the last commenter', async () => {
+    mockOctokitInstance.search.issuesAndPullRequests.mockResolvedValue({
+      data: {
+        items: [makeSearchItem()],
+        total_count: 1,
+      },
+    });
+
+    mockOctokitInstance.issues.listComments.mockResolvedValue({
+      data: [
+        makeComment('other-person', 'Some context on this issue', '2026-01-30T10:00:00Z'),
+        makeComment('testuser', 'I can work on this', '2026-02-01T10:00:00Z'),
+      ],
+    });
+
+    const monitor = new IssueConversationMonitor('fake-token');
+    const { issues } = await monitor.fetchCommentedIssues();
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0].status).toBe('acknowledged');
+  });
+
+  it('should truncate long response bodies to 200 chars', async () => {
+    const longBody = 'A'.repeat(300);
+
+    mockOctokitInstance.search.issuesAndPullRequests.mockResolvedValue({
+      data: {
+        items: [makeSearchItem()],
+        total_count: 1,
+      },
+    });
+
+    mockOctokitInstance.issues.listComments.mockResolvedValue({
+      data: [
+        makeComment('testuser', 'Question', '2026-02-01T10:00:00Z'),
+        makeComment('maintainer', longBody, '2026-02-02T10:00:00Z'),
+      ],
+    });
+
+    const monitor = new IssueConversationMonitor('fake-token');
+    const { issues } = await monitor.fetchCommentedIssues();
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0].lastResponseBody!.length).toBeLessThanOrEqual(203); // 200 + "..."
+  });
+
+  it('should sort results with new_response first', async () => {
+    mockOctokitInstance.search.issuesAndPullRequests.mockResolvedValue({
+      data: {
+        items: [
+          makeSearchItem({
+            html_url: 'https://github.com/owner/repo/issues/1',
+            number: 1,
+            title: 'Waiting issue',
+          }),
+          makeSearchItem({
+            html_url: 'https://github.com/owner/repo/issues/2',
+            number: 2,
+            title: 'Responded issue',
+          }),
+        ],
+        total_count: 2,
+      },
+    });
+
+    // First call for issue 1 (no response)
+    // Second call for issue 2 (has response)
+    let callCount = 0;
+    mockOctokitInstance.issues.listComments.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // Issue 1: user commented, no response
+        return Promise.resolve({
+          data: [
+            makeComment('testuser', 'I can help', '2026-02-01T10:00:00Z'),
+          ],
+        });
+      } else {
+        // Issue 2: user commented, maintainer responded
+        return Promise.resolve({
+          data: [
+            makeComment('testuser', 'Can I work on this?', '2026-02-01T10:00:00Z'),
+            makeComment('maintainer', 'Yes please!', '2026-02-02T10:00:00Z'),
+          ],
+        });
+      }
+    });
+
+    const monitor = new IssueConversationMonitor('fake-token');
+    const { issues } = await monitor.fetchCommentedIssues();
+
+    expect(issues).toHaveLength(2);
+    // new_response should come first
+    expect(issues[0].status).toBe('new_response');
+    expect(issues[0].number).toBe(2);
+    expect(issues[1].status).toBe('acknowledged');
+    expect(issues[1].number).toBe(1);
+  });
+
+  it('should include labels from the issue', async () => {
+    mockOctokitInstance.search.issuesAndPullRequests.mockResolvedValue({
+      data: {
+        items: [makeSearchItem({
+          labels: [{ name: 'bug' }, { name: 'help wanted' }],
+        })],
+        total_count: 1,
+      },
+    });
+
+    mockOctokitInstance.issues.listComments.mockResolvedValue({
+      data: [
+        makeComment('testuser', 'I can help', '2026-02-01T10:00:00Z'),
+        makeComment('maintainer', 'Great, go ahead', '2026-02-02T10:00:00Z'),
+      ],
+    });
+
+    const monitor = new IssueConversationMonitor('fake-token');
+    const { issues } = await monitor.fetchCommentedIssues();
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0].labels).toEqual(['bug', 'help wanted']);
+  });
+
+  it('should throw when githubUsername is not configured', async () => {
+    mockState = {
+      ...defaultState(),
+      config: {
+        ...defaultState().config,
+        githubUsername: '',
+      },
+    };
+
+    const monitor = new IssueConversationMonitor('fake-token');
+    await expect(monitor.fetchCommentedIssues()).rejects.toThrow('No GitHub username configured');
+  });
+
+  it('should continue processing when one issue analysis fails', async () => {
+    mockOctokitInstance.search.issuesAndPullRequests.mockResolvedValue({
+      data: {
+        items: [
+          makeSearchItem({ html_url: 'https://github.com/owner/repo/issues/1', number: 1 }),
+          makeSearchItem({ html_url: 'https://github.com/owner/repo/issues/2', number: 2 }),
+        ],
+        total_count: 2,
+      },
+    });
+
+    let callCount = 0;
+    mockOctokitInstance.issues.listComments.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return Promise.reject(new Error('API rate limit exceeded'));
+      }
+      return Promise.resolve({
+        data: [
+          makeComment('testuser', 'Question', '2026-02-01T10:00:00Z'),
+          makeComment('maintainer', 'Answer', '2026-02-02T10:00:00Z'),
+        ],
+      });
+    });
+
+    const monitor = new IssueConversationMonitor('fake-token');
+    const { issues, failures } = await monitor.fetchCommentedIssues();
+
+    // One failed, one succeeded
+    expect(issues).toHaveLength(1);
+    expect(issues[0].status).toBe('new_response');
+    expect(failures).toHaveLength(1);
+    expect(failures[0].error).toContain('rate limit');
+  });
+
+  it('should filter out excludeRepos', async () => {
+    mockState = {
+      ...defaultState(),
+      config: {
+        ...defaultState().config,
+        excludeRepos: ['excluded/repo'],
+        aiPolicyBlocklist: [],
+      },
+    };
+
+    mockOctokitInstance.search.issuesAndPullRequests.mockResolvedValue({
+      data: {
+        items: [
+          makeSearchItem({ html_url: 'https://github.com/excluded/repo/issues/1', number: 1 }),
+        ],
+        total_count: 1,
+      },
+    });
+
+    const monitor = new IssueConversationMonitor('fake-token');
+    const { issues } = await monitor.fetchCommentedIssues();
+
+    expect(issues).toHaveLength(0);
+  });
+
+  it('should use case-sensitive matching for excludeRepos (matches PRMonitor)', async () => {
+    mockState = {
+      ...defaultState(),
+      config: {
+        ...defaultState().config,
+        excludeRepos: ['Excluded/Repo'],
+        aiPolicyBlocklist: [],
+      },
+    };
+
+    mockOctokitInstance.search.issuesAndPullRequests.mockResolvedValue({
+      data: {
+        items: [
+          makeSearchItem({ html_url: 'https://github.com/excluded/repo/issues/1', number: 1 }),
+        ],
+        total_count: 1,
+      },
+    });
+
+    mockOctokitInstance.issues.listComments.mockResolvedValue({
+      data: [
+        { user: { login: 'testuser' }, body: 'I can help', created_at: '2026-02-01T10:00:00Z' },
+        { user: { login: 'maintainer' }, body: 'Go ahead', created_at: '2026-02-02T10:00:00Z' },
+      ],
+    });
+
+    const monitor = new IssueConversationMonitor('fake-token');
+    const { issues } = await monitor.fetchCommentedIssues();
+
+    // Case mismatch: 'Excluded/Repo' does not match 'excluded/repo', so issue is NOT filtered
+    expect(issues).toHaveLength(1);
+  });
+
+  it('should filter out excludeOrgs', async () => {
+    mockState = {
+      ...defaultState(),
+      config: {
+        ...defaultState().config,
+        excludeOrgs: ['excludedorg'],
+        aiPolicyBlocklist: [],
+      },
+    };
+
+    mockOctokitInstance.search.issuesAndPullRequests.mockResolvedValue({
+      data: {
+        items: [
+          makeSearchItem({ html_url: 'https://github.com/ExcludedOrg/some-repo/issues/5', number: 5 }),
+        ],
+        total_count: 1,
+      },
+    });
+
+    const monitor = new IssueConversationMonitor('fake-token');
+    const { issues } = await monitor.fetchCommentedIssues();
+
+    // Case-insensitive: 'ExcludedOrg' should match 'excludedorg'
+    expect(issues).toHaveLength(0);
+  });
+
+  it('should filter out issues in user-owned repos', async () => {
+    mockOctokitInstance.search.issuesAndPullRequests.mockResolvedValue({
+      data: {
+        items: [
+          // Repo owned by testuser — someone else opened the issue
+          makeSearchItem({
+            html_url: 'https://github.com/testuser/my-project/issues/10',
+            number: 10,
+            user: { login: 'contributor' },
+          }),
+        ],
+        total_count: 1,
+      },
+    });
+
+    const monitor = new IssueConversationMonitor('fake-token');
+    const { issues } = await monitor.fetchCommentedIssues();
+
+    expect(issues).toHaveLength(0);
+  });
+
+  it('should return empty failures array on success', async () => {
+    mockOctokitInstance.search.issuesAndPullRequests.mockResolvedValue({
+      data: { items: [], total_count: 0 },
+    });
+
+    const monitor = new IssueConversationMonitor('fake-token');
+    const { issues, failures } = await monitor.fetchCommentedIssues();
+
+    expect(issues).toHaveLength(0);
+    expect(failures).toHaveLength(0);
+  });
+});

--- a/src/core/issue-conversation.ts
+++ b/src/core/issue-conversation.ts
@@ -1,0 +1,260 @@
+/**
+ * Issue Conversation Monitor — tracks issues the user has commented on
+ * and detects maintainer responses that need attention.
+ *
+ * Follows the same pattern as PRMonitor: stateless fetch from GitHub,
+ * bounded concurrency via worker pool, bot/acknowledgment filtering.
+ */
+
+import { Octokit } from '@octokit/rest';
+import { getOctokit } from './github.js';
+import { getStateManager } from './state.js';
+import { daysBetween, splitRepo } from './utils.js';
+import type { CommentedIssue, IssueConversationStatus } from './types.js';
+
+const MAX_CONCURRENT_REQUESTS = 5;
+
+export class IssueConversationMonitor {
+  private octokit: Octokit;
+  private stateManager: ReturnType<typeof getStateManager>;
+
+  constructor(githubToken: string) {
+    this.octokit = getOctokit(githubToken);
+    this.stateManager = getStateManager();
+  }
+
+  /**
+   * Fetch issues the user has commented on and determine conversation state.
+   * Filters out: user-authored issues, user-owned repos, excluded repos/orgs,
+   * AI policy blocklisted repos, already-tracked issues, and pull requests.
+   */
+  async fetchCommentedIssues(maxDays: number = 30): Promise<{ issues: CommentedIssue[]; failures: Array<{ issueUrl: string; error: string }> }> {
+    const config = this.stateManager.getState().config;
+
+    if (!config.githubUsername) {
+      throw new Error('No GitHub username configured. Run setup first.');
+    }
+
+    const username = config.githubUsername;
+    const cutoffDate = new Date();
+    cutoffDate.setDate(cutoffDate.getDate() - maxDays);
+    const since = cutoffDate.toISOString().split('T')[0];
+
+    console.error(`Fetching commented issues for @${username} (last ${maxDays} days)...`);
+
+    // Search for open issues the user has commented on, updated within window
+    // Single page (100) is sufficient for most users; log if truncated.
+    const { data } = await this.octokit.search.issuesAndPullRequests({
+      q: `commenter:${username} type:issue state:open updated:>=${since}`,
+      sort: 'updated',
+      order: 'desc',
+      per_page: 100,
+    });
+
+    if (data.total_count > 100) {
+      console.error(`[ISSUE_CONVERSATION] Search returned ${data.total_count} results but only first 100 were fetched. Some commented issues may be missing.`);
+    }
+
+    // Build sets for filtering
+    const trackedIssues = this.stateManager.getState().activeIssues || [];
+    const trackedIssueKeys = new Set(
+      trackedIssues
+        .filter(i => i.status === 'claimed' || i.status === 'in_progress' || i.status === 'pr_submitted')
+        .map(i => `${i.repo}#${i.number}`)
+    );
+    const blocklist = new Set((config.aiPolicyBlocklist || []).map(r => r.toLowerCase()));
+
+    // Filter out PRs, user-authored issues, excluded repos, blocklisted repos, and already-tracked issues.
+    // Also parse repo info for each candidate to avoid re-parsing in analyzeIssueConversation.
+    const candidates: Array<{ item: typeof data.items[0]; repoFullName: string }> = [];
+    for (const item of data.items) {
+      // Defensive: skip pull requests in case type:issue qualifier is unreliable
+      if (item.pull_request) continue;
+
+      const repoMatch = item.html_url.match(/github\.com\/([^/]+)\/([^/]+)\/issues\//);
+      if (!repoMatch) {
+        console.error(`[ISSUE_CONVERSATION] Skipping issue with unparseable URL: ${item.html_url}`);
+        continue;
+      }
+
+      const owner = repoMatch[1];
+      const repoFullName = `${owner}/${repoMatch[2]}`;
+
+      // Skip issues in user-owned repos (we only care about contributing to others' projects)
+      if (owner.toLowerCase() === username.toLowerCase()) continue;
+
+      // Skip user-authored issues
+      if (item.user?.login?.toLowerCase() === username.toLowerCase()) continue;
+
+      // Skip excluded repos and orgs
+      if (config.excludeRepos.includes(repoFullName)) continue;
+      if (config.excludeOrgs?.some(org => owner.toLowerCase() === org.toLowerCase())) continue;
+
+      // Skip blocklisted repos
+      if (blocklist.has(repoFullName.toLowerCase())) continue;
+
+      // Skip issues already in the tracked pipeline
+      if (trackedIssueKeys.has(`${repoFullName}#${item.number}`)) continue;
+
+      candidates.push({ item, repoFullName });
+    }
+
+    console.error(`Found ${candidates.length} commented issues to check`);
+
+    // Fetch comments for each issue using worker pool.
+    // N workers consume from a shared index — simpler than Promise.race + splice.
+    // Safe because JS is single-threaded: nextIndex++ and results.push() are never interleaved mid-operation.
+    const results: CommentedIssue[] = [];
+    const failures: Array<{ issueUrl: string; error: string }> = [];
+    let nextIndex = 0;
+
+    const fetchWorker = async () => {
+      while (nextIndex < candidates.length) {
+        const { item, repoFullName } = candidates[nextIndex++];
+        try {
+          const issue = await this.analyzeIssueConversation(item, repoFullName, username);
+          if (issue) results.push(issue);
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          failures.push({ issueUrl: item.html_url, error: msg });
+          console.error(`Error analyzing issue ${item.html_url}: ${msg}`);
+        }
+      }
+    };
+
+    const workerCount = Math.min(MAX_CONCURRENT_REQUESTS, candidates.length);
+    await Promise.all(Array.from({ length: workerCount }, () => fetchWorker()));
+
+    if (failures.length > 0) {
+      console.error(`[ISSUE_CONVERSATION] ${failures.length}/${candidates.length} issue analysis call(s) failed`);
+    }
+    if (failures.length === candidates.length && candidates.length > 0) {
+      console.error(`[ISSUE_CONVERSATION_ALL_FAILED] All ${candidates.length} issue analysis call(s) failed. Possible systemic issue (rate limit, auth, network).`);
+    }
+
+    // Sort: new_response first, then waiting, then acknowledged
+    const statusOrder: Record<IssueConversationStatus, number> = {
+      new_response: 0,
+      waiting: 1,
+      acknowledged: 2,
+    };
+    results.sort((a, b) => statusOrder[a.status] - statusOrder[b.status]);
+
+    console.error(`Analyzed ${results.length} issue conversations (${results.filter(i => i.status === 'new_response').length} with new responses)`);
+    return { issues: results, failures };
+  }
+
+  /**
+   * Analyze a single issue's comment thread to determine conversation status.
+   */
+  private async analyzeIssueConversation(
+    item: { html_url: string; number: number; title: string; labels?: Array<{ name?: string }> },
+    repoFullName: string,
+    username: string,
+  ): Promise<CommentedIssue | null> {
+    const { owner, repo } = splitRepo(repoFullName);
+
+    const comments = await this.octokit.issues.listComments({
+      owner,
+      repo,
+      issue_number: item.number,
+      per_page: 100,
+    });
+
+    const timeline: Array<{ author: string; body: string; createdAt: string; isUser: boolean }> = [];
+    for (const comment of comments.data) {
+      if (!comment.user?.login) continue; // Skip comments from deleted accounts
+      const author = comment.user.login;
+      timeline.push({
+        author,
+        body: comment.body || '',
+        createdAt: comment.created_at,
+        isUser: author.toLowerCase() === username.toLowerCase(),
+      });
+    }
+
+    timeline.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+
+    // Find the user's last comment
+    let userLastComment: typeof timeline[0] | undefined;
+    for (const entry of timeline) {
+      if (entry.isUser) userLastComment = entry;
+    }
+
+    // If user never commented (shouldn't happen with commenter: search, but be safe)
+    if (!userLastComment) {
+      console.error(`[ISSUE_CONVERSATION] No user comment found for ${item.html_url} despite commenter: search match`);
+      return null;
+    }
+
+    const userLastCommentTime = new Date(userLastComment.createdAt);
+
+    // Find maintainer responses after the user's last comment
+    let lastResponse: { author: string; body: string; createdAt: string } | undefined;
+    for (const entry of timeline) {
+      if (entry.isUser) continue;
+      if (entry.author.includes('[bot]')) continue;
+
+      const entryTime = new Date(entry.createdAt);
+      if (entryTime > userLastCommentTime) {
+        // Skip pure acknowledgments
+        if (isAcknowledgmentComment(entry.body)) continue;
+
+        lastResponse = {
+          author: entry.author,
+          body: entry.body.slice(0, 200) + (entry.body.length > 200 ? '...' : ''),
+          createdAt: entry.createdAt,
+        };
+      }
+    }
+
+    // Determine status
+    let status: IssueConversationStatus;
+    if (lastResponse) {
+      status = 'new_response';
+    } else {
+      // No substantive response found. If user is the last non-bot commenter,
+      // mark as acknowledged; otherwise mark as waiting.
+      const lastNonBotComment = [...timeline].reverse().find(
+        e => !e.author.includes('[bot]')
+      );
+      status = lastNonBotComment?.isUser ? 'acknowledged' : 'waiting';
+    }
+
+    const labels = (item.labels || []).map(l => l.name || '').filter(Boolean);
+
+    return {
+      repo: repoFullName,
+      number: item.number,
+      title: item.title,
+      url: item.html_url,
+      status,
+      userLastCommentedAt: userLastComment.createdAt,
+      lastResponseAuthor: lastResponse?.author,
+      lastResponseBody: lastResponse?.body,
+      lastResponseAt: lastResponse?.createdAt,
+      labels,
+      daysSinceUserComment: daysBetween(userLastCommentTime, new Date()),
+    };
+  }
+}
+
+/**
+ * Detect acknowledgment comments that don't require a response.
+ * Returns true only when: no question mark, matches an acknowledgment keyword, and under 100 chars.
+ * Conservative -- missing a real acknowledgment (false negative) is safer than suppressing a substantive response (false positive).
+ * Used by both IssueConversationMonitor and PRMonitor.
+ */
+export function isAcknowledgmentComment(body: string): boolean {
+  if (!body || body.length > 100) return false;
+  if (body.includes('?')) return false;
+
+  const lower = body.toLowerCase();
+  const ackKeywords = [
+    'thanks', 'thank you', 'lgtm', 'looks good',
+    'will review', "we'll review", "we'll get to this",
+    'noted', 'got it', 'will look', 'will check',
+  ];
+
+  return ackKeywords.some(kw => lower.includes(kw));
+}

--- a/src/core/pr-monitor.test.ts
+++ b/src/core/pr-monitor.test.ts
@@ -19,6 +19,7 @@ vi.mock('./state.js', () => ({
 
 // Import after mocks are set up
 const { PRMonitor, computeDisplayLabel, classifyCICheck, classifyFailingChecks } = await import('./pr-monitor.js');
+const { isAcknowledgmentComment } = await import('./issue-conversation.js');
 const { getStateManager } = await import('./state.js');
 
 describe('PRMonitor CI status deduplication', () => {
@@ -1165,60 +1166,46 @@ describe('PRMonitor CI failure overrides changes_addressed (Issue #68)', () => {
   });
 });
 
-describe('PRMonitor acknowledgment comment detection (Issue #69)', () => {
-  beforeEach(() => {
-    mockOctokitInstance = {};
-  });
-
+describe('isAcknowledgmentComment (Issue #69)', () => {
   it('should detect "thanks" as acknowledgment', () => {
-    const monitor = new PRMonitor('fake-token');
-    expect((monitor as any).isAcknowledgmentComment('thanks')).toBe(true);
+    expect(isAcknowledgmentComment('thanks')).toBe(true);
   });
 
   it('should detect "Thank you!" as acknowledgment', () => {
-    const monitor = new PRMonitor('fake-token');
-    expect((monitor as any).isAcknowledgmentComment('Thank you!')).toBe(true);
+    expect(isAcknowledgmentComment('Thank you!')).toBe(true);
   });
 
   it('should detect "LGTM" as acknowledgment', () => {
-    const monitor = new PRMonitor('fake-token');
-    expect((monitor as any).isAcknowledgmentComment('LGTM')).toBe(true);
+    expect(isAcknowledgmentComment('LGTM')).toBe(true);
   });
 
   it('should detect "Looks good, will review soon" as acknowledgment', () => {
-    const monitor = new PRMonitor('fake-token');
-    expect((monitor as any).isAcknowledgmentComment('Looks good, will review soon')).toBe(true);
+    expect(isAcknowledgmentComment('Looks good, will review soon')).toBe(true);
   });
 
   it('should detect "we\'ll get to this shortly" as acknowledgment', () => {
-    const monitor = new PRMonitor('fake-token');
-    expect((monitor as any).isAcknowledgmentComment("we'll get to this shortly")).toBe(true);
+    expect(isAcknowledgmentComment("we'll get to this shortly")).toBe(true);
   });
 
   it('should detect "noted" as acknowledgment', () => {
-    const monitor = new PRMonitor('fake-token');
-    expect((monitor as any).isAcknowledgmentComment('noted')).toBe(true);
+    expect(isAcknowledgmentComment('noted')).toBe(true);
   });
 
   it('should NOT detect actionable comment as acknowledgment', () => {
-    const monitor = new PRMonitor('fake-token');
-    expect((monitor as any).isAcknowledgmentComment('Please fix linting errors')).toBe(false);
+    expect(isAcknowledgmentComment('Please fix linting errors')).toBe(false);
   });
 
   it('should NOT detect empty string as acknowledgment', () => {
-    const monitor = new PRMonitor('fake-token');
-    expect((monitor as any).isAcknowledgmentComment('')).toBe(false);
+    expect(isAcknowledgmentComment('')).toBe(false);
   });
 
   it('should NOT detect comment with question mark as acknowledgment', () => {
-    const monitor = new PRMonitor('fake-token');
-    expect((monitor as any).isAcknowledgmentComment('Thanks, can you add tests?')).toBe(false);
+    expect(isAcknowledgmentComment('Thanks, can you add tests?')).toBe(false);
   });
 
   it('should NOT detect long comment with keyword as acknowledgment', () => {
-    const monitor = new PRMonitor('fake-token');
     const longComment = 'Thanks for this PR! ' + 'x'.repeat(100);
-    expect((monitor as any).isAcknowledgmentComment(longComment)).toBe(false);
+    expect(isAcknowledgmentComment(longComment)).toBe(false);
   });
 
   it('should not trigger hasUnrespondedComment for acknowledgment comments', () => {

--- a/src/core/pr-monitor.ts
+++ b/src/core/pr-monitor.ts
@@ -9,6 +9,7 @@ import { getOctokit } from './github.js';
 import { getStateManager } from './state.js';
 import { daysBetween } from './utils.js';
 import { FetchedPR, FetchedPRStatus, CIStatus, ReviewDecision, DailyDigest, MaintainerActionHint, ClosedPR, CIFailureCategory, ClassifiedCheck } from './types.js';
+import { isAcknowledgmentComment } from './issue-conversation.js';
 
 // Concurrency limit for parallel API calls
 const MAX_CONCURRENT_REQUESTS = 5;
@@ -328,7 +329,7 @@ export class PRMonitor {
     }
 
     // Filter out pure acknowledgment comments that don't require a response
-    if (lastMaintainerComment && this.isAcknowledgmentComment(lastMaintainerComment.body)) {
+    if (lastMaintainerComment && isAcknowledgmentComment(lastMaintainerComment.body)) {
       lastMaintainerComment = undefined;
     }
 
@@ -336,25 +337,6 @@ export class PRMonitor {
       hasUnrespondedComment: !!lastMaintainerComment,
       lastMaintainerComment,
     };
-  }
-
-  /**
-   * Detect acknowledgment comments that don't require a response.
-   * Returns true only when: no question mark, matches an acknowledgment keyword, and under 100 chars.
-   * Conservative — false negatives (flagging an acknowledgment) are safer than false positives.
-   */
-  private isAcknowledgmentComment(body: string): boolean {
-    if (!body || body.length > 100) return false;
-    if (body.includes('?')) return false;
-
-    const lower = body.toLowerCase();
-    const ackKeywords = [
-      'thanks', 'thank you', 'lgtm', 'looks good',
-      'will review', "we'll review", "we'll get to this",
-      'noted', 'got it', 'will look', 'will check',
-    ];
-
-    return ackKeywords.some(kw => lower.includes(kw));
   }
 
   /**

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -574,6 +574,27 @@ export interface AgentConfig {
   aiPolicyBlocklist?: string[];
 }
 
+/** Status of a user's comment thread on a GitHub issue. */
+export type IssueConversationStatus =
+  | 'new_response'      // Maintainer responded after user's last comment
+  | 'waiting'           // Last non-bot commenter is not the user; no substantive (non-acknowledgment) response found
+  | 'acknowledged';     // User was the last non-bot commenter; no action needed
+
+/** A GitHub issue the user has commented on, with conversation state. */
+export interface CommentedIssue {
+  repo: string;         // "owner/repo"
+  number: number;
+  title: string;
+  url: string;
+  status: IssueConversationStatus;
+  userLastCommentedAt: string;
+  lastResponseAuthor?: string;
+  lastResponseBody?: string;    // Truncated to 200 chars (+ "..." suffix when truncated)
+  lastResponseAt?: string;
+  labels: string[];
+  daysSinceUserComment: number;
+}
+
 /** Default configuration applied to new state files. All fields can be overridden via `/setup-oss`. */
 export const DEFAULT_CONFIG: AgentConfig = {
   setupComplete: false,

--- a/src/formatters/json.ts
+++ b/src/formatters/json.ts
@@ -3,7 +3,7 @@
  * Provides structured output that can be consumed by scripts and plugins
  */
 
-import type { TrackedPR, FetchedPR, DailyDigest, AgentState, RepoGroup } from '../core/types.js';
+import type { TrackedPR, FetchedPR, DailyDigest, AgentState, RepoGroup, CommentedIssue } from '../core/types.js';
 import type { PRCheckFailure } from '../core/pr-monitor.js';
 import type { SearchPriority } from '../core/issue-discovery.js';
 
@@ -49,13 +49,15 @@ export interface ActionMenuItem {
  * plus context flags so the orchestration can insert issue-list options.
  */
 export interface ActionMenu {
-  /** Ordered list of menu items. The orchestration may insert issue-list items after `address_all` (index 1) or at the start (index 0) when no actionable issues exist. */
+  /** Ordered list of menu items. The orchestration may insert issue-list items after the CLI-generated items (address_all, issue_replies) or at the start when none exist. */
   items: ActionMenuItem[];
   /** Context flags for the orchestration layer to decide on issue-list options. */
   context: {
     hasActionableIssues: boolean;
     actionableCount: number;
     hasCapacity: boolean;
+    hasIssueResponses: boolean;
+    issueResponseCount: number;
   };
 }
 
@@ -67,6 +69,7 @@ export interface DailyOutput {
   briefSummary: string; // One-liner for action-first flow
   actionableIssues: ActionableIssue[]; // Structured list for AskUserQuestion
   actionMenu: ActionMenu; // Pre-computed action menu for Step 3
+  commentedIssues: CommentedIssue[]; // Issues user commented on with conversation state
   repoGroups: RepoGroup[]; // PRs grouped by repo for safe parallel dispatch (#80)
   failures: PRCheckFailure[]; // PRs that failed to fetch (e.g., rate limits, network errors)
 }


### PR DESCRIPTION
## Summary

- **Issue conversation tracking** — `/oss` daily check now monitors GitHub issues the user has commented on and surfaces maintainer responses
- New `IssueConversationMonitor` class following the `PRMonitor` pattern: stateless GitHub Search API fetch, bounded concurrency worker pool, bot/acknowledgment filtering
- Results appear in daily summary, action menu ("Review N issue replies"), and HTML dashboard
- Users can claim issues directly from the replies flow, entering the existing `TrackedIssue` pipeline
- Consolidated `isAcknowledgmentComment()` as shared utility (was duplicated in `PRMonitor`)
- Extracted `buildRepoMap()` helper, replaced duplicate `formatIssueResponseTime` with existing `formatRelativeTime`

Closes #114

## Test plan

- [x] All 456 tests pass (`npm test`)
- [x] Bundle builds successfully at 549KB (`npm run bundle`)
- [x] Version bump synced across package.json, plugin.json, README badge (0.25.0)
- [x] 20 new tests covering: maintainer response detection, bot filtering, acknowledgment filtering, waiting/acknowledged/new_response status paths, blocklist filtering, case-insensitive matching, sort order, body truncation, label inclusion
- [ ] Manual: comment on a test issue, wait for response, run `daily --json` to confirm `commentedIssues` field
- [ ] Manual: verify HTML dashboard shows "Issue Conversations" section