### PR TITLE
chore: repo health improvements — CI badge and first GitHub Release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "AI-powered autopilot for managing open source contributions - track PRs, respond to maintainers, discover issues, and maintain contribution velocity",
   "author": {
     "name": "John Costa"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.24.1] - 2026-02-11
+
+### Added
+
+- **CI status badge in README** — Build status badge from GitHub Actions CI workflow now displayed alongside existing badges
+
 ## [0.24.0] - 2026-02-11
 
 ### Added
@@ -500,6 +506,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR monitoring and health checking
 - Dashboard HTML generation
 
+[0.24.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.24.0...v0.24.1
 [0.24.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.23.2...v0.24.0
 [0.23.2]: https://github.com/costajohnt/oss-autopilot/compare/v0.23.1...v0.23.2
 [0.23.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.23.0...v0.23.1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Discover issues worth contributing to, track your PRs across repos, and draft responses to maintainer feedback. An AI copilot for your open source journey.
 
-![Version](https://img.shields.io/badge/version-0.24.0-blue)
+![Version](https://img.shields.io/badge/version-0.24.1-blue)
+![CI](https://github.com/costajohnt/oss-autopilot/actions/workflows/ci.yml/badge.svg)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)
 ![Node Version](https://img.shields.io/badge/node-%3E%3D18-brightgreen)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "AI-powered autopilot for managing open source contributions with Claude Code",
   "type": "module",
   "main": "dist/cli.js",


### PR DESCRIPTION
## Summary

- Add CI status badge to README (workflow already existed at `.github/workflows/ci.yml`)
- Create first GitHub Release (`v0.24.0`) to establish release history and enable CHANGELOG.md comparison links
- Issue templates were already present — GitHub's community profile API had stale cache

Closes #121. Consolidates #118, #119, #120.

## Test plan

- [x] All 436 tests pass
- [x] Version synced across `package.json`, `plugin.json`, README badge (0.24.1)
- [x] CI badge URL points to correct workflow
- [x] GitHub Release v0.24.0 visible at https://github.com/costajohnt/oss-autopilot/releases/tag/v0.24.0
- [x] CHANGELOG comparison link for 0.24.1 added