### PR TITLE
fix: simplify action menu to always show search option

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "AI-powered autopilot for managing open source contributions - track PRs, respond to maintainers, discover issues, and maintain contribution velocity",
   "author": {
     "name": "John Costa"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.26.1] - 2026-02-11
+
+### Changed
+
+- **Simplified action menu** — Removed `view_healthy` and `view_details` options from the action menu. "Search for new issues" is now always available regardless of capacity, and the issue-list integration (pick from list / replenish) no longer requires `hasCapacity`. This makes the flow more action-oriented: address issues first, then pick new work or search.
+
 ## [0.26.0] - 2026-02-11
 
 ### Added
@@ -536,6 +542,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR monitoring and health checking
 - Dashboard HTML generation
 
+[0.26.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.26.0...v0.26.1
 [0.26.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.25.1...v0.26.0
 [0.25.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.25.0...v0.25.1
 [0.25.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.24.1...v0.25.0

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ You have 12 open PRs across GitHub. A maintainer asked a question 5 days ago. Tw
 
 OSS Autopilot is an AI copilot that tracks all your open source PRs, alerts you when something needs attention, and helps you respond to maintainer feedback so your contributions actually get merged.
 
-![Version](https://img.shields.io/badge/version-0.26.0-blue)
+![Version](https://img.shields.io/badge/version-0.26.1-blue)
 ![CI](https://github.com/costajohnt/oss-autopilot/actions/workflows/ci.yml/badge.svg)
-![Tests](https://img.shields.io/badge/tests-451_passing-success)
+![Tests](https://img.shields.io/badge/tests-447_passing-success)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)
 

--- a/commands/oss.md
+++ b/commands/oss.md
@@ -155,7 +155,7 @@ Use AskUserQuestion with these options:
 
 The CLI pre-computes the action menu in `data.daily.actionMenu`. Use these items directly in AskUserQuestion instead of manually deriving options.
 
-**Fallback:** If `data.daily.actionMenu` is missing (e.g., older CLI version), tell the user: "Action menu not found in CLI output — you may need to rebuild the CLI: `cd ${CLAUDE_PLUGIN_ROOT} && npm run bundle`". Then derive options manually: always include "Done for now"; add "Work through all N issues (Recommended)" if `data.daily.actionableIssues.length > 0`; add "Search for new issues" if `data.daily.capacity.hasCapacity`; add "View healthy PRs" if not `data.daily.capacity.hasCapacity` and `data.daily.actionableIssues.length > 0`; otherwise add "View PR status details".
+**Fallback:** If `data.daily.actionMenu` is missing (e.g., older CLI version), tell the user: "Action menu not found in CLI output — you may need to rebuild the CLI: `cd ${CLAUDE_PLUGIN_ROOT} && npm run bundle`". Then derive options manually: always include "Done for now"; add "Work through all N issues (Recommended)" if `data.daily.actionableIssues.length > 0`; always add "Search for new issues".
 
 ### If No Actionable Issues
 
@@ -213,13 +213,13 @@ Use `issue.pr.daysSinceActivity` from the CLI output (already computed).
 
 Use `data.daily.actionMenu.items` directly as AskUserQuestion options. Each item has `key`, `label`, and `description` fields ready for display.
 
-**Issue list integration:** If the user has a curated issue list (detected from `data.issueList` in the startup output), insert an issue-list option **after `address_all`** (index 1) or **at the start** (index 0) when no actionable issues exist — i.e., always before the `search`/`view_details`/`view_healthy` item:
+**Issue list integration:** If the user has a curated issue list (detected from `data.issueList` in the startup output), insert an issue-list option **after `address_all`** (index 1) or **at the start** (index 0) when no actionable issues exist — i.e., always before the `search` item:
 
 | Condition | Insert Item |
 |-----------|-------------|
-| `hasIssueList && availableCount >= 5 && context.hasCapacity` | Key: `pick_from_list`, Label: `"Pick from your issue list ({availableCount} ready)"`, Description: `"You have {availableCount} vetted issues ready to work on — starting one would be higher ROI than searching for more"` |
-| `hasIssueList && availableCount > 0 && availableCount < 5 && context.hasCapacity` | Key: `pick_from_list`, Label: `"Pick from your issue list ({availableCount} available)"`, Description: `"Choose from your curated list of vetted issues"` |
-| `hasIssueList && availableCount === 0 && context.hasCapacity` | Key: `replenish_list`, Label: `"Replenish your issue list"`, Description: `"All {completedCount} issues done — search for fresh ones"`. Also **remove** the `search` item (replenish replaces it). |
+| `hasIssueList && availableCount >= 5` | Key: `pick_from_list`, Label: `"Pick from your issue list ({availableCount} ready)"`, Description: `"You have {availableCount} vetted issues ready to work on — starting one would be higher ROI than searching for more"` |
+| `hasIssueList && availableCount > 0 && availableCount < 5` | Key: `pick_from_list`, Label: `"Pick from your issue list ({availableCount} available)"`, Description: `"Choose from your curated list of vetted issues"` |
+| `hasIssueList && availableCount === 0` | Key: `replenish_list`, Label: `"Replenish your issue list"`, Description: `"All {completedCount} issues done — search for fresh ones"`. Also **remove** the `search` item (replenish replaces it). |
 
 When inserting issue-list items, keep within the 4-option limit (the 5th is the auto "Other").
 
@@ -612,8 +612,8 @@ Or update the config file directly to add repos to `excludeRepos`.
 **After the "Work through all issues" flow completes (Phase C ends or user selects "Done for now" during it), and after "After Each Action" runs its state refresh, ALWAYS present the session-level menu. Never end with just a summary.**
 
 Use AskUserQuestion:
-- "Pick from your issue list" (if `hasIssueList` and `availableCount > 0` and `hasCapacity`) — "{availableCount} vetted issues available"
-- "Search for new issues" (if `hasCapacity`)
+- "Pick from your issue list" (if `hasIssueList` and `availableCount > 0`) — "{availableCount} vetted issues available"
+- "Search for new issues"
 - "Check for more PR updates" (re-run daily check)
 - "Done for now"
 
@@ -624,26 +624,7 @@ Use AskUserQuestion:
 When user selects specific PRs (e.g., "1 and 3"), dispatch only those agents in parallel.
 Still group by repo if selected PRs share a repository.
 
-### Handle "View Healthy PRs"
-
-Show when `capacity.hasCapacity === false` (user has critical issues to address first).
-
-Display healthy PRs from `data.daily.digest.healthyPRs`:
-```
-Healthy PRs (no action needed):
-
-- owner/repo#123 - Title here (approved, CI passing)
-- owner/repo#456 - Title here (waiting for review)
-...
-
-These PRs are progressing normally. Focus on the {count} issues that need attention.
-```
-
-Then return to Step 3 to present action choices again.
-
 ### Handle "Find New Issues"
-
-Only available if `capacity.hasCapacity === true`.
 
 **Initialize search session state** (reset each time this handler is entered):
 - `searchRoundScores`: number[] = [] (average vetting score per search round, for diminishing returns check)
@@ -847,9 +828,6 @@ Use AskUserQuestion (if `availableCount >= 5` and an advisory was shown, place t
 - `issueContext = { title, url, description }` — for scope-aware review in Step 5.6
 
 This activates the same draft-first workflow as the curated list path (see "Handle Pick Issue From List" section 6 for the full sequence: Steps 5.5 through 6).
-
-If user requests this but `hasCapacity === false`:
-> "You currently have [N] critical issues that need attention. Would you like to address those first, or override and search anyway?"
 
 ### Handle "Pick Issue From List"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "AI-powered autopilot for managing open source contributions with Claude Code",
   "type": "module",
   "main": "dist/cli.js",

--- a/src/commands/daily.test.ts
+++ b/src/commands/daily.test.ts
@@ -80,27 +80,12 @@ describe('computeActionMenu', () => {
     expect(menu.context.actionableCount).toBe(0);
   });
 
-  it('should include search when user has capacity', () => {
-    const menu = computeActionMenu([], makeCapacity({ hasCapacity: true }));
+  it('should always include search regardless of capacity', () => {
+    const withCapacity = computeActionMenu([], makeCapacity({ hasCapacity: true }));
+    const withoutCapacity = computeActionMenu([], makeCapacity({ hasCapacity: false }));
 
-    expect(menu.items.find(i => i.key === 'search')).toBeDefined();
-    expect(menu.items.find(i => i.key === 'view_healthy')).toBeUndefined();
-  });
-
-  it('should include view_healthy (not search) when no capacity and has actionable issues', () => {
-    const issues = [makeActionableIssue()];
-    const menu = computeActionMenu(issues, makeCapacity({ hasCapacity: false }));
-
-    expect(menu.items.find(i => i.key === 'view_healthy')).toBeDefined();
-    expect(menu.items.find(i => i.key === 'search')).toBeUndefined();
-  });
-
-  it('should include view_details when no capacity and no actionable issues', () => {
-    const menu = computeActionMenu([], makeCapacity({ hasCapacity: false }));
-
-    expect(menu.items.find(i => i.key === 'view_details')).toBeDefined();
-    expect(menu.items.find(i => i.key === 'search')).toBeUndefined();
-    expect(menu.items.find(i => i.key === 'view_healthy')).toBeUndefined();
+    expect(withCapacity.items.find(i => i.key === 'search')).toBeDefined();
+    expect(withoutCapacity.items.find(i => i.key === 'search')).toBeDefined();
   });
 
   it('should always include done as the last item', () => {
@@ -124,33 +109,21 @@ describe('computeActionMenu', () => {
     });
   });
 
-  it('should produce 3 items when actionable issues exist and has capacity', () => {
-    const menu = computeActionMenu([makeActionableIssue()], makeCapacity());
-
-    expect(menu.items).toHaveLength(3);
-    expect(menu.items.map(i => i.key)).toEqual(['address_all', 'search', 'done']);
-  });
-
-  it('should produce 2 items when no actionable issues and has capacity', () => {
-    const menu = computeActionMenu([], makeCapacity());
-
-    expect(menu.items).toHaveLength(2);
-    expect(menu.items.map(i => i.key)).toEqual(['search', 'done']);
-  });
-
-  it('should produce 2 items when no actionable issues and no capacity', () => {
-    const menu = computeActionMenu([], makeCapacity({ hasCapacity: false }));
-
-    expect(menu.items).toHaveLength(2);
-    expect(menu.items.map(i => i.key)).toEqual(['view_details', 'done']);
-  });
-
-  it('should produce 3 items when actionable issues exist and no capacity', () => {
+  it('should produce [address_all, search, done] when actionable issues exist', () => {
     const issues = [makeActionableIssue(), makeActionableIssue('needs_response')];
-    const menu = computeActionMenu(issues, makeCapacity({ hasCapacity: false }));
+    const withCapacity = computeActionMenu(issues, makeCapacity({ hasCapacity: true }));
+    const withoutCapacity = computeActionMenu(issues, makeCapacity({ hasCapacity: false }));
 
-    expect(menu.items).toHaveLength(3);
-    expect(menu.items.map(i => i.key)).toEqual(['address_all', 'view_healthy', 'done']);
+    expect(withCapacity.items.map(i => i.key)).toEqual(['address_all', 'search', 'done']);
+    expect(withoutCapacity.items.map(i => i.key)).toEqual(['address_all', 'search', 'done']);
+  });
+
+  it('should produce [search, done] when no actionable issues exist', () => {
+    const withCapacity = computeActionMenu([], makeCapacity({ hasCapacity: true }));
+    const withoutCapacity = computeActionMenu([], makeCapacity({ hasCapacity: false }));
+
+    expect(withCapacity.items.map(i => i.key)).toEqual(['search', 'done']);
+    expect(withoutCapacity.items.map(i => i.key)).toEqual(['search', 'done']);
   });
 });
 

--- a/src/commands/daily.ts
+++ b/src/commands/daily.ts
@@ -624,30 +624,14 @@ export function computeActionMenu(
     });
   }
 
-  // Slot for issue-list options — the orchestration layer may insert items here
-  // (index 1 when address_all is present, index 0 otherwise).
-  // See commands/oss.md Step 3 for the insertion logic.
+  // The orchestration layer (commands/oss.md Step 3) may insert issue-list
+  // options before this item when a curated list is available.
 
-  if (capacity.hasCapacity) {
-    items.push({
-      key: 'search',
-      label: 'Search for new issues',
-      description: 'Look for new contribution opportunities',
-    });
-  } else if (!hasActionableIssues) {
-    // When no actionable issues and no capacity, offer status details
-    items.push({
-      key: 'view_details',
-      label: 'View PR status details',
-      description: 'See full status of all tracked PRs',
-    });
-  } else {
-    items.push({
-      key: 'view_healthy',
-      label: 'View healthy PRs',
-      description: 'See status of PRs not needing attention',
-    });
-  }
+  items.push({
+    key: 'search',
+    label: 'Search for new issues',
+    description: 'Look for new contribution opportunities',
+  });
 
   items.push({
     key: 'done',


### PR DESCRIPTION
## Summary

- Removed `view_healthy` and `view_details` options from the action menu — "Search for new issues" is now always available regardless of capacity
- Removed `hasCapacity` gate from issue-list integration in `oss.md` — pick-from-list and replenish options are always available
- Removed stale capacity soft-warning from "Handle Find New Issues" handler
- Net -58 lines across CLI, tests, and prompt

## Test plan

- [x] All 447 tests pass (`npm test`)
- [x] `computeActionMenu` produces `[address_all, search, done]` with actionable issues (both capacity states)
- [x] `computeActionMenu` produces `[search, done]` without actionable issues (both capacity states)
- [x] No stale `view_healthy`/`view_details` references remain in codebase
- [x] Remaining `hasCapacity` references are informational-only (example JSON, session summary display)