### PR TITLE
fix: display content before approval prompts

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.26.3",
+  "version": "0.26.4",
   "description": "AI-powered autopilot for managing open source contributions - track PRs, respond to maintainers, discover issues, and maintain contribution velocity",
   "author": {
     "name": "John Costa"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.26.4] - 2026-02-12
+
+### Fixed
+
+- **Display content before approval prompts** — Diffs and drafted comments are now shown inline before presenting approval buttons, so users can review content before deciding.
+
 ## [0.26.3] - 2026-02-11
 
 ### Changed
@@ -554,6 +560,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR monitoring and health checking
 - Dashboard HTML generation
 
+[0.26.4]: https://github.com/costajohnt/oss-autopilot/compare/v0.26.3...v0.26.4
 [0.26.3]: https://github.com/costajohnt/oss-autopilot/compare/v0.26.2...v0.26.3
 [0.26.2]: https://github.com/costajohnt/oss-autopilot/compare/v0.26.1...v0.26.2
 [0.26.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.26.0...v0.26.1

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ You have 12 open PRs across GitHub. A maintainer asked a question 5 days ago. Tw
 
 OSS Autopilot is an AI copilot that tracks all your open source PRs, alerts you when something needs attention, and helps you respond to maintainer feedback so your contributions actually get merged.
 
-![Version](https://img.shields.io/badge/version-0.26.3-blue)
+![Version](https://img.shields.io/badge/version-0.26.4-blue)
 ![CI](https://github.com/costajohnt/oss-autopilot/actions/workflows/ci.yml/badge.svg)
 ![Tests](https://img.shields.io/badge/tests-447_passing-success)
 ![License](https://img.shields.io/badge/license-MIT-green)

--- a/agents/pre-commit-reviewer.md
+++ b/agents/pre-commit-reviewer.md
@@ -172,6 +172,20 @@ Then use AskUserQuestion:
 - "Commit and push (Recommended)" — "Stage, commit, and push changes"
 - "Done for now" — "Cancel, return without committing"
 
+**When user selects "Show full diff" / "Show full diff first":**
+- Run `git diff` and **output the full diff as a markdown code block in your text response** so the user can read it
+- **If `git diff` fails**, report the error and offer: "Retry" / "Continue without diff" / "Done for now". If the user selects "Continue without diff", skip the diff display and present the follow-up prompt directly.
+- **After** the diff is visible in your response (or user chose to continue without), use AskUserQuestion:
+  ```
+  Question: "Diff reviewed. Ready to proceed?"
+  Header: "Diff"
+
+  Options:
+  1. "Commit and push (Recommended)" — "Stage and push these changes"
+  2. "Fix something first" — "Make additional changes before committing"
+  3. "Done for now" — "Cancel"
+  ```
+
 ## Important Rules
 
 1. **Be specific** — always include file paths and line numbers

--- a/commands/oss.md
+++ b/commands/oss.md
@@ -1240,8 +1240,9 @@ Options:
 - Continue until user is satisfied or selects a different option
 
 **"Show full diff" / "Show full diff first":**
-- Display the full `git diff` output
-- Then ask:
+- Run `git diff` and **output the full diff as a markdown code block in your text response** so the user can read it
+- **If `git diff` fails**, report the error and offer: "Retry" / "Continue without diff" / "Done for now". If the user selects "Continue without diff", skip the diff display and present the follow-up prompt directly (the user has explicitly chosen to proceed without reviewing the raw diff).
+- **After** the diff is visible in your response (or user chose to continue without), use AskUserQuestion:
   ```
   Question: "Diff reviewed. Ready to proceed?"
   Header: "Diff"
@@ -1275,7 +1276,9 @@ Options:
    - Mention any points that were intentionally NOT changed, with a brief explanation why
    - Keep the tone professional and grateful (see `oss-contribution` skill for guidelines)
 
-2. Present the draft to the user:
+2. **Output the drafted comment as a blockquote in your text response** so the user can read it.
+
+3. **After** the draft is visible in your response, use AskUserQuestion:
    ```
    Question: "Post this response to the maintainer?"
    Header: "PR Comment"
@@ -1286,12 +1289,12 @@ Options:
    3. "Skip — don't post a comment" — "Push is enough, no comment needed"
    ```
 
-3. Handle choice:
+4. Handle choice:
    - **"Post this response":** Write comment to `/tmp/pr-comment-{pr_number}.md` and post via `gh pr comment {pr_number} --repo {upstream_repo} --body-file /tmp/pr-comment-{pr_number}.md` (avoids shell escaping issues with inline `--body`). Verify exit code 0, then delete the temp file.
    - **"Edit before posting":** Let the user modify the draft, re-present for approval, then post using the same method.
    - **"Skip":** No comment posted.
 
-4. **If `gh pr comment` fails (for either "Post" or "Edit" path):** Report the error, display the drafted comment so the user can copy it, and offer: "Retry" / "Copy and post manually" / "Skip". Do NOT silently proceed without the comment.
+5. **If `gh pr comment` fails (for either "Post" or "Edit" path):** Report the error, display the drafted comment so the user can copy it, and offer: "Retry" / "Copy and post manually" / "Skip". Do NOT silently proceed without the comment.
 
 **After this sub-step completes (or is skipped):** If currently in Phase C's sequential loop, return to Phase C to process the next item. Otherwise, proceed to Step 6.
 
@@ -1447,8 +1450,9 @@ Options:
 ```
 
 **"Show full diff" / "Show full diff first":**
-- Display the full `git diff origin/$baseBranch..HEAD` output
-- Then ask:
+- Run `git diff origin/$baseBranch..HEAD` and **output the full diff as a markdown code block in your text response** so the user can read it
+- **If `git diff` fails** (e.g., remote ref not found), try `git fetch origin $baseBranch` and retry. If still failing, report the error and offer: "Retry" / "Continue without diff" / "Done for now". If the user selects "Continue without diff", skip the diff display and present the follow-up prompt directly.
+- **After** the diff is visible in your response (or user chose to continue without), use AskUserQuestion:
   ```
   Question: "Diff reviewed. Ready to proceed?"
   Header: "Diff"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.26.3",
+  "version": "0.26.4",
   "description": "AI-powered autopilot for managing open source contributions with Claude Code",
   "type": "module",
   "main": "dist/cli.js",


### PR DESCRIPTION
## Summary

- Diffs and drafted comments are now shown inline before presenting approval buttons, so users can review content before deciding
- Added `git diff` failure handling with recovery options to all "Show full diff" handlers
- Added complete "Show full diff" handler to `pre-commit-reviewer` agent for standalone use

## Test plan

- [x] All 447 tests pass (`npm test`)
- [x] 3 rounds of parallel code review (code-reviewer, silent-failure-hunter, code-simplifier)
- [ ] Manual verification: trigger Step 5.5 "Show full diff" flow and confirm diff renders before prompt
- [ ] Manual verification: trigger Step 5.5 post-response comment flow and confirm draft renders before prompt
- [ ] Manual verification: trigger Step 5.6 "Show full diff" flow and confirm diff renders before prompt

Fixes #130