### PR TITLE
fix: batch skill prompt fixes (#133, #134, #135, #137, #144)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.26.4",
+  "version": "0.26.5",
   "description": "AI-powered autopilot for managing open source contributions - track PRs, respond to maintainers, discover issues, and maintain contribution velocity",
   "author": {
     "name": "John Costa"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.26.5] - 2026-02-13
+
+### Added
+
+- **Manual testing auto-skip for non-visual changes (#134)** — Added auto-skip criteria to Step 5.7b so non-visual utility changes with passing automated tests bypass the manual testing prompt.
+- **Branch prefix vs commit type mismatch (#135)** — Added guidance at issue claim time to choose a consistent change type (fix/feat/docs) for both branch prefix and commit message based on issue labels.
+
+### Fixed
+
+- **Force push refspec bash concatenation bug (#133)** — Simplified `git fetch origin "$branch:refs/remotes/origin/$branch"` to `git fetch origin "$branch"` to avoid shell quoting issues with the colon-separated refspec when chained via `&&` in bash commands.
+- **CI re-run permission failures (#144)** — Added fallback guidance when `gh run rerun --failed` fails with permission or other errors on fork PRs. Suggests alternatives: empty commit retrigger, maintainer request, or waiting.
+- **Full review tier for new contributions (#137)** — Strengthened Step 5.6 to explicitly override size-based scaling, ensuring the full Large-tier review suite is dispatched for new contributions regardless of diff size.
+
 ## [0.26.4] - 2026-02-12
 
 ### Fixed
@@ -560,6 +573,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR monitoring and health checking
 - Dashboard HTML generation
 
+[0.26.5]: https://github.com/costajohnt/oss-autopilot/compare/v0.26.4...v0.26.5
 [0.26.4]: https://github.com/costajohnt/oss-autopilot/compare/v0.26.3...v0.26.4
 [0.26.3]: https://github.com/costajohnt/oss-autopilot/compare/v0.26.2...v0.26.3
 [0.26.2]: https://github.com/costajohnt/oss-autopilot/compare/v0.26.1...v0.26.2

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ You have 12 open PRs across GitHub. A maintainer asked a question 5 days ago. Tw
 
 OSS Autopilot is an AI copilot that tracks all your open source PRs, alerts you when something needs attention, and helps you respond to maintainer feedback so your contributions actually get merged.
 
-![Version](https://img.shields.io/badge/version-0.26.4-blue)
+![Version](https://img.shields.io/badge/version-0.26.5-blue)
 ![CI](https://github.com/costajohnt/oss-autopilot/actions/workflows/ci.yml/badge.svg)
 ![Tests](https://img.shields.io/badge/tests-447_passing-success)
 ![License](https://img.shields.io/badge/license-MIT-green)

--- a/agents/pr-health-checker.md
+++ b/agents/pr-health-checker.md
@@ -241,6 +241,17 @@ For branches behind upstream:
 For CI failures (code issues):
 > Analyze the failing check output. Identify whether it's a test failure, lint error, build error, or type error. Recommend a specific fix.
 
+For CI re-runs:
+> Attempt `gh run rerun <id> --repo <repo> --failed`. If it fails, do NOT retry. Handle based on error:
+> - "Must have admin rights" (common for fork PRs) → Report permission issue and suggest alternatives for user approval:
+>   1. Push an empty commit to retrigger CI: `git commit --allow-empty -m "retrigger CI" && git push`
+>   2. Leave a comment asking the maintainer to re-run CI
+>   3. Wait — maintainers often re-run CI during review
+> - "not in a rerunnable state" → Report that the run cannot be rerun (still in progress or cancelled). Suggest waiting.
+> - Any other error → Report the exact error message. Do NOT push an empty commit (the issue is not permissions-related).
+>
+> **Retrigger limit:** Suggest the empty commit approach at most once per PR. If CI fails again after retriggering, the failure is likely a real issue. Note that empty retrigger commits will be squashed out during Step 5.7.
+
 For linting failures:
 > Run the project's lint fix command (usually `npm run lint:fix` or similar), then commit and push.
 

--- a/commands/oss.md
+++ b/commands/oss.md
@@ -419,7 +419,7 @@ For each issue in `actionableIssues`, include a Task tool call grouped by repo:
 | Issue Type | Tier | Agent Action |
 |------------|------|--------------|
 | Needs Rebase | Tier 1 | Clone if needed, fetch upstream, rebase, force push. Report result. |
-| CI Failing | Tier 2 | Investigate CI failures. Analyze logs, identify root cause, recommend fixes. DO NOT push. |
+| CI Failing | Tier 2 | Investigate CI failures. Analyze logs, identify root cause, recommend fixes. DO NOT push code fixes without approval. If a re-run is needed, attempt `gh run rerun <id> --repo <repo> --failed`. If it fails (permission error, non-rerunnable state, or other error), report the error and suggest alternatives for user approval: push an empty commit to retrigger, ask maintainer to re-run, or wait. |
 | CI Blocked | Info | Report that CI needs maintainer trigger. Suggest commenting to request it. |
 | CI Not Running | Info | Investigate why CI isn't running. Check if workflows exist, if fork has actions enabled. |
 | Fork Limitation | Info | Note as expected — no action needed. |
@@ -827,7 +827,7 @@ Use AskUserQuestion (if `availableCount >= 5` and an advisory was shown, place t
 - `isNewContribution = true`
 - `issueContext = { title, url, description }` — for scope-aware review in Step 5.6
 
-This activates the same draft-first workflow as the curated list path (see "Handle Pick Issue From List" section 6 for the full sequence: Steps 5.5 through 6).
+This activates the same draft-first workflow as the curated list path (see "Handle Pick Issue From List" section 6 for the full sequence: Steps 5.5 through 6, including change type selection rules).
 
 ### Handle "Pick Issue From List"
 
@@ -896,6 +896,11 @@ Show the vetting summary. If claimable, offer:
 When the user claims an issue and starts implementing, set:
 - `isNewContribution = true`
 - `issueContext = { title, url, description }` — the issue being addressed (used for scope-aware review in Step 5.6)
+- **Choose a consistent change type** based on the issue labels and nature of the change. Use this type for both the branch prefix and the commit message to avoid mismatches flagged by the compliance checker:
+  - Issue labeled `bug` or fixes broken behavior → `fix/` branch, `fix:` commit
+  - Issue labeled `enhancement`, `feature`, or adds new functionality → `feat/` branch, `feat:` commit
+  - Documentation-only changes → `docs/` branch, `docs:` commit
+  - If ambiguous, prefer `fix/` for correcting existing behavior and `feat/` for adding new capabilities
 
 After implementation, the flow proceeds through the **draft-first workflow**:
 1. Step 5.5 detects `isNewContribution` → commits, pushes, creates draft PR
@@ -1340,7 +1345,7 @@ Read the target repo's conventions if not already loaded:
 
 **CRITICAL: Dispatch ALL agents in a SINGLE message for true parallelism.**
 
-Use the same agent dispatch pattern as Step 5.5 sub-step 3, **always using the Large tier** (code-reviewer, silent-failure-hunter, code-simplifier, pr-test-analyzer, plus conditional agents), since this reviews the full branch diff for a new contribution. Step 5.5's size-based scaling does not apply here. Include the `Working directory: {local repo path}` line in every prompt. Additionally, **prepend the following SCOPE block** to each agent prompt. The SCOPE block constrains findings to the PR's purpose and prevents scope creep from pre-existing issues:
+Use the same agent dispatch pattern as Step 5.5 sub-step 3, but **do NOT use Step 5.5's size-based scaling — regardless of how small the diff is (even < 50 lines, ≤ 2 files), always dispatch the full Large tier** (code-reviewer, silent-failure-hunter, code-simplifier, pr-test-analyzer, plus conditional agents). New contributions warrant maximum review coverage. Include the `Working directory: {local repo path}` line in every prompt. Additionally, **prepend the following SCOPE block** to each agent prompt. The SCOPE block constrains findings to the PR's purpose and prevents scope creep from pre-existing issues:
 
 ```
 SCOPE: This PR addresses issue '{issueContext.title}' ({issueContext.url}).
@@ -1547,6 +1552,13 @@ Options:
 
 Automated review catches code patterns, but cannot verify runtime behavior (UI rendering, keyboard shortcuts, browser behavior, CLI output, etc.). This step gives the user a chance to manually verify the feature works before finalizing.
 
+**Auto-skip when ALL of the following are true:**
+- The change is a utility function, library code, or backend logic (no visual/UI component)
+- All relevant automated test suites pass
+- Manual testing would require non-trivial environment setup (e.g., CSP headers, specific server config, browser extension loading)
+
+When auto-skipping, note: "Skipping manual testing — non-visual change, all automated tests pass, and manual testing would require non-trivial environment setup." Then proceed directly to Step 5.7.
+
 ### 1. Prompt for Manual Testing
 
 ```
@@ -1719,7 +1731,7 @@ When a session has pushed multiple times, `--force-with-lease` can fail because 
 
 ```bash
 branch=$(git branch --show-current)
-git fetch origin "$branch:refs/remotes/origin/$branch"
+git fetch origin "$branch"
 git push --force-with-lease
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.26.4",
+  "version": "0.26.5",
   "description": "AI-powered autopilot for managing open source contributions with Claude Code",
   "type": "module",
   "main": "dist/cli.js",


### PR DESCRIPTION
## Summary

- **Fix force push refspec bash bug (#133)** — `git fetch origin "$branch:refs/remotes/origin/$branch"` → `git fetch origin "$branch"` to avoid shell quoting issues with colon-separated refspec
- **Add manual testing auto-skip (#134)** — Auto-skip Step 5.7b for non-visual utility changes with passing tests and non-trivial manual setup requirements
- **Add branch/commit type alignment (#135)** — Guidance at issue claim time to choose consistent `fix/`/`feat/`/`docs/` prefix for both branch and commit message
- **Enforce full review tier for new contributions (#137)** — Explicitly override Step 5.5's size-based scaling in Step 5.6 to always dispatch Large tier
- **Handle CI re-run failures (#144)** — Comprehensive error handling for `gh run rerun` failures (permission, non-rerunnable, generic) with retrigger limits and squash cleanup

## Test plan

- [x] All 447 tests pass (`npm test`)
- [x] Version bumped to 0.26.5 in all 3 locations (package.json, plugin.json, README badge)
- [x] CHANGELOG updated with correct Added/Fixed categorization
- [x] Two rounds of pr-review-toolkit review (code-reviewer, silent-failure-hunter, code-simplifier, comment-analyzer) — 8 findings identified and resolved

Closes #133, closes #134, closes #135, closes #137, closes #144