### PR TITLE
fix: filter bot comments from needs-response detection

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.26.6",
+  "version": "0.26.7",
   "description": "AI-powered autopilot for managing open source contributions - track PRs, respond to maintainers, discover issues, and maintain contribution velocity",
   "author": {
     "name": "John Costa"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.26.7] - 2026-02-13
+
+### Fixed
+
+- **Filter bot comments from "Needs Response" detection (#143)** — Bot accounts like CLAassistant, codecov-commenter, and changeset-bot (without the `[bot]` suffix) now correctly filtered alongside `[bot]`-suffixed accounts. PRs with only bot comments no longer trigger false positive investigation cycles.
+
 ## [0.26.6] - 2026-02-13
 
 ### Fixed
@@ -581,6 +587,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR monitoring and health checking
 - Dashboard HTML generation
 
+[0.26.7]: https://github.com/costajohnt/oss-autopilot/compare/v0.26.6...v0.26.7
 [0.26.6]: https://github.com/costajohnt/oss-autopilot/compare/v0.26.5...v0.26.6
 [0.26.5]: https://github.com/costajohnt/oss-autopilot/compare/v0.26.4...v0.26.5
 [0.26.4]: https://github.com/costajohnt/oss-autopilot/compare/v0.26.3...v0.26.4

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ You have 12 open PRs across GitHub. A maintainer asked a question 5 days ago. Tw
 
 OSS Autopilot is an AI copilot that tracks all your open source PRs, alerts you when something needs attention, and helps you respond to maintainer feedback so your contributions actually get merged.
 
-![Version](https://img.shields.io/badge/version-0.26.6-blue)
+![Version](https://img.shields.io/badge/version-0.26.7-blue)
 ![CI](https://github.com/costajohnt/oss-autopilot/actions/workflows/ci.yml/badge.svg)
-![Tests](https://img.shields.io/badge/tests-447_passing-success)
+![Tests](https://img.shields.io/badge/tests-454_passing-success)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.26.6",
+  "version": "0.26.7",
   "description": "AI-powered autopilot for managing open source contributions with Claude Code",
   "type": "module",
   "main": "dist/cli.js",

--- a/src/core/pr-monitor.test.ts
+++ b/src/core/pr-monitor.test.ts
@@ -18,7 +18,7 @@ vi.mock('./state.js', () => ({
 }));
 
 // Import after mocks are set up
-const { PRMonitor, computeDisplayLabel, classifyCICheck, classifyFailingChecks } = await import('./pr-monitor.js');
+const { PRMonitor, computeDisplayLabel, classifyCICheck, classifyFailingChecks, isBotAuthor } = await import('./pr-monitor.js');
 const { getStateManager } = await import('./state.js');
 
 describe('PRMonitor CI status deduplication', () => {
@@ -733,12 +733,56 @@ describe('PRMonitor checkUnrespondedComments', () => {
     expect(result.hasUnrespondedComment).toBe(false);
   });
 
-  it('should skip bot comments', () => {
+  it('should skip bot comments with [bot] suffix', () => {
     const monitor = new PRMonitor('fake-token');
     const result = (monitor as any).checkUnrespondedComments(
       [
         { user: { login: 'testuser' }, body: 'My PR', created_at: '2026-02-07T10:00:00Z' },
         { user: { login: 'dependabot[bot]' }, body: 'Dependency update', created_at: '2026-02-07T12:00:00Z' },
+      ],
+      [],
+      'testuser'
+    );
+    expect(result.hasUnrespondedComment).toBe(false);
+  });
+
+  it('should skip known bot accounts without [bot] suffix', () => {
+    const monitor = new PRMonitor('fake-token');
+    const knownBots = ['CLAassistant', 'codecov-commenter', 'changeset-bot', 'netlify', 'sonarcloud'];
+    for (const bot of knownBots) {
+      const result = (monitor as any).checkUnrespondedComments(
+        [
+          { user: { login: 'testuser' }, body: 'My PR', created_at: '2026-02-07T10:00:00Z' },
+          { user: { login: bot }, body: 'Automated check passed', created_at: '2026-02-07T12:00:00Z' },
+        ],
+        [],
+        'testuser'
+      );
+      expect(result.hasUnrespondedComment).toBe(false);
+    }
+  });
+
+  it('should still flag non-bot maintainer comments when bot comments also exist', () => {
+    const monitor = new PRMonitor('fake-token');
+    const result = (monitor as any).checkUnrespondedComments(
+      [
+        { user: { login: 'testuser' }, body: 'My PR', created_at: '2026-02-07T10:00:00Z' },
+        { user: { login: 'CLAassistant' }, body: 'CLA signed', created_at: '2026-02-07T11:00:00Z' },
+        { user: { login: 'maintainer' }, body: 'Please add tests', created_at: '2026-02-07T12:00:00Z' },
+      ],
+      [],
+      'testuser'
+    );
+    expect(result.hasUnrespondedComment).toBe(true);
+    expect(result.lastMaintainerComment?.author).toBe('maintainer');
+  });
+
+  it('should skip comments from deleted accounts (null user)', () => {
+    const monitor = new PRMonitor('fake-token');
+    const result = (monitor as any).checkUnrespondedComments(
+      [
+        { user: { login: 'testuser' }, body: 'My PR', created_at: '2026-02-07T10:00:00Z' },
+        { user: null, body: 'Ghost comment', created_at: '2026-02-07T12:00:00Z' },
       ],
       [],
       'testuser'
@@ -1532,5 +1576,36 @@ describe('classifyFailingChecks (#81)', () => {
     const result = classifyFailingChecks(['Vercel', 'Build']);
     expect(result[0].name).toBe('Vercel');
     expect(result[1].name).toBe('Build');
+  });
+});
+
+describe('isBotAuthor (#143)', () => {
+  it('should identify [bot] suffix accounts', () => {
+    expect(isBotAuthor('dependabot[bot]')).toBe(true);
+    expect(isBotAuthor('github-actions[bot]')).toBe(true);
+    expect(isBotAuthor('n8n-assistant[bot]')).toBe(true);
+  });
+
+  it('should identify known bot accounts without [bot] suffix', () => {
+    expect(isBotAuthor('CLAassistant')).toBe(true);
+    expect(isBotAuthor('codecov-commenter')).toBe(true);
+    expect(isBotAuthor('changeset-bot')).toBe(true);
+    expect(isBotAuthor('netlify')).toBe(true);
+    expect(isBotAuthor('sonarcloud')).toBe(true);
+    expect(isBotAuthor('renovate')).toBe(true);
+    expect(isBotAuthor('imgbot')).toBe(true);
+    expect(isBotAuthor('snyk-bot')).toBe(true);
+  });
+
+  it('should be case-insensitive for known bots', () => {
+    expect(isBotAuthor('claassistant')).toBe(true);
+    expect(isBotAuthor('CLAASSISTANT')).toBe(true);
+    expect(isBotAuthor('Netlify')).toBe(true);
+  });
+
+  it('should not flag human users', () => {
+    expect(isBotAuthor('maintainer')).toBe(false);
+    expect(isBotAuthor('sindresorhus')).toBe(false);
+    expect(isBotAuthor('costajohnt')).toBe(false);
   });
 });

--- a/src/core/pr-monitor.ts
+++ b/src/core/pr-monitor.ts
@@ -13,6 +13,30 @@ import { FetchedPR, FetchedPRStatus, CIStatus, ReviewDecision, DailyDigest, Main
 // Concurrency limit for parallel API calls
 const MAX_CONCURRENT_REQUESTS = 5;
 
+// Bot accounts that don't follow the [bot] suffix convention
+const KNOWN_BOT_USERNAMES = new Set([
+  'allcontributors',
+  'changeset-bot',
+  'claassistant',
+  'codecov-commenter',
+  'greenkeeper',
+  'imgbot',
+  'netlify',
+  'renovate',
+  'snyk-bot',
+  'sonarcloud',
+  'stale',
+  'vercel',
+]);
+
+/**
+ * Check if a comment author is a bot account.
+ * Matches the [bot] suffix convention and known bot usernames (case-insensitive).
+ */
+export function isBotAuthor(author: string): boolean {
+  return author.includes('[bot]') || KNOWN_BOT_USERNAMES.has(author.toLowerCase());
+}
+
 export interface PRCheckFailure {
   prUrl: string;
   error: string;
@@ -315,7 +339,8 @@ export class PRMonitor {
 
     for (const item of timeline) {
       if (item.isUser) continue; // Skip user's own comments
-      if (item.author.includes('[bot]')) continue; // Skip bots
+      if (item.author === 'unknown') continue; // Skip deleted/null accounts
+      if (isBotAuthor(item.author)) continue; // Skip bots
 
       const itemTime = new Date(item.createdAt);
       if (!lastUserCommentTime || itemTime > lastUserCommentTime) {


### PR DESCRIPTION
## Summary

- **Filter known bot accounts without `[bot]` suffix (#143)** — Added `isBotAuthor()` function and `KNOWN_BOT_USERNAMES` set to catch bot accounts like `CLAassistant`, `codecov-commenter`, `changeset-bot`, `netlify`, `sonarcloud`, etc. that don't follow the `[bot]` suffix convention. PRs with only bot comments no longer trigger false positive "Needs Response" status.
- **Skip deleted account comments** — Comments from deleted/null GitHub accounts (author resolves to `'unknown'`) are now skipped instead of being treated as maintainer comments.

Closes #143

## Test plan

- [x] All 454 tests pass (7 new tests added)
- [x] Existing `[bot]` suffix filtering still works (renamed test confirms)
- [x] Known bots without suffix correctly filtered (CLAassistant, codecov-commenter, changeset-bot, netlify, sonarcloud)
- [x] Case-insensitive matching works (CLAassistant, claassistant, CLAASSISTANT)
- [x] Real maintainer comments still flagged when mixed with bot comments
- [x] Null/deleted user accounts correctly skipped