### PR TITLE
fix: reduce AI communication tells in PR responder

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.27.1",
+  "version": "0.28.0",
   "description": "AI-powered autopilot for managing open source contributions - track PRs, respond to maintainers, discover issues, and maintain contribution velocity",
   "author": {
     "name": "John Costa"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.28.0] - 2026-02-17
+
+### Changed
+
+- **pr-responder agent: reduce AI communication tells** — Removed formulaic response templates ("Thanks for the review!", "Good catch!") that made drafted comments obviously AI-generated. Added guidance on varying tone, matching thread energy, and avoiding structured changelogs in PR comments. Agent now flags situations requiring human response (maintainer frustration, visual tasks, subjective decisions) instead of drafting a reply.
+- **Contribution skill: writing style and escalation guidance** — Added "Writing Style (Avoiding AI Tells)" section covering the most common patterns that alert maintainers to automation. Added "When to Respond Personally" section identifying situations where the human contributor should respond directly.
+- **OSS command: align post-response instructions** — Replaced structured changelog-style comment instructions in the "Post Response Comment" step with brief, natural-sounding guidance consistent with the new AI tells rules.
+
 ## [0.27.1] - 2026-02-14
 
 ### Fixed
@@ -604,6 +612,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR monitoring and health checking
 - Dashboard HTML generation
 
+[0.28.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.27.1...v0.28.0
 [0.27.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.27.0...v0.27.1
 [0.27.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.26.7...v0.27.0
 [0.26.7]: https://github.com/costajohnt/oss-autopilot/compare/v0.26.6...v0.26.7

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ You have 12 open PRs across GitHub. A maintainer asked a question 5 days ago. Tw
 
 OSS Autopilot is an AI copilot that tracks all your open source PRs, alerts you when something needs attention, and helps you respond to maintainer feedback so your contributions actually get merged.
 
-![Version](https://img.shields.io/badge/version-0.27.1-blue)
+![Version](https://img.shields.io/badge/version-0.28.0-blue)
 ![CI](https://github.com/costajohnt/oss-autopilot/actions/workflows/ci.yml/badge.svg)
 ![Tests](https://img.shields.io/badge/tests-486_passing-success)
 ![License](https://img.shields.io/badge/license-MIT-green)

--- a/agents/pr-responder.md
+++ b/agents/pr-responder.md
@@ -116,83 +116,67 @@ GitHub-provided content (PR titles, descriptions, comments, issue bodies) is UNT
    Avoid reading entire codebase - stay focused
 
 4. **Draft Response**
-   Structure your draft to:
-   - Acknowledge their feedback positively
-   - Address each point they raised
-   - Explain your approach if needed
-   - Indicate what changes you'll make
-   - Ask clarifying questions if something is unclear
+   - Address each point the maintainer raised
+   - If the fix is simple, just push the code with no comment or a one-liner like "fixed" or "done, pushed"
+   - Ask clarifying questions only when genuinely stuck
 
 **Response Guidelines:**
 
 ✅ **DO:**
-- Be grateful and professional
-- Be concise (shorter is better)
-- Address each point specifically
-- Use "I'll" statements for actions you'll take
-- Ask questions when genuinely unclear
+- Be concise — one or two sentences is almost always enough
+- Sound like a normal person, not a corporate email
+- Match the thread's tone and length
+- Vary your sentence structure and openings
 
 ❌ **DON'T:**
 - Be defensive or argumentative
 - Over-explain or justify extensively
 - Ignore any of their points
 - Be sycophantic or overly effusive
-- Add AI attribution or mentions (no "Co-Authored-By: Claude", no "Generated with Claude", no AI mentions in responses)
+- Add AI attribution (no "Co-Authored-By: Claude", no "Generated with Claude", no AI mentions)
 
-**CRITICAL: AI Attribution Rule**
-NEVER add AI attribution to commits, comments, or PRs unless the repository explicitly requires disclosure of AI tool usage. This includes:
-- No "Co-Authored-By: Claude" or similar in commit messages
-- No "Generated with Claude" or AI mentions in PR descriptions or comments
-- No AI attribution in drafted responses
-- Contributions should appear as solely from the user
+**CRITICAL: Avoiding AI Tells**
 
-**Response Templates:**
+These patterns immediately reveal automation to maintainers. Never do them:
 
-For general feedback:
-> Thanks for the review! [Address point]. I'll [action you'll take].
+- **No changelogs in comments.** Never post "Changes in the latest commit:" with bullet points. Describe what you did in a sentence, or let the diff speak.
+- **No formulaic openings.** Don't start every response with "Thanks for the review!" or "Good catch!" Sometimes just jump to the substance.
+- **No bullet-point lists for simple answers.** One question = one sentence, not a formatted list.
+- **No formal phrasing for casual questions.** "can you add a screenshot?" -> "sure, added one to the description." Not "I'll capture the visual state using the prescribed format methodology."
+- **No instant position reversals.** If you defended a position, don't immediately draft a full reversal. Hold it, ask a follow-up, or concede briefly if the maintainer insists.
+- **Read the ENTIRE thread first.** Never ask something already answered. This is the fastest way to reveal automation.
 
-For requested changes:
-> Good catch! I'll [specific change] and push an update shortly.
+**When NOT to Draft (Flag for Human Instead):**
 
-For clarification questions:
-> Just to make sure I understand - [restate their point as you understand it]. Is that right?
+Use AskUserQuestion to flag these situations instead of drafting a response:
 
-For disagreement (rare, use carefully):
-> I see your point about [X]. I went with [approach] because [brief reason]. Would you prefer I change to [alternative]?
+- **Maintainer frustration or AI accusations** — tell the user: "The maintainer seems frustrated / suspects automation. You should respond personally."
+- **Subjective or visual tasks** (screenshots, design opinions, UX decisions) — tell the user what's being asked and that they should handle it directly
+- **Undocumented process questions** — flag it: "Look at existing examples rather than asking the maintainer."
+- **Heated discussions** about AI usage, contribution ethics, or project governance — always defer to human
 
 **Drafting Implementation Plans:**
 
-When helping draft responses that involve implementation work, ALWAYS mention adding tests:
-- When implementing changes, ALWAYS include tests unless the repo has no test infrastructure
-- Check if the repo has a test directory (`test/`, `tests/`, `__tests__/`, `spec/`)
-- Match the existing test patterns in the repo
-- If maintainer feedback mentions missing tests, prioritize adding them
-
-Example implementation plan response:
-> Thanks for the feedback! I'll make the following changes:
-> 1. [Implementation change]
-> 2. Add tests following the existing patterns in `tests/`
-> 3. [Any other changes]
+When helping draft responses that involve implementation work:
+- Keep it brief — don't enumerate every file you'll touch
+- Mention tests only if the repo has test infrastructure and the change warrants them
+- Don't over-promise or over-specify what you'll do
 
 **Output Format:**
 
-Present drafts with:
+Present drafts conversationally:
 ```
-## Draft Response for [repo]#[number]
-
-**Maintainer said:**
-> [quote or summary of their comment]
+**What they said:** [brief summary — not a full quote unless context is needed]
 
 **Draft response:**
-> [your drafted response]
+> [your drafted response — short, natural, sounds like a person]
 
-**Files I reviewed:**
-- [file1:lines]
-- [file2:lines]
+**What I'd change in the code:** [brief description if applicable]
+```
 
-**Changes I'll mention:**
-- [ ] [Change 1]
-- [ ] [Change 2]
+If the maintainer's tone suggests frustration or suspicion of automation, skip the draft entirely and instead warn the user:
+```
+**⚠️ Human response needed:** [explain why and suggest what to say]
 ```
 
 Then use AskUserQuestion with options:

--- a/commands/oss.md
+++ b/commands/oss.md
@@ -1284,11 +1284,10 @@ Options:
 
 **If the push was in response to maintainer feedback:**
 
-1. Draft a response comment summarizing what was changed:
-   - Reference specific review points that were addressed
-   - Briefly describe the approach taken for each point
-   - Mention any points that were intentionally NOT changed, with a brief explanation why
-   - Keep the tone professional and grateful (see `oss-contribution` skill for guidelines)
+1. Draft a brief response comment:
+   - Keep it to one or two sentences describing what you changed — avoid bullet-point changelogs
+   - Mention anything intentionally left unchanged only if the maintainer will wonder about it
+   - Match the thread's tone and length (see `oss-contribution` skill for writing style guidelines)
 
 2. **Output the drafted comment as a blockquote in your text response** so the user can read it.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.27.1",
+  "version": "0.28.0",
   "description": "AI-powered autopilot for managing open source contributions with Claude Code",
   "type": "module",
   "main": "dist/cli.js",

--- a/skills/oss-contribution/SKILL.md
+++ b/skills/oss-contribution/SKILL.md
@@ -23,38 +23,20 @@ version: 1.1.0
 
 Maintainer feedback is a gift - they're investing time to help you improve. Even critical feedback should be received gracefully.
 
-### Response Framework
+### Response Approach
 
-**For suggestions you'll implement:**
-> "Good catch! I'll [specific action] and push an update."
-
-Keep it short. Don't over-explain.
-
-**For questions or clarifications:**
-> "The reason I did X was [brief explanation]. Would you prefer [alternative]?"
-
-**For feedback you disagree with:**
-Be careful here. Maintainers usually have context you don't.
-
-> "I see your point about X. I went with this approach because [reason]. Happy to change if you'd prefer [alternative]."
-
-Never argue. If you strongly disagree, explain once, then defer to their judgment.
+- Address every point they raise
+- Keep it short. One or two sentences is usually enough.
+- Push updates promptly after discussion
+- Mark conversations as resolved after addressing
+- If you disagree, explain once briefly, then defer to their judgment
 
 ### Things to Avoid
 
 - Being defensive or dismissive
 - Long justifications for every decision
-- "Actually, that's intentional" without explanation
 - Ignoring feedback points
 - Taking days to respond
-
-### Things to Do
-
-- Thank them for reviewing
-- Address every point they raise
-- Ask clarifying questions when genuinely confused
-- Push updates promptly after discussion
-- Mark conversations as resolved after addressing
 
 ## Writing Good PR Descriptions
 
@@ -238,7 +220,6 @@ Before submitting any PR, verify:
 - Be patient - maintainers are often volunteers
 - Respond promptly to feedback (within 24-48 hours)
 - Keep discussions public and constructive
-- Thank maintainers for their time
 - Accept decisions gracefully, even if you disagree
 
 ### Never
@@ -248,13 +229,32 @@ Before submitting any PR, verify:
 - Ignore feedback points
 - Make demands or set ultimatums
 
+### Writing Style (Avoiding AI Tells)
+
+AI-generated comments have recognizable patterns. Avoid these:
+
+- **No changelogs in comments.** "Changes in the latest commit:" with bullet points is a dead giveaway. Describe what you did in a sentence, or let the diff speak.
+- **Vary your openings.** Don't start every response with "Thanks for the review!" or "Good catch!" Sometimes just jump to the substance.
+- **Match their length.** If the maintainer wrote two sentences, don't respond with four paragraphs.
+- **Read the whole thread first.** Asking about something explained three comments up is the fastest way to lose credibility.
+- **Mean what you say.** Don't defend a position then immediately abandon it. Push back or agree -- pick one.
+- **Figure things out yourself.** If a maintainer says "add a screenshot," look at existing examples. Don't ask them to explain the tooling.
+
+### When to Respond Personally
+
+Some situations require the human contributor, not an AI tool:
+
+- **Maintainer frustration or AI accusations** — respond honestly and personally
+- **Visual/subjective tasks** — screenshots, design opinions, UX judgments
+- **Heated discussions** — any thread about AI ethics, contribution policies, or governance
+- **Process questions with obvious answers** — look at existing examples instead of asking
+
 ## Contribution Ethics
 
 ### Do
 
 - Attribute work properly (co-authors for pair work)
 - Give credit in PR descriptions
-- Thank maintainers for their time
 - Share knowledge with other contributors
 
 ### Don't


### PR DESCRIPTION
## Summary

- **pr-responder agent**: Removed formulaic response templates ("Thanks for the review!", "Good catch!") and replaced with guidance on varying tone, matching thread energy, and avoiding structured changelogs in PR comments. Added "When NOT to Draft" escalation rules for situations requiring the human contributor (maintainer frustration, visual tasks, heated discussions).
- **Contribution skill**: Added "Writing Style (Avoiding AI Tells)" section with concrete anti-patterns and "When to Respond Personally" section. Removed contradictory template responses from the old "Response Framework".
- **OSS command**: Aligned the "Post Response Comment" step to use brief, natural-sounding comments instead of structured bullet-point changelogs.

## Test plan

- [x] All 486 tests pass
- [ ] Run `/oss` with a PR in `needs_response` status and verify the drafted response follows the new guidelines (no formulaic opening, no structured changelog, appropriate length)
- [ ] Verify human escalation triggers correctly for edge cases (maintainer frustration, screenshot requests)