### PR TITLE
fix: exclude recently closed PRs from Need Attention count

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "description": "AI-powered autopilot for managing open source contributions - track PRs, respond to maintainers, discover issues, and maintain contribution velocity",
   "author": {
     "name": "John Costa"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.28.1] - 2026-02-17
+
+### Fixed
+
+- **Recently closed PRs no longer counted as "Need Attention" (#156)** — PRs closed without merge were being included in the actionable issues list with priority numbers, inflating the "N need attention" count. They are now excluded from `actionableIssues` and displayed in a separate informational section. The `recently_closed` type has been removed from `ActionableIssueType`.
+
 ## [0.28.0] - 2026-02-17
 
 ### Changed
@@ -612,6 +618,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR monitoring and health checking
 - Dashboard HTML generation
 
+[0.28.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.28.0...v0.28.1
 [0.28.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.27.1...v0.28.0
 [0.27.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.27.0...v0.27.1
 [0.27.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.26.7...v0.27.0

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ You have 12 open PRs across GitHub. A maintainer asked a question 5 days ago. Tw
 
 OSS Autopilot is an AI copilot that tracks all your open source PRs, alerts you when something needs attention, and helps you respond to maintainer feedback so your contributions actually get merged.
 
-![Version](https://img.shields.io/badge/version-0.28.0-blue)
+![Version](https://img.shields.io/badge/version-0.28.1-blue)
 ![CI](https://github.com/costajohnt/oss-autopilot/actions/workflows/ci.yml/badge.svg)
 ![Tests](https://img.shields.io/badge/tests-486_passing-success)
 ![License](https://img.shields.io/badge/license-MIT-green)

--- a/commands/oss.md
+++ b/commands/oss.md
@@ -173,7 +173,7 @@ Your curated issue list is depleted ({completedCount} done). Time to find new is
 
 When there are actionable issues, display them **before asking the user anything**.
 
-Issues are listed in priority order: `needs_response` → `needs_changes` → `ci_failing` → `merge_conflict` → `incomplete_checklist` → `approaching_dormant` → `recently_closed`. This matches the ordering from `collectActionableIssues()` in the CLI.
+Issues are listed in priority order: `needs_response` → `needs_changes` → `ci_failing` → `merge_conflict` → `incomplete_checklist` → `approaching_dormant`. This matches the ordering from `collectActionableIssues()` in the CLI. Recently closed PRs are NOT included here — they appear in a separate informational section below (see "Recently Closed PRs").
 
 For each issue, show the enriched format using data already available on `FetchedPR`:
 
@@ -199,7 +199,7 @@ For each issue, show the enriched format using data already available on `Fetche
 
 | Effort | Condition |
 |--------|-----------|
-| **Small** | `needs_response` with 0-1 hints (just a reply), `incomplete_checklist`, `approaching_dormant`, `recently_closed` (informational only) |
+| **Small** | `needs_response` with 0-1 hints (just a reply), `incomplete_checklist`, `approaching_dormant` |
 | **Medium** | `needs_response` with 2+ hints (reply + code changes), `needs_changes` with 0-2 hints, `ci_failing` |
 | **Large** | `merge_conflict`, `needs_changes` with 3+ hints |
 
@@ -208,6 +208,17 @@ If an issue type doesn't match any row above, default to **Medium**.
 **Action summary**: Brief description based on type (e.g., "respond + code changes", "rebase + push", "investigate CI logs").
 
 Use `issue.pr.daysSinceActivity` from the CLI output (already computed).
+
+### Recently Closed PRs (Informational)
+
+If `data.daily.digest.recentlyClosedPRs` has entries, display them **after** the actionable issues list (or after "All PRs are healthy" if none) as a separate informational section. These are NOT counted in the "Need Attention" total and do NOT receive priority numbers:
+
+```
+Recently closed (informational):
+- {repo}#{number} — {title} (closed without merge on {closedAt date})
+```
+
+These do not require any action. They exist so the user knows what was closed. The Auto-Exclude prompt (Step 6) may offer to exclude these repos from future searches.
 
 ### Ask for Action (Using Pre-Computed Menu)
 
@@ -429,7 +440,6 @@ For each issue in `actionableIssues`, include a Task tool call grouped by repo:
 | Changes Addressed | Info | Note that changes were pushed after maintainer review — no contributor action needed, awaiting re-review. |
 | Missing Required Files | Tier 2 | Identify what's missing (changeset, CLA, etc.), draft the file. DO NOT push. |
 | Approaching Dormant | Tier 2 | Assess if still relevant, recommend follow-up action. |
-| Recently Closed | Info | Note as closed without merge. DO NOT clone, checkout, or rebase — the PR branch may not exist. Report closure for the Auto-Exclude prompt. |
 
 **Agent dispatch prompt template for comprehensive PR check:**
 
@@ -588,7 +598,7 @@ Proceed to the "After Each Action" section.
 
 ### Auto-Exclude Prompt for Rejected PRs
 
-When the daily digest includes `[Recently Closed]` entries (PRs closed without merge), offer to exclude those repos from future searches:
+When `data.daily.digest.recentlyClosedPRs` has entries (PRs closed without merge), offer to exclude those repos from future searches:
 
 For each recently closed PR where the repo is NOT already excluded and the user has no merged PRs in that repo:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "description": "AI-powered autopilot for managing open source contributions with Claude Code",
   "type": "module",
   "main": "dist/cli.js",

--- a/src/commands/daily.ts
+++ b/src/commands/daily.ts
@@ -4,7 +4,7 @@
  * generates a digest, and updates repo scores and analytics in local state.
  */
 
-import { getStateManager, PRMonitor, getGitHubToken, type DailyDigest, type FetchedPR, type FetchedPRStatus, type PRCheckFailure, type MaintainerActionHint, type ClosedPR, type ComputedRepoSignals, type RepoGroup } from '../core/index.js';
+import { getStateManager, PRMonitor, getGitHubToken, type DailyDigest, type FetchedPR, type FetchedPRStatus, type PRCheckFailure, type MaintainerActionHint, type ComputedRepoSignals, type RepoGroup } from '../core/index.js';
 import { outputJson, outputJsonError, type DailyOutput, type CapacityAssessment, type ActionableIssue, type ActionMenu, type ActionMenuItem } from '../formatters/json.js';
 
 interface DailyOptions {
@@ -199,7 +199,7 @@ export async function executeDailyCheck(token: string): Promise<DailyOutput> {
 
   // Build output fields
   const summary = formatSummary(digest, capacity);
-  const actionableIssues = collectActionableIssues(prs, recentlyClosedPRs);
+  const actionableIssues = collectActionableIssues(prs);
   const briefSummary = formatBriefSummary(digest, actionableIssues.length);
   const actionMenu = computeActionMenu(actionableIssues, capacity);
   const repoGroups = groupPRsByRepo(prs);
@@ -509,10 +509,13 @@ function formatBriefSummary(digest: DailyDigest, issueCount: number): string {
 }
 
 /**
- * Collect all actionable issues across PRs for the action-first flow
- * Order: Needs response → Needs changes → CI failing → Merge conflicts → Incomplete checklist → Approaching dormant → Recently closed
+ * Collect all actionable issues across PRs for the action-first flow.
+ * Order: Needs response → Needs changes → CI failing → Merge conflicts → Incomplete checklist → Approaching dormant
+ *
+ * Note: Recently closed PRs are informational only and excluded from this list.
+ * They are available separately in digest.recentlyClosedPRs (#156).
  */
-function collectActionableIssues(prs: FetchedPR[], recentlyClosedPRs: ClosedPR[] = []): ActionableIssue[] {
+function collectActionableIssues(prs: FetchedPR[]): ActionableIssue[] {
   const issues: ActionableIssue[] = [];
 
   // 1. Needs Response (highest priority - someone is waiting for you)
@@ -559,33 +562,6 @@ function collectActionableIssues(prs: FetchedPR[], recentlyClosedPRs: ClosedPR[]
     if (pr.status === 'approaching_dormant') {
       issues.push({ type: 'approaching_dormant', pr, label: '[Approaching Dormant]' });
     }
-  }
-
-  // 7. Recently Closed (informational - PRs closed without merge in last 7 days)
-  for (const closedPR of recentlyClosedPRs) {
-    // Create a minimal FetchedPR-like object for the ActionableIssue interface
-    const pr: FetchedPR = {
-      id: 0,
-      url: closedPR.url,
-      repo: closedPR.repo,
-      number: closedPR.number,
-      title: closedPR.title,
-      status: 'healthy', // placeholder
-      displayLabel: '[Recently Closed]',
-      displayDescription: `Closed without merge${closedPR.closedAt ? ` on ${new Date(closedPR.closedAt).toLocaleDateString()}` : ''}`,
-      createdAt: '',
-      updatedAt: closedPR.closedAt || '',
-      daysSinceActivity: 0,
-      ciStatus: 'unknown',
-      failingCheckNames: [],
-      classifiedChecks: [],
-      hasMergeConflict: false,
-      reviewDecision: 'unknown',
-      hasUnrespondedComment: false,
-      hasIncompleteChecklist: false,
-      maintainerActionHints: [],
-    };
-    issues.push({ type: 'recently_closed', pr, label: '[Recently Closed]' });
   }
 
   return issues;

--- a/src/formatters/json.ts
+++ b/src/formatters/json.ts
@@ -22,7 +22,7 @@ export interface CapacityAssessment {
   reason: string;
 }
 
-export type ActionableIssueType = 'ci_failing' | 'merge_conflict' | 'needs_response' | 'needs_changes' | 'incomplete_checklist' | 'approaching_dormant' | 'recently_closed';
+export type ActionableIssueType = 'ci_failing' | 'merge_conflict' | 'needs_response' | 'needs_changes' | 'incomplete_checklist' | 'approaching_dormant';
 
 export interface ActionableIssue {
   type: ActionableIssueType;


### PR DESCRIPTION
## Summary

- Fixes #156 — recently closed PRs were included in the `actionableIssues` array, inflating the "N need attention" count and receiving priority numbers
- Removed the `recently_closed` block from `collectActionableIssues()` and the type from `ActionableIssueType`
- Added a separate "Recently Closed PRs (Informational)" display section in `oss.md` pointing to `digest.recentlyClosedPRs`

## Test plan

- [x] All 486 tests pass
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Bundle builds successfully
- [x] `recently_closed` no longer appears in any TypeScript source (only historical CHANGELOG)
- [x] `digest.recentlyClosedPRs` data flow unchanged (fetch → digest → summary/console/dashboard)
- [x] Auto-exclude prompt updated to reference `data.daily.digest.recentlyClosedPRs`