### PR TITLE
ci: add auto-release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
             BODY="Release v${VERSION} (no changelog entry found)"
           fi
 
-          echo "$BODY" > /tmp/release-body.md
+          printf '%s\n' "$BODY" > /tmp/release-body.md
 
       - name: Create release
         if: steps.version.outputs.exists == 'false'


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that automatically creates releases when a version bump lands on main
- Reads version from `package.json`, checks if the tag already exists, extracts the relevant changelog section, and creates the release via `gh release create`
- Fixes the session-start hook's update detection, which checks GitHub releases to notify users — releases stopped being created after v0.24.0 while versions continued incrementing per-PR

## Test plan

- [ ] Verify CI passes on this PR
- [ ] After merge, confirm the workflow runs and creates a `v0.32.0` release with the correct changelog body
- [ ] Verify future PRs with version bumps trigger new releases automatically