### PR TITLE
chore: enable Dependabot for npm dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` to enable automated npm dependency updates
- Configured to check weekly, targeting the `main` branch
- Uses `chore` prefix for Dependabot commit messages