### PR TITLE
fix: exempt shelved PRs from excludeRepos/excludeOrgs filtering

### DIFF
--- a/src/core/pr-monitor.test.ts
+++ b/src/core/pr-monitor.test.ts
@@ -2056,6 +2056,196 @@ describe('isConditionalChecklistItem (#152)', () => {
   });
 });
 
+describe('fetchUserOpenPRs excludeRepos/excludeOrgs exempts shelved PRs (#175)', () => {
+  const makeSearchItem = (url: string) => ({
+    html_url: url,
+    title: 'Test PR',
+    pull_request: { html_url: url },
+    created_at: '2026-02-01T00:00:00Z',
+    updated_at: '2026-02-07T00:00:00Z',
+  });
+
+  // Minimal mock for fetchPRDetails — just enough for the PR to pass through
+  const makePRDetailMocks = (prUrl: string) => {
+    const match = prUrl.match(/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
+    if (!match) throw new Error(`Bad URL: ${prUrl}`);
+    const [, owner, repo, num] = match;
+    return {
+      pulls: {
+        get: vi.fn().mockResolvedValue({
+          data: {
+            id: Number(num),
+            title: 'Test PR',
+            created_at: '2026-02-01T00:00:00Z',
+            updated_at: '2026-02-07T00:00:00Z',
+            head: { sha: 'abc123' },
+            mergeable: true,
+            mergeable_state: 'clean',
+            body: '',
+            draft: false,
+            review_comments: 0,
+            commits: 1,
+          },
+        }),
+        listReviews: vi.fn().mockResolvedValue({ data: [] }),
+      },
+      issues: {
+        listComments: vi.fn().mockResolvedValue({ data: [] }),
+      },
+      repos: {
+        getCombinedStatusForRef: vi.fn().mockResolvedValue({
+          data: { state: 'success', statuses: [] },
+        }),
+      },
+      checks: {
+        listForRef: vi.fn().mockResolvedValue({ data: { check_runs: [] } }),
+      },
+    };
+  };
+
+  beforeEach(() => {
+    mockOctokitInstance = {};
+  });
+
+  it('should include shelved PR from excluded repo', async () => {
+    const shelvedUrl = 'https://github.com/excluded/repo/pull/42';
+
+    vi.mocked(getStateManager).mockReturnValue({
+      getState: () => ({
+        config: {
+          githubUsername: 'testuser',
+          excludeRepos: ['excluded/repo'],
+          excludeOrgs: [],
+          shelvedPRUrls: [shelvedUrl],
+          dormantThresholdDays: 30,
+          approachingDormantDays: 25,
+        },
+      }),
+    } as any);
+
+    const detailMocks = makePRDetailMocks(shelvedUrl);
+    mockOctokitInstance = {
+      search: {
+        issuesAndPullRequests: vi.fn().mockResolvedValue({
+          data: {
+            total_count: 1,
+            items: [makeSearchItem(shelvedUrl)],
+          },
+        }),
+      },
+      ...detailMocks,
+    };
+
+    const monitor = new PRMonitor('fake-token');
+    const { prs } = await monitor.fetchUserOpenPRs();
+
+    expect(prs).toHaveLength(1);
+    expect(prs[0].url).toBe(shelvedUrl);
+  });
+
+  it('should include shelved PR from excluded org', async () => {
+    const shelvedUrl = 'https://github.com/excludedorg/somerepo/pull/10';
+
+    vi.mocked(getStateManager).mockReturnValue({
+      getState: () => ({
+        config: {
+          githubUsername: 'testuser',
+          excludeRepos: [],
+          excludeOrgs: ['excludedorg'],
+          shelvedPRUrls: [shelvedUrl],
+          dormantThresholdDays: 30,
+          approachingDormantDays: 25,
+        },
+      }),
+    } as any);
+
+    const detailMocks = makePRDetailMocks(shelvedUrl);
+    mockOctokitInstance = {
+      search: {
+        issuesAndPullRequests: vi.fn().mockResolvedValue({
+          data: {
+            total_count: 1,
+            items: [makeSearchItem(shelvedUrl)],
+          },
+        }),
+      },
+      ...detailMocks,
+    };
+
+    const monitor = new PRMonitor('fake-token');
+    const { prs } = await monitor.fetchUserOpenPRs();
+
+    expect(prs).toHaveLength(1);
+    expect(prs[0].url).toBe(shelvedUrl);
+  });
+
+  it('should still exclude non-shelved PR from excluded repo', async () => {
+    const excludedUrl = 'https://github.com/excluded/repo/pull/99';
+
+    vi.mocked(getStateManager).mockReturnValue({
+      getState: () => ({
+        config: {
+          githubUsername: 'testuser',
+          excludeRepos: ['excluded/repo'],
+          excludeOrgs: [],
+          shelvedPRUrls: [],
+          dormantThresholdDays: 30,
+          approachingDormantDays: 25,
+        },
+      }),
+    } as any);
+
+    mockOctokitInstance = {
+      search: {
+        issuesAndPullRequests: vi.fn().mockResolvedValue({
+          data: {
+            total_count: 1,
+            items: [makeSearchItem(excludedUrl)],
+          },
+        }),
+      },
+    };
+
+    const monitor = new PRMonitor('fake-token');
+    const { prs } = await monitor.fetchUserOpenPRs();
+
+    expect(prs).toHaveLength(0);
+  });
+
+  it('should still exclude non-shelved PR from excluded org', async () => {
+    const excludedUrl = 'https://github.com/excludedorg/somerepo/pull/77';
+
+    vi.mocked(getStateManager).mockReturnValue({
+      getState: () => ({
+        config: {
+          githubUsername: 'testuser',
+          excludeRepos: [],
+          excludeOrgs: ['excludedorg'],
+          shelvedPRUrls: [],
+          dormantThresholdDays: 30,
+          approachingDormantDays: 25,
+        },
+      }),
+    } as any);
+
+    mockOctokitInstance = {
+      search: {
+        issuesAndPullRequests: vi.fn().mockResolvedValue({
+          data: {
+            total_count: 1,
+            items: [makeSearchItem(excludedUrl)],
+          },
+        }),
+      },
+    };
+
+    const monitor = new PRMonitor('fake-token');
+    const { prs } = await monitor.fetchUserOpenPRs();
+
+    expect(prs).toHaveLength(0);
+  });
+});
+
 describe('PRMonitor status with inline review after commit (#151)', () => {
   beforeEach(() => {
     mockOctokitInstance = {};

--- a/src/core/pr-monitor.ts
+++ b/src/core/pr-monitor.ts
@@ -84,6 +84,8 @@ export class PRMonitor {
     const prs: FetchedPR[] = [];
     const failures: PRCheckFailure[] = [];
 
+    const shelvedUrls = new Set(config.shelvedPRUrls || []);
+
     const filteredItems = allItems.filter(item => {
       if (!item.pull_request) return false;
       // Skip PRs to repos owned by the user (not OSS contributions)
@@ -95,8 +97,11 @@ export class PRMonitor {
       const ownerLower = parsed.owner.toLowerCase();
       if (ownerLower === config.githubUsername.toLowerCase()) return false;
       const repoFullName = `${parsed.owner}/${parsed.repo}`;
-      if (config.excludeRepos.includes(repoFullName)) return false;
-      if (config.excludeOrgs?.some(org => ownerLower === org.toLowerCase())) return false;
+      // Keep shelved PRs even from excluded repos/orgs — excludeRepos is meant
+      // to stop finding *new* issues there, not hide open PRs already being tracked (#175)
+      const isShelved = shelvedUrls.has(item.html_url);
+      if (config.excludeRepos.includes(repoFullName) && !isShelved) return false;
+      if (config.excludeOrgs?.some(org => ownerLower === org.toLowerCase()) && !isShelved) return false;
       return true;
     });
 


### PR DESCRIPTION
## Summary

- `excludeRepos`/`excludeOrgs` in config is meant to stop **issue discovery** — not hide already-tracked PRs. Shelved PRs from excluded repos/orgs were being filtered out of `fetchUserOpenPRs()`, causing them to vanish from the dashboard.
- Pre-compute a `Set` of shelved PR URLs and exempt them from repo/org exclusion in the filter. Non-shelved PRs from excluded repos are still filtered as before.
- Added 3 tests: shelved PR from excluded repo passes, shelved PR from excluded org passes, non-shelved PR from excluded repo is still filtered (regression guard).

Fixes #175

## Test plan

- [x] `npm test` — all 555 tests pass, including 3 new ones
- [x] `npm run build` — TypeScript compiles cleanly
- [ ] Manual: shelve a PR from an excluded repo, run dashboard, confirm it appears in the shelved section