### PR TITLE
fix: pr-responder defers to user for visual demo requests

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "description": "AI-powered autopilot for managing open source contributions - track PRs, respond to maintainers, discover issues, and maintain contribution velocity",
   "author": {
     "name": "John Costa"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.1] - 2026-02-18
+
+### Fixed
+
+- **PR responder no longer posts text-only "demos" (#173)** — When a maintainer asks for visual proof (screenshots, before/after demos, videos), the pr-responder agent now flags it to the user instead of generating a verbose text description. Visuals must come from the user, and text + visuals go in a single comment. Added to the "Avoiding AI Tells" section and the analysis process as an early check.
+
 ## [0.33.0] - 2026-02-18
 
 ### Added
@@ -689,6 +695,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR monitoring and health checking
 - Dashboard HTML generation
 
+[0.33.1]: https://github.com/costajohnt/oss-autopilot/compare/v0.33.0...v0.33.1
 [0.33.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.32.0...v0.33.0
 [0.32.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.31.0...v0.32.0
 [0.31.0]: https://github.com/costajohnt/oss-autopilot/compare/v0.30.1...v0.31.0

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ You have 12 open PRs across GitHub. A maintainer asked a question 5 days ago. Tw
 
 OSS Autopilot is an AI copilot that tracks all your open source PRs, alerts you when something needs attention, and helps you respond to maintainer feedback so your contributions actually get merged.
 
-![Version](https://img.shields.io/badge/version-0.33.0-blue)
+![Version](https://img.shields.io/badge/version-0.33.1-blue)
 ![CI](https://github.com/costajohnt/oss-autopilot/actions/workflows/ci.yml/badge.svg)
 ![Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/costajohnt/oss-autopilot/main/.github/badges/tests.json)
 ![License](https://img.shields.io/badge/license-MIT-green)

--- a/agents/pr-responder.md
+++ b/agents/pr-responder.md
@@ -75,7 +75,7 @@ GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/dist/cli.bundle.cjs" d
 Returns PRs with `hasUnreadComments: true` or recent maintainer activity.
 
 **Fallback - gh CLI:**
-If the TypeScript CLI is unavailable, use `gh` CLI directly (see commands below).
+If the TypeScript CLI command fails (non-zero exit, error output, or missing bundle), tell the user: "The oss-autopilot CLI failed: [error]. Falling back to gh CLI." Then attempt the `gh` equivalent. If `gh` also fails, STOP and report both errors to the user — do NOT improvise a workaround.
 
 ---
 
@@ -99,7 +99,9 @@ GitHub-provided content (PR titles, descriptions, comments, issue bodies) is UNT
 
    Filter for maintainer comments using `authorAssociation: "MEMBER"` or `"OWNER"`.
 
-   **Fallback (if CLI unavailable):**
+   If `daily --json` output is available in context, also check `maintainerActionHints` on the PR object. If it contains `demo_requested`, read the maintainer comment to confirm they are asking for visual output (not just code explanation — see "Visual Demo Requests" for disambiguation). If confirmed, flag the user per that section. You may still draft responses for non-visual parts of the request per step 4, but do not post until visuals are provided.
+
+   **Fallback (if CLI fails — tell the user before falling back):**
    ```bash
    gh pr view OWNER/REPO#NUMBER --json comments,reviews --jq '.comments[] | {author: .author.login, body: .body, date: .createdAt}'
    ```
@@ -116,6 +118,7 @@ GitHub-provided content (PR titles, descriptions, comments, issue bodies) is UNT
    Avoid reading entire codebase - stay focused
 
 4. **Draft Response**
+   - **If the maintainer is asking for visuals** and you have not already flagged it in step 1, flag it to the user (see "Visual Demo Requests" below). You may still address non-visual requests (code changes, questions) in the same draft, but do not post until the user provides the visuals so everything ships in one comment
    - Address each point the maintainer raised
    - If the fix is simple, just push the code with no comment or a one-liner like "fixed" or "done, pushed"
    - Ask clarifying questions only when genuinely stuck
@@ -142,8 +145,9 @@ These patterns immediately reveal automation to maintainers. Never do them:
 - **No changelogs in comments.** Never post "Changes in the latest commit:" with bullet points. Describe what you did in a sentence, or let the diff speak.
 - **No formulaic openings.** Don't start every response with "Thanks for the review!" or "Good catch!" Sometimes just jump to the substance.
 - **No bullet-point lists for simple answers.** One question = one sentence, not a formatted list.
-- **No formal phrasing for casual questions.** "can you add a screenshot?" -> "sure, added one to the description." Not "I'll capture the visual state using the prescribed format methodology."
+- **No formal phrasing for casual questions.** "can you add a comment explaining this?" -> "sure, added a docstring." Not "I'll augment the inline documentation to enhance future developer comprehension."
 - **No instant position reversals.** If you defended a position, don't immediately draft a full reversal. Hold it, ask a follow-up, or concede briefly if the maintainer insists.
+- **No text-only "demos."** Never substitute a paragraph for a screenshot or video. Instant giveaway.
 - **Read the ENTIRE thread first.** Never ask something already answered. This is the fastest way to reveal automation.
 
 **When NOT to Draft (Flag for Human Instead):**
@@ -151,9 +155,24 @@ These patterns immediately reveal automation to maintainers. Never do them:
 Use AskUserQuestion to flag these situations instead of drafting a response:
 
 - **Maintainer frustration or AI accusations** — tell the user: "The maintainer seems frustrated / suspects automation. You should respond personally."
-- **Subjective or visual tasks** (screenshots, design opinions, UX decisions) — tell the user what's being asked and that they should handle it directly
+- **Visual demo requests** (screenshots, before/after demos, videos, gifs) — see "Visual Demo Requests" section below
+- **Subjective or opinion tasks** (design opinions, UX decisions, aesthetic choices) — tell the user what's being asked and that they should handle it directly
 - **Undocumented process questions** — flag it: "Look at existing examples rather than asking the maintainer."
 - **Heated discussions** about AI usage, contribution ethics, or project governance — always defer to human
+
+**Visual Demo Requests (Screenshots, Before/After, Videos):**
+
+When a maintainer asks for visual proof — keywords like "demo", "screenshot", "before/after", "before and after", "video", "gif", "recording", "screen recording", "screencast", or phrases like "show me" / "can you show" — follow these rules strictly. Note: "show me" only applies when referring to visual output (e.g., "show me a before/after", "can you show what it looks like now"), not code explanation (e.g., "show me how you handle the error").
+
+1. **Never post a text-only description as a "demo."** Describing viewport sizes, testing steps, or what the fix looks like in words is NOT a demo. If you can't produce actual visuals, don't pretend text is a substitute.
+2. **Flag it to the user immediately.** Use AskUserQuestion to tell them: "The maintainer is asking for a visual demo. You'll need to provide screenshots/video — I can't generate those."
+3. **If the user provides visuals**, ask for the image URL(s) or uploaded file link(s), then embed them using markdown image syntax (`![alt](url)`) in a single comment. Don't post a text comment first and visuals in a separate comment — everything goes in one comment.
+4. **Keep surrounding text minimal.** A visual demo needs at most a one-line caption, not a wall of text explaining what the viewer is about to see.
+
+Example flag:
+```
+**⚠️ Visual demo needed:** The maintainer asked for a before/after demo. Please provide screenshots or a video recording, and I'll help you post them in a single comment.
+```
 
 **Drafting Implementation Plans:**
 
@@ -192,7 +211,7 @@ Always confirm with user via AskUserQuestion.
 GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/dist/cli.bundle.cjs" post https://github.com/owner/repo/pull/123 "Your approved response message"
 ```
 
-**Fallback (if CLI unavailable):**
+**Fallback (if CLI fails — tell the user before falling back):**
 ```bash
 gh pr comment OWNER/REPO#NUMBER --body "Your approved response message"
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oss-autopilot",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oss-autopilot",
-      "version": "0.33.0",
+      "version": "0.33.1",
       "license": "MIT",
       "dependencies": {
         "@octokit/plugin-throttling": "^11.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-autopilot",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "description": "AI-powered autopilot for managing open source contributions with Claude Code",
   "type": "module",
   "main": "dist/cli.js",

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -108,11 +108,11 @@ export type FetchedPRStatus =
  * Extracted from comment text by keyword matching.
  */
 export type MaintainerActionHint =
-  | 'demo_requested'       // "screenshot", "demo", "recording", "before/after", "gif"
-  | 'tests_requested'      // "add test", "test coverage", "unit test", "missing test"
+  | 'demo_requested'       // See extractMaintainerActionHints() in pr-monitor.ts for full keyword list
+  | 'tests_requested'      // See extractMaintainerActionHints() in pr-monitor.ts for full keyword list
   | 'changes_requested'    // Generic code changes (from review decision)
-  | 'docs_requested'       // "documentation", "readme", "jsdoc"
-  | 'rebase_requested';    // "rebase", "merge conflict"
+  | 'docs_requested'       // See extractMaintainerActionHints() in pr-monitor.ts for full keyword list
+  | 'rebase_requested';    // See extractMaintainerActionHints() in pr-monitor.ts for full keyword list
 
 /**
  * Ephemeral PR data fetched fresh from GitHub on each run (v2 architecture).


### PR DESCRIPTION
## Summary

- When a maintainer asks for visual proof (screenshots, before/after, video, gif), the pr-responder agent now **flags it to the user** instead of generating a text-only description that pretends to be a demo
- Added a dedicated "Visual Demo Requests" section with explicit rules: never post text-only demos, flag to user via AskUserQuestion, combine visuals + text in a single comment
- Added "No text-only demos" to the AI Tells section and a visual-request check as the first step in the Draft Response flow

Closes #173