### PR TITLE
feat: auto-pull marketplace clone on session start

### DIFF
--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -9,6 +9,14 @@ PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 messages=""
 
+# --- Step 0: Auto-pull marketplace clone for self-updates ---
+# Workaround for https://github.com/anthropics/claude-code/issues/26744
+# Marketplace plugins don't auto-update, so we pull on session start.
+MARKETPLACE_DIR="${HOME}/.claude/plugins/marketplaces/oss-autopilot"
+if [ -d "${MARKETPLACE_DIR}/.git" ]; then
+  (cd "${MARKETPLACE_DIR}" && git pull --ff-only) >/dev/null 2>&1 || true
+fi
+
 # --- Step 1: Rebuild stale bundle (if needed) ---
 if [ -f "${PLUGIN_ROOT}/dist/cli.bundle.cjs" ] && [ "${PLUGIN_ROOT}/package.json" -nt "${PLUGIN_ROOT}/dist/cli.bundle.cjs" ]; then
   if (cd "${PLUGIN_ROOT}" && npm install --silent 2>/dev/null && npm run bundle --silent 2>/dev/null); then


### PR DESCRIPTION
## Summary

- Adds a `SessionStart` hook step that runs `git pull --ff-only` on the marketplace clone at `~/.claude/plugins/marketplaces/oss-autopilot/`
- Workaround for [anthropics/claude-code#26744](https://github.com/anthropics/claude-code/issues/26744) — marketplace plugins don't auto-update on session start
- Runs before the stale-bundle check so pulled changes trigger a rebuild if needed

## Details

- Only activates if the marketplace `.git` directory exists (no-op for non-marketplace installs)
- Uses `--ff-only` to avoid merge conflicts
- Fully silent — all output suppressed, `|| true` ensures it never breaks session start

Closes #178

## Test plan

- [ ] Install plugin via marketplace, verify `git pull --ff-only` runs on session start
- [ ] Confirm no-op when marketplace directory doesn't exist (e.g. dev install)
- [ ] Confirm session start still works when offline (git pull fails silently)
- [ ] Confirm pulled changes trigger bundle rebuild via existing Step 1