### PR TITLE
fix: don't prompt after informational responses

### DIFF
--- a/commands/oss.md
+++ b/commands/oss.md
@@ -281,7 +281,9 @@ When the user types a simple question via "Other" input (or at any point during 
 
 **Why:** In Claude Code, AskUserQuestion renders as an interactive picker that replaces preceding text output. If informational text is immediately followed by a prompt, the user sees the answer for a brief moment before it's hidden behind the picker.
 
-**Rule of thumb:** If the user's input is purely asking for information (starts with "what", "how many", "which", "where") or uses display verbs ("show", "list") without an accompanying action verb ("fix", "address", "rebase"), treat it as informational. If the input contains both an informational request and an action (e.g., "show me the CI logs and fix #3"), treat it as actionable.
+**Rule of thumb:** If the user's input is purely asking for information (starts with "what", "how many", "which", "where") or uses display verbs ("show", "list") without an accompanying action verb ("fix", "address", "rebase", "search"), treat it as informational. If the input contains both an informational request and an action (e.g., "show me the CI logs and fix #3"), treat it as actionable. This heuristic applies equally when the user sends a free-form message outside of an AskUserQuestion picker.
+
+**After an informational response:** When the user sends their next message, route it through the same informational-vs-actionable classification. If their follow-up is actionable or selects a menu item, return to normal Step 3 flow.
 
 ---
 
@@ -437,7 +439,7 @@ This is a quality gate that catches issues before they reach the maintainer.
 5. **After workflow actions, always ask what's next** - after completing a workflow action (addressing a PR, running maintenance, searching for issues), prompt the user for the next step. **Exception:** If the user asked a simple informational question (e.g., "show me a link to issue #1", "what's the status of PR #5"), respond with text only — no AskUserQuestion. See "Handling Informational Questions" in Step 3.
 6. **Drive the conversation** - Claude controls the flow, user responds to prompts
 7. **Session ends ONLY when user selects "Done for now"** - never assume user is finished
-8. **ALWAYS include "Done for now"** in every AskUserQuestion
+8. **ALWAYS include "Done for now"** in every AskUserQuestion (when one is used — see rule 14 for the informational exception)
 9. **Draft-first workflow is mandatory** — after Step 5.5, complete all steps (5.6 → 5.6b → 5.7b → 5.7) in order before reaching Step 5.8. The `gh pr ready` call belongs exclusively in Step 5.8. Never skip to it directly.
 
 ### UX Guidelines


### PR DESCRIPTION
## Summary

- Softens Rule #5 to exempt informational questions from the mandatory `AskUserQuestion` follow-up
- Adds a "Handling Informational Questions" section with a decision table (informational vs actionable)
- Adds UX rule #14: "Don't prompt after informational responses"

Closes #188