### PR TITLE
chore: migrate to release-please-only versioning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,9 +130,8 @@ Branch naming: `feature/description`, `fix/description`, `chore/description`.
 
 Then:
 1. Make changes and test: `npm test`
-2. **Bump version and update changelog** (see Versioning below)
-3. Commit with conventional format: `feat:`, `fix:`, `refactor:`
-4. Push and open PR
+2. Commit with conventional format: `feat:`, `fix:`, `refactor:`
+3. Push and open PR
 
 **Important:**
 - Do NOT push directly to main
@@ -158,16 +157,11 @@ Always look for opportunities to refactor, simplify, and remove dead code. Fix a
 
 ## Versioning
 
-**Every PR must include a version bump and changelog entry.**
+**Versioning is automated via [release-please](https://github.com/googleapis/release-please).** Do NOT manually bump versions or edit CHANGELOG.md.
 
-- Bump the version in **all four** places (they must always match):
-  - `package.json`
-  - `.claude-plugin/plugin.json`
-  - `README.md` badge (`![Version](https://img.shields.io/badge/version-X.Y.Z-blue)`)
-  - `.release-please-manifest.json`
-- Follow [semver](https://semver.org/): bug fix = patch, new feature = minor
-- Add a new section to `CHANGELOG.md` with the bumped version and a description of your changes (use `Added`, `Changed`, `Fixed` headings)
-- Add a comparison link at the bottom of `CHANGELOG.md` for the new version
+- Use [conventional commits](https://www.conventionalcommits.org/): `feat:` (minor), `fix:` (patch), `chore:` (no release). Releasable commits (`feat:`, `fix:`) become CHANGELOG entries, so write them descriptively
+- On push to main, release-please opens or updates a release PR that bumps all version-bearing files (configured in `release-please-config.json`)
+- Merge the release-please PR to create a GitHub release, which triggers npm publish
 
 ## AI Attribution Rule (CRITICAL)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ You have 12 open PRs across GitHub. A maintainer asked a question 5 days ago. Tw
 
 OSS Autopilot is an AI copilot that tracks all your open source PRs, alerts you when something needs attention, and helps you respond to maintainer feedback so your contributions actually get merged.
 
-![Version](https://img.shields.io/badge/version-0.35.0-blue) <!-- x-release-please-version -->
+<!-- x-release-please-start-version -->
+![Version](https://img.shields.io/badge/version-0.35.0-blue)
+<!-- x-release-please-end -->
 ![CI](https://github.com/costajohnt/oss-autopilot/actions/workflows/ci.yml/badge.svg)
 ![Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/costajohnt/oss-autopilot/main/.github/badges/tests.json)
 ![License](https://img.shields.io/badge/license-MIT-green)


### PR DESCRIPTION
## Summary

- **Fix README badge**: Switch from inline `x-release-please-version` annotation to block `x-release-please-start-version`/`x-release-please-end` so release-please preserves the `-blue` suffix in the shields.io badge URL
- **Update CLAUDE.md**: Replace manual 4-file version bump instructions with release-please automation guidance — conventional commits, automated PRs, no manual CHANGELOG edits
- **Close stale PR #194**: The old release-please PR was based on stale state with full project history in changelog

## Why

Two versioning systems were fighting: CLAUDE.md required manual bumps in 4 files per PR, and release-please ran on every push to main creating another version bump PR. This caused double-bumps and a broken README badge (release-please stripped `-blue` from the badge URL). The fix is to let release-please own versioning entirely.

## Test plan

- [x] `npm test` — all 1098 tests pass (no code changes)
- [ ] Merge this PR, verify release-please creates a clean new PR with correct badge format
- [ ] Future PRs should not include manual version bumps or CHANGELOG edits