### PR TITLE
fix: remove static version badge to prevent release-please corruption

### DIFF
--- a/.claude/hooks/check-versions.sh
+++ b/.claude/hooks/check-versions.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Hook: Blocks git commits when versions are out of sync across
-# package.json, .claude-plugin/plugin.json, and README.md badge.
+# package.json and .claude-plugin/plugin.json.
 #
 # Registered as a PreToolUse hook on Bash commands.
 
@@ -17,19 +17,13 @@ fi
 # Extract versions
 PKG_VERSION=$(jq -r '.version' < package.json 2>/dev/null || echo "MISSING")
 PLUGIN_VERSION=$(jq -r '.version' < .claude-plugin/plugin.json 2>/dev/null || echo "MISSING")
-README_VERSION=$(grep -o 'version-[0-9]*\.[0-9]*\.[0-9]*' README.md | head -1 | sed 's/version-//')
 
-if [ -z "$README_VERSION" ]; then
-  README_VERSION="MISSING"
-fi
-
-# Check if all versions match
-if [ "$PKG_VERSION" != "$PLUGIN_VERSION" ] || [ "$PKG_VERSION" != "$README_VERSION" ]; then
+# Check if versions match
+if [ "$PKG_VERSION" != "$PLUGIN_VERSION" ]; then
   cat >&2 <<EOF
-Version mismatch detected! All three must match before committing.
+Version mismatch detected! Both must match before committing.
   package.json:                $PKG_VERSION
   .claude-plugin/plugin.json:  $PLUGIN_VERSION
-  README.md badge:             $README_VERSION
 EOF
   exit 2
 fi

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,5 @@ Closes #
 ## Checklist
 
 - [ ] Tests pass (`npm test`)
-- [ ] Version bumped in `package.json`, `plugin.json`, and README badge
-- [ ] `CHANGELOG.md` updated with new version section
 - [ ] Commits follow conventional format (`feat:`, `fix:`, `chore:`)
+- [ ] No manual version bumps or CHANGELOG edits (automated via release-please)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,8 +61,7 @@ git checkout -b fix/your-bug-fix
 - Add tests if applicable
 - Run `npm test` to ensure tests pass
 - Run `npm run build` to ensure it compiles
-- **Bump the version** in all three places (they must match): `package.json`, `.claude-plugin/plugin.json`, and the `README.md` version badge. Follow [semver](https://semver.org/): bug fix = patch, new feature = minor
-- **Update `CHANGELOG.md`** with a new version section describing your changes (use `Added`, `Changed`, `Fixed` headings as appropriate). Add a comparison link at the bottom of the file
+- **Do NOT manually bump versions or edit CHANGELOG.md** — versioning is automated via [release-please](https://github.com/googleapis/release-please)
 
 ### 4. Commit
 
@@ -108,16 +107,11 @@ npx vitest src/core/state.test.ts
 
 ## Release Process
 
-When preparing a new release:
+Releases are automated via [release-please](https://github.com/googleapis/release-please). Contributors do NOT need to bump versions, edit CHANGELOG.md, or create tags.
 
-1. **Decide version number** following [semver](https://semver.org/): new feature = minor bump, bug fix = patch bump
-2. **Update version** in both `.claude-plugin/plugin.json` and `package.json` (they must always match)
-3. **Update CHANGELOG.md** with the new version section (Added, Changed, Fixed as appropriate)
-4. **Update version badge** in `README.md` to reflect the new version
-5. **Commit**: `git commit -m "chore: release vX.Y.Z"`
-6. **Tag**: `git tag vX.Y.Z`
-7. **Push with tags**: `git push origin main --tags`
-8. **Optional**: Create a GitHub release with `gh release create vX.Y.Z --notes "See CHANGELOG.md"`
+1. Use [conventional commits](https://www.conventionalcommits.org/): `feat:` (minor bump), `fix:` (patch bump), `chore:` (no release)
+2. On merge to main, release-please opens or updates a release PR that bumps versions and generates the changelog
+3. A maintainer merges the release-please PR to create a GitHub release, which triggers npm publish
 
 ## Questions?
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@ You have 12 open PRs across GitHub. A maintainer asked a question 5 days ago. Tw
 
 OSS Autopilot is an AI copilot that tracks all your open source PRs, alerts you when something needs attention, and helps you respond to maintainer feedback so your contributions actually get merged.
 
-<!-- x-release-please-start-version -->
-![Version](https://img.shields.io/badge/version-0.35.0-blue)
-<!-- x-release-please-end -->
 ![CI](https://github.com/costajohnt/oss-autopilot/actions/workflows/ci.yml/badge.svg)
 ![Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/costajohnt/oss-autopilot/main/.github/badges/tests.json)
 ![License](https://img.shields.io/badge/license-MIT-green)
@@ -296,7 +293,7 @@ claude --plugin-dir ./oss-autopilot
 
 | Hook | What it blocks |
 |------|----------------|
-| `check-versions.sh` | Commits when `package.json`, `plugin.json`, and README badge versions don't match |
+| `check-versions.sh` | Commits when `package.json` and `plugin.json` versions don't match |
 | `no-ai-attribution.sh` | Commits containing AI attribution phrases |
 | `no-commit-on-main.sh` | Direct commits to `main` or `master` |
 | `conventional-commits.sh` | Commit messages without `feat:`/`fix:`/`chore:` prefix |

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,8 +12,7 @@
           "type": "json",
           "path": ".claude-plugin/plugin.json",
           "jsonpath": "$.version"
-        },
-        "README.md"
+        }
       ]
     }
   }


### PR DESCRIPTION
## Summary

- **Remove static version badge** from README.md — the shields.io URL format `version-0.35.0-blue` caused release-please's `VERSION_REGEX` to match `0.35.0-blue` as a semver string with a prerelease suffix, stripping `-blue` on every release
- **Keep the npm badge** (`[![npm](https://img.shields.io/npm/v/oss-autopilot)]`) which already shows the version dynamically from the npm registry
- **Remove `README.md` from `release-please-config.json` `extra-files`** since there's nothing to update
- **Update `check-versions.sh` hook** to validate only `package.json` and `plugin.json` (was also checking the now-removed badge)
- **Update `CONTRIBUTING.md`** and **PR template** to replace manual versioning instructions with release-please guidance

## Why

PR #195 changed the badge annotation from inline to block format, but release-please PR #196 showed that the block annotation still didn't prevent the issue. The root cause is that `VERSION_REGEX` (`/\d+\.\d+\.\d+(-[\w.]+)?/`) matches `-blue` as a prerelease suffix. Rather than fighting the regex, we remove the redundant badge.

## Test plan

- [x] `npm test` — all 1098 tests pass
- [x] Codebase-wide grep confirms zero orphaned references to the removed badge
- [x] `check-versions.sh` validated: passes when versions match, blocks when they don't
- [ ] After merge, verify release-please PR #196 no longer modifies README.md