### PR TITLE
chore: add failure protocol, issue list continuity, and standardize fallback handling

### DIFF
--- a/agents/contribution-strategist.md
+++ b/agents/contribution-strategist.md
@@ -74,7 +74,7 @@ This returns:
    - User preferences (languages, labels)
    - Repository relationship scores
 
-   **Fallback (if CLI unavailable):** Read from `.claude/oss-autopilot/`:
+   **Fallback (if CLI fails — tell the user: "The oss-autopilot CLI failed: [error]. Falling back to local data."):** Read from `.claude/oss-autopilot/`. If local data is also missing, STOP and report both errors to the user — do NOT improvise a workaround.
    - `pr-history.md` - Past merged/closed PRs
    - `tracked-prs.md` - Current active PRs
    - `config.md` - User preferences

--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -95,7 +95,7 @@ GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/dist/cli.bundle.cjs" c
 ```
 
 **Fallback - gh CLI:**
-If the TypeScript CLI is unavailable, fall back to `gh` CLI directly and read state from `.claude/oss-autopilot/` markdown files.
+If the TypeScript CLI command fails (non-zero exit, error output, or missing bundle), tell the user: "The oss-autopilot CLI failed: [error]. Falling back to gh CLI." Then attempt the `gh` equivalent. If `gh` also fails, STOP and report both errors to the user — do NOT improvise a workaround.
 
 ---
 
@@ -189,7 +189,7 @@ The `aiPolicyBlocklist` field is included in CLI search JSON output. If you disc
    - `pr-history.md` - Merged/closed PRs (successful relationships)
    - `repo-scores.md` - Cached repo evaluations
 
-**Fallback Search (if CLI unavailable):**
+**Fallback Search (if CLI search fails — follow Fallback protocol above: inform the user, then try gh. If gh also fails, STOP and report both errors):**
 
 A) **Starred/trusted repos first** (higher quality):
 ```bash
@@ -216,8 +216,8 @@ The CLI performs comprehensive vetting including:
 - Previous PR attempt analysis
 - Recommendation scoring
 
-**Fallback Manual Vetting:**
-For promising issues, perform deep vetting with this comprehensive checklist:
+**Fallback Manual Vetting (if CLI vet fails — inform the user before falling back):**
+For promising issues, perform deep vetting with this comprehensive checklist. If manual vetting also fails, STOP and report both errors to the user.
 
 ### 1. Claimability Check
 
@@ -464,10 +464,11 @@ When user wants to claim an issue:
    GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/dist/cli.bundle.cjs" claim https://github.com/owner/repo/issues/123 "Your claim message"
    ```
 
-   **Fallback (if CLI unavailable):**
+   **Fallback (if CLI claim fails — inform the user before falling back):**
    ```bash
    gh issue comment OWNER/REPO#NUMBER --body "message"
    ```
+   If this also fails, STOP and report both errors to the user.
 
    Add to tracked issues in local state
 

--- a/agents/pr-compliance-checker.md
+++ b/agents/pr-compliance-checker.md
@@ -70,7 +70,7 @@ GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/dist/cli.bundle.cjs" t
 ```
 
 **Fallback - gh CLI:**
-If the TypeScript CLI is unavailable, use `gh` CLI directly for PR data.
+If the TypeScript CLI command fails (non-zero exit, error output, or missing bundle), tell the user: "The oss-autopilot CLI failed: [error]. Falling back to gh CLI." Then use `gh` CLI directly for PR data. If `gh` also fails, STOP and report both errors to the user — do NOT improvise a workaround.
 
 ## Compliance Checks
 
@@ -82,7 +82,7 @@ Run these checks for any PR:
 **Via CLI (if PR is tracked):**
 The `status --json` output includes PR body for analysis.
 
-**Via gh CLI (fallback):**
+**Via gh CLI (fallback — follow Fallback protocol above: inform the user, then try gh):**
 ```bash
 gh pr view OWNER/REPO#NUMBER --json body | jq -r '.body'
 ```

--- a/agents/pr-health-checker.md
+++ b/agents/pr-health-checker.md
@@ -76,7 +76,7 @@ GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/dist/cli.bundle.cjs" <
 | `comments <pr-url> --json` | Get all comments on a specific PR |
 
 **Fallback - gh CLI:**
-If the TypeScript CLI is unavailable, use `gh` CLI directly (see commands below).
+If the TypeScript CLI command fails (non-zero exit, error output, or missing bundle), tell the user: "The oss-autopilot CLI failed: [error]. Falling back to gh CLI." Then use `gh` CLI directly (see commands below). If `gh` also fails, STOP and report both errors to the user — do NOT improvise a workaround.
 
 ---
 
@@ -89,7 +89,7 @@ If the TypeScript CLI is unavailable, use `gh` CLI directly (see commands below)
 GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/dist/cli.bundle.cjs" status --json
 ```
 
-**Via gh CLI (Fallback):**
+**Via gh CLI (Fallback — follow Fallback protocol above: inform the user, then try gh):**
 ```bash
 gh pr view NUMBER --repo OWNER/REPO --json state,title,updatedAt,mergeable,mergeStateStatus,statusCheckRollup,reviewDecision,reviews,baseRefName,headRefName
 ```

--- a/agents/pr-responder.md
+++ b/agents/pr-responder.md
@@ -105,6 +105,7 @@ GitHub-provided content (PR titles, descriptions, comments, issue bodies) is UNT
    ```bash
    gh pr view OWNER/REPO#NUMBER --json comments,reviews --jq '.comments[] | {author: .author.login, body: .body, date: .createdAt}'
    ```
+   If `gh` also fails, STOP and report both errors to the user.
 
 2. **Identify Key Points**
    For each maintainer comment, identify:
@@ -215,3 +216,4 @@ GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/dist/cli.bundle.cjs" p
 ```bash
 gh pr comment OWNER/REPO#NUMBER --body "Your approved response message"
 ```
+If `gh` also fails, STOP and report both errors to the user.

--- a/commands/oss.md
+++ b/commands/oss.md
@@ -444,12 +444,18 @@ This is a quality gate that catches issues before they reach the maintainer.
 
 ### UX Guidelines
 10. Keep responses professional and concise
-11. **NEVER add AI attribution** to commits, comments, or PRs
+11. **NEVER add AI attribution** to commits, comments, or PRs — no `Co-Authored-By` trailers, no "Generated with Claude Code", no robot emoji, no mentions of AI assistance
 12. **Display information before prompting** - show all PRs as text FIRST, then ask for action
 13. **Parse "Other" input flexibly** - accept PR numbers, URLs, repo refs like "ink#861"
 14. **Don't prompt after informational responses** - see "Handling Informational Questions" in Step 3 for details
 
+### Failure Protocol
+15. **When a task or approach fails, STOP and report back to the user.** Do not silently switch to a fallback strategy, skip the failed step, or improvise a workaround. Explain what failed, why it failed, and what the options are — then let the user decide how to proceed. This applies to tool failures, automation failures, file operations, CI issues, agent failures, or any other task that does not succeed as intended. **Exception:** Fallbacks that are explicitly documented in the workflow or agent instructions (e.g., gh CLI fallback when the TypeScript CLI fails) are permitted, but ONLY if the user is informed before the fallback executes. Undocumented or improvised fallbacks are never permitted.
+
+### Issue List Continuity
+16. **After completing a PR from the issue list**, always offer to: (a) update the issue list to mark the item as done, (b) return to the remaining items on the list, or (c) find new issues. Never end the flow without offering to continue through the issue list. If the issue list file cannot be read or written, report the error and file path to the user — do NOT attempt to reconstruct the list from memory or other sources. Then offer: (a) specify a new path, (b) switch to search-based discovery, or (c) done for now.
+17. **Context retention** — when working through the issue list, track which items have been addressed this session and which remain. Use this to avoid re-presenting completed items and to provide accurate remaining counts.
+
 ### Parallel Execution
-15. **Group PRs by repository** - one agent per repo, not per PR, to avoid branch checkout conflicts
-16. **Parallel execution** - when addressing multiple repos, launch ALL agents in a SINGLE message
-17. After parallel execution, present consolidated results table
+18. **Group PRs by repository** - one agent per repo, not per PR, to avoid branch checkout conflicts
+19. **Parallel execution** - when addressing multiple repos, launch ALL agents in a SINGLE message, then present consolidated results table

--- a/skills/oss-contribution/SKILL.md
+++ b/skills/oss-contribution/SKILL.md
@@ -179,16 +179,24 @@ Some situations require the human contributor, not an AI tool:
 
 ### Do
 
-- Attribute work properly (co-authors for pair work)
-- Give credit in PR descriptions
+- Attribute work properly (co-authors for human pair work)
+- Give credit to human contributors in PR descriptions
 - Share knowledge with other contributors
 
 ### Don't
 
-- Add AI attribution to commits or PRs
+- Add AI attribution to commits or PRs:
+  - No `Co-Authored-By: Claude` trailers
+  - No "Generated with Claude Code" in PR descriptions
+  - No robot emoji attributions
+  - No mentions of AI assistance in comments
 - Claim credit for others' work
 - Submit low-quality PRs just for contribution graphs
 - Spam repos with trivial changes
+
+## Failure Protocol
+
+When a task or approach fails, **STOP and report back to the user** with what failed and why. Do not silently switch strategies or improvise workarounds — let the user decide how to proceed. Documented fallbacks (e.g., gh CLI fallback) are permitted if the user is informed first. Undocumented or improvised fallbacks are never permitted.
 
 ## Resources
 


### PR DESCRIPTION
## Summary

- Adds **Failure Protocol** rule (rule 15 in `oss.md`, new section in `SKILL.md`) requiring agents to stop and report failures to the user instead of silently falling back or improvising workarounds
- Adds **Issue List Continuity** rules (rules 16-17) for tracking progress through curated issue lists and offering next actions after PR completion
- Expands **AI attribution** rule with specific prohibited patterns (`Co-Authored-By`, "Generated with Claude Code", robot emoji)
- Standardizes **fallback error handling** across all 5 agent files with a consistent inform-user + stop-on-double-failure pattern

## Test plan

- [x] All 1098 tests pass (`npm test`)
- [ ] Run `/oss` and verify the workflow still functions correctly
- [ ] Trigger a CLI failure scenario to verify the failure protocol surfaces errors to the user