### PR TITLE
fix: resolve TS18048 type-check error failing CI

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -35,48 +35,49 @@ export async function runConfig(options: ConfigOptions): Promise<void> {
   if (!options.value) {
     exitWithError('Value required', options.json);
   }
+  const value = options.value;
 
   // Handle specific config keys
   switch (options.key) {
     case 'username':
-      stateManager.updateConfig({ githubUsername: options.value });
+      stateManager.updateConfig({ githubUsername: value });
       break;
     case 'add-language':
-      if (!currentConfig.languages.includes(options.value)) {
-        stateManager.updateConfig({ languages: [...currentConfig.languages, options.value] });
+      if (!currentConfig.languages.includes(value)) {
+        stateManager.updateConfig({ languages: [...currentConfig.languages, value] });
       }
       break;
     case 'add-label':
-      if (!currentConfig.labels.includes(options.value)) {
-        stateManager.updateConfig({ labels: [...currentConfig.labels, options.value] });
+      if (!currentConfig.labels.includes(value)) {
+        stateManager.updateConfig({ labels: [...currentConfig.labels, value] });
       }
       break;
     case 'exclude-repo': {
-      const parts = options.value.split('/');
+      const parts = value.split('/');
       if (parts.length !== 2 || !parts[0] || !parts[1]) {
         exitWithError(
-          `Invalid repo format "${options.value}". Use "owner/repo" format. To exclude an entire org, use: config exclude-org ${options.value}`,
+          `Invalid repo format "${value}". Use "owner/repo" format. To exclude an entire org, use: config exclude-org ${value}`,
           options.json,
         );
       }
-      const valueLower = options.value.toLowerCase();
+      const valueLower = value.toLowerCase();
       if (!currentConfig.excludeRepos.some(r => r.toLowerCase() === valueLower)) {
-        stateManager.updateConfig({ excludeRepos: [...currentConfig.excludeRepos, options.value] });
-        stateManager.cleanupExcludedData([options.value], []);
+        stateManager.updateConfig({ excludeRepos: [...currentConfig.excludeRepos, value] });
+        stateManager.cleanupExcludedData([value], []);
       }
       break;
     }
     case 'exclude-org': {
-      if (options.value.includes('/')) {
+      if (value.includes('/')) {
         exitWithError(
-          `Invalid org name "${options.value}". Use just the org name (e.g., "facebook"), not "owner/repo" format. To exclude a specific repo, use: config exclude-repo ${options.value}`,
+          `Invalid org name "${value}". Use just the org name (e.g., "facebook"), not "owner/repo" format. To exclude a specific repo, use: config exclude-repo ${value}`,
           options.json,
         );
       }
       const currentOrgs = currentConfig.excludeOrgs ?? [];
-      if (!currentOrgs.some(o => o.toLowerCase() === options.value.toLowerCase())) {
-        stateManager.updateConfig({ excludeOrgs: [...currentOrgs, options.value] });
-        stateManager.cleanupExcludedData([], [options.value]);
+      if (!currentOrgs.some(o => o.toLowerCase() === value.toLowerCase())) {
+        stateManager.updateConfig({ excludeOrgs: [...currentOrgs, value] });
+        stateManager.cleanupExcludedData([], [value]);
       }
       break;
     }
@@ -87,8 +88,8 @@ export async function runConfig(options: ConfigOptions): Promise<void> {
   stateManager.save();
 
   if (options.json) {
-    outputJson({ success: true, key: options.key, value: options.value });
+    outputJson({ success: true, key: options.key, value });
   } else {
-    console.log(`Set ${options.key} to: ${options.value}`);
+    console.log(`Set ${options.key} to: ${value}`);
   }
 }


### PR DESCRIPTION
## Summary

- Fix TypeScript strict null check error (`TS18048: 'options.value' is possibly 'undefined'`) in `src/commands/config.ts` that was failing CI on all Node versions (18, 20, 22)
- Extract `options.value` into a `const value` after the `exitWithError` guard so TypeScript definitively narrows the type across switch-case block scopes
- Enable branch protection on `main` requiring all three CI matrix jobs (Node 18, 20, 22) to pass before merging

## Test plan

- [x] `npx tsc --noEmit` passes locally (was failing before)
- [x] `npm test` — all tests pass
- [x] `npm run bundle` — bundle builds successfully
- [ ] CI passes on this PR (Node 18, 20, 22)