### PR TITLE
fix: auto-trigger CI on release-please PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   release-please:
@@ -15,6 +16,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release-please
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # GITHUB_TOKEN events don't trigger workflows, but workflow_dispatch
+      # is an explicit exception. Dispatch CI so the release PR gets checks.
+      - name: Trigger CI on release PR
+        if: steps.release-please.outputs.prs_created == 'true' || steps.release-please.outputs.prs_updated == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_DATA: ${{ steps.release-please.outputs.pr }}
+        run: |
+          PR_BRANCH=$(echo "$PR_DATA" | jq -r '.headBranchName')
+          if [ -n "$PR_BRANCH" ] && [ "$PR_BRANCH" != "null" ]; then
+            gh workflow run ci.yml --ref "$PR_BRANCH"
+          fi


### PR DESCRIPTION
## Summary

- `GITHUB_TOKEN` events don't trigger other workflows, so release-please PRs never get CI checks — blocking merge since branch protection now requires them
- Add `workflow_dispatch` trigger to CI workflow (one of two exceptions to the GITHUB_TOKEN restriction)
- Add a dispatch step to the release-please workflow that triggers CI on the release PR branch after creation/update
- Uses release-please action's `pr` output directly (no extra API call), passed through `env:` for injection safety

## Test plan

- [x] TypeScript compiles, all tests pass
- [ ] CI passes on this PR
- [ ] After merge, next push to main triggers release-please which dispatches CI on its PR branch