### PR TITLE
fix: add GH_REPO for CI dispatch in release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,6 +27,7 @@ jobs:
         if: steps.release-please.outputs.prs_created == 'true' || steps.release-please.outputs.prs_updated == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           PR_DATA: ${{ steps.release-please.outputs.pr }}
         run: |
           PR_BRANCH=$(echo "$PR_DATA" | jq -r '.headBranchName')


### PR DESCRIPTION
## Summary

- The release-please workflow doesn't checkout code, so `gh workflow run` fails with `fatal: not a git repository`
- Set `GH_REPO` env var (recognized by `gh` CLI) so the dispatch command knows which repo to target

One-line fix for the dispatch added in #220.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, release-please dispatches CI on PR #218 successfully