### PR TITLE
fix: narrow error handling for review comment fetch

### DIFF
--- a/src/core/pr-monitor.test.ts
+++ b/src/core/pr-monitor.test.ts
@@ -3026,6 +3026,23 @@ describe('review comment fetch error handling (#229)', () => {
     expect(failures[0].error).toContain('API rate limit exceeded');
   });
 
+  it('should degrade gracefully on non-rate-limit 403 (e.g. private repo)', async () => {
+    mockOctokitInstance = makeMocksWithReviewCommentError({ status: 403, message: 'Resource not accessible by integration' });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const monitor = new PRMonitor('fake-token');
+    const { prs } = await monitor.fetchUserOpenPRs();
+
+    // Non-rate-limit 403 should NOT re-throw — PR still returned
+    expect(prs).toHaveLength(1);
+    expect(prs[0].url).toBe(prUrl);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('403 fetching review comments'),
+    );
+
+    warnSpy.mockRestore();
+  });
+
   it('should return empty data on 500 server error with warning', async () => {
     mockOctokitInstance = makeMocksWithReviewCommentError({ status: 500, message: 'Internal Server Error' });
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/src/core/pr-monitor.ts
+++ b/src/core/pr-monitor.ts
@@ -186,8 +186,17 @@ export class PRMonitor {
           const status = (err as { status?: number })?.status;
           // Rate limit errors must propagate — silently swallowing them hides
           // a systemic problem and produces misleading results (#229).
-          if (status === 403 || status === 429) {
+          if (status === 429) {
             throw err;
+          }
+          if (status === 403) {
+            const msg = ((err as { message?: string })?.message ?? '').toLowerCase();
+            if (msg.includes('rate limit') || msg.includes('abuse detection')) {
+              throw err;
+            }
+            // Non-rate-limit 403 (DMCA, private repo, SSO) — degrade gracefully
+            console.warn(`[PR_MONITOR] 403 fetching review comments for ${owner}/${repo}#${number}: ${msg}`);
+            return { data: [] as Array<any> };
           }
           if (status === 404) {
             console.debug(`[PR_MONITOR] 404 fetching review comments for ${owner}/${repo}#${number} — skipping self-reply detection`);


### PR DESCRIPTION
## Summary

Closes #229

- Rate limit errors (403/429) on `listReviewComments` are now re-thrown instead of silently swallowed, making rate limiting visible in fetch results
- 404 errors logged at `console.debug` level (expected for some repos with different permissions)
- Other errors (e.g. 500) continue to degrade gracefully with improved `console.warn` logging

## Test plan

- [x] New test: 404 error → returns PR with empty review comments
- [x] New test: 429 rate limit → propagates as failure
- [x] New test: 403 rate limit → propagates as failure
- [x] New test: 500 server error → returns PR with empty data + warning
- [x] All 626 existing tests pass