### PR TITLE
chore: add exports field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,13 @@
   "bin": {
     "oss-autopilot": "./dist/cli.js"
   },
+  "exports": {
+    ".": {
+      "import": "./dist/cli.js",
+      "require": "./dist/cli.bundle.cjs"
+    },
+    "./cli": "./dist/cli.bundle.cjs"
+  },
   "scripts": {
     "build": "tsc",
     "bundle": "esbuild src/cli.ts --bundle --platform=node --target=node18 --format=cjs --outfile=dist/cli.bundle.cjs",


### PR DESCRIPTION
## Summary

Closes #231

- Adds the `exports` field to `package.json` with dual ESM/CJS entry points
- ESM consumers get `./dist/cli.js` (via `import` condition)
- CJS consumers get `./dist/cli.bundle.cjs` (via `require` condition)
- Named subpath `./cli` for direct bundle access
- Existing `main` field preserved for backward compatibility

## Test plan

- [x] `npm test` — all 622 tests pass
- [x] `npm run bundle` — builds successfully (584.7kb)
- [x] Existing `bin` entry unaffected