### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,11 @@
 
 # CI/CD and Infrastructure
 /.github/ @costajohnt
+/workflows/ @costajohnt
 
-# Plugin manifest
+# Plugin manifest and hooks
 /.claude-plugin/ @costajohnt
+/hooks/ @costajohnt
+
+# Documentation
+/docs/ @costajohnt


### PR DESCRIPTION
## Summary

Closes #235

- Adds `.github/CODEOWNERS` with @costajohnt as default owner
- Explicit ownership rules for: plugin components, core TypeScript, CI/CD, plugin manifest
- GitHub will auto-request reviews from code owner on PRs

## Test plan

- [x] `npm test` — all 622 tests pass
- [x] CODEOWNERS syntax is valid (follows GitHub format)