### PR TITLE
chore: add npm audit to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Security audit
+        run: npm audit --audit-level=high
+
       - name: Type check
         run: npx tsc --noEmit
 


### PR DESCRIPTION
## Summary

Closes #236

- Adds `npm audit --audit-level=high` step to CI workflow after `npm ci`
- Only fails on high/critical severity vulnerabilities (avoids noisy low/moderate findings)
- Runs across all Node.js versions in the matrix

## Test plan

- [x] CI workflow syntax is valid YAML
- [x] Audit step runs after dependency installation
- [x] All existing tests unaffected