### PR TITLE
refactor: extract shared worker pool utility

### DIFF
--- a/src/core/concurrency.test.ts
+++ b/src/core/concurrency.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { runWorkerPool } from './concurrency.js';
+
+describe('runWorkerPool', () => {
+  it('processes all items', async () => {
+    const items = [1, 2, 3, 4, 5];
+    const processed: number[] = [];
+
+    await runWorkerPool(items, async (item) => {
+      processed.push(item);
+    }, 3);
+
+    expect(processed.sort()).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('respects concurrency limit', async () => {
+    let activeConcurrency = 0;
+    let maxObservedConcurrency = 0;
+    const items = [1, 2, 3, 4, 5, 6, 7, 8];
+
+    await runWorkerPool(items, async () => {
+      activeConcurrency++;
+      maxObservedConcurrency = Math.max(maxObservedConcurrency, activeConcurrency);
+      // Simulate async work so workers can overlap
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      activeConcurrency--;
+    }, 3);
+
+    expect(maxObservedConcurrency).toBeLessThanOrEqual(3);
+    // With 8 items and concurrency 3, we should actually see concurrency > 1
+    expect(maxObservedConcurrency).toBeGreaterThan(1);
+  });
+
+  it('handles empty array', async () => {
+    const processed: number[] = [];
+
+    await runWorkerPool([], async (item: number) => {
+      processed.push(item);
+    }, 5);
+
+    expect(processed).toEqual([]);
+  });
+
+  it('propagates worker errors', async () => {
+    const items = [1, 2, 3];
+
+    await expect(
+      runWorkerPool(items, async (item) => {
+        if (item === 2) throw new Error('item 2 failed');
+      }, 1),
+    ).rejects.toThrow('item 2 failed');
+  });
+
+  it('processes items in order with concurrency=1', async () => {
+    const items = ['a', 'b', 'c', 'd', 'e'];
+    const processed: string[] = [];
+
+    await runWorkerPool(items, async (item) => {
+      processed.push(item);
+    }, 1);
+
+    expect(processed).toEqual(['a', 'b', 'c', 'd', 'e']);
+  });
+});

--- a/src/core/concurrency.ts
+++ b/src/core/concurrency.ts
@@ -1,0 +1,19 @@
+/**
+ * Runs a worker pool that processes items with bounded concurrency.
+ * N workers consume from a shared index — simpler than Promise.race + splice.
+ */
+export async function runWorkerPool<T>(
+  items: T[],
+  worker: (item: T) => Promise<void>,
+  concurrency: number,
+): Promise<void> {
+  let index = 0;
+  const poolWorker = async () => {
+    while (index < items.length) {
+      const item = items[index++];
+      await worker(item);
+    }
+  };
+  const workerCount = Math.min(concurrency, items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => poolWorker()));
+}

--- a/src/core/issue-conversation.ts
+++ b/src/core/issue-conversation.ts
@@ -11,6 +11,7 @@ import { getOctokit } from './github.js';
 import { isBotAuthor, isAcknowledgmentComment } from './comment-utils.js';
 import { getStateManager } from './state.js';
 import { daysBetween, splitRepo, extractOwnerRepo } from './utils.js';
+import { runWorkerPool } from './concurrency.js';
 import type { CommentedIssue, IssueConversationStatus } from './types.js';
 
 const MAX_CONCURRENT_REQUESTS = 5;
@@ -103,32 +104,23 @@ export class IssueConversationMonitor {
     console.error(`Found ${candidates.length} commented issues to check`);
 
     // Fetch comments for each issue using worker pool.
-    // N workers consume from a shared index — simpler than Promise.race + splice.
-    // Safe because JS is single-threaded: nextIndex++ and results.push() are never interleaved mid-operation.
     const results: CommentedIssue[] = [];
     const failures: Array<{ issueUrl: string; error: string }> = [];
-    let nextIndex = 0;
 
-    const fetchWorker = async () => {
-      while (nextIndex < candidates.length) {
-        const { item, repoFullName } = candidates[nextIndex++];
-        try {
-          const issue = await this.analyzeIssueConversation(item, repoFullName, username);
-          if (issue) {
-            results.push(issue);
-          } else {
-            failures.push({ issueUrl: item.html_url, error: 'No user comment found despite commenter: search match (possible pagination or eventual consistency)' });
-          }
-        } catch (error) {
-          const msg = error instanceof Error ? error.message : String(error);
-          failures.push({ issueUrl: item.html_url, error: msg });
-          console.error(`Error analyzing issue ${item.html_url}: ${msg}`);
+    await runWorkerPool(candidates, async ({ item, repoFullName }) => {
+      try {
+        const issue = await this.analyzeIssueConversation(item, repoFullName, username);
+        if (issue) {
+          results.push(issue);
+        } else {
+          failures.push({ issueUrl: item.html_url, error: 'No user comment found despite commenter: search match (possible pagination or eventual consistency)' });
         }
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        failures.push({ issueUrl: item.html_url, error: msg });
+        console.error(`Error analyzing issue ${item.html_url}: ${msg}`);
       }
-    };
-
-    const workerCount = Math.min(MAX_CONCURRENT_REQUESTS, candidates.length);
-    await Promise.all(Array.from({ length: workerCount }, () => fetchWorker()));
+    }, MAX_CONCURRENT_REQUESTS);
 
     if (failures.length > 0) {
       console.error(`[ISSUE_CONVERSATION] ${failures.length}/${candidates.length} issue analysis call(s) failed`);

--- a/src/core/pr-monitor.ts
+++ b/src/core/pr-monitor.ts
@@ -10,6 +10,7 @@ import { getStateManager } from './state.js';
 import { daysBetween, parseGitHubUrl, extractOwnerRepo } from './utils.js';
 import { FetchedPR, FetchedPRStatus, CIStatus, CIStatusResult, ReviewDecision, DailyDigest, MaintainerActionHint, ClosedPR, MergedPR, CIFailureCategory, ClassifiedCheck } from './types.js';
 import { isBotAuthor, isAcknowledgmentComment } from './comment-utils.js';
+import { runWorkerPool } from './concurrency.js';
 
 // Re-export so existing consumers (tests, index.ts) can still import from pr-monitor
 export { isBotAuthor };
@@ -116,25 +117,16 @@ export class PRMonitor {
     });
 
     // Fetch detailed info using a worker pool for bounded concurrency.
-    // N workers consume from a shared index — simpler than Promise.race + splice.
-    // Safe because JS is single-threaded: nextIndex++ and prs.push() are never interleaved mid-operation.
-    let nextIndex = 0;
-    const fetchWorker = async () => {
-      while (nextIndex < filteredItems.length) {
-        const item = filteredItems[nextIndex++];
-        try {
-          const pr = await this.fetchPRDetails(item.html_url);
-          if (pr) prs.push(pr);
-        } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : String(error);
-          console.error(`Error fetching ${item.html_url}: ${errorMessage}`);
-          failures.push({ prUrl: item.html_url, error: errorMessage });
-        }
+    await runWorkerPool(filteredItems, async (item) => {
+      try {
+        const pr = await this.fetchPRDetails(item.html_url);
+        if (pr) prs.push(pr);
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        console.error(`Error fetching ${item.html_url}: ${errorMessage}`);
+        failures.push({ prUrl: item.html_url, error: errorMessage });
       }
-    };
-
-    const workerCount = Math.min(MAX_CONCURRENT_REQUESTS, filteredItems.length);
-    await Promise.all(Array.from({ length: workerCount }, () => fetchWorker()));
+    }, MAX_CONCURRENT_REQUESTS);
 
     // Sort by days since activity (most urgent first)
     prs.sort((a, b) => {


### PR DESCRIPTION
## Summary

Closes #239

Extracts the duplicated "N workers consume from shared index" pattern into a shared utility:

- New `src/core/concurrency.ts` with generic `runWorkerPool<T>()` function
- `pr-monitor.ts` updated to use `runWorkerPool` instead of inline pattern
- `issue-conversation.ts` updated to use `runWorkerPool` instead of inline pattern
- 5 new unit tests for the utility (concurrency limits, empty arrays, error propagation, ordering)

## Test plan

- [x] All 627 tests pass (622 existing + 5 new)
- [x] Behavior identical — refactoring only, no logic changes
- [x] Concurrency limits verified in tests