### PR TITLE
feat: add concurrent state write protection

### DIFF
--- a/src/core/state.test.ts
+++ b/src/core/state.test.ts
@@ -1186,8 +1186,8 @@ describe('Concurrent State Write Protection', () => {
 
       expect(() => acquireLock(lockPath)).toThrow('State file is locked by another process');
 
-      // Clean up
-      releaseLock(lockPath);
+      // Clean up (use unlinkSync directly since releaseLock checks PID ownership)
+      fs.unlinkSync(lockPath);
     });
 
     it('should recover from stale locks', () => {
@@ -1204,6 +1204,35 @@ describe('Concurrent State Write Protection', () => {
       expect(newLockData.pid).toBe(process.pid);
 
       releaseLock(lockPath);
+    });
+
+    it('should recover from corrupt lock files', () => {
+      const lockPath = path.join(tmpDir, 'state.json.lock');
+      // Write invalid JSON to simulate a corrupt lock file
+      fs.writeFileSync(lockPath, 'NOT VALID JSON', { flag: 'wx' });
+
+      // Should succeed because corrupt locks are treated as stale
+      acquireLock(lockPath);
+      expect(fs.existsSync(lockPath)).toBe(true);
+
+      const newLockData = JSON.parse(fs.readFileSync(lockPath, 'utf-8'));
+      expect(newLockData.pid).toBe(process.pid);
+
+      releaseLock(lockPath);
+    });
+
+    it('should not release a lock owned by another process', () => {
+      const lockPath = path.join(tmpDir, 'state.json.lock');
+      // Simulate a lock from another process
+      const lockData = JSON.stringify({ pid: 999999, timestamp: Date.now() });
+      fs.writeFileSync(lockPath, lockData, { flag: 'wx' });
+
+      // releaseLock should not remove it because PID doesn't match
+      releaseLock(lockPath);
+      expect(fs.existsSync(lockPath)).toBe(true);
+
+      // Clean up
+      fs.unlinkSync(lockPath);
     });
 
     it('should silently handle releasing a non-existent lock', () => {

--- a/src/core/state.ts
+++ b/src/core/state.ts
@@ -22,47 +22,60 @@ const LEGACY_STATE_FILE = path.join(process.cwd(), 'data', 'state.json');
 const LEGACY_BACKUP_DIR = path.join(process.cwd(), 'data', 'backups');
 
 /**
+ * Check whether an existing lock file is stale (expired or corrupt).
+ * Returns true if the lock should be considered stale and can be removed.
+ */
+function isLockStale(lockPath: string): boolean {
+  try {
+    const existing = JSON.parse(fs.readFileSync(lockPath, 'utf-8'));
+    return Date.now() - existing.timestamp > LOCK_TIMEOUT_MS;
+  } catch {
+    // Lock file is unreadable or contains invalid JSON — treat as stale
+    return true;
+  }
+}
+
+/**
  * Acquire an advisory file lock using exclusive-create (`wx` flag).
- * If the lock file already exists but is older than LOCK_TIMEOUT_MS, it is treated as stale and removed.
+ * If the lock file already exists but is stale (older than LOCK_TIMEOUT_MS or corrupt),
+ * it is removed and re-acquired.
  * @throws Error if the lock is held by another active process.
  */
 export function acquireLock(lockPath: string): void {
   const lockData = JSON.stringify({ pid: process.pid, timestamp: Date.now() });
   try {
-    fs.writeFileSync(lockPath, lockData, { flag: 'wx' }); // Fails if exists
+    fs.writeFileSync(lockPath, lockData, { flag: 'wx' }); // Fails if file exists
+    return;
   } catch {
     // Lock file exists — check if it is stale
-    try {
-      const existing = JSON.parse(fs.readFileSync(lockPath, 'utf-8'));
-      if (Date.now() - existing.timestamp > LOCK_TIMEOUT_MS) {
-        fs.unlinkSync(lockPath); // Remove stale lock
-        fs.writeFileSync(lockPath, lockData, { flag: 'wx' });
-      } else {
-        throw new Error('State file is locked by another process');
-      }
-    } catch (innerError) {
-      // Re-throw our own error; wrap unexpected ones
-      if (innerError instanceof Error && innerError.message === 'State file is locked by another process') {
-        throw innerError;
-      }
-      // Lock file disappeared between check and read, or other race — retry once
-      try {
-        fs.writeFileSync(lockPath, lockData, { flag: 'wx' });
-      } catch {
-        throw new Error('State file is locked by another process');
-      }
-    }
+  }
+
+  if (!isLockStale(lockPath)) {
+    throw new Error('State file is locked by another process');
+  }
+
+  // Stale lock detected — remove it and try to re-acquire
+  try { fs.unlinkSync(lockPath); } catch { /* already removed */ }
+  try {
+    fs.writeFileSync(lockPath, lockData, { flag: 'wx' });
+  } catch {
+    // Another process grabbed the lock between unlink and write
+    throw new Error('State file is locked by another process');
   }
 }
 
 /**
- * Release an advisory file lock. Silently ignores missing lock files.
+ * Release an advisory file lock, but only if this process owns it.
+ * Silently ignores missing lock files or locks owned by other processes.
  */
 export function releaseLock(lockPath: string): void {
   try {
-    fs.unlinkSync(lockPath);
+    const data = JSON.parse(fs.readFileSync(lockPath, 'utf-8'));
+    if (data.pid === process.pid) {
+      fs.unlinkSync(lockPath);
+    }
   } catch {
-    /* lock already removed — nothing to do */
+    /* lock already removed or unreadable — nothing to do */
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #232

Adds two protections against state file corruption:

**Atomic writes** — State is written to `state.json.tmp` then renamed to `state.json`. The rename is atomic on POSIX filesystems, preventing partial writes from crashes.

**Advisory file locking** — A `state.json.lock` file with PID and timestamp prevents concurrent writes. Stale locks (>30s) are automatically cleaned up.

Applied to all 3 state write locations: main save, v1→v2 migration, and restore-from-backup.

## Test plan

- [x] 8 new tests for atomic writes and locking (temp file cleanup, overwrite, file mode, lock create/release, stale lock recovery, concurrent access rejection)
- [x] All 630 tests pass (112 in state.test.ts)