### PR TITLE
feat: add --debug flag with verbose logging

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,7 @@
  */
 
 import { Command } from 'commander';
-import { getGitHubToken } from './core/index.js';
+import { getGitHubToken, enableDebug, debug } from './core/index.js';
 import { runDaily } from './commands/daily.js';
 import { runStatus } from './commands/status.js';
 import { runSearch } from './commands/search.js';
@@ -47,7 +47,8 @@ const program = new Command();
 program
   .name('oss-autopilot')
   .description('AI-powered autopilot for managing open source contributions')
-  .version(VERSION);
+  .version(VERSION)
+  .option('--debug', 'Enable debug logging');
 
 // Daily check command
 program
@@ -289,6 +290,13 @@ program
 
 // Validate GitHub token before running commands that need it
 program.hook('preAction', async (thisCommand, actionCommand) => {
+  // Enable debug logging if --debug flag is set
+  const globalOpts = thisCommand.opts();
+  if (globalOpts.debug) {
+    enableDebug();
+    debug('cli', `Running command: ${actionCommand.name()}`);
+  }
+
   // actionCommand is the command being executed (e.g., 'status', 'daily')
   const commandName = actionCommand.name();
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -23,4 +23,5 @@ export {
   requireGitHubToken,
   resetGitHubTokenCache,
 } from './utils.js';
+export { enableDebug, isDebugEnabled, debug, warn, timed } from './logger.js';
 export * from './types.js';

--- a/src/core/logger.test.ts
+++ b/src/core/logger.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// We need to test the module's internal state, so we import and reset between tests.
+// The module uses a private `debugEnabled` flag — we reset it by re-importing or
+// calling enableDebug / checking isDebugEnabled.
+
+let loggerModule: typeof import('./logger.js');
+
+describe('logger', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    // Fresh import to reset module-level state
+    vi.resetModules();
+    loggerModule = await import('./logger.js');
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe('enableDebug / isDebugEnabled', () => {
+    it('should default to disabled', () => {
+      expect(loggerModule.isDebugEnabled()).toBe(false);
+    });
+
+    it('should enable debug mode', () => {
+      loggerModule.enableDebug();
+      expect(loggerModule.isDebugEnabled()).toBe(true);
+    });
+  });
+
+  describe('debug', () => {
+    it('should output nothing when debug is disabled', () => {
+      loggerModule.debug('test', 'hello');
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it('should output to stderr when debug is enabled', () => {
+      loggerModule.enableDebug();
+      loggerModule.debug('test-module', 'some message');
+      expect(consoleErrorSpy).toHaveBeenCalledOnce();
+      const output = consoleErrorSpy.mock.calls[0][0] as string;
+      expect(output).toContain('[DEBUG]');
+      expect(output).toContain('[test-module]');
+      expect(output).toContain('some message');
+    });
+
+    it('should include a timestamp in ISO format', () => {
+      loggerModule.enableDebug();
+      loggerModule.debug('mod', 'msg');
+      const output = consoleErrorSpy.mock.calls[0][0] as string;
+      // Should match ISO timestamp pattern like [2024-01-15T10:30:00.000Z]
+      expect(output).toMatch(/\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    });
+
+    it('should pass extra args through', () => {
+      loggerModule.enableDebug();
+      loggerModule.debug('mod', 'msg', { key: 'value' }, 42);
+      expect(consoleErrorSpy).toHaveBeenCalledOnce();
+      expect(consoleErrorSpy.mock.calls[0][1]).toEqual({ key: 'value' });
+      expect(consoleErrorSpy.mock.calls[0][2]).toBe(42);
+    });
+  });
+
+  describe('warn', () => {
+    it('should always output, even when debug is disabled', () => {
+      expect(loggerModule.isDebugEnabled()).toBe(false);
+      loggerModule.warn('test-module', 'warning message');
+      expect(consoleErrorSpy).toHaveBeenCalledOnce();
+      const output = consoleErrorSpy.mock.calls[0][0] as string;
+      expect(output).toContain('[WARN]');
+      expect(output).toContain('[test-module]');
+      expect(output).toContain('warning message');
+    });
+
+    it('should also output when debug is enabled', () => {
+      loggerModule.enableDebug();
+      loggerModule.warn('mod', 'a warning');
+      expect(consoleErrorSpy).toHaveBeenCalledOnce();
+      const output = consoleErrorSpy.mock.calls[0][0] as string;
+      expect(output).toContain('[WARN]');
+    });
+  });
+
+  describe('timed', () => {
+    it('should return the result without logging when debug is disabled', async () => {
+      const result = await loggerModule.timed('mod', 'op', async () => 42);
+      expect(result).toBe(42);
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it('should return the result and log duration when debug is enabled', async () => {
+      loggerModule.enableDebug();
+      const result = await loggerModule.timed('mod', 'op', async () => 'hello');
+      expect(result).toBe('hello');
+      // Should have logged a "completed in Xms" message
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      const output = consoleErrorSpy.mock.calls[0][0] as string;
+      expect(output).toContain('op completed in');
+      expect(output).toContain('ms');
+    });
+
+    it('should log "failed after" and re-throw on error when debug is enabled', async () => {
+      loggerModule.enableDebug();
+      const err = new Error('boom');
+      await expect(
+        loggerModule.timed('mod', 'op', async () => { throw err; })
+      ).rejects.toThrow('boom');
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      const output = consoleErrorSpy.mock.calls[0][0] as string;
+      expect(output).toContain('op failed after');
+      expect(output).toContain('ms');
+    });
+
+    it('should re-throw on error without logging when debug is disabled', async () => {
+      const err = new Error('boom');
+      await expect(
+        loggerModule.timed('mod', 'op', async () => { throw err; })
+      ).rejects.toThrow('boom');
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -1,0 +1,52 @@
+/**
+ * Lightweight debug logger for oss-autopilot.
+ * Activated by the global --debug CLI flag.
+ *
+ * All debug/warn output goes to stderr so it never contaminates
+ * the --json stdout contract.
+ */
+
+let debugEnabled = false;
+
+export function enableDebug(): void {
+  debugEnabled = true;
+}
+
+export function isDebugEnabled(): boolean {
+  return debugEnabled;
+}
+
+/**
+ * Log a debug message. Only outputs when --debug is enabled.
+ */
+export function debug(module: string, message: string, ...args: unknown[]): void {
+  if (!debugEnabled) return;
+  const timestamp = new Date().toISOString();
+  console.error(`[${timestamp}] [DEBUG] [${module}] ${message}`, ...args);
+}
+
+/**
+ * Log a warning. Always outputs.
+ */
+export function warn(module: string, message: string, ...args: unknown[]): void {
+  const timestamp = new Date().toISOString();
+  console.error(`[${timestamp}] [WARN] [${module}] ${message}`, ...args);
+}
+
+/**
+ * Time an async operation and log duration in debug mode.
+ */
+export async function timed<T>(module: string, label: string, fn: () => Promise<T>): Promise<T> {
+  if (!debugEnabled) return fn();
+  const start = performance.now();
+  try {
+    const result = await fn();
+    const duration = (performance.now() - start).toFixed(0);
+    debug(module, `${label} completed in ${duration}ms`);
+    return result;
+  } catch (err) {
+    const duration = (performance.now() - start).toFixed(0);
+    debug(module, `${label} failed after ${duration}ms`);
+    throw err;
+  }
+}

--- a/src/core/pr-monitor.test.ts
+++ b/src/core/pr-monitor.test.ts
@@ -2364,7 +2364,8 @@ describe('getCIStatus error handling (#182)', () => {
 
     expect(result.status).toBe('unknown');
     expect(result.failingCheckNames).toEqual([]);
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('[AUTH ERROR]'));
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('CI check failed'));
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid token'));
   });
 
   it('should return unknown status on 403 rate limit and log RATE LIMIT', async () => {
@@ -2374,7 +2375,8 @@ describe('getCIStatus error handling (#182)', () => {
 
     expect(result.status).toBe('unknown');
     expect(result.failingCheckNames).toEqual([]);
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('[RATE LIMIT]'));
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('CI check failed'));
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Rate limit exceeded'));
   });
 
   it('should return unknown status on 404 without logging an error', async () => {
@@ -2394,7 +2396,7 @@ describe('getCIStatus error handling (#182)', () => {
 
     expect(result.status).toBe('unknown');
     expect(result.failingCheckNames).toEqual([]);
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('[CI ERROR]'));
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to check CI'));
   });
 
   it('should return unknown status on network timeout error and log CI ERROR', async () => {
@@ -2404,7 +2406,7 @@ describe('getCIStatus error handling (#182)', () => {
 
     expect(result.status).toBe('unknown');
     expect(result.failingCheckNames).toEqual([]);
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('[CI ERROR]'));
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to check CI'));
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('ETIMEDOUT'));
   });
 
@@ -2419,7 +2421,7 @@ describe('getCIStatus error handling (#182)', () => {
     expect(result).toBeDefined();
     expect(result.status).not.toBe('failing');
     expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('[PR_MONITOR] Non-404 error fetching check runs')
+      expect.stringContaining('Non-404 error fetching check runs')
     );
   });
 
@@ -3028,7 +3030,7 @@ describe('review comment fetch error handling (#229)', () => {
 
   it('should degrade gracefully on non-rate-limit 403 (e.g. private repo)', async () => {
     mockOctokitInstance = makeMocksWithReviewCommentError({ status: 403, message: 'Resource not accessible by integration' });
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const monitor = new PRMonitor('fake-token');
     const { prs } = await monitor.fetchUserOpenPRs();
@@ -3036,16 +3038,16 @@ describe('review comment fetch error handling (#229)', () => {
     // Non-rate-limit 403 should NOT re-throw — PR still returned
     expect(prs).toHaveLength(1);
     expect(prs[0].url).toBe(prUrl);
-    expect(warnSpy).toHaveBeenCalledWith(
+    expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining('403 fetching review comments'),
     );
 
-    warnSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 
   it('should return empty data on 500 server error with warning', async () => {
     mockOctokitInstance = makeMocksWithReviewCommentError({ status: 500, message: 'Internal Server Error' });
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const monitor = new PRMonitor('fake-token');
     const { prs } = await monitor.fetchUserOpenPRs();
@@ -3053,10 +3055,10 @@ describe('review comment fetch error handling (#229)', () => {
     // PR should still be returned — 500 is gracefully degraded
     expect(prs).toHaveLength(1);
     expect(prs[0].url).toBe(prUrl);
-    expect(warnSpy).toHaveBeenCalledWith(
+    expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining('Failed to fetch review comments'),
     );
 
-    warnSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 });

--- a/src/core/pr-monitor.ts
+++ b/src/core/pr-monitor.ts
@@ -13,6 +13,7 @@ import { isBotAuthor, isAcknowledgmentComment } from './comment-utils.js';
 import { runWorkerPool } from './concurrency.js';
 import { ConfigurationError, ValidationError } from './errors.js';
 import { paginateAll } from './pagination.js';
+import { debug, warn, timed } from './logger.js';
 
 // Re-export so existing consumers (tests, index.ts) can still import from pr-monitor
 export { isBotAuthor };
@@ -60,7 +61,7 @@ export class PRMonitor {
       throw new ConfigurationError('No GitHub username configured. Run setup first.');
     }
 
-    console.error(`Fetching open PRs for @${config.githubUsername}...`);
+    debug('pr-monitor', `Fetching open PRs for @${config.githubUsername}...`);
 
     // Search for all open PRs authored by the user with pagination
     const allItems: typeof firstPage.data.items = [];
@@ -77,7 +78,7 @@ export class PRMonitor {
 
     allItems.push(...firstPage.data.items);
     const totalCount = firstPage.data.total_count;
-    console.error(`Found ${totalCount} open PRs`);
+    debug('pr-monitor', `Found ${totalCount} open PRs`);
 
     // Fetch remaining pages if needed (GitHub search API returns max 1000 results)
     const totalPages = Math.min(Math.ceil(totalCount / perPage), 10); // Cap at 1000 results
@@ -104,7 +105,7 @@ export class PRMonitor {
       // Skip PRs to repos owned by the user (not OSS contributions)
       const parsed = extractOwnerRepo(item.html_url);
       if (!parsed) {
-        console.error(`[PR_MONITOR] Skipping PR with unparseable URL: ${item.html_url}`);
+        warn('pr-monitor', `Skipping PR with unparseable URL: ${item.html_url}`);
         return false;
       }
       const ownerLower = parsed.owner.toLowerCase();
@@ -118,17 +119,22 @@ export class PRMonitor {
       return true;
     });
 
+    debug('pr-monitor', `Filtered to ${filteredItems.length} PRs after excluding own repos, shelved, and excluded orgs/repos`);
+
     // Fetch detailed info using a worker pool for bounded concurrency.
-    await runWorkerPool(filteredItems, async (item) => {
-      try {
-        const pr = await this.fetchPRDetails(item.html_url);
-        if (pr) prs.push(pr);
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        console.error(`Error fetching ${item.html_url}: ${errorMessage}`);
-        failures.push({ prUrl: item.html_url, error: errorMessage });
-      }
-    }, MAX_CONCURRENT_REQUESTS);
+    await timed('pr-monitor', `Fetch details for ${filteredItems.length} PRs`, async () => {
+      await runWorkerPool(filteredItems, async (item) => {
+        try {
+          debug('pr-monitor', `Fetching details for ${item.html_url}`);
+          const pr = await this.fetchPRDetails(item.html_url);
+          if (pr) prs.push(pr);
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          warn('pr-monitor', `Error fetching ${item.html_url}: ${errorMessage}`);
+          failures.push({ prUrl: item.html_url, error: errorMessage });
+        }
+      }, MAX_CONCURRENT_REQUESTS);
+    });
 
     // Sort by days since activity (most urgent first)
     prs.sort((a, b) => {
@@ -189,13 +195,13 @@ export class PRMonitor {
               throw err;
             }
             // Non-rate-limit 403 (DMCA, private repo, SSO) — degrade gracefully
-            console.warn(`[PR_MONITOR] 403 fetching review comments for ${owner}/${repo}#${number}: ${msg}`);
+            warn('pr-monitor', `403 fetching review comments for ${owner}/${repo}#${number}: ${msg}`);
             return { data: [] as Array<any> };
           }
           if (status === 404) {
-            console.debug(`[PR_MONITOR] 404 fetching review comments for ${owner}/${repo}#${number} — skipping self-reply detection`);
+            debug('pr-monitor', `Review comments 404 for ${owner}/${repo}#${number} (likely no inline comments)`);
           } else {
-            console.warn(`[PR_MONITOR] Failed to fetch review comments for ${owner}/${repo}#${number} (status ${status ?? 'unknown'}): self-reply detection will be skipped`);
+            warn('pr-monitor', `Failed to fetch review comments for ${owner}/${repo}#${number} (status ${status ?? 'unknown'}): self-reply detection will be skipped`);
           }
           return [] as Array<any>;
         }),
@@ -722,8 +728,10 @@ export class PRMonitor {
         // 404 is expected for repos without check runs configured; log other errors for debugging
         this.octokit.checks.listForRef({ owner, repo, ref: sha }).catch((err: unknown) => {
           const status = (err as { status?: number })?.status;
-          if (status !== 404) {
-            console.error(`[PR_MONITOR] Non-404 error fetching check runs for ${owner}/${repo}@${sha.slice(0, 7)}: ${status ?? err}`);
+          if (status === 404) {
+            debug('pr-monitor', `Check runs 404 for ${owner}/${repo}@${sha.slice(0, 7)} (no checks configured)`);
+          } else {
+            warn('pr-monitor', `Non-404 error fetching check runs for ${owner}/${repo}@${sha.slice(0, 7)}: ${status ?? err}`);
           }
           return null;
         }),
@@ -753,14 +761,15 @@ export class PRMonitor {
       const errorMessage = error instanceof Error ? error.message : String(error);
 
       if (statusCode === 401) {
-        console.error(`[AUTH ERROR] CI check failed for ${owner}/${repo}: Invalid token`);
+        warn('pr-monitor', `CI check failed for ${owner}/${repo}: Invalid token`);
       } else if (statusCode === 403) {
-        console.error(`[RATE LIMIT] CI check failed for ${owner}/${repo}: Rate limit exceeded`);
+        warn('pr-monitor', `CI check failed for ${owner}/${repo}: Rate limit exceeded`);
       } else if (statusCode === 404) {
         // Repo might not have CI configured, this is normal
+        debug('pr-monitor', `CI check 404 for ${owner}/${repo} (no CI configured)`);
         return { status: 'unknown', failingCheckNames: [], failingCheckConclusions: new Map() };
       } else {
-        console.error(`[CI ERROR] Failed to check CI for ${owner}/${repo}@${sha.slice(0, 7)}: ${errorMessage}`);
+        warn('pr-monitor', `Failed to check CI for ${owner}/${repo}@${sha.slice(0, 7)}: ${errorMessage}`);
       }
       return { status: 'unknown', failingCheckNames: [], failingCheckConclusions: new Map() };
     }


### PR DESCRIPTION
## Summary

Closes #228

Adds a global `--debug` flag to the CLI with structured logging:

- New `src/core/logger.ts` with `debug()`, `warn()`, and `timed()` utilities
- `--debug` flag on all CLI commands via commander global option
- All output goes to stderr (never contaminates `--json` stdout)
- Structured format: `[TIMESTAMP] [LEVEL] [MODULE] message`
- `timed()` wrapper logs durations for expensive operations
- Replaced `console.error` calls in pr-monitor.ts with structured logger

## Test plan

- [x] 12 new tests for logger utilities
- [x] All 634 existing tests pass
- [x] Normal mode produces zero debug output (backward compatible)
- [x] `--json` mode unaffected by `--debug`