### PR TITLE
chore: add ESLint and Prettier configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Security audit
         run: npm audit --audit-level=high
 
+      - name: Lint
+        run: npm run lint
+
+      - name: Format check
+        run: npm run format:check
+
       - name: Type check
         run: npx tsc --noEmit
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+dist/
+node_modules/
+package-lock.json
+CHANGELOG.md
+*.md

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 120,
+  "tabWidth": 2
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,30 @@
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import eslintConfigPrettier from 'eslint-config-prettier';
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  eslintConfigPrettier,
+  {
+    ignores: ['dist/**', 'node_modules/**', '*.cjs'],
+  },
+  {
+    rules: {
+      // Allow unused vars prefixed with _ (common pattern)
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
+        },
+      ],
+      // Allow explicit any for now (codebase uses it extensively)
+      '@typescript-eslint/no-explicit-any': 'off',
+      // Allow non-null assertion (used in tests)
+      '@typescript-eslint/no-non-null-assertion': 'off',
+    },
+  },
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,11 +17,16 @@
         "oss-autopilot": "dist/cli.js"
       },
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@types/node": "^25.2.3",
         "@vitest/coverage-v8": "^4.0.18",
         "esbuild": "^0.27.3",
+        "eslint": "^10.0.2",
+        "eslint-config-prettier": "^10.1.8",
+        "prettier": "^3.8.1",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
+        "typescript-eslint": "^8.56.1",
         "vitest": "^4.0.16"
       },
       "engines": {
@@ -528,6 +533,186 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.2.tgz",
+      "integrity": "sha512-YF+fE6LV4v5MGWRGj7G404/OZzGNepVF8fxk7jqmqo3lrza7a0uUcDnROGRBG1WFC1omYUS/Wp1f42i0M+3Q3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.2",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.2.tgz",
+      "integrity": "sha512-a5MxrdDXEvqnIq+LisyCX6tQMPF/dSJpCfBgBauY+pNZ28yCtSsTvyTYrMhaI+LK26bVyCJfJkT0u8KIj2i1dQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.0.tgz",
+      "integrity": "sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.2.tgz",
+      "integrity": "sha512-HOy56KJt48Bx8KmJ+XGQNSUMT/6dZee/M54XyUyuvTvPXJmsERRvBchsUVx1UMe1WwIH49XLAczNC7V2INsuUw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.0.tgz",
+      "integrity": "sha512-bIZEUzOI1jkhviX2cp5vNyXQc6olzb2ohewQubuYlMXZ2Q/XjBO0x0XhGPvc9fjSIiUN0vw+0hq53BJ4eQSJKQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -1103,10 +1288,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1118,6 +1317,236 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
+      "integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/type-utils": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.56.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
+      "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
+      "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.56.1",
+        "@typescript-eslint/types": "^8.56.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
+      "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
+      "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.1.tgz",
+      "integrity": "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
+      "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
+      "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.56.1",
+        "@typescript-eslint/tsconfig-utils": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
+      "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
+      "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@vitest/coverage-v8": {
@@ -1262,6 +1691,46 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1284,6 +1753,16 @@
         "js-tokens": "^10.0.0"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/before-after-hook": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
@@ -1295,6 +1774,19 @@
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
       "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
       "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -1314,6 +1806,46 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
@@ -1364,6 +1896,177 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.2.tgz",
+      "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.2",
+        "@eslint/config-helpers": "^0.5.2",
+        "@eslint/core": "^1.1.0",
+        "@eslint/plugin-kit": "^0.6.0",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.1",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.1.1",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.1.tgz",
+      "integrity": "sha512-GaUN0sWim5qc8KVErfPBWmc31LEsOkrUJbvJZV+xuL3u2phMUK4HIvXlWAakfC8W4nzlK+chPEAkYOYb5ZScIw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.1.1.tgz",
+      "integrity": "sha512-AVHPqQoZYc+RUM4/3Ly5udlZY/U4LS8pIG05jEjWM2lQMU/oaZ7qshzAl2YP1tfNmXfftH3ohurfwNAug+MnsQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1372,6 +2075,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/expect-type": {
@@ -1400,6 +2113,27 @@
       ],
       "license": "MIT"
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1417,6 +2151,57 @@
           "optional": true
         }
       }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1446,6 +2231,19 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1462,6 +2260,56 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -1509,6 +2357,67 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1547,6 +2456,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -1566,6 +2498,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -1576,6 +2515,76 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -1631,6 +2640,42 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -1699,6 +2744,29 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/siginfo": {
@@ -1789,6 +2857,19 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tsx": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
@@ -1809,6 +2890,19 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1823,6 +2917,30 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typescript-eslint": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.56.1.tgz",
+      "integrity": "sha512-U4lM6pjmBX7J5wk4szltF7I1cGBHXZopnAXCMXb3+fZ3B/0Z3hq3wS/CCUB2NZBNAExK92mCU2tEohWuwVMsDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.56.1",
+        "@typescript-eslint/parser": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
@@ -1835,6 +2953,16 @@
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
       "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
       "license": "ISC"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
     },
     "node_modules/vite": {
       "version": "7.3.1",
@@ -1989,6 +3117,22 @@
         }
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -2004,6 +3148,29 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
     "daily": "tsx src/cli.ts daily",
     "search": "tsx src/cli.ts search",
     "status": "tsx src/cli.ts status",
+    "lint": "eslint src/",
+    "lint:fix": "eslint src/ --fix",
+    "format": "prettier --write src/",
+    "format:check": "prettier --check src/",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
@@ -61,11 +65,16 @@
     "node": ">=20.0.0"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@types/node": "^25.2.3",
     "@vitest/coverage-v8": "^4.0.18",
     "esbuild": "^0.27.3",
+    "eslint": "^10.0.2",
+    "eslint-config-prettier": "^10.1.8",
+    "prettier": "^3.8.1",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
+    "typescript-eslint": "^8.56.1",
     "vitest": "^4.0.16"
   },
   "dependencies": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,9 @@ import { runSnooze, runUnsnooze } from './commands/snooze.js';
 
 const VERSION = (() => {
   try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const fs = require('fs');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const path = require('path');
     const pkgPath = path.join(path.dirname(process.argv[1]), '..', 'package.json');
     return JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).version;
@@ -40,7 +42,27 @@ const VERSION = (() => {
 
 // Commands that skip the preAction GitHub token check.
 // startup handles auth internally (returns authError in JSON instead of process.exit).
-const LOCAL_ONLY_COMMANDS = ['help', 'status', 'config', 'read', 'untrack', 'version', 'setup', 'checkSetup', 'dashboard', 'parse-issue-list', 'check-integration', 'local-repos', 'startup', 'shelve', 'unshelve', 'dismiss', 'undismiss', 'snooze', 'unsnooze'];
+const LOCAL_ONLY_COMMANDS = [
+  'help',
+  'status',
+  'config',
+  'read',
+  'untrack',
+  'version',
+  'setup',
+  'checkSetup',
+  'dashboard',
+  'parse-issue-list',
+  'check-integration',
+  'local-repos',
+  'startup',
+  'shelve',
+  'unshelve',
+  'dismiss',
+  'undismiss',
+  'snooze',
+  'unsnooze',
+];
 
 const program = new Command();
 

--- a/src/commands/check-integration.ts
+++ b/src/commands/check-integration.ts
@@ -14,9 +14,20 @@ interface CheckIntegrationOptions {
 
 /** File extensions we consider "code" that should be imported/referenced */
 const CODE_EXTENSIONS = new Set([
-  '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs',
-  '.py', '.rb', '.go', '.rs', '.java', '.kt',
-  '.vue', '.svelte',
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+  '.py',
+  '.rb',
+  '.go',
+  '.rs',
+  '.java',
+  '.kt',
+  '.vue',
+  '.svelte',
 ]);
 
 /** Files that are typically entry points or config, not expected to be imported */
@@ -89,10 +100,10 @@ export async function runCheckIntegration(options: CheckIntegrationOptions): Pro
   }
 
   // Filter to code files, excluding tests, configs, etc.
-  const codeFiles = newFiles.filter(f => {
+  const codeFiles = newFiles.filter((f) => {
     const ext = path.extname(f);
     if (!CODE_EXTENSIONS.has(ext)) return false;
-    return !IGNORED_PATTERNS.some(p => p.test(f));
+    return !IGNORED_PATTERNS.some((p) => p.test(f));
   });
 
   if (codeFiles.length === 0) {
@@ -111,7 +122,10 @@ export async function runCheckIntegration(options: CheckIntegrationOptions): Pro
     allFiles = execFileSync('git', ['ls-files'], {
       encoding: 'utf-8',
       timeout: 10000,
-    }).trim().split('\n').filter(Boolean);
+    })
+      .trim()
+      .split('\n')
+      .filter(Boolean);
   } catch {
     allFiles = [];
   }
@@ -142,12 +156,13 @@ export async function runCheckIntegration(options: CheckIntegrationOptions): Pro
           timeout: 10000,
         }).trim();
         if (grepOutput) {
-          const matches = grepOutput.split('\n').filter(f => f !== newFile);
+          const matches = grepOutput.split('\n').filter((f) => f !== newFile);
           referencedBy.push(...matches);
         }
       } catch (error: unknown) {
         // git grep exit code 1 = no matches (expected), exit code 2+ = real error
-        const exitCode = error && typeof error === 'object' && 'status' in error ? (error as { status: number }).status : null;
+        const exitCode =
+          error && typeof error === 'object' && 'status' in error ? (error as { status: number }).status : null;
         if (exitCode !== null && exitCode !== 1) {
           const msg = error instanceof Error ? error.message : String(error);
           console.error(`Warning: git grep failed for "${pattern}": ${msg}`);
@@ -172,7 +187,7 @@ export async function runCheckIntegration(options: CheckIntegrationOptions): Pro
     results.push(info);
   }
 
-  const unreferencedCount = results.filter(r => !r.isIntegrated).length;
+  const unreferencedCount = results.filter((r) => !r.isIntegrated).length;
   const output: CheckIntegrationOutput = { newFiles: results, unreferencedCount };
 
   if (options.json) {

--- a/src/commands/comments.test.ts
+++ b/src/commands/comments.test.ts
@@ -41,7 +41,9 @@ describe('runComments', () => {
 
   it('should exit with error when no GitHub token', async () => {
     mockGetGitHubToken.mockReturnValue(null as any);
-    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
 
     await expect(runComments({ prUrl: TEST_PR_URL, json: true })).rejects.toThrow('exit');
 
@@ -52,7 +54,9 @@ describe('runComments', () => {
   it('should exit with error for invalid PR URL', async () => {
     mockGetGitHubToken.mockReturnValue('ghp_test123');
     mockParseGitHubUrl.mockReturnValue(null as any);
-    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
 
     await expect(runComments({ prUrl: 'invalid-url', json: true })).rejects.toThrow('exit');
 
@@ -65,13 +69,25 @@ describe('runComments', () => {
     mockParseGitHubUrl.mockReturnValue({ owner: 'owner', repo: 'repo', number: 42, type: 'pull' });
 
     const mockPullsGet = vi.fn().mockResolvedValue({
-      data: { title: 'Test PR', state: 'open', mergeable: true, head: { ref: 'feature' }, base: { ref: 'main' }, html_url: TEST_PR_URL },
+      data: {
+        title: 'Test PR',
+        state: 'open',
+        mergeable: true,
+        head: { ref: 'feature' },
+        base: { ref: 'main' },
+        html_url: TEST_PR_URL,
+      },
     });
     const mockListReviewComments = vi.fn().mockResolvedValue({ data: [] });
     const mockListComments = vi.fn().mockResolvedValue({ data: [] });
     const mockListReviews = vi.fn().mockResolvedValue({
       data: [
-        { user: { login: 'reviewer', type: 'User' }, state: 'APPROVED', body: 'LGTM', submitted_at: '2026-01-15T10:00:00Z' },
+        {
+          user: { login: 'reviewer', type: 'User' },
+          state: 'APPROVED',
+          body: 'LGTM',
+          submitted_at: '2026-01-15T10:00:00Z',
+        },
       ],
     });
 
@@ -82,11 +98,13 @@ describe('runComments', () => {
 
     await runComments({ prUrl: TEST_PR_URL, json: true });
 
-    expect(mockOutputJson).toHaveBeenCalledWith(expect.objectContaining({
-      pr: expect.objectContaining({ title: 'Test PR', state: 'open' }),
-      reviews: [{ user: 'reviewer', state: 'APPROVED', body: 'LGTM', submittedAt: '2026-01-15T10:00:00Z' }],
-      summary: { reviewCount: 1, inlineCommentCount: 0, discussionCommentCount: 0 },
-    }));
+    expect(mockOutputJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pr: expect.objectContaining({ title: 'Test PR', state: 'open' }),
+        reviews: [{ user: 'reviewer', state: 'APPROVED', body: 'LGTM', submittedAt: '2026-01-15T10:00:00Z' }],
+        summary: { reviewCount: 1, inlineCommentCount: 0, discussionCommentCount: 0 },
+      }),
+    );
   });
 
   it('should filter out own comments', async () => {
@@ -94,7 +112,14 @@ describe('runComments', () => {
     mockParseGitHubUrl.mockReturnValue({ owner: 'owner', repo: 'repo', number: 42, type: 'pull' });
 
     const mockPullsGet = vi.fn().mockResolvedValue({
-      data: { title: 'Test PR', state: 'open', mergeable: true, head: { ref: 'feature' }, base: { ref: 'main' }, html_url: TEST_PR_URL },
+      data: {
+        title: 'Test PR',
+        state: 'open',
+        mergeable: true,
+        head: { ref: 'feature' },
+        base: { ref: 'main' },
+        html_url: TEST_PR_URL,
+      },
     });
     const mockListReviewComments = vi.fn().mockResolvedValue({ data: [] });
     const mockListComments = vi.fn().mockResolvedValue({
@@ -125,7 +150,9 @@ describe('runPost', () => {
 
   it('should exit with error when no GitHub token', async () => {
     mockGetGitHubToken.mockReturnValue(null as any);
-    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
 
     await expect(runPost({ url: TEST_PR_URL, message: 'Hello', json: true })).rejects.toThrow('exit');
 
@@ -135,7 +162,9 @@ describe('runPost', () => {
 
   it('should exit with error when no message provided', async () => {
     mockGetGitHubToken.mockReturnValue('ghp_test123');
-    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
 
     await expect(runPost({ url: TEST_PR_URL, json: true })).rejects.toThrow('exit');
 
@@ -146,7 +175,9 @@ describe('runPost', () => {
   it('should exit with error for invalid URL', async () => {
     mockGetGitHubToken.mockReturnValue('ghp_test123');
     mockParseGitHubUrl.mockReturnValue(null as any);
-    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
 
     await expect(runPost({ url: 'bad-url', message: 'Hello', json: true })).rejects.toThrow('exit');
 
@@ -192,7 +223,9 @@ describe('runClaim', () => {
 
   it('should exit with error when no GitHub token', async () => {
     mockGetGitHubToken.mockReturnValue(null as any);
-    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
 
     await expect(runClaim({ issueUrl: TEST_ISSUE_URL, json: true })).rejects.toThrow('exit');
 
@@ -203,7 +236,9 @@ describe('runClaim', () => {
   it('should exit with error for non-issue URL', async () => {
     mockGetGitHubToken.mockReturnValue('ghp_test123');
     mockParseGitHubUrl.mockReturnValue({ owner: 'owner', repo: 'repo', number: 42, type: 'pull' });
-    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
 
     await expect(runClaim({ issueUrl: TEST_PR_URL, json: true })).rejects.toThrow('exit');
 
@@ -231,12 +266,14 @@ describe('runClaim', () => {
     await runClaim({ issueUrl: TEST_ISSUE_URL, json: true });
 
     expect(mockCreateComment).toHaveBeenCalled();
-    expect(mockAddIssue).toHaveBeenCalledWith(expect.objectContaining({
-      url: TEST_ISSUE_URL,
-      repo: 'owner/repo',
-      number: 10,
-      status: 'claimed',
-    }));
+    expect(mockAddIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: TEST_ISSUE_URL,
+        repo: 'owner/repo',
+        number: 10,
+        status: 'claimed',
+      }),
+    );
     expect(mockSave).toHaveBeenCalled();
     expect(mockOutputJson).toHaveBeenCalledWith({
       commentUrl: 'https://github.com/owner/repo/issues/10#issuecomment-1',

--- a/src/commands/comments.ts
+++ b/src/commands/comments.ts
@@ -64,31 +64,37 @@ export async function runComments(options: CommentsOptions): Promise<void> {
   const { data: pr } = await octokit.pulls.get({ owner, repo, pull_number });
 
   // Get review comments (inline code comments)
-  const reviewComments = await paginateAll((page) => octokit.pulls.listReviewComments({
-    owner,
-    repo,
-    pull_number,
-    per_page: 100,
-    page,
-  }));
+  const reviewComments = await paginateAll((page) =>
+    octokit.pulls.listReviewComments({
+      owner,
+      repo,
+      pull_number,
+      per_page: 100,
+      page,
+    }),
+  );
 
   // Get issue comments (general PR discussion)
-  const issueComments = await paginateAll((page) => octokit.issues.listComments({
-    owner,
-    repo,
-    issue_number: pull_number,
-    per_page: 100,
-    page,
-  }));
+  const issueComments = await paginateAll((page) =>
+    octokit.issues.listComments({
+      owner,
+      repo,
+      issue_number: pull_number,
+      per_page: 100,
+      page,
+    }),
+  );
 
   // Get reviews
-  const reviews = await paginateAll((page) => octokit.pulls.listReviews({
-    owner,
-    repo,
-    pull_number,
-    per_page: 100,
-    page,
-  }));
+  const reviews = await paginateAll((page) =>
+    octokit.pulls.listReviews({
+      owner,
+      repo,
+      pull_number,
+      per_page: 100,
+      page,
+    }),
+  );
 
   // Filter out own comments, optionally show bots
   const username = stateManager.getState().config.githubUsername;
@@ -107,7 +113,7 @@ export async function runComments(options: CommentsOptions): Promise<void> {
     .filter(filterComment)
     .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
   const relevantReviews = reviews
-    .filter(r => filterComment(r) && r.body && r.body.trim())
+    .filter((r) => filterComment(r) && r.body && r.body.trim())
     .sort((a, b) => new Date(b.submitted_at || 0).getTime() - new Date(a.submitted_at || 0).getTime());
 
   if (options.json) {
@@ -120,19 +126,19 @@ export async function runComments(options: CommentsOptions): Promise<void> {
         base: pr.base.ref,
         url: pr.html_url,
       },
-      reviews: relevantReviews.map(r => ({
+      reviews: relevantReviews.map((r) => ({
         user: r.user?.login,
         state: r.state,
         body: r.body,
         submittedAt: r.submitted_at,
       })),
-      reviewComments: relevantReviewComments.map(c => ({
+      reviewComments: relevantReviewComments.map((c) => ({
         user: c.user?.login,
         body: c.body,
         path: c.path,
         createdAt: c.created_at,
       })),
-      issueComments: relevantIssueComments.map(c => ({
+      issueComments: relevantIssueComments.map((c) => ({
         user: c.user?.login,
         body: c.body,
         createdAt: c.created_at,
@@ -156,8 +162,7 @@ export async function runComments(options: CommentsOptions): Promise<void> {
   if (relevantReviews.length > 0) {
     console.log('### Reviews (newest first)\n');
     for (const review of relevantReviews) {
-      const state = review.state === 'APPROVED' ? '✅' :
-                    review.state === 'CHANGES_REQUESTED' ? '❌' : '💬';
+      const state = review.state === 'APPROVED' ? '✅' : review.state === 'CHANGES_REQUESTED' ? '❌' : '💬';
       const time = review.submitted_at ? formatRelativeTime(review.submitted_at) : '';
       console.log(`${state} **@${review.user?.login}** (${review.state}) - ${time}`);
       if (review.body) {
@@ -188,14 +193,14 @@ export async function runComments(options: CommentsOptions): Promise<void> {
     }
   }
 
-  if (relevantReviewComments.length === 0 &&
-      relevantIssueComments.length === 0 &&
-      relevantReviews.length === 0) {
+  if (relevantReviewComments.length === 0 && relevantIssueComments.length === 0 && relevantReviews.length === 0) {
     console.log('No comments from other users.\n');
   }
 
   console.log('---');
-  console.log(`**Summary:** ${relevantReviews.length} reviews, ${relevantReviewComments.length} inline comments, ${relevantIssueComments.length} discussion comments`);
+  console.log(
+    `**Summary:** ${relevantReviews.length} reviews, ${relevantReviewComments.length} inline comments, ${relevantIssueComments.length} discussion comments`,
+  );
 }
 
 export async function runPost(options: PostOptions): Promise<void> {
@@ -320,8 +325,7 @@ export async function runClaim(options: ClaimOptions): Promise<void> {
   const { owner, repo, number } = parsed;
 
   // Default claim message or custom
-  const message = options.message ||
-    "Hi! I'd like to work on this issue. Could you assign it to me?";
+  const message = options.message || "Hi! I'd like to work on this issue. Could you assign it to me?";
 
   if (!options.json) {
     console.log('\n🙋 Claiming issue:', options.issueUrl);

--- a/src/commands/config.test.ts
+++ b/src/commands/config.test.ts
@@ -98,7 +98,9 @@ describe('runConfig', () => {
   });
 
   it('should exit with error for invalid repo format in exclude-repo', async () => {
-    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
 
     await expect(runConfig({ key: 'exclude-repo', value: 'invalid', json: true })).rejects.toThrow('exit');
 
@@ -117,7 +119,9 @@ describe('runConfig', () => {
   });
 
   it('should exit with error for invalid org name with slash', async () => {
-    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
 
     await expect(runConfig({ key: 'exclude-org', value: 'owner/repo', json: true })).rejects.toThrow('exit');
 
@@ -126,7 +130,9 @@ describe('runConfig', () => {
   });
 
   it('should exit with error for unknown config key', async () => {
-    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
 
     await expect(runConfig({ key: 'unknown-key', value: 'val', json: true })).rejects.toThrow('exit');
 
@@ -135,7 +141,9 @@ describe('runConfig', () => {
   });
 
   it('should exit with error when value is missing', async () => {
-    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
 
     await expect(runConfig({ key: 'username', json: true })).rejects.toThrow('exit');
 

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -13,7 +13,11 @@ interface ConfigOptions {
 }
 
 function exitWithError(msg: string, json?: boolean): never {
-  if (json) { outputJsonError(msg); } else { console.error(msg); }
+  if (json) {
+    outputJsonError(msg);
+  } else {
+    console.error(msg);
+  }
   process.exit(1);
 }
 
@@ -61,7 +65,7 @@ export async function runConfig(options: ConfigOptions): Promise<void> {
         );
       }
       const valueLower = value.toLowerCase();
-      if (!currentConfig.excludeRepos.some(r => r.toLowerCase() === valueLower)) {
+      if (!currentConfig.excludeRepos.some((r) => r.toLowerCase() === valueLower)) {
         stateManager.updateConfig({ excludeRepos: [...currentConfig.excludeRepos, value] });
         stateManager.cleanupExcludedData([value], []);
       }
@@ -75,7 +79,7 @@ export async function runConfig(options: ConfigOptions): Promise<void> {
         );
       }
       const currentOrgs = currentConfig.excludeOrgs ?? [];
-      if (!currentOrgs.some(o => o.toLowerCase() === value.toLowerCase())) {
+      if (!currentOrgs.some((o) => o.toLowerCase() === value.toLowerCase())) {
         stateManager.updateConfig({ excludeOrgs: [...currentOrgs, value] });
         stateManager.cleanupExcludedData([], [value]);
       }

--- a/src/commands/daily.test.ts
+++ b/src/commands/daily.test.ts
@@ -76,7 +76,7 @@ describe('computeActionMenu', () => {
   it('should not include address_all when there are no actionable issues', () => {
     const menu = computeActionMenu([], makeCapacity());
 
-    expect(menu.items.find(i => i.key === 'address_all')).toBeUndefined();
+    expect(menu.items.find((i) => i.key === 'address_all')).toBeUndefined();
     expect(menu.context.hasActionableIssues).toBe(false);
     expect(menu.context.actionableCount).toBe(0);
   });
@@ -85,8 +85,8 @@ describe('computeActionMenu', () => {
     const withCapacity = computeActionMenu([], makeCapacity({ hasCapacity: true }));
     const withoutCapacity = computeActionMenu([], makeCapacity({ hasCapacity: false }));
 
-    expect(withCapacity.items.find(i => i.key === 'search')).toBeDefined();
-    expect(withoutCapacity.items.find(i => i.key === 'search')).toBeDefined();
+    expect(withCapacity.items.find((i) => i.key === 'search')).toBeDefined();
+    expect(withoutCapacity.items.find((i) => i.key === 'search')).toBeDefined();
   });
 
   it('should always include done as the last item', () => {
@@ -98,10 +98,7 @@ describe('computeActionMenu', () => {
   });
 
   it('should have correct context flags', () => {
-    const menu = computeActionMenu(
-      [makeActionableIssue()],
-      makeCapacity({ hasCapacity: true }),
-    );
+    const menu = computeActionMenu([makeActionableIssue()], makeCapacity({ hasCapacity: true }));
 
     expect(menu.context).toEqual({
       hasActionableIssues: true,
@@ -117,16 +114,16 @@ describe('computeActionMenu', () => {
     const withCapacity = computeActionMenu(issues, makeCapacity({ hasCapacity: true }));
     const withoutCapacity = computeActionMenu(issues, makeCapacity({ hasCapacity: false }));
 
-    expect(withCapacity.items.map(i => i.key)).toEqual(['address_all', 'search', 'done']);
-    expect(withoutCapacity.items.map(i => i.key)).toEqual(['address_all', 'search', 'done']);
+    expect(withCapacity.items.map((i) => i.key)).toEqual(['address_all', 'search', 'done']);
+    expect(withoutCapacity.items.map((i) => i.key)).toEqual(['address_all', 'search', 'done']);
   });
 
   it('should produce [search, done] when no actionable issues exist', () => {
     const withCapacity = computeActionMenu([], makeCapacity({ hasCapacity: true }));
     const withoutCapacity = computeActionMenu([], makeCapacity({ hasCapacity: false }));
 
-    expect(withCapacity.items.map(i => i.key)).toEqual(['search', 'done']);
-    expect(withoutCapacity.items.map(i => i.key)).toEqual(['search', 'done']);
+    expect(withCapacity.items.map((i) => i.key)).toEqual(['search', 'done']);
+    expect(withoutCapacity.items.map((i) => i.key)).toEqual(['search', 'done']);
   });
 
   it('should include issue_replies item and context when issue responses exist', () => {
@@ -147,7 +144,7 @@ describe('computeActionMenu', () => {
     ];
     const menu = computeActionMenu([], makeCapacity(), issueResponses);
 
-    expect(menu.items.map(i => i.key)).toEqual(['issue_replies', 'search', 'done']);
+    expect(menu.items.map((i) => i.key)).toEqual(['issue_replies', 'search', 'done']);
     expect(menu.items[0].label).toBe('Review 1 issue reply');
     expect(menu.context).toEqual({
       hasActionableIssues: false,
@@ -160,17 +157,53 @@ describe('computeActionMenu', () => {
 
   it('should order address_all before issue_replies when both present', () => {
     const issueResponses: CommentedIssue[] = [
-      { repo: 'a/b', number: 1, title: 'T', url: 'u', status: 'new_response', userLastCommentedAt: '', lastResponseAuthor: 'm', lastResponseBody: 'x', lastResponseAt: '', labels: [], daysSinceUserComment: 0 },
+      {
+        repo: 'a/b',
+        number: 1,
+        title: 'T',
+        url: 'u',
+        status: 'new_response',
+        userLastCommentedAt: '',
+        lastResponseAuthor: 'm',
+        lastResponseBody: 'x',
+        lastResponseAt: '',
+        labels: [],
+        daysSinceUserComment: 0,
+      },
     ];
     const menu = computeActionMenu([makeActionableIssue()], makeCapacity(), issueResponses);
 
-    expect(menu.items.map(i => i.key)).toEqual(['address_all', 'issue_replies', 'search', 'done']);
+    expect(menu.items.map((i) => i.key)).toEqual(['address_all', 'issue_replies', 'search', 'done']);
   });
 
   it('should use plural label for multiple issue responses', () => {
     const issueResponses: CommentedIssue[] = [
-      { repo: 'a/b', number: 1, title: 'T', url: 'u', status: 'new_response', userLastCommentedAt: '', lastResponseAuthor: 'm', lastResponseBody: 'x', lastResponseAt: '', labels: [], daysSinceUserComment: 0 },
-      { repo: 'c/d', number: 2, title: 'T', url: 'u', status: 'new_response', userLastCommentedAt: '', lastResponseAuthor: 'm', lastResponseBody: 'x', lastResponseAt: '', labels: [], daysSinceUserComment: 0 },
+      {
+        repo: 'a/b',
+        number: 1,
+        title: 'T',
+        url: 'u',
+        status: 'new_response',
+        userLastCommentedAt: '',
+        lastResponseAuthor: 'm',
+        lastResponseBody: 'x',
+        lastResponseAt: '',
+        labels: [],
+        daysSinceUserComment: 0,
+      },
+      {
+        repo: 'c/d',
+        number: 2,
+        title: 'T',
+        url: 'u',
+        status: 'new_response',
+        userLastCommentedAt: '',
+        lastResponseAuthor: 'm',
+        lastResponseBody: 'x',
+        lastResponseAt: '',
+        labels: [],
+        daysSinceUserComment: 0,
+      },
     ];
     const menu = computeActionMenu([], makeCapacity(), issueResponses);
 
@@ -248,7 +281,13 @@ describe('computeRepoSignals', () => {
   });
 
   it('should NOT mark repo as having active maintainers for non-review statuses', () => {
-    const inactiveStatuses = ['failing_ci', 'merge_conflict', 'dormant', 'approaching_dormant', 'incomplete_checklist'] as const;
+    const inactiveStatuses = [
+      'failing_ci',
+      'merge_conflict',
+      'dormant',
+      'approaching_dormant',
+      'incomplete_checklist',
+    ] as const;
     for (const status of inactiveStatuses) {
       const prs = [makePR({ repo: `owner/${status}`, status })];
       const result = computeRepoSignals(prs);
@@ -339,13 +378,10 @@ describe('groupPRsByRepo (#80)', () => {
   });
 
   it('should separate PRs in different repos', () => {
-    const prs = [
-      makePR({ repo: 'owner/repo-a', number: 1 }),
-      makePR({ repo: 'owner/repo-b', number: 2 }),
-    ];
+    const prs = [makePR({ repo: 'owner/repo-a', number: 1 }), makePR({ repo: 'owner/repo-b', number: 2 })];
     const groups = groupPRsByRepo(prs);
     expect(groups).toHaveLength(2);
-    expect(groups.map(g => g.repo).sort()).toEqual(['owner/repo-a', 'owner/repo-b']);
+    expect(groups.map((g) => g.repo).sort()).toEqual(['owner/repo-a', 'owner/repo-b']);
   });
 
   it('should correctly group mixed PRs from multiple repos', () => {
@@ -358,21 +394,18 @@ describe('groupPRsByRepo (#80)', () => {
     const groups = groupPRsByRepo(prs);
     expect(groups).toHaveLength(3);
 
-    const inkGroup = groups.find(g => g.repo === 'vadimdemedes/ink');
+    const inkGroup = groups.find((g) => g.repo === 'vadimdemedes/ink');
     expect(inkGroup).toBeDefined();
     expect(inkGroup!.prs).toHaveLength(2);
-    expect(inkGroup!.prs.map(p => p.number).sort()).toEqual([855, 856]);
+    expect(inkGroup!.prs.map((p) => p.number).sort()).toEqual([855, 856]);
 
-    const uiGroup = groups.find(g => g.repo === 'shadcn-ui/ui');
+    const uiGroup = groups.find((g) => g.repo === 'shadcn-ui/ui');
     expect(uiGroup).toBeDefined();
     expect(uiGroup!.prs).toHaveLength(1);
   });
 
   it('should skip PRs with empty repo field', () => {
-    const prs = [
-      makePR({ repo: '' as any }),
-      makePR({ repo: 'owner/valid', number: 2 }),
-    ];
+    const prs = [makePR({ repo: '' as any }), makePR({ repo: 'owner/valid', number: 2 })];
     const groups = groupPRsByRepo(prs);
     expect(groups).toHaveLength(1);
     expect(groups[0].repo).toBe('owner/valid');

--- a/src/commands/daily.ts
+++ b/src/commands/daily.ts
@@ -4,15 +4,42 @@
  * generates a digest, and updates repo scores and analytics in local state.
  */
 
-import { getStateManager, PRMonitor, IssueConversationMonitor, getGitHubToken, formatRelativeTime, type DailyDigest, type FetchedPR, type FetchedPRStatus, type PRCheckFailure, type MaintainerActionHint, type ComputedRepoSignals, type RepoGroup, type MergedPR, type ClosedPR, type CommentedIssue, type CommentedIssueWithResponse } from '../core/index.js';
-import { outputJson, outputJsonError, type DailyOutput, type CapacityAssessment, type ActionableIssue, type ActionMenu, type ActionMenuItem } from '../formatters/json.js';
+import {
+  getStateManager,
+  PRMonitor,
+  IssueConversationMonitor,
+  getGitHubToken,
+  formatRelativeTime,
+  type DailyDigest,
+  type FetchedPR,
+  type FetchedPRStatus,
+  type MaintainerActionHint,
+  type ComputedRepoSignals,
+  type RepoGroup,
+  type MergedPR,
+  type ClosedPR,
+  type CommentedIssue,
+  type CommentedIssueWithResponse,
+} from '../core/index.js';
+import {
+  outputJson,
+  outputJsonError,
+  type DailyOutput,
+  type CapacityAssessment,
+  type ActionableIssue,
+  type ActionMenu,
+  type ActionMenuItem,
+} from '../formatters/json.js';
 
 /**
  * Statuses indicating maintainer engagement or action needed from the contributor.
  * Used both for auto-unshelving shelved PRs and for counting critical issues in capacity assessment.
  */
 const CRITICAL_STATUSES: ReadonlySet<FetchedPRStatus> = new Set([
-  'needs_response', 'needs_changes', 'failing_ci', 'merge_conflict',
+  'needs_response',
+  'needs_changes',
+  'failing_ci',
+  'merge_conflict',
 ]);
 
 interface DailyOptions {
@@ -23,7 +50,9 @@ export async function runDaily(options: DailyOptions): Promise<void> {
   const token = getGitHubToken();
   if (!token) {
     if (options.json) {
-      outputJsonError('GitHub authentication required. Install GitHub CLI (https://cli.github.com/) and run "gh auth login", or set GITHUB_TOKEN.');
+      outputJsonError(
+        'GitHub authentication required. Install GitHub CLI (https://cli.github.com/) and run "gh auth login", or set GITHUB_TOKEN.',
+      );
     } else {
       console.error('Error: GitHub authentication required.');
       console.error('');
@@ -72,27 +101,32 @@ export async function executeDailyCheck(token: string): Promise<DailyOutput> {
   // Fetch merged PR counts, closed PR counts, recently closed PRs, recently merged PRs, and commented issues in parallel
   // Recently closed/merged are non-critical (cosmetic sections), so isolate their failure
   const issueMonitor = new IssueConversationMonitor(token);
-  const [mergedResult, closedResult, recentlyClosedPRs, recentlyMergedPRs, issueConversationResult] = await Promise.all([
-    prMonitor.fetchUserMergedPRCounts(),
-    prMonitor.fetchUserClosedPRCounts(),
-    prMonitor.fetchRecentlyClosedPRs().catch((err): ClosedPR[] => {
-      console.error(`Warning: Failed to fetch recently closed PRs: ${err instanceof Error ? err.message : err}`);
-      return [];
-    }),
-    prMonitor.fetchRecentlyMergedPRs().catch((err): MergedPR[] => {
-      console.error(`Warning: Failed to fetch recently merged PRs: ${err instanceof Error ? err.message : err}`);
-      return [];
-    }),
-    issueMonitor.fetchCommentedIssues().catch(error => {
-      const msg = error instanceof Error ? error.message : String(error);
-      if (msg.includes('No GitHub username configured')) {
-        console.error(`[DAILY] Issue conversation tracking requires setup: ${msg}`);
-      } else {
-        console.error(`[DAILY] Issue conversation fetch failed: ${msg}`);
-      }
-      return { issues: [] as CommentedIssue[], failures: [{ issueUrl: 'N/A', error: `Issue conversation fetch failed: ${msg}` }] };
-    }),
-  ]);
+  const [mergedResult, closedResult, recentlyClosedPRs, recentlyMergedPRs, issueConversationResult] = await Promise.all(
+    [
+      prMonitor.fetchUserMergedPRCounts(),
+      prMonitor.fetchUserClosedPRCounts(),
+      prMonitor.fetchRecentlyClosedPRs().catch((err): ClosedPR[] => {
+        console.error(`Warning: Failed to fetch recently closed PRs: ${err instanceof Error ? err.message : err}`);
+        return [];
+      }),
+      prMonitor.fetchRecentlyMergedPRs().catch((err): MergedPR[] => {
+        console.error(`Warning: Failed to fetch recently merged PRs: ${err instanceof Error ? err.message : err}`);
+        return [];
+      }),
+      issueMonitor.fetchCommentedIssues().catch((error) => {
+        const msg = error instanceof Error ? error.message : String(error);
+        if (msg.includes('No GitHub username configured')) {
+          console.error(`[DAILY] Issue conversation tracking requires setup: ${msg}`);
+        } else {
+          console.error(`[DAILY] Issue conversation fetch failed: ${msg}`);
+        }
+        return {
+          issues: [] as CommentedIssue[],
+          failures: [{ issueUrl: 'N/A', error: `Issue conversation fetch failed: ${msg}` }],
+        };
+      }),
+    ],
+  );
 
   const commentedIssues = issueConversationResult.issues;
   if (issueConversationResult.failures.length > 0) {
@@ -100,15 +134,20 @@ export async function executeDailyCheck(token: string): Promise<DailyOutput> {
   }
 
   const { repos: mergedCounts, monthlyCounts, monthlyOpenedCounts: openedFromMerged } = mergedResult;
-  const { repos: closedCounts, monthlyCounts: monthlyClosedCounts, monthlyOpenedCounts: openedFromClosed } = closedResult;
+  const {
+    repos: closedCounts,
+    monthlyCounts: monthlyClosedCounts,
+    monthlyOpenedCounts: openedFromClosed,
+  } = closedResult;
 
   // Reset stale repos first (so excluded/removed repos get zeroed).
   // Guard: if the API returned zero results but we have existing repos with merged PRs,
   // skip the reset to avoid wiping scores due to transient API failures.
-  const existingReposWithMerges = Object.values(stateManager.getState().repoScores)
-    .filter(s => s.mergedPRCount > 0);
+  const existingReposWithMerges = Object.values(stateManager.getState().repoScores).filter((s) => s.mergedPRCount > 0);
   if (mergedCounts.size === 0 && existingReposWithMerges.length > 0) {
-    console.error(`[DAILY] Skipping stale repo reset: API returned 0 merged PR results but state has ${existingReposWithMerges.length} repo(s) with merges. Possible API issue.`);
+    console.error(
+      `[DAILY] Skipping stale repo reset: API returned 0 merged PR results but state has ${existingReposWithMerges.length} repo(s) with merges. Possible API issue.`,
+    );
   } else {
     for (const score of Object.values(stateManager.getState().repoScores)) {
       if (!mergedCounts.has(score.repo)) {
@@ -124,7 +163,10 @@ export async function executeDailyCheck(token: string): Promise<DailyOutput> {
       stateManager.updateRepoScore(repo, { mergedPRCount: count, lastMergedAt: lastMergedAt || undefined });
     } catch (error) {
       mergedCountFailures++;
-      console.error(`[DAILY] Failed to update merged count for ${repo}:`, error instanceof Error ? error.message : error);
+      console.error(
+        `[DAILY] Failed to update merged count for ${repo}:`,
+        error instanceof Error ? error.message : error,
+      );
     }
   }
   if (mergedCountFailures === mergedCounts.size && mergedCounts.size > 0) {
@@ -134,10 +176,13 @@ export async function executeDailyCheck(token: string): Promise<DailyOutput> {
   // Populate closedWithoutMergeCount in repo scores.
   // Diagnostic: warn if API returned empty but we have known closed PRs (possible transient API failure).
   // Unlike merged counts above, there is no stale-reset loop for closed counts, so no skip is needed.
-  const existingReposWithClosed = Object.values(stateManager.getState().repoScores)
-    .filter(s => (s.closedWithoutMergeCount || 0) > 0);
+  const existingReposWithClosed = Object.values(stateManager.getState().repoScores).filter(
+    (s) => (s.closedWithoutMergeCount || 0) > 0,
+  );
   if (closedCounts.size === 0 && existingReposWithClosed.length > 0) {
-    console.error(`[DAILY] Warning: API returned 0 closed PR results but state has ${existingReposWithClosed.length} repo(s) with closed PRs. Possible transient API issue.`);
+    console.error(
+      `[DAILY] Warning: API returned 0 closed PR results but state has ${existingReposWithClosed.length} repo(s) with closed PRs. Possible transient API issue.`,
+    );
   }
   let closedCountFailures = 0;
   for (const [repo, count] of closedCounts) {
@@ -145,7 +190,10 @@ export async function executeDailyCheck(token: string): Promise<DailyOutput> {
       stateManager.updateRepoScore(repo, { closedWithoutMergeCount: count });
     } catch (error) {
       closedCountFailures++;
-      console.error(`[DAILY] Failed to update closed count for ${repo}:`, error instanceof Error ? error.message : error);
+      console.error(
+        `[DAILY] Failed to update closed count for ${repo}:`,
+        error instanceof Error ? error.message : error,
+      );
     }
   }
   if (closedCountFailures === closedCounts.size && closedCounts.size > 0) {
@@ -168,7 +216,9 @@ export async function executeDailyCheck(token: string): Promise<DailyOutput> {
     }
   }
   if (signalUpdateFailures === repoSignals.size && repoSignals.size > 0) {
-    console.error(`[DAILY_ALL_SIGNAL_UPDATES_FAILED] All ${repoSignals.size} signal update(s) failed. This may indicate corrupted state.`);
+    console.error(
+      `[DAILY_ALL_SIGNAL_UPDATES_FAILED] All ${repoSignals.size} signal update(s) failed. This may indicate corrupted state.`,
+    );
   }
 
   // Fetch star counts for all scored repos (used by dashboard minStars filter, #216)
@@ -178,7 +228,9 @@ export async function executeDailyCheck(token: string): Promise<DailyOutput> {
     starCounts = await prMonitor.fetchRepoStarCounts(allRepos);
   } catch (error) {
     console.error('[DAILY] Failed to fetch repo star counts:', error instanceof Error ? error.message : error);
-    console.error('[DAILY] Dashboard minStars filter will use cached star counts (or be skipped for repos without cached data).');
+    console.error(
+      '[DAILY] Dashboard minStars filter will use cached star counts (or be skipped for repos without cached data).',
+    );
     starCounts = new Map();
   }
   let starUpdateFailures = 0;
@@ -205,7 +257,9 @@ export async function executeDailyCheck(token: string): Promise<DailyOutput> {
     }
   }
   if (trustSyncFailures === mergedCounts.size && mergedCounts.size > 0) {
-    console.error(`[DAILY_ALL_TRUST_SYNCS_FAILED] All ${mergedCounts.size} trusted project sync(s) failed. This may indicate corrupted state.`);
+    console.error(
+      `[DAILY_ALL_TRUST_SYNCS_FAILED] All ${mergedCounts.size} trusted project sync(s) failed. This may indicate corrupted state.`,
+    );
   }
 
   // Store monthly chart data (non-critical — each metric isolated so partial failures don't leave inconsistent state)
@@ -236,7 +290,10 @@ export async function executeDailyCheck(token: string): Promise<DailyOutput> {
     }
     stateManager.setMonthlyOpenedCounts(combinedOpenedCounts);
   } catch (error) {
-    console.error('[DAILY] Failed to compute/store monthly opened counts:', error instanceof Error ? error.message : error);
+    console.error(
+      '[DAILY] Failed to compute/store monthly opened counts:',
+      error instanceof Error ? error.message : error,
+    );
   }
 
   // Expire any snoozes that have passed their expiresAt timestamp.
@@ -297,7 +354,7 @@ export async function executeDailyCheck(token: string): Promise<DailyOutput> {
 
   // Filter dismissed issues: suppress if dismissed after last response, resurface + auto-undismiss if new activity
   let hasAutoUndismissed = false;
-  const filteredCommentedIssues = commentedIssues.filter(issue => {
+  const filteredCommentedIssues = commentedIssues.filter((issue) => {
     const dismissedAt = stateManager.getIssueDismissedAt(issue.url);
     if (!dismissedAt) return true; // Not dismissed — include
     if (issue.status === 'new_response') {
@@ -324,10 +381,12 @@ export async function executeDailyCheck(token: string): Promise<DailyOutput> {
     stateManager.save();
   }
 
-  const issueResponses = filteredCommentedIssues.filter((i): i is CommentedIssueWithResponse => i.status === 'new_response');
+  const issueResponses = filteredCommentedIssues.filter(
+    (i): i is CommentedIssueWithResponse => i.status === 'new_response',
+  );
   const summary = formatSummary(digest, capacity, issueResponses);
   const snoozedUrls = new Set(
-    Object.keys(stateManager.getState().config.snoozedPRs ?? {}).filter(url => stateManager.isSnoozed(url)),
+    Object.keys(stateManager.getState().config.snoozedPRs ?? {}).filter((url) => stateManager.isSnoozed(url)),
   );
   const actionableIssues = collectActionableIssues(activePRs, snoozedUrls);
   digest.summary.totalNeedingAttention = actionableIssues.length;
@@ -335,7 +394,18 @@ export async function executeDailyCheck(token: string): Promise<DailyOutput> {
   const actionMenu = computeActionMenu(actionableIssues, capacity, filteredCommentedIssues);
   const repoGroups = groupPRsByRepo(activePRs);
 
-  return { digest, updates: [], capacity, summary, briefSummary, actionableIssues, actionMenu, commentedIssues: filteredCommentedIssues, repoGroups, failures };
+  return {
+    digest,
+    updates: [],
+    capacity,
+    summary,
+    briefSummary,
+    actionableIssues,
+    actionMenu,
+    commentedIssues: filteredCommentedIssues,
+    repoGroups,
+    failures,
+  };
 }
 
 async function runDailyInner(token: string, options: DailyOptions): Promise<void> {
@@ -351,13 +421,19 @@ async function runDailyInner(token: string, options: DailyOptions): Promise<void
 /**
  * Format summary as markdown (used in JSON output for Claude to display verbatim)
  */
-function formatSummary(digest: DailyDigest, capacity: CapacityAssessment, issueResponses: CommentedIssueWithResponse[] = []): string {
+function formatSummary(
+  digest: DailyDigest,
+  capacity: CapacityAssessment,
+  issueResponses: CommentedIssueWithResponse[] = [],
+): string {
   const lines: string[] = [];
 
   // Header
   lines.push('## OSS Dashboard');
   lines.push('');
-  lines.push(`📊 **${digest.summary.totalActivePRs} Active PRs** | ${digest.summary.totalMergedAllTime} Merged | ${digest.summary.mergeRate}% Merge Rate`);
+  lines.push(
+    `📊 **${digest.summary.totalActivePRs} Active PRs** | ${digest.summary.totalMergedAllTime} Merged | ${digest.summary.mergeRate}% Merge Rate`,
+  );
   lines.push('✓ Dashboard generated — say "open dashboard" to view in browser');
   lines.push('');
 
@@ -491,7 +567,9 @@ function formatSummary(digest: DailyDigest, capacity: CapacityAssessment, issueR
     for (const issue of issueResponses) {
       lines.push(`- [${issue.repo}#${issue.number}](${issue.url}): ${issue.title}`);
       const timeAgo = formatRelativeTime(issue.lastResponseAt);
-      lines.push(`  └─ @${issue.lastResponseAuthor}: "${issue.lastResponseBody.slice(0, 80)}${issue.lastResponseBody.length > 80 ? '...' : ''}"${timeAgo ? ` (${timeAgo})` : ''}`);
+      lines.push(
+        `  └─ @${issue.lastResponseAuthor}: "${issue.lastResponseBody.slice(0, 80)}${issue.lastResponseBody.length > 80 ? '...' : ''}"${timeAgo ? ` (${timeAgo})` : ''}`,
+      );
     }
     lines.push('');
   }
@@ -500,7 +578,9 @@ function formatSummary(digest: DailyDigest, capacity: CapacityAssessment, issueR
   const capacityIcon = capacity.hasCapacity ? '✅' : '⚠️';
   const capacityLabel = capacity.hasCapacity ? 'Ready for new work' : 'Focus on existing PRs';
   const shelvedNote = capacity.shelvedPRCount > 0 ? ` + ${capacity.shelvedPRCount} shelved` : '';
-  lines.push(`**Capacity:** ${capacityIcon} ${capacityLabel} (${capacity.activePRCount}/${capacity.maxActivePRs} PRs${shelvedNote})`);
+  lines.push(
+    `**Capacity:** ${capacityIcon} ${capacityLabel} (${capacity.activePRCount}/${capacity.maxActivePRs} PRs${shelvedNote})`,
+  );
 
   return lines.join('\n');
 }
@@ -623,7 +703,9 @@ function printDigest(digest: DailyDigest, capacity: CapacityAssessment, commente
     console.log('💬 Issue Replies:');
     for (const issue of issueResponses) {
       console.log(`  - ${issue.repo}#${issue.number}: ${issue.title}`);
-      console.log(`    @${issue.lastResponseAuthor}: ${issue.lastResponseBody.slice(0, 80)}${issue.lastResponseBody.length > 80 ? '...' : ''}`);
+      console.log(
+        `    @${issue.lastResponseAuthor}: ${issue.lastResponseBody.slice(0, 80)}${issue.lastResponseBody.length > 80 ? '...' : ''}`,
+      );
     }
     console.log('');
   }
@@ -638,7 +720,7 @@ function printDigest(digest: DailyDigest, capacity: CapacityAssessment, commente
  */
 function assessCapacity(activePRs: FetchedPR[], maxActivePRs: number, shelvedPRCount: number): CapacityAssessment {
   const activePRCount = activePRs.length;
-  const criticalIssueCount = activePRs.filter(pr => CRITICAL_STATUSES.has(pr.status)).length;
+  const criticalIssueCount = activePRs.filter((pr) => CRITICAL_STATUSES.has(pr.status)).length;
 
   // Has capacity if: under PR limit AND no critical issues
   const underPRLimit = activePRCount < maxActivePRs;
@@ -675,12 +757,9 @@ function assessCapacity(activePRs: FetchedPR[], maxActivePRs: number, shelvedPRC
  * Format a brief one-liner summary for the action-first flow
  */
 function formatBriefSummary(digest: DailyDigest, issueCount: number, issueResponseCount: number = 0): string {
-  const attentionText = issueCount > 0
-    ? `${issueCount} need${issueCount === 1 ? 's' : ''} attention`
-    : 'all healthy';
-  const issueReplyText = issueResponseCount > 0
-    ? ` | ${issueResponseCount} issue repl${issueResponseCount === 1 ? 'y' : 'ies'}`
-    : '';
+  const attentionText = issueCount > 0 ? `${issueCount} need${issueCount === 1 ? 's' : ''} attention` : 'all healthy';
+  const issueReplyText =
+    issueResponseCount > 0 ? ` | ${issueResponseCount} issue repl${issueResponseCount === 1 ? 'y' : 'ies'}` : '';
   return `📊 ${digest.summary.totalActivePRs} Active PRs | ${attentionText}${issueReplyText}`;
 }
 
@@ -712,9 +791,7 @@ function collectActionableIssues(prs: FetchedPR[], snoozedUrls: Set<string> = ne
   // Skip snoozed PRs — their CI failures are known and temporarily dismissed
   for (const pr of prs) {
     if (pr.status === 'failing_ci' && !snoozedUrls.has(pr.url)) {
-      const checkInfo = pr.failingCheckNames.length > 0
-        ? ` (${pr.failingCheckNames.join(', ')})`
-        : '';
+      const checkInfo = pr.failingCheckNames.length > 0 ? ` (${pr.failingCheckNames.join(', ')})` : '';
       issues.push({ type: 'ci_failing', pr, label: `[CI Failing${checkInfo}]` });
     }
   }
@@ -742,11 +819,16 @@ function collectActionableIssues(prs: FetchedPR[], snoozedUrls: Set<string> = ne
  */
 function formatActionHint(hint: MaintainerActionHint): string {
   switch (hint) {
-    case 'demo_requested': return 'demo/screenshot requested';
-    case 'tests_requested': return 'tests requested';
-    case 'changes_requested': return 'code changes requested';
-    case 'docs_requested': return 'documentation requested';
-    case 'rebase_requested': return 'rebase requested';
+    case 'demo_requested':
+      return 'demo/screenshot requested';
+    case 'tests_requested':
+      return 'tests requested';
+    case 'changes_requested':
+      return 'code changes requested';
+    case 'docs_requested':
+      return 'documentation requested';
+    case 'rebase_requested':
+      return 'rebase requested';
   }
 }
 
@@ -811,13 +893,15 @@ export function computeActionMenu(
 
 /** Statuses indicating active maintainer engagement (reviews, feedback, merges). */
 const ACTIVE_MAINTAINER_STATUSES: Set<FetchedPRStatus> = new Set([
-  'healthy', 'waiting_on_maintainer', 'changes_addressed', 'needs_response', 'needs_changes',
+  'healthy',
+  'waiting_on_maintainer',
+  'changes_addressed',
+  'needs_response',
+  'needs_changes',
 ]);
 
 /** Statuses indicating staleness — maintainer comments during these statuses don't count as responsive. */
-const STALE_STATUSES: Set<FetchedPRStatus> = new Set([
-  'dormant', 'approaching_dormant',
-]);
+const STALE_STATUSES: Set<FetchedPRStatus> = new Set(['dormant', 'approaching_dormant']);
 
 /**
  * Build a map grouping PRs by repository, skipping PRs with empty repo fields.
@@ -860,12 +944,8 @@ export function computeRepoSignals(prs: FetchedPR[]): Map<string, ComputedRepoSi
   const repoMap = buildRepoMap(prs, 'COMPUTE_SIGNALS');
   const result = new Map<string, ComputedRepoSignals>();
   for (const [repo, repoPRs] of repoMap) {
-    const isResponsive = repoPRs.some(pr =>
-      pr.lastMaintainerComment && !STALE_STATUSES.has(pr.status)
-    );
-    const hasActiveMaintainers = repoPRs.some(pr =>
-      ACTIVE_MAINTAINER_STATUSES.has(pr.status)
-    );
+    const isResponsive = repoPRs.some((pr) => pr.lastMaintainerComment && !STALE_STATUSES.has(pr.status));
+    const hasActiveMaintainers = repoPRs.some((pr) => ACTIVE_MAINTAINER_STATUSES.has(pr.status));
     result.set(repo, { isResponsive, hasActiveMaintainers });
   }
   return result;

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -6,9 +6,23 @@
 
 import * as fs from 'fs';
 import { execFile } from 'child_process';
-import { getStateManager, getDashboardPath, PRMonitor, IssueConversationMonitor, getGitHubToken } from '../core/index.js';
+import {
+  getStateManager,
+  getDashboardPath,
+  PRMonitor,
+  IssueConversationMonitor,
+  getGitHubToken,
+} from '../core/index.js';
 import { outputJson } from '../formatters/json.js';
-import type { FetchedPR, DailyDigest, AgentState, RepoScore, ClosedPR, MergedPR, CommentedIssue, CommentedIssueWithResponse } from '../core/types.js';
+import type {
+  FetchedPR,
+  DailyDigest,
+  AgentState,
+  ClosedPR,
+  MergedPR,
+  CommentedIssue,
+  CommentedIssueWithResponse,
+} from '../core/types.js';
 
 interface DashboardOptions {
   open?: boolean;
@@ -28,28 +42,32 @@ export async function runDashboard(options: DashboardOptions): Promise<void> {
       const prMonitor = new PRMonitor(token);
       // Recently closed/merged are non-critical (cosmetic sections), so isolate their failure
       const issueMonitor = new IssueConversationMonitor(token);
-      const [{ prs, failures }, recentlyClosedPRs, recentlyMergedPRs, mergedResult, closedResult, fetchedIssues] = await Promise.all([
-        prMonitor.fetchUserOpenPRs(),
-        prMonitor.fetchRecentlyClosedPRs().catch((err): ClosedPR[] => {
-          console.error(`Warning: Failed to fetch recently closed PRs: ${err instanceof Error ? err.message : err}`);
-          return [];
-        }),
-        prMonitor.fetchRecentlyMergedPRs().catch((err): MergedPR[] => {
-          console.error(`Warning: Failed to fetch recently merged PRs: ${err instanceof Error ? err.message : err}`);
-          return [];
-        }),
-        prMonitor.fetchUserMergedPRCounts(),
-        prMonitor.fetchUserClosedPRCounts(),
-        issueMonitor.fetchCommentedIssues().catch(error => {
-          const msg = error instanceof Error ? error.message : String(error);
-          if (msg.includes('No GitHub username configured')) {
-            console.error(`[DASHBOARD] Issue conversation tracking requires setup: ${msg}`);
-          } else {
-            console.error(`[DASHBOARD] Issue conversation fetch failed: ${msg}`);
-          }
-          return { issues: [] as CommentedIssue[], failures: [{ issueUrl: 'N/A', error: `Issue conversation fetch failed: ${msg}` }] };
-        }),
-      ]);
+      const [{ prs, failures }, recentlyClosedPRs, recentlyMergedPRs, mergedResult, closedResult, fetchedIssues] =
+        await Promise.all([
+          prMonitor.fetchUserOpenPRs(),
+          prMonitor.fetchRecentlyClosedPRs().catch((err): ClosedPR[] => {
+            console.error(`Warning: Failed to fetch recently closed PRs: ${err instanceof Error ? err.message : err}`);
+            return [];
+          }),
+          prMonitor.fetchRecentlyMergedPRs().catch((err): MergedPR[] => {
+            console.error(`Warning: Failed to fetch recently merged PRs: ${err instanceof Error ? err.message : err}`);
+            return [];
+          }),
+          prMonitor.fetchUserMergedPRCounts(),
+          prMonitor.fetchUserClosedPRCounts(),
+          issueMonitor.fetchCommentedIssues().catch((error) => {
+            const msg = error instanceof Error ? error.message : String(error);
+            if (msg.includes('No GitHub username configured')) {
+              console.error(`[DASHBOARD] Issue conversation tracking requires setup: ${msg}`);
+            } else {
+              console.error(`[DASHBOARD] Issue conversation fetch failed: ${msg}`);
+            }
+            return {
+              issues: [] as CommentedIssue[],
+              failures: [{ issueUrl: 'N/A', error: `Issue conversation fetch failed: ${msg}` }],
+            };
+          }),
+        ]);
       commentedIssues = fetchedIssues.issues;
       if (fetchedIssues.failures.length > 0) {
         console.error(`[DASHBOARD] ${fetchedIssues.failures.length} issue conversation check(s) failed`);
@@ -63,11 +81,21 @@ export async function runDashboard(options: DashboardOptions): Promise<void> {
       const { monthlyCounts, monthlyOpenedCounts: openedFromMerged } = mergedResult;
       const { monthlyCounts: monthlyClosedCounts, monthlyOpenedCounts: openedFromClosed } = closedResult;
 
-      try { stateManager.setMonthlyMergedCounts(monthlyCounts); } catch (error) {
-        console.error('[DASHBOARD] Failed to store monthly merged counts:', error instanceof Error ? error.message : error);
+      try {
+        stateManager.setMonthlyMergedCounts(monthlyCounts);
+      } catch (error) {
+        console.error(
+          '[DASHBOARD] Failed to store monthly merged counts:',
+          error instanceof Error ? error.message : error,
+        );
       }
-      try { stateManager.setMonthlyClosedCounts(monthlyClosedCounts); } catch (error) {
-        console.error('[DASHBOARD] Failed to store monthly closed counts:', error instanceof Error ? error.message : error);
+      try {
+        stateManager.setMonthlyClosedCounts(monthlyClosedCounts);
+      } catch (error) {
+        console.error(
+          '[DASHBOARD] Failed to store monthly closed counts:',
+          error instanceof Error ? error.message : error,
+        );
       }
       try {
         const combinedOpenedCounts: Record<string, number> = { ...openedFromMerged };
@@ -82,7 +110,10 @@ export async function runDashboard(options: DashboardOptions): Promise<void> {
         }
         stateManager.setMonthlyOpenedCounts(combinedOpenedCounts);
       } catch (error) {
-        console.error('[DASHBOARD] Failed to store monthly opened counts:', error instanceof Error ? error.message : error);
+        console.error(
+          '[DASHBOARD] Failed to store monthly opened counts:',
+          error instanceof Error ? error.message : error,
+        );
       }
 
       digest = prMonitor.generateDigest(prs, recentlyClosedPRs, recentlyMergedPRs);
@@ -90,7 +121,7 @@ export async function runDashboard(options: DashboardOptions): Promise<void> {
       // Apply shelve partitioning for display (auto-unshelve only runs in daily check)
       // Dormant PRs are treated as shelved for display purposes
       const shelvedUrls = new Set(stateManager.getState().config.shelvedPRUrls || []);
-      const freshShelved = prs.filter(pr => shelvedUrls.has(pr.url) || pr.status === 'dormant');
+      const freshShelved = prs.filter((pr) => shelvedUrls.has(pr.url) || pr.status === 'dormant');
       digest.shelvedPRs = freshShelved;
       digest.autoUnshelvedPRs = [];
       digest.summary.totalActivePRs = prs.length - freshShelved.length;
@@ -125,7 +156,7 @@ export async function runDashboard(options: DashboardOptions): Promise<void> {
   const prsByRepo: Record<string, { active: number; merged: number; closed: number }> = {};
 
   // Count active PRs by repo from digest
-  for (const pr of (digest.openPRs || [])) {
+  for (const pr of digest.openPRs || []) {
     if (!prsByRepo[pr.repo]) prsByRepo[pr.repo] = { active: 0, merged: 0, closed: 0 };
     prsByRepo[pr.repo].active++;
   }
@@ -139,7 +170,7 @@ export async function runDashboard(options: DashboardOptions): Promise<void> {
 
   // Sort repos by total PRs (merged + active + closed) — matches the HTML chart sort order
   const topRepos = Object.entries(prsByRepo)
-    .sort((a, b) => (b[1].merged + b[1].active + b[1].closed) - (a[1].merged + a[1].active + a[1].closed))
+    .sort((a, b) => b[1].merged + b[1].active + b[1].closed - (a[1].merged + a[1].active + a[1].closed))
     .slice(0, 10);
 
   // Monthly activity from per-PR merge dates (populated during daily check)
@@ -176,8 +207,7 @@ export async function runDashboard(options: DashboardOptions): Promise<void> {
   if (options.open) {
     // Use platform-specific open command - path is hardcoded, not user input
     const isWindows = process.platform === 'win32';
-    const openCmd = process.platform === 'darwin' ? 'open' :
-                    isWindows ? 'cmd' : 'xdg-open';
+    const openCmd = process.platform === 'darwin' ? 'open' : isWindows ? 'cmd' : 'xdg-open';
     const args = isWindows ? ['/c', 'start', '', dashboardPath] : [dashboardPath];
 
     console.log(`Dashboard: ${dashboardPath}`);
@@ -230,7 +260,12 @@ interface DashboardStats {
 }
 
 function buildDashboardStats(digest: DailyDigest, state: AgentState): DashboardStats {
-  const summary = digest.summary || { totalActivePRs: 0, totalMergedAllTime: 0, mergeRate: 0, totalNeedingAttention: 0 };
+  const summary = digest.summary || {
+    totalActivePRs: 0,
+    totalMergedAllTime: 0,
+    mergeRate: 0,
+    totalNeedingAttention: 0,
+  };
   return {
     activePRs: summary.totalActivePRs,
     shelvedPRs: (digest.shelvedPRs || []).length,
@@ -269,8 +304,8 @@ function generateDashboardHtml(
   const shelvedPRs = digest.shelvedPRs || [];
   const autoUnshelvedPRs = digest.autoUnshelvedPRs || [];
   const recentlyMerged = digest.recentlyMergedPRs || [];
-  const shelvedUrls = new Set(shelvedPRs.map(pr => pr.url));
-  const activePRList = (digest.openPRs || []).filter(pr => !shelvedUrls.has(pr.url));
+  const shelvedUrls = new Set(shelvedPRs.map((pr) => pr.url));
+  const activePRList = (digest.openPRs || []).filter((pr) => !shelvedUrls.has(pr.url));
 
   // Action Required: contributor must do something
   const actionRequired = [
@@ -308,10 +343,11 @@ function generateDashboardHtml(
     labelFn: string | ((pr: FetchedPR) => string),
     metaFn: (pr: FetchedPR) => string,
   ): string {
-    return prs.map(pr => {
-      const rawLabel = typeof labelFn === 'string' ? labelFn : labelFn(pr);
-      const label = escapeHtml(rawLabel);
-      return `
+    return prs
+      .map((pr) => {
+        const rawLabel = typeof labelFn === 'string' ? labelFn : labelFn(pr);
+        const label = escapeHtml(rawLabel);
+        return `
         <div class="health-item ${cssClass}" data-status="${cssClass}" data-repo="${escapeHtml(pr.repo)}" data-title="${escapeHtml(pr.title.toLowerCase())}">
           <div class="health-icon">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -323,25 +359,30 @@ function generateDashboardHtml(
             <div class="health-meta">${metaFn(pr)}</div>
           </div>
         </div>`;
-    }).join('');
+      })
+      .join('');
   }
 
   // SVG path constants for health item icons
   const SVG = {
     comment: '<path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>',
     edit: '<path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>',
-    xCircle: '<circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/>',
-    conflict: '<path d="M8 3v3a2 2 0 0 1-2 2H3"/><path d="M21 8h-3a2 2 0 0 1-2-2V3"/><path d="M3 16h3a2 2 0 0 1 2 2v3"/><path d="M16 21v-3a2 2 0 0 1 2-2h3"/>',
+    xCircle:
+      '<circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/>',
+    conflict:
+      '<path d="M8 3v3a2 2 0 0 1-2 2H3"/><path d="M21 8h-3a2 2 0 0 1-2-2V3"/><path d="M3 16h3a2 2 0 0 1 2 2v3"/><path d="M16 21v-3a2 2 0 0 1 2-2h3"/>',
     checklist: '<path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/>',
     file: '<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="12" y1="18" x2="12" y2="12"/><line x1="9" y1="15" x2="15" y2="15"/>',
     checkCircle: '<path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/>',
     clock: '<circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>',
     lock: '<rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/>',
-    infoCircle: '<circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>',
+    infoCircle:
+      '<circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>',
     refresh: '<polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/>',
     box: '<path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/>',
     bell: '<path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/>',
-    gitMerge: '<circle cx="7" cy="18" r="3"/><circle cx="7" cy="6" r="3"/><circle cx="17" cy="12" r="3"/><line x1="7" y1="9" x2="7" y2="15"/><path d="M7 9c0 4 10 3 10 3"/>',
+    gitMerge:
+      '<circle cx="7" cy="18" r="3"/><circle cx="7" cy="6" r="3"/><circle cx="17" cy="12" r="3"/><line x1="7" y1="9" x2="7" y2="15"/><path d="M7 9c0 4 10 3 10 3"/>',
   };
 
   // Default meta: truncated PR title
@@ -1136,16 +1177,20 @@ function generateDashboardHtml(
       </div>
       <div class="header-controls">
         <div class="timestamp">
-          Last updated: ${digest.generatedAt ? new Date(digest.generatedAt).toLocaleString('en-US', {
-            weekday: 'short',
-            month: 'short',
-            day: 'numeric',
-            year: 'numeric',
-            hour: '2-digit',
-            minute: '2-digit',
-            second: '2-digit',
-            hour12: false
-          }) : 'Unknown'}
+          Last updated: ${
+            digest.generatedAt
+              ? new Date(digest.generatedAt).toLocaleString('en-US', {
+                  weekday: 'short',
+                  month: 'short',
+                  day: 'numeric',
+                  year: 'numeric',
+                  hour: '2-digit',
+                  minute: '2-digit',
+                  second: '2-digit',
+                  hour12: false,
+                })
+              : 'Unknown'
+          }
         </div>
         <button class="theme-toggle" id="themeToggle" title="Toggle light/dark mode">
           <svg id="themeIconSun" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -1221,15 +1266,20 @@ function generateDashboardHtml(
           for (const pr of actionRequired) repos.add(pr.repo);
           for (const pr of waitingOnOthers) repos.add(pr.repo);
           for (const pr of recentlyMerged) repos.add(pr.repo);
-          for (const pr of (digest.recentlyClosedPRs || [])) repos.add(pr.repo);
+          for (const pr of digest.recentlyClosedPRs || []) repos.add(pr.repo);
           for (const pr of autoUnshelvedPRs) repos.add(pr.repo);
-          return Array.from(repos).sort().map(repo => `<option value="${escapeHtml(repo)}">${escapeHtml(repo)}</option>`).join('\n        ');
+          return Array.from(repos)
+            .sort()
+            .map((repo) => `<option value="${escapeHtml(repo)}">${escapeHtml(repo)}</option>`)
+            .join('\n        ');
         })()}
       </select>
       <span class="filter-count" id="filterCount"></span>
     </div>
 
-    ${actionRequired.length > 0 ? `
+    ${
+      actionRequired.length > 0
+        ? `
     <section class="health-section">
       <div class="health-header">
         <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--accent-warning)" stroke-width="2">
@@ -1241,22 +1291,45 @@ function generateDashboardHtml(
         <span class="health-badge">${actionRequired.length} issue${actionRequired.length !== 1 ? 's' : ''}</span>
       </div>
       <div class="health-items">
-        ${renderHealthItems(digest.prsNeedingResponse || [], 'needs-response', SVG.comment, 'Needs Response',
-          pr => pr.lastMaintainerComment ? `@${escapeHtml(pr.lastMaintainerComment.author)}: ${truncateTitle(pr.lastMaintainerComment.body, 40)}` : truncateTitle(pr.title))}
+        ${renderHealthItems(digest.prsNeedingResponse || [], 'needs-response', SVG.comment, 'Needs Response', (pr) =>
+          pr.lastMaintainerComment
+            ? `@${escapeHtml(pr.lastMaintainerComment.author)}: ${truncateTitle(pr.lastMaintainerComment.body, 40)}`
+            : truncateTitle(pr.title),
+        )}
         ${renderHealthItems(digest.needsChangesPRs || [], 'needs-changes', SVG.edit, 'Needs Changes', titleMeta)}
         ${renderHealthItems(digest.ciFailingPRs || [], 'ci-failing', SVG.xCircle, 'CI Failing', titleMeta)}
         ${renderHealthItems(digest.mergeConflictPRs || [], 'conflict', SVG.conflict, 'Merge Conflict', titleMeta)}
-        ${renderHealthItems(digest.incompleteChecklistPRs || [], 'incomplete-checklist', SVG.checklist,
-          pr => `Incomplete Checklist${pr.checklistStats ? ` (${pr.checklistStats.checked}/${pr.checklistStats.total})` : ''}`, titleMeta)}
-        ${renderHealthItems(digest.missingRequiredFilesPRs || [], 'missing-files', SVG.file, 'Missing Required Files',
-          pr => pr.missingRequiredFiles ? escapeHtml(pr.missingRequiredFiles.join(', ')) : truncateTitle(pr.title))}
-        ${renderHealthItems(digest.needsRebasePRs || [], 'needs-rebase', SVG.refresh,
-          pr => `Needs Rebase${pr.commitsBehindUpstream ? ` (${pr.commitsBehindUpstream} behind)` : ''}`, titleMeta)}
+        ${renderHealthItems(
+          digest.incompleteChecklistPRs || [],
+          'incomplete-checklist',
+          SVG.checklist,
+          (pr) =>
+            `Incomplete Checklist${pr.checklistStats ? ` (${pr.checklistStats.checked}/${pr.checklistStats.total})` : ''}`,
+          titleMeta,
+        )}
+        ${renderHealthItems(
+          digest.missingRequiredFilesPRs || [],
+          'missing-files',
+          SVG.file,
+          'Missing Required Files',
+          (pr) => (pr.missingRequiredFiles ? escapeHtml(pr.missingRequiredFiles.join(', ')) : truncateTitle(pr.title)),
+        )}
+        ${renderHealthItems(
+          digest.needsRebasePRs || [],
+          'needs-rebase',
+          SVG.refresh,
+          (pr) => `Needs Rebase${pr.commitsBehindUpstream ? ` (${pr.commitsBehindUpstream} behind)` : ''}`,
+          titleMeta,
+        )}
       </div>
     </section>
-    ` : ''}
+    `
+        : ''
+    }
 
-    ${waitingOnOthers.length > 0 ? `
+    ${
+      waitingOnOthers.length > 0
+        ? `
     <section class="health-section waiting-section">
       <div class="health-header">
         <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--accent-info)" stroke-width="2">
@@ -1267,16 +1340,26 @@ function generateDashboardHtml(
         <span class="health-badge" style="background: var(--accent-info-dim); color: var(--accent-info);">${waitingOnOthers.length} PR${waitingOnOthers.length !== 1 ? 's' : ''}</span>
       </div>
       <div class="health-items">
-        ${renderHealthItems(digest.changesAddressedPRs || [], 'changes-addressed', SVG.checkCircle, 'Changes Addressed',
-          pr => `Awaiting re-review${pr.lastMaintainerComment ? ` from @${escapeHtml(pr.lastMaintainerComment.author)}` : ''}`)}
+        ${renderHealthItems(
+          digest.changesAddressedPRs || [],
+          'changes-addressed',
+          SVG.checkCircle,
+          'Changes Addressed',
+          (pr) =>
+            `Awaiting re-review${pr.lastMaintainerComment ? ` from @${escapeHtml(pr.lastMaintainerComment.author)}` : ''}`,
+        )}
         ${renderHealthItems(digest.waitingOnMaintainerPRs || [], 'waiting-maintainer', SVG.clock, 'Waiting on Maintainer', titleMeta)}
         ${renderHealthItems(digest.ciBlockedPRs || [], 'ci-blocked', SVG.lock, 'CI Blocked', titleMeta)}
         ${renderHealthItems(digest.ciNotRunningPRs || [], 'ci-not-running', SVG.infoCircle, 'CI Not Running', titleMeta)}
       </div>
     </section>
-    ` : ''}
+    `
+        : ''
+    }
 
-    ${actionRequired.length === 0 && waitingOnOthers.length === 0 ? `
+    ${
+      actionRequired.length === 0 && waitingOnOthers.length === 0
+        ? `
     <section class="health-section">
       <div class="health-header">
         <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--accent-open)" stroke-width="2">
@@ -1289,9 +1372,13 @@ function generateDashboardHtml(
         All PRs are healthy - no CI failures, conflicts, or pending responses
       </div>
     </section>
-    ` : ''}
+    `
+        : ''
+    }
 
-    ${recentlyMerged.length > 0 ? `
+    ${
+      recentlyMerged.length > 0
+        ? `
     <section class="health-section" style="animation-delay: 0.15s;">
       <div class="health-header">
         <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--accent-merged)" stroke-width="2">
@@ -1301,7 +1388,9 @@ function generateDashboardHtml(
         <span class="health-badge" style="background: var(--accent-merged-dim); color: var(--accent-merged);">${recentlyMerged.length} merged</span>
       </div>
       <div class="health-items">
-        ${recentlyMerged.map(pr => `
+        ${recentlyMerged
+          .map(
+            (pr) => `
         <div class="health-item" style="border-left-color: var(--accent-merged);" data-status="merged" data-repo="${escapeHtml(pr.repo)}" data-title="${escapeHtml(pr.title.toLowerCase())}">
           <div class="health-icon" style="background: var(--accent-merged-dim); color: var(--accent-merged);">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -1313,12 +1402,18 @@ function generateDashboardHtml(
             <div class="health-meta">${truncateTitle(pr.title)}${pr.mergedAt ? ` · ${new Date(pr.mergedAt).toLocaleDateString()}` : ''}</div>
           </div>
         </div>
-        `).join('')}
+        `,
+          )
+          .join('')}
       </div>
     </section>
-    ` : ''}
+    `
+        : ''
+    }
 
-    ${(digest.recentlyClosedPRs || []).length > 0 ? `
+    ${
+      (digest.recentlyClosedPRs || []).length > 0
+        ? `
     <section class="health-section" style="animation-delay: 0.2s;">
       <div class="health-header">
         <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--text-muted)" stroke-width="2">
@@ -1330,7 +1425,9 @@ function generateDashboardHtml(
         <span class="health-badge" style="background: rgba(110, 118, 129, 0.15); color: var(--text-muted);">${(digest.recentlyClosedPRs || []).length} closed</span>
       </div>
       <div class="health-items">
-        ${(digest.recentlyClosedPRs || []).map(pr => `
+        ${(digest.recentlyClosedPRs || [])
+          .map(
+            (pr) => `
         <div class="health-item" style="border-left-color: var(--text-muted); opacity: 0.7;" data-status="closed" data-repo="${escapeHtml(pr.repo)}" data-title="${escapeHtml(pr.title.toLowerCase())}">
           <div class="health-icon" style="background: rgba(110, 118, 129, 0.15); color: var(--text-muted);">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -1344,12 +1441,18 @@ function generateDashboardHtml(
             <div class="health-meta">${truncateTitle(pr.title)}${pr.closedAt ? ` · ${new Date(pr.closedAt).toLocaleDateString()}` : ''}</div>
           </div>
         </div>
-        `).join('')}
+        `,
+          )
+          .join('')}
       </div>
     </section>
-    ` : ''}
+    `
+        : ''
+    }
 
-    ${autoUnshelvedPRs.length > 0 ? `
+    ${
+      autoUnshelvedPRs.length > 0
+        ? `
     <section class="health-section" style="animation-delay: 0.25s;">
       <div class="health-header">
         <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--accent-info)" stroke-width="2">
@@ -1359,13 +1462,22 @@ function generateDashboardHtml(
         <span class="health-badge" style="background: var(--accent-info-dim); color: var(--accent-info);">${autoUnshelvedPRs.length} unshelved</span>
       </div>
       <div class="health-items">
-        ${renderHealthItems(autoUnshelvedPRs, 'auto-unshelved', SVG.bell,
-          pr => 'Auto-Unshelved (' + pr.status.replace(/_/g, ' ') + ')', titleMeta)}
+        ${renderHealthItems(
+          autoUnshelvedPRs,
+          'auto-unshelved',
+          SVG.bell,
+          (pr) => 'Auto-Unshelved (' + pr.status.replace(/_/g, ' ') + ')',
+          titleMeta,
+        )}
       </div>
     </section>
-    ` : ''}
+    `
+        : ''
+    }
 
-    ${issueResponses.length > 0 ? `
+    ${
+      issueResponses.length > 0
+        ? `
     <section class="health-section" style="animation-delay: 0.3s;">
       <div class="health-header">
         <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--accent-info)" stroke-width="2">
@@ -1375,7 +1487,9 @@ function generateDashboardHtml(
         <span class="health-badge" style="background: var(--accent-info-dim); color: var(--accent-info);">${issueResponses.length} repl${issueResponses.length !== 1 ? 'ies' : 'y'}</span>
       </div>
       <div class="health-items">
-        ${issueResponses.map(issue => `
+        ${issueResponses
+          .map(
+            (issue) => `
         <div class="health-item changes-addressed">
           <div class="health-icon" style="background: var(--accent-info-dim); color: var(--accent-info);">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -1387,10 +1501,14 @@ function generateDashboardHtml(
             <div class="health-meta">@${escapeHtml(issue.lastResponseAuthor)}: ${escapeHtml(issue.lastResponseBody.slice(0, 60))}${issue.lastResponseBody.length > 60 ? '...' : ''}</div>
           </div>
         </div>
-        `).join('')}
+        `,
+          )
+          .join('')}
       </div>
     </section>
-    ` : ''}
+    `
+        : ''
+    }
 
     <div class="main-grid">
       <div class="card">
@@ -1428,41 +1546,58 @@ function generateDashboardHtml(
     </div>
 
 
-    ${activePRList.length > 0 ? `
+    ${
+      activePRList.length > 0
+        ? `
     <section class="pr-list-section">
       <div class="pr-list-header">
         <h2 class="pr-list-title">Active Pull Requests</h2>
         <span class="pr-count">${activePRList.length} open</span>
       </div>
       <div class="pr-list">
-        ${activePRList.map(pr => {
-          const hasIssues = pr.ciStatus === 'failing' || pr.hasMergeConflict || (pr.hasUnrespondedComment && pr.status !== 'changes_addressed') || pr.status === 'needs_changes';
-          const isStale = pr.daysSinceActivity >= approachingDormantDays;
-          const itemClass = hasIssues ? 'has-issues' : (isStale ? 'stale' : '');
+        ${activePRList
+          .map((pr) => {
+            const hasIssues =
+              pr.ciStatus === 'failing' ||
+              pr.hasMergeConflict ||
+              (pr.hasUnrespondedComment && pr.status !== 'changes_addressed') ||
+              pr.status === 'needs_changes';
+            const isStale = pr.daysSinceActivity >= approachingDormantDays;
+            const itemClass = hasIssues ? 'has-issues' : isStale ? 'stale' : '';
 
-          const prStatus = pr.ciStatus === 'failing' ? 'ci-failing' :
-            pr.hasMergeConflict ? 'conflict' :
-            (pr.hasUnrespondedComment && pr.status !== 'changes_addressed' && pr.status !== 'failing_ci') ? 'needs-response' :
-            pr.status === 'needs_changes' ? 'needs-changes' :
-            pr.status === 'changes_addressed' ? 'changes-addressed' :
-            'active';
+            const prStatus =
+              pr.ciStatus === 'failing'
+                ? 'ci-failing'
+                : pr.hasMergeConflict
+                  ? 'conflict'
+                  : pr.hasUnrespondedComment && pr.status !== 'changes_addressed' && pr.status !== 'failing_ci'
+                    ? 'needs-response'
+                    : pr.status === 'needs_changes'
+                      ? 'needs-changes'
+                      : pr.status === 'changes_addressed'
+                        ? 'changes-addressed'
+                        : 'active';
 
-          return `
+            return `
         <div class="pr-item ${itemClass}" data-status="${prStatus}" data-repo="${escapeHtml(pr.repo)}" data-title="${escapeHtml(pr.title.toLowerCase())}">
           <div class="pr-status-indicator">
-            ${hasIssues ? `
+            ${
+              hasIssues
+                ? `
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <circle cx="12" cy="12" r="10"/>
               <line x1="12" y1="8" x2="12" y2="12"/>
               <line x1="12" y1="16" x2="12.01" y2="16"/>
             </svg>
-            ` : `
+            `
+                : `
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <circle cx="12" cy="12" r="10"/>
               <line x1="12" y1="16" x2="12" y2="12"/>
               <line x1="12" y1="8" x2="12.01" y2="8"/>
             </svg>
-            `}
+            `
+            }
           </div>
           <div class="pr-content">
             <div class="pr-title-row">
@@ -1481,13 +1616,15 @@ function generateDashboardHtml(
             </div>
           </div>
           <div class="pr-activity">
-            ${pr.daysSinceActivity === 0 ? 'Today' : (pr.daysSinceActivity === 1 ? 'Yesterday' : pr.daysSinceActivity + 'd ago')}
+            ${pr.daysSinceActivity === 0 ? 'Today' : pr.daysSinceActivity === 1 ? 'Yesterday' : pr.daysSinceActivity + 'd ago'}
           </div>
         </div>`;
-        }).join('')}
+          })
+          .join('')}
       </div>
     </section>
-    ` : `
+    `
+        : `
     <section class="pr-list-section">
       <div class="pr-list-header">
         <h2 class="pr-list-title">Active Pull Requests</h2>
@@ -1503,16 +1640,21 @@ function generateDashboardHtml(
         <p>No active pull requests</p>
       </div>
     </section>
-    `}
+    `
+    }
 
-    ${shelvedPRs.length > 0 ? `
+    ${
+      shelvedPRs.length > 0
+        ? `
     <section class="pr-list-section" style="margin-top: 1.25rem; opacity: 0.7;">
       <div class="pr-list-header">
         <h2 class="pr-list-title">Shelved Pull Requests</h2>
         <span class="pr-count" style="background: rgba(110, 118, 129, 0.15); color: var(--text-muted);">${shelvedPRs.length} shelved</span>
       </div>
       <div class="pr-list">
-        ${shelvedPRs.map(pr => `
+        ${shelvedPRs
+          .map(
+            (pr) => `
         <div class="pr-item" data-status="shelved" data-repo="${escapeHtml(pr.repo)}" data-title="${escapeHtml(pr.title.toLowerCase())}">
           <div class="pr-status-indicator" style="background: rgba(110, 118, 129, 0.1); color: var(--text-muted);">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -1529,12 +1671,16 @@ function generateDashboardHtml(
             </div>
           </div>
           <div class="pr-activity">
-            ${pr.daysSinceActivity === 0 ? 'Today' : (pr.daysSinceActivity === 1 ? 'Yesterday' : pr.daysSinceActivity + 'd ago')}
+            ${pr.daysSinceActivity === 0 ? 'Today' : pr.daysSinceActivity === 1 ? 'Yesterday' : pr.daysSinceActivity + 'd ago'}
           </div>
-        </div>`).join('')}
+        </div>`,
+          )
+          .join('')}
       </div>
     </section>
-    ` : ''}
+    `
+        : ''
+    }
 
     <footer class="footer">
       <p>OSS Autopilot // Mission Control</p>
@@ -1674,8 +1820,8 @@ function generateDashboardHtml(
       const starThreshold = minStars ?? 50;
       const shouldExcludeRepo = (repo: string): boolean => {
         const repoLower = repo.toLowerCase();
-        if (exRepos.some(r => r.toLowerCase() === repoLower)) return true;
-        if (exOrgs?.some(o => o.toLowerCase() === repoLower.split('/')[0])) return true;
+        if (exRepos.some((r) => r.toLowerCase() === repoLower)) return true;
+        if (exOrgs?.some((o) => o.toLowerCase() === repoLower.split('/')[0])) return true;
         const score = (state.repoScores || {})[repo];
         // Fail-open: repos without cached star data are shown (not excluded).
         // Unlike issue-discovery (fail-closed), the dashboard shows the user's own
@@ -1689,7 +1835,7 @@ function generateDashboardHtml(
         // Rebuild from full prsByRepo to get all repos, not just top 10
         (() => {
           const all: Record<string, { active: number; merged: number; closed: number }> = {};
-          for (const pr of (digest.openPRs || [])) {
+          for (const pr of digest.openPRs || []) {
             if (shouldExcludeRepo(pr.repo)) continue;
             if (!all[pr.repo]) all[pr.repo] = { active: 0, merged: 0, closed: 0 };
             all[pr.repo].active++;
@@ -1701,7 +1847,7 @@ function generateDashboardHtml(
             all[repo].closed = score.closedWithoutMergeCount;
           }
           return all;
-        })()
+        })(),
       ).sort((a, b) => {
         const totalA = a[1].merged + a[1].active + a[1].closed;
         const totalB = b[1].merged + b[1].active + b[1].closed;
@@ -1714,13 +1860,17 @@ function generateDashboardHtml(
 
       if (otherRepos.length > 0) {
         const otherData = otherRepos.reduce(
-          (acc, [, d]) => ({ active: acc.active + d.active, merged: acc.merged + d.merged, closed: acc.closed + d.closed }),
-          { active: 0, merged: 0, closed: 0 }
+          (acc, [, d]) => ({
+            active: acc.active + d.active,
+            merged: acc.merged + d.merged,
+            closed: acc.closed + d.closed,
+          }),
+          { active: 0, merged: 0, closed: 0 },
         );
         displayRepos.push(['Other', otherData]);
       }
 
-      const repoLabels = displayRepos.map(([repo]) => repo === 'Other' ? 'Other' : (repo.split('/')[1] || repo));
+      const repoLabels = displayRepos.map(([repo]) => (repo === 'Other' ? 'Other' : repo.split('/')[1] || repo));
       const mergedData = displayRepos.map(([, d]) => d.merged);
       const activeData = displayRepos.map(([, d]) => d.active);
       const closedData = displayRepos.map(([, d]) => d.closed);

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -47,7 +47,9 @@ describe('runInit', () => {
 
   it('should exit with error when no GitHub token is available', async () => {
     mockGetGitHubToken.mockReturnValue(null as any);
-    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
 
     await expect(runInit({ username: 'testuser', json: true })).rejects.toThrow('exit');
 
@@ -128,9 +130,7 @@ describe('runInit', () => {
     const mockSearch = vi.fn().mockResolvedValue({
       data: {
         total_count: 1,
-        items: [
-          { html_url: 'https://github.com/owner/repo/issues/5' },
-        ],
+        items: [{ html_url: 'https://github.com/owner/repo/issues/5' }],
       },
     });
     mockGetOctokit.mockReturnValue({

--- a/src/commands/local-repos.ts
+++ b/src/commands/local-repos.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { execFileSync } from 'child_process';
 import { getStateManager } from '../core/index.js';
-import { outputJson, outputJsonError, type LocalReposOutput, type LocalRepoInfo } from '../formatters/json.js';
+import { outputJson, type LocalReposOutput, type LocalRepoInfo } from '../formatters/json.js';
 
 interface LocalReposOptions {
   scan?: boolean;
@@ -52,11 +52,13 @@ function getGitHubRemote(repoPath: string): string | null {
 /** Get the current branch of a git repo */
 function getCurrentBranch(repoPath: string): string | null {
   try {
-    return execFileSync('git', ['-C', repoPath, 'branch', '--show-current'], {
-      encoding: 'utf-8',
-      timeout: 5000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim() || null;
+    return (
+      execFileSync('git', ['-C', repoPath, 'branch', '--show-current'], {
+        encoding: 'utf-8',
+        timeout: 5000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }).trim() || null
+    );
   } catch {
     return null;
   }
@@ -72,9 +74,7 @@ export function scanForRepos(scanPaths: string[]): Record<string, LocalRepoInfo>
     // Find git repos up to 3 levels deep
     let gitDirs: string[];
     try {
-      const output = execFileSync('find', [
-        scanPath, '-maxdepth', '4', '-name', '.git', '-type', 'd',
-      ], {
+      const output = execFileSync('find', [scanPath, '-maxdepth', '4', '-name', '.git', '-type', 'd'], {
         encoding: 'utf-8',
         timeout: 30000,
         stdio: ['pipe', 'pipe', 'pipe'],
@@ -104,9 +104,10 @@ export function scanForRepos(scanPaths: string[]): Record<string, LocalRepoInfo>
 export async function runLocalRepos(options: LocalReposOptions): Promise<void> {
   const stateManager = getStateManager();
   const state = stateManager.getState();
-  const scanPaths = options.paths?.map(p => path.resolve(p)) ??
+  const scanPaths =
+    options.paths?.map((p) => path.resolve(p)) ??
     state.config.localRepoScanPaths ??
-    DEFAULT_SCAN_PATHS.filter(p => fs.existsSync(p));
+    DEFAULT_SCAN_PATHS.filter((p) => fs.existsSync(p));
 
   // Use cached data unless --scan is specified
   if (!options.scan && state.localRepoCache) {

--- a/src/commands/read.test.ts
+++ b/src/commands/read.test.ts
@@ -67,7 +67,9 @@ describe('runRead', () => {
   });
 
   it('should exit with error when neither prUrl nor --all is provided', async () => {
-    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
 
     await expect(runRead({ json: true })).rejects.toThrow('exit');
 
@@ -82,7 +84,7 @@ describe('runRead', () => {
     await runRead({ all: true, json: false });
 
     expect(consoleSpy).toHaveBeenCalled();
-    const allOutput = consoleSpy.mock.calls.map(c => c[0]).join('\n');
+    const allOutput = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
     expect(allOutput).toContain('Marked 3 PRs as read');
     consoleSpy.mockRestore();
   });

--- a/src/commands/search.test.ts
+++ b/src/commands/search.test.ts
@@ -57,7 +57,9 @@ describe('runSearch', () => {
 
   it('should exit with error when no GitHub token is available', async () => {
     mockGetGitHubToken.mockReturnValue(null as any);
-    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
 
     await expect(runSearch({ maxResults: 10, json: true })).rejects.toThrow('exit');
 
@@ -69,7 +71,13 @@ describe('runSearch', () => {
     mockGetGitHubToken.mockReturnValue('ghp_test123');
     mockSearchIssues.mockResolvedValue([
       {
-        issue: { repo: 'owner/repo', number: 5, title: 'Fix bug', url: 'https://github.com/owner/repo/issues/5', labels: ['bug'] },
+        issue: {
+          repo: 'owner/repo',
+          number: 5,
+          title: 'Fix bug',
+          url: 'https://github.com/owner/repo/issues/5',
+          labels: ['bug'],
+        },
         recommendation: 'approve',
         reasonsToApprove: ['Active maintainers'],
         reasonsToSkip: [],
@@ -81,23 +89,37 @@ describe('runSearch', () => {
     await runSearch({ maxResults: 10, json: true });
 
     expect(mockSearchIssues).toHaveBeenCalledWith({ maxResults: 10 });
-    expect(mockOutputJson).toHaveBeenCalledWith(expect.objectContaining({
-      candidates: expect.arrayContaining([
-        expect.objectContaining({
-          issue: { repo: 'owner/repo', number: 5, title: 'Fix bug', url: 'https://github.com/owner/repo/issues/5', labels: ['bug'] },
-          recommendation: 'approve',
-        }),
-      ]),
-      excludedRepos: ['excluded/repo'],
-      aiPolicyBlocklist: ['matplotlib/matplotlib'],
-    }));
+    expect(mockOutputJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        candidates: expect.arrayContaining([
+          expect.objectContaining({
+            issue: {
+              repo: 'owner/repo',
+              number: 5,
+              title: 'Fix bug',
+              url: 'https://github.com/owner/repo/issues/5',
+              labels: ['bug'],
+            },
+            recommendation: 'approve',
+          }),
+        ]),
+        excludedRepos: ['excluded/repo'],
+        aiPolicyBlocklist: ['matplotlib/matplotlib'],
+      }),
+    );
   });
 
   it('should include repo score when available', async () => {
     mockGetGitHubToken.mockReturnValue('ghp_test123');
     mockSearchIssues.mockResolvedValue([
       {
-        issue: { repo: 'scored/repo', number: 1, title: 'Issue', url: 'https://github.com/scored/repo/issues/1', labels: [] },
+        issue: {
+          repo: 'scored/repo',
+          number: 1,
+          title: 'Issue',
+          url: 'https://github.com/scored/repo/issues/1',
+          labels: [],
+        },
         recommendation: 'approve',
         reasonsToApprove: [],
         reasonsToSkip: [],
@@ -149,7 +171,7 @@ describe('runSearch', () => {
     await runSearch({ maxResults: 10, json: false });
 
     expect(consoleSpy).toHaveBeenCalled();
-    const allOutput = consoleSpy.mock.calls.map(c => c[0]).join('\n');
+    const allOutput = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
     expect(allOutput).toContain('No matching issues found');
     consoleSpy.mockRestore();
   });

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -40,7 +40,7 @@ export async function runSearch(options: SearchOptions): Promise<void> {
     const excludedRepos = config.excludeRepos || [];
     const aiPolicyBlocklist = config.aiPolicyBlocklist ?? DEFAULT_CONFIG.aiPolicyBlocklist ?? [];
     const searchOutput: SearchOutput = {
-      candidates: candidates.map(c => {
+      candidates: candidates.map((c) => {
         const repoScoreRecord = stateManager.getRepoScore(c.issue.repo);
         return {
           issue: {
@@ -55,13 +55,15 @@ export async function runSearch(options: SearchOptions): Promise<void> {
           reasonsToSkip: c.reasonsToSkip,
           searchPriority: c.searchPriority,
           viabilityScore: c.viabilityScore,
-          repoScore: repoScoreRecord ? {
-            score: repoScoreRecord.score,
-            mergedPRCount: repoScoreRecord.mergedPRCount,
-            closedWithoutMergeCount: repoScoreRecord.closedWithoutMergeCount,
-            isResponsive: repoScoreRecord.signals?.isResponsive ?? false,
-            lastMergedAt: repoScoreRecord.lastMergedAt,
-          } : undefined,
+          repoScore: repoScoreRecord
+            ? {
+                score: repoScoreRecord.score,
+                mergedPRCount: repoScoreRecord.mergedPRCount,
+                closedWithoutMergeCount: repoScoreRecord.closedWithoutMergeCount,
+                isResponsive: repoScoreRecord.signals?.isResponsive ?? false,
+                lastMergedAt: repoScoreRecord.lastMergedAt,
+              }
+            : undefined,
         };
       }),
       excludedRepos,

--- a/src/commands/setup.test.ts
+++ b/src/commands/setup.test.ts
@@ -51,13 +51,15 @@ describe('runSetup', () => {
   it('should show setup status when already complete in JSON mode', async () => {
     await runSetup({ json: true });
 
-    expect(mockOutputJson).toHaveBeenCalledWith(expect.objectContaining({
-      setupComplete: true,
-      config: expect.objectContaining({
-        githubUsername: 'testuser',
-        maxActivePRs: 10,
+    expect(mockOutputJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        setupComplete: true,
+        config: expect.objectContaining({
+          githubUsername: 'testuser',
+          maxActivePRs: 10,
+        }),
       }),
-    }));
+    );
   });
 
   it('should show setup prompts when setup is incomplete in JSON mode', async () => {
@@ -69,21 +71,25 @@ describe('runSetup', () => {
 
     await runSetup({ json: true });
 
-    expect(mockOutputJson).toHaveBeenCalledWith(expect.objectContaining({
-      setupRequired: true,
-      prompts: expect.arrayContaining([
-        expect.objectContaining({ setting: 'username' }),
-        expect.objectContaining({ setting: 'maxActivePRs' }),
-      ]),
-    }));
+    expect(mockOutputJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        setupRequired: true,
+        prompts: expect.arrayContaining([
+          expect.objectContaining({ setting: 'username' }),
+          expect.objectContaining({ setting: 'maxActivePRs' }),
+        ]),
+      }),
+    );
   });
 
   it('should show setup prompts when --reset is used', async () => {
     await runSetup({ reset: true, json: true });
 
-    expect(mockOutputJson).toHaveBeenCalledWith(expect.objectContaining({
-      setupRequired: true,
-    }));
+    expect(mockOutputJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        setupRequired: true,
+      }),
+    );
   });
 
   it('should apply --set settings correctly', async () => {
@@ -92,13 +98,15 @@ describe('runSetup', () => {
     expect(mockUpdateConfig).toHaveBeenCalledWith({ githubUsername: 'newuser' });
     expect(mockUpdateConfig).toHaveBeenCalledWith({ maxActivePRs: 5 });
     expect(mockSave).toHaveBeenCalled();
-    expect(mockOutputJson).toHaveBeenCalledWith(expect.objectContaining({
-      success: true,
-      settings: expect.objectContaining({
-        username: 'newuser',
-        maxActivePRs: '5',
+    expect(mockOutputJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        settings: expect.objectContaining({
+          username: 'newuser',
+          maxActivePRs: '5',
+        }),
       }),
-    }));
+    );
   });
 
   it('should handle languages setting with comma-separated values', async () => {
@@ -185,7 +193,7 @@ describe('runCheckSetup', () => {
 
     await runCheckSetup({ json: false });
 
-    const allOutput = consoleSpy.mock.calls.map(c => c[0]).join('\n');
+    const allOutput = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
     expect(allOutput).toContain('SETUP_COMPLETE');
     expect(allOutput).toContain('username=testuser');
     consoleSpy.mockRestore();
@@ -200,7 +208,7 @@ describe('runCheckSetup', () => {
 
     await runCheckSetup({ json: false });
 
-    const allOutput = consoleSpy.mock.calls.map(c => c[0]).join('\n');
+    const allOutput = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
     expect(allOutput).toContain('SETUP_INCOMPLETE');
     consoleSpy.mockRestore();
   });

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -46,11 +46,11 @@ export async function runSetup(options: SetupOptions): Promise<void> {
           results[key] = value;
           break;
         case 'languages':
-          stateManager.updateConfig({ languages: value.split(',').map(l => l.trim()) });
+          stateManager.updateConfig({ languages: value.split(',').map((l) => l.trim()) });
           results[key] = value;
           break;
         case 'labels':
-          stateManager.updateConfig({ labels: value.split(',').map(l => l.trim()) });
+          stateManager.updateConfig({ labels: value.split(',').map((l) => l.trim()) });
           results[key] = value;
           break;
         case 'showHealthCheck':
@@ -77,7 +77,10 @@ export async function runSetup(options: SetupOptions): Promise<void> {
           results[key] = value === 'true' ? 'true' : 'false';
           break;
         case 'aiPolicyBlocklist': {
-          const entries = value.split(',').map(r => r.trim()).filter(Boolean);
+          const entries = value
+            .split(',')
+            .map((r) => r.trim())
+            .filter(Boolean);
           const valid: string[] = [];
           const invalid: string[] = [];
           for (const entry of entries) {

--- a/src/commands/snooze.test.ts
+++ b/src/commands/snooze.test.ts
@@ -84,7 +84,9 @@ describe('runSnooze', () => {
   });
 
   it('should reject non-positive snooze duration', async () => {
-    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
 
     await expect(runSnooze({ prUrl: TEST_PR_URL, reason: 'test', days: 0, json: true })).rejects.toThrow('exit');
 
@@ -93,7 +95,9 @@ describe('runSnooze', () => {
   });
 
   it('should reject negative snooze duration', async () => {
-    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
 
     await expect(runSnooze({ prUrl: TEST_PR_URL, reason: 'test', days: -5, json: true })).rejects.toThrow('exit');
 

--- a/src/commands/snooze.ts
+++ b/src/commands/snooze.ts
@@ -48,7 +48,13 @@ export async function runSnooze(options: SnoozeCommandOptions): Promise<void> {
     const snoozeInfo = stateManager.getSnoozeInfo(options.prUrl);
 
     if (options.json) {
-      outputJson({ snoozed: added, url: options.prUrl, days, reason: options.reason, expiresAt: snoozeInfo?.expiresAt });
+      outputJson({
+        snoozed: added,
+        url: options.prUrl,
+        days,
+        reason: options.reason,
+        expiresAt: snoozeInfo?.expiresAt,
+      });
     } else if (added) {
       console.log(`Snoozed: ${options.prUrl}`);
       console.log(`Reason: ${options.reason}`);

--- a/src/commands/startup.e2e.test.ts
+++ b/src/commands/startup.e2e.test.ts
@@ -15,9 +15,7 @@ const BUNDLE_PATH = path.resolve(__dirname, '../../dist/cli.bundle.cjs');
 const BUNDLE_EXISTS = fs.existsSync(BUNDLE_PATH);
 const TEST_HOME = '/tmp/oss-autopilot-e2e-test-' + process.pid;
 
-async function runStartup(
-  env?: Record<string, string>,
-): Promise<{ stdout: string; stderr: string; json: any }> {
+async function runStartup(env?: Record<string, string>): Promise<{ stdout: string; stderr: string; json: any }> {
   let exitCode: number | null = 0;
   let signal: string | null = null;
 
@@ -41,8 +39,8 @@ async function runStartup(
   } catch (parseError) {
     console.warn(
       `[E2E] Failed to parse CLI stdout as JSON (exit=${exitCode}, signal=${signal}):\n` +
-      `parse error: ${parseError instanceof Error ? parseError.message : parseError}\n` +
-      `stdout: ${result.stdout.slice(0, 500) || '(empty)'}\nstderr: ${result.stderr.slice(0, 500) || '(empty)'}`
+        `parse error: ${parseError instanceof Error ? parseError.message : parseError}\n` +
+        `stdout: ${result.stdout.slice(0, 500) || '(empty)'}\nstderr: ${result.stderr.slice(0, 500) || '(empty)'}`,
     );
     json = null;
   }

--- a/src/commands/startup.test.ts
+++ b/src/commands/startup.test.ts
@@ -279,10 +279,7 @@ describe('runStartup dashboard behavior', () => {
 
     expect(execFile).not.toHaveBeenCalled();
     expect(daily.briefSummary).not.toContain('Dashboard opened in browser');
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Dashboard'),
-      'Dashboard write failed',
-    );
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Dashboard'), 'Dashboard write failed');
     consoleErrorSpy.mockRestore();
   });
 });

--- a/src/commands/startup.ts
+++ b/src/commands/startup.ts
@@ -106,15 +106,17 @@ export function detectIssueList(): IssueListInfo | undefined {
     const { availableCount, completedCount } = countIssueListItems(content);
     return { path: issueListPath, source, availableCount, completedCount };
   } catch (error) {
-    console.error(`[STARTUP] Failed to read issue list at ${issueListPath}:`, error instanceof Error ? error.message : error);
+    console.error(
+      `[STARTUP] Failed to read issue list at ${issueListPath}:`,
+      error instanceof Error ? error.message : error,
+    );
     return { path: issueListPath, source, availableCount: 0, completedCount: 0 };
   }
 }
 
 function openInBrowser(filePath: string): void {
   const isWindows = process.platform === 'win32';
-  const openCmd = process.platform === 'darwin' ? 'open' :
-                  isWindows ? 'cmd' : 'xdg-open';
+  const openCmd = process.platform === 'darwin' ? 'open' : isWindows ? 'cmd' : 'xdg-open';
   const args = isWindows ? ['/c', 'start', '', filePath] : [filePath];
   execFile(openCmd, args, (error) => {
     if (error) {
@@ -144,7 +146,8 @@ export async function runStartup(options: StartupOptions): Promise<void> {
       outputJson<StartupOutput>({
         version,
         setupComplete: true,
-        authError: 'GitHub authentication required. Install GitHub CLI (https://cli.github.com/) and run "gh auth login", or set GITHUB_TOKEN.',
+        authError:
+          'GitHub authentication required. Install GitHub CLI (https://cli.github.com/) and run "gh auth login", or set GITHUB_TOKEN.',
       });
     } else {
       console.error('Error: GitHub authentication required.');

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -36,9 +36,7 @@ describe('runStatus', () => {
     { repo: 'owner/repo', number: 2, title: 'Add feature', hasUnreadComments: false },
   ];
 
-  const mockDormantPRs = [
-    { repo: 'other/repo', number: 10, title: 'Old PR', hasUnreadComments: false },
-  ];
+  const mockDormantPRs = [{ repo: 'other/repo', number: 10, title: 'Old PR', hasUnreadComments: false }];
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -69,7 +67,7 @@ describe('runStatus', () => {
     await runStatus({ json: false });
 
     expect(consoleSpy).toHaveBeenCalled();
-    const allOutput = consoleSpy.mock.calls.map(c => c[0]).join('\n');
+    const allOutput = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
     expect(allOutput).toContain('Active PRs: 3');
     expect(allOutput).toContain('Dormant PRs: 1');
     expect(allOutput).toContain('Merge Rate: 71%');

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -17,7 +17,7 @@ export async function runStatus(options: StatusOptions): Promise<void> {
 
   if (options.json) {
     // Extract only the stats we want to output (exclude totalTracked)
-    const { totalTracked, ...outputStats } = stats as typeof stats & { totalTracked?: number };
+    const { totalTracked: _totalTracked, ...outputStats } = stats as typeof stats & { totalTracked?: number };
     outputJson<StatusOutput>({
       stats: outputStats,
       activePRs: [...state.activePRs],

--- a/src/commands/track.test.ts
+++ b/src/commands/track.test.ts
@@ -45,7 +45,9 @@ describe('runTrack', () => {
 
   it('should exit with error when no GitHub token is available', async () => {
     mockGetGitHubToken.mockReturnValue(null as any);
-    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
 
     await expect(runTrack({ prUrl: TEST_PR_URL, json: true })).rejects.toThrow('exit');
 
@@ -74,7 +76,7 @@ describe('runTrack', () => {
     await runTrack({ prUrl: TEST_PR_URL, json: false });
 
     expect(consoleSpy).toHaveBeenCalled();
-    const allOutput = consoleSpy.mock.calls.map(c => c[0]).join('\n');
+    const allOutput = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
     expect(allOutput).toContain('owner/repo#42');
     consoleSpy.mockRestore();
   });

--- a/src/commands/validation.ts
+++ b/src/commands/validation.ts
@@ -25,9 +25,8 @@ const REPO_PATTERN = /^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/;
 export function validateGitHubUrl(url: string, pattern: RegExp, entityType: 'PR' | 'issue', json?: boolean): void {
   if (pattern.test(url)) return;
 
-  const example = entityType === 'PR'
-    ? 'https://github.com/owner/repo/pull/123'
-    : 'https://github.com/owner/repo/issues/123';
+  const example =
+    entityType === 'PR' ? 'https://github.com/owner/repo/pull/123' : 'https://github.com/owner/repo/issues/123';
   const msg = `Invalid ${entityType} URL: ${url}. Expected format: ${example}`;
 
   if (json) {

--- a/src/commands/vet.test.ts
+++ b/src/commands/vet.test.ts
@@ -40,7 +40,9 @@ describe('runVet', () => {
 
   it('should exit with error when no GitHub token', async () => {
     mockGetGitHubToken.mockReturnValue(null as any);
-    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
 
     await expect(runVet({ issueUrl: TEST_ISSUE_URL, json: true })).rejects.toThrow('exit');
 

--- a/src/core/comment-utils.ts
+++ b/src/core/comment-utils.ts
@@ -38,10 +38,18 @@ export function isAcknowledgmentComment(body: string): boolean {
 
   const lower = body.toLowerCase();
   const ackKeywords = [
-    'thanks', 'thank you', 'lgtm', 'looks good',
-    'will review', "we'll review", "we'll get to this",
-    'noted', 'got it', 'will look', 'will check',
+    'thanks',
+    'thank you',
+    'lgtm',
+    'looks good',
+    'will review',
+    "we'll review",
+    "we'll get to this",
+    'noted',
+    'got it',
+    'will look',
+    'will check',
   ];
 
-  return ackKeywords.some(kw => lower.includes(kw));
+  return ackKeywords.some((kw) => lower.includes(kw));
 }

--- a/src/core/concurrency.test.ts
+++ b/src/core/concurrency.test.ts
@@ -6,9 +6,13 @@ describe('runWorkerPool', () => {
     const items = [1, 2, 3, 4, 5];
     const processed: number[] = [];
 
-    await runWorkerPool(items, async (item) => {
-      processed.push(item);
-    }, 3);
+    await runWorkerPool(
+      items,
+      async (item) => {
+        processed.push(item);
+      },
+      3,
+    );
 
     expect(processed.sort()).toEqual([1, 2, 3, 4, 5]);
   });
@@ -18,13 +22,17 @@ describe('runWorkerPool', () => {
     let maxObservedConcurrency = 0;
     const items = [1, 2, 3, 4, 5, 6, 7, 8];
 
-    await runWorkerPool(items, async () => {
-      activeConcurrency++;
-      maxObservedConcurrency = Math.max(maxObservedConcurrency, activeConcurrency);
-      // Simulate async work so workers can overlap
-      await new Promise((resolve) => setTimeout(resolve, 10));
-      activeConcurrency--;
-    }, 3);
+    await runWorkerPool(
+      items,
+      async () => {
+        activeConcurrency++;
+        maxObservedConcurrency = Math.max(maxObservedConcurrency, activeConcurrency);
+        // Simulate async work so workers can overlap
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        activeConcurrency--;
+      },
+      3,
+    );
 
     expect(maxObservedConcurrency).toBeLessThanOrEqual(3);
     // With 8 items and concurrency 3, we should actually see concurrency > 1
@@ -34,9 +42,13 @@ describe('runWorkerPool', () => {
   it('handles empty array', async () => {
     const processed: number[] = [];
 
-    await runWorkerPool([], async (item: number) => {
-      processed.push(item);
-    }, 5);
+    await runWorkerPool(
+      [],
+      async (item: number) => {
+        processed.push(item);
+      },
+      5,
+    );
 
     expect(processed).toEqual([]);
   });
@@ -45,9 +57,13 @@ describe('runWorkerPool', () => {
     const items = [1, 2, 3];
 
     await expect(
-      runWorkerPool(items, async (item) => {
-        if (item === 2) throw new Error('item 2 failed');
-      }, 1),
+      runWorkerPool(
+        items,
+        async (item) => {
+          if (item === 2) throw new Error('item 2 failed');
+        },
+        1,
+      ),
     ).rejects.toThrow('item 2 failed');
   });
 
@@ -55,9 +71,13 @@ describe('runWorkerPool', () => {
     const items = ['a', 'b', 'c', 'd', 'e'];
     const processed: string[] = [];
 
-    await runWorkerPool(items, async (item) => {
-      processed.push(item);
-    }, 1);
+    await runWorkerPool(
+      items,
+      async (item) => {
+        processed.push(item);
+      },
+      1,
+    );
 
     expect(processed).toEqual(['a', 'b', 'c', 'd', 'e']);
   });

--- a/src/core/errors.test.ts
+++ b/src/core/errors.test.ts
@@ -1,11 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  OssAutopilotError,
-  ConfigurationError,
-  GitHubAPIError,
-  ValidationError,
-  StateError,
-} from './errors.js';
+import { OssAutopilotError, ConfigurationError, GitHubAPIError, ValidationError, StateError } from './errors.js';
 
 describe('Custom Error Hierarchy', () => {
   describe('OssAutopilotError', () => {

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -8,7 +8,10 @@
  * Base error for all oss-autopilot errors.
  */
 export class OssAutopilotError extends Error {
-  constructor(message: string, public readonly code: string) {
+  constructor(
+    message: string,
+    public readonly code: string,
+  ) {
     super(message);
     this.name = 'OssAutopilotError';
   }
@@ -28,7 +31,10 @@ export class ConfigurationError extends OssAutopilotError {
  * GitHub API errors (rate limits, auth failures, network).
  */
 export class GitHubAPIError extends OssAutopilotError {
-  constructor(message: string, public readonly status?: number) {
+  constructor(
+    message: string,
+    public readonly status?: number,
+  ) {
     super(message, 'GITHUB_API_ERROR');
     this.name = 'GitHubAPIError';
   }

--- a/src/core/github.ts
+++ b/src/core/github.ts
@@ -37,12 +37,12 @@ export function getOctokit(token: string): Octokit {
         const resetAt = new Date(Date.now() + retryAfter * 1000);
         if (retryCount < 2) {
           console.warn(
-            `Rate limit hit (retry ${retryCount + 1}/2, waiting ${retryAfter}s, resets at ${formatResetTime(resetAt)}) — ${opts.method} ${opts.url}`
+            `Rate limit hit (retry ${retryCount + 1}/2, waiting ${retryAfter}s, resets at ${formatResetTime(resetAt)}) — ${opts.method} ${opts.url}`,
           );
           return true;
         }
         console.error(
-          `Rate limit exceeded, not retrying — ${opts.method} ${opts.url} (resets at ${formatResetTime(resetAt)})`
+          `Rate limit exceeded, not retrying — ${opts.method} ${opts.url} (resets at ${formatResetTime(resetAt)})`,
         );
         return false;
       },
@@ -51,12 +51,12 @@ export function getOctokit(token: string): Octokit {
         const resetAt = new Date(Date.now() + retryAfter * 1000);
         if (retryCount < 1) {
           console.warn(
-            `Secondary rate limit hit (retry ${retryCount + 1}/1, waiting ${retryAfter}s, resets at ${formatResetTime(resetAt)}) — ${opts.method} ${opts.url}`
+            `Secondary rate limit hit (retry ${retryCount + 1}/1, waiting ${retryAfter}s, resets at ${formatResetTime(resetAt)}) — ${opts.method} ${opts.url}`,
           );
           return true;
         }
         console.error(
-          `Secondary rate limit exceeded, not retrying — ${opts.method} ${opts.url} (resets at ${formatResetTime(resetAt)})`
+          `Secondary rate limit exceeded, not retrying — ${opts.method} ${opts.url} (resets at ${formatResetTime(resetAt)})`,
         );
         return false;
       },

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -4,8 +4,22 @@
  */
 
 export { StateManager, getStateManager, resetStateManager } from './state.js';
-export { PRMonitor, type PRCheckFailure, type FetchPRsResult, computeDisplayLabel, classifyCICheck, classifyFailingChecks } from './pr-monitor.js';
-export { IssueDiscovery, type IssueCandidate, type SearchPriority, isDocOnlyIssue, applyPerRepoCap, DOC_ONLY_LABELS } from './issue-discovery.js';
+export {
+  PRMonitor,
+  type PRCheckFailure,
+  type FetchPRsResult,
+  computeDisplayLabel,
+  classifyCICheck,
+  classifyFailingChecks,
+} from './pr-monitor.js';
+export {
+  IssueDiscovery,
+  type IssueCandidate,
+  type SearchPriority,
+  isDocOnlyIssue,
+  applyPerRepoCap,
+  DOC_ONLY_LABELS,
+} from './issue-discovery.js';
 export { IssueConversationMonitor } from './issue-conversation.js';
 export { isBotAuthor, isAcknowledgmentComment } from './comment-utils.js';
 export { getOctokit, checkRateLimit, type RateLimitInfo } from './github.js';

--- a/src/core/issue-conversation.test.ts
+++ b/src/core/issue-conversation.test.ts
@@ -198,11 +198,13 @@ describe('IssueConversationMonitor', () => {
         ...defaultState().config,
         aiPolicyBlocklist: [],
       },
-      activeIssues: [{
-        repo: 'owner/repo',
-        number: 42,
-        status: 'claimed',
-      }],
+      activeIssues: [
+        {
+          repo: 'owner/repo',
+          number: 42,
+          status: 'claimed',
+        },
+      ],
     };
 
     mockOctokitInstance.search.issuesAndPullRequests.mockResolvedValue({
@@ -221,10 +223,12 @@ describe('IssueConversationMonitor', () => {
   it('should handle empty comment threads', async () => {
     mockOctokitInstance.search.issuesAndPullRequests.mockResolvedValue({
       data: {
-        items: [makeSearchItem({
-          html_url: 'https://github.com/owner/repo/issues/99',
-          number: 99,
-        })],
+        items: [
+          makeSearchItem({
+            html_url: 'https://github.com/owner/repo/issues/99',
+            number: 99,
+          }),
+        ],
         total_count: 1,
       },
     });
@@ -250,7 +254,7 @@ describe('IssueConversationMonitor', () => {
 
     mockOctokitInstance.issues.listComments.mockResolvedValue({
       data: [
-        makeComment('TestUser', 'Can I work on this?', '2026-02-01T10:00:00Z'),  // Different case
+        makeComment('TestUser', 'Can I work on this?', '2026-02-01T10:00:00Z'), // Different case
         makeComment('maintainer', 'Sure, go ahead!', '2026-02-02T10:00:00Z'),
       ],
     });
@@ -373,9 +377,7 @@ describe('IssueConversationMonitor', () => {
       if (callCount === 1) {
         // Issue 1: user commented, no response
         return Promise.resolve({
-          data: [
-            makeComment('testuser', 'I can help', '2026-02-01T10:00:00Z'),
-          ],
+          data: [makeComment('testuser', 'I can help', '2026-02-01T10:00:00Z')],
         });
       } else {
         // Issue 2: user commented, maintainer responded
@@ -402,9 +404,11 @@ describe('IssueConversationMonitor', () => {
   it('should include labels from the issue', async () => {
     mockOctokitInstance.search.issuesAndPullRequests.mockResolvedValue({
       data: {
-        items: [makeSearchItem({
-          labels: [{ name: 'bug' }, { name: 'help wanted' }],
-        })],
+        items: [
+          makeSearchItem({
+            labels: [{ name: 'bug' }, { name: 'help wanted' }],
+          }),
+        ],
         total_count: 1,
       },
     });
@@ -483,9 +487,7 @@ describe('IssueConversationMonitor', () => {
 
     mockOctokitInstance.search.issuesAndPullRequests.mockResolvedValue({
       data: {
-        items: [
-          makeSearchItem({ html_url: 'https://github.com/excluded/repo/issues/1', number: 1 }),
-        ],
+        items: [makeSearchItem({ html_url: 'https://github.com/excluded/repo/issues/1', number: 1 })],
         total_count: 1,
       },
     });
@@ -508,9 +510,7 @@ describe('IssueConversationMonitor', () => {
 
     mockOctokitInstance.search.issuesAndPullRequests.mockResolvedValue({
       data: {
-        items: [
-          makeSearchItem({ html_url: 'https://github.com/excluded/repo/issues/1', number: 1 }),
-        ],
+        items: [makeSearchItem({ html_url: 'https://github.com/excluded/repo/issues/1', number: 1 })],
         total_count: 1,
       },
     });
@@ -541,9 +541,7 @@ describe('IssueConversationMonitor', () => {
 
     mockOctokitInstance.search.issuesAndPullRequests.mockResolvedValue({
       data: {
-        items: [
-          makeSearchItem({ html_url: 'https://github.com/ExcludedOrg/some-repo/issues/5', number: 5 }),
-        ],
+        items: [makeSearchItem({ html_url: 'https://github.com/ExcludedOrg/some-repo/issues/5', number: 5 })],
         total_count: 1,
       },
     });
@@ -589,9 +587,7 @@ describe('IssueConversationMonitor', () => {
   });
 
   it('should propagate search API failure as thrown error', async () => {
-    mockOctokitInstance.search.issuesAndPullRequests.mockRejectedValue(
-      new Error('API rate limit exceeded'),
-    );
+    mockOctokitInstance.search.issuesAndPullRequests.mockRejectedValue(new Error('API rate limit exceeded'));
 
     const monitor = new IssueConversationMonitor('fake-token');
     await expect(monitor.fetchCommentedIssues()).rejects.toThrow('API rate limit exceeded');

--- a/src/core/issue-conversation.ts
+++ b/src/core/issue-conversation.ts
@@ -32,7 +32,9 @@ export class IssueConversationMonitor {
    * Filters out: user-authored issues, user-owned repos, excluded repos/orgs,
    * AI policy blocklisted repos, already-tracked issues, and pull requests.
    */
-  async fetchCommentedIssues(maxDays: number = 30): Promise<{ issues: CommentedIssue[]; failures: Array<{ issueUrl: string; error: string }> }> {
+  async fetchCommentedIssues(
+    maxDays: number = 30,
+  ): Promise<{ issues: CommentedIssue[]; failures: Array<{ issueUrl: string; error: string }> }> {
     const config = this.stateManager.getState().config;
 
     if (!config.githubUsername) {
@@ -56,21 +58,23 @@ export class IssueConversationMonitor {
     });
 
     if (data.total_count > 100) {
-      console.error(`[ISSUE_CONVERSATION] Search returned ${data.total_count} results but only first 100 were fetched. Some commented issues may be missing.`);
+      console.error(
+        `[ISSUE_CONVERSATION] Search returned ${data.total_count} results but only first 100 were fetched. Some commented issues may be missing.`,
+      );
     }
 
     // Build sets for filtering
     const trackedIssues = this.stateManager.getState().activeIssues || [];
     const trackedIssueKeys = new Set(
       trackedIssues
-        .filter(i => i.status === 'claimed' || i.status === 'in_progress' || i.status === 'pr_submitted')
-        .map(i => `${i.repo}#${i.number}`)
+        .filter((i) => i.status === 'claimed' || i.status === 'in_progress' || i.status === 'pr_submitted')
+        .map((i) => `${i.repo}#${i.number}`),
     );
-    const blocklist = new Set((config.aiPolicyBlocklist || []).map(r => r.toLowerCase()));
+    const blocklist = new Set((config.aiPolicyBlocklist || []).map((r) => r.toLowerCase()));
 
     // Filter out PRs, user-authored issues, excluded repos, blocklisted repos, and already-tracked issues.
     // Also parse repo info for each candidate to avoid re-parsing in analyzeIssueConversation.
-    const candidates: Array<{ item: typeof data.items[0]; repoFullName: string }> = [];
+    const candidates: Array<{ item: (typeof data.items)[0]; repoFullName: string }> = [];
     for (const item of data.items) {
       // Defensive: skip pull requests in case type:issue qualifier is unreliable
       if (item.pull_request) continue;
@@ -92,7 +96,7 @@ export class IssueConversationMonitor {
 
       // Skip excluded repos and orgs
       if (config.excludeRepos.includes(repoFullName)) continue;
-      if (config.excludeOrgs?.some(org => owner.toLowerCase() === org.toLowerCase())) continue;
+      if (config.excludeOrgs?.some((org) => owner.toLowerCase() === org.toLowerCase())) continue;
 
       // Skip blocklisted repos
       if (blocklist.has(repoFullName.toLowerCase())) continue;
@@ -109,26 +113,36 @@ export class IssueConversationMonitor {
     const results: CommentedIssue[] = [];
     const failures: Array<{ issueUrl: string; error: string }> = [];
 
-    await runWorkerPool(candidates, async ({ item, repoFullName }) => {
-      try {
-        const issue = await this.analyzeIssueConversation(item, repoFullName, username);
-        if (issue) {
-          results.push(issue);
-        } else {
-          failures.push({ issueUrl: item.html_url, error: 'No user comment found despite commenter: search match (possible pagination or eventual consistency)' });
+    await runWorkerPool(
+      candidates,
+      async ({ item, repoFullName }) => {
+        try {
+          const issue = await this.analyzeIssueConversation(item, repoFullName, username);
+          if (issue) {
+            results.push(issue);
+          } else {
+            failures.push({
+              issueUrl: item.html_url,
+              error:
+                'No user comment found despite commenter: search match (possible pagination or eventual consistency)',
+            });
+          }
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          failures.push({ issueUrl: item.html_url, error: msg });
+          console.error(`Error analyzing issue ${item.html_url}: ${msg}`);
         }
-      } catch (error) {
-        const msg = error instanceof Error ? error.message : String(error);
-        failures.push({ issueUrl: item.html_url, error: msg });
-        console.error(`Error analyzing issue ${item.html_url}: ${msg}`);
-      }
-    }, MAX_CONCURRENT_REQUESTS);
+      },
+      MAX_CONCURRENT_REQUESTS,
+    );
 
     if (failures.length > 0) {
       console.error(`[ISSUE_CONVERSATION] ${failures.length}/${candidates.length} issue analysis call(s) failed`);
     }
     if (failures.length === candidates.length && candidates.length > 0) {
-      console.error(`[ISSUE_CONVERSATION_ALL_FAILED] All ${candidates.length} issue analysis call(s) failed. Possible systemic issue (rate limit, auth, network).`);
+      console.error(
+        `[ISSUE_CONVERSATION_ALL_FAILED] All ${candidates.length} issue analysis call(s) failed. Possible systemic issue (rate limit, auth, network).`,
+      );
     }
 
     // Sort: new_response first, then waiting, then acknowledged
@@ -139,7 +153,9 @@ export class IssueConversationMonitor {
     };
     results.sort((a, b) => statusOrder[a.status] - statusOrder[b.status]);
 
-    console.error(`Analyzed ${results.length} issue conversations (${results.filter(i => i.status === 'new_response').length} with new responses)`);
+    console.error(
+      `Analyzed ${results.length} issue conversations (${results.filter((i) => i.status === 'new_response').length} with new responses)`,
+    );
     return { issues: results, failures };
   }
 
@@ -153,13 +169,15 @@ export class IssueConversationMonitor {
   ): Promise<CommentedIssue | null> {
     const { owner, repo } = splitRepo(repoFullName);
 
-    const allComments = await paginateAll((page) => this.octokit.issues.listComments({
-      owner,
-      repo,
-      issue_number: item.number,
-      per_page: 100,
-      page,
-    }));
+    const allComments = await paginateAll((page) =>
+      this.octokit.issues.listComments({
+        owner,
+        repo,
+        issue_number: item.number,
+        per_page: 100,
+        page,
+      }),
+    );
 
     const timeline: Array<{ author: string; body: string; createdAt: string; isUser: boolean }> = [];
     for (const comment of allComments) {
@@ -176,7 +194,7 @@ export class IssueConversationMonitor {
     timeline.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
 
     // Find the user's last comment
-    let userLastComment: typeof timeline[0] | undefined;
+    let userLastComment: (typeof timeline)[0] | undefined;
     for (const entry of timeline) {
       if (entry.isUser) userLastComment = entry;
     }
@@ -208,7 +226,7 @@ export class IssueConversationMonitor {
       }
     }
 
-    const labels = (item.labels || []).map(l => l.name || '').filter(Boolean);
+    const labels = (item.labels || []).map((l) => l.name || '').filter(Boolean);
 
     const base = {
       repo: repoFullName,
@@ -232,11 +250,8 @@ export class IssueConversationMonitor {
 
     // No substantive response found. If user is the last non-bot commenter,
     // mark as acknowledged; otherwise mark as waiting.
-    const lastNonBotComment = [...timeline].reverse().find(
-      e => !isBotAuthor(e.author)
-    );
-    const status = lastNonBotComment?.isUser ? 'acknowledged' as const : 'waiting' as const;
+    const lastNonBotComment = [...timeline].reverse().find((e) => !isBotAuthor(e.author));
+    const status = lastNonBotComment?.isUser ? ('acknowledged' as const) : ('waiting' as const);
     return { ...base, status };
   }
 }
-

--- a/src/core/issue-discovery.test.ts
+++ b/src/core/issue-discovery.test.ts
@@ -34,7 +34,7 @@ const {
   isDocOnlyIssue,
   applyPerRepoCap,
   DOC_ONLY_LABELS,
-  BEGINNER_LABELS,
+  BEGINNER_LABELS: _BEGINNER_LABELS,
 } = await import('./issue-discovery.js');
 
 const { getStateManager } = await import('./state.js');
@@ -398,18 +398,14 @@ describe('IssueDiscovery.vetIssue inconclusive downgrade', () => {
 
   it('should downgrade to needs_review when checkNoExistingPR is inconclusive', async () => {
     // Make the search call throw (simulating rate limit / API error)
-    mockOctokitInstance.search.issuesAndPullRequests.mockRejectedValue(
-      new Error('API rate limit exceeded')
-    );
+    mockOctokitInstance.search.issuesAndPullRequests.mockRejectedValue(new Error('API rate limit exceeded'));
 
     const candidate = await discovery.vetIssue('https://github.com/owner/repo/issues/42');
     expect(candidate.recommendation).toBe('needs_review');
     expect(candidate.vettingResult.notes).toContainEqual(
-      expect.stringContaining('Could not verify absence of existing PRs')
+      expect.stringContaining('Could not verify absence of existing PRs'),
     );
-    expect(candidate.vettingResult.notes).toContainEqual(
-      expect.stringContaining('Recommendation downgraded')
-    );
+    expect(candidate.vettingResult.notes).toContainEqual(expect.stringContaining('Recommendation downgraded'));
   });
 
   it('should downgrade to needs_review when checkNotClaimed is inconclusive', async () => {
@@ -418,37 +414,27 @@ describe('IssueDiscovery.vetIssue inconclusive downgrade', () => {
       data: { ...makeGhIssue(), comments: 3 },
     });
     // Make paginate throw (simulating API error)
-    mockOctokitInstance.paginate = vi.fn().mockRejectedValue(
-      new Error('Server error')
-    );
+    mockOctokitInstance.paginate = vi.fn().mockRejectedValue(new Error('Server error'));
 
     const candidate = await discovery.vetIssue('https://github.com/owner/repo/issues/42');
     expect(candidate.recommendation).toBe('needs_review');
-    expect(candidate.vettingResult.notes).toContainEqual(
-      expect.stringContaining('Could not verify claim status')
-    );
+    expect(candidate.vettingResult.notes).toContainEqual(expect.stringContaining('Could not verify claim status'));
   });
 
   it('should downgrade to needs_review when project health check fails', async () => {
     // Make repos.get throw (simulating API error)
-    mockOctokitInstance.repos.get.mockRejectedValue(
-      new Error('Not Found')
-    );
+    mockOctokitInstance.repos.get.mockRejectedValue(new Error('Not Found'));
 
     const candidate = await discovery.vetIssue('https://github.com/owner/repo/issues/42');
     expect(candidate.recommendation).toBe('needs_review');
-    expect(candidate.vettingResult.notes).toContainEqual(
-      expect.stringContaining('Could not verify project activity')
-    );
+    expect(candidate.vettingResult.notes).toContainEqual(expect.stringContaining('Could not verify project activity'));
   });
 
   it('should note unavailable quality bonus when health check fails', async () => {
     mockOctokitInstance.repos.get.mockRejectedValue(new Error('Not Found'));
 
     const candidate = await discovery.vetIssue('https://github.com/owner/repo/issues/42');
-    expect(candidate.vettingResult.notes).toContainEqual(
-      expect.stringContaining('Repo quality bonus unavailable')
-    );
+    expect(candidate.vettingResult.notes).toContainEqual(expect.stringContaining('Repo quality bonus unavailable'));
   });
 
   it('should populate stargazersCount and forksCount from checkProjectHealth', async () => {
@@ -467,25 +453,21 @@ describe('isLabelFarming', () => {
     html_url: 'https://github.com/spam/repo/issues/1',
     repository_url: 'https://api.github.com/repos/spam/repo',
     updated_at: '2026-01-01T00:00:00Z',
-    labels: labels.map(name => ({ name })),
+    labels: labels.map((name) => ({ name })),
   });
 
   it('should return false with 4 beginner labels', () => {
-    expect(isLabelFarming(makeItem([
-      'good first issue', 'hacktoberfest', 'easy', 'beginner',
-    ]))).toBe(false);
+    expect(isLabelFarming(makeItem(['good first issue', 'hacktoberfest', 'easy', 'beginner']))).toBe(false);
   });
 
   it('should return true with 5 beginner labels', () => {
-    expect(isLabelFarming(makeItem([
-      'good first issue', 'hacktoberfest', 'easy', 'beginner', 'starter',
-    ]))).toBe(true);
+    expect(isLabelFarming(makeItem(['good first issue', 'hacktoberfest', 'easy', 'beginner', 'starter']))).toBe(true);
   });
 
   it('should count only beginner labels, ignoring non-beginner labels', () => {
-    expect(isLabelFarming(makeItem([
-      'good first issue', 'hacktoberfest', 'bug', 'enhancement', 'easy', 'documentation',
-    ]))).toBe(false); // Only 3 beginner labels
+    expect(
+      isLabelFarming(makeItem(['good first issue', 'hacktoberfest', 'bug', 'enhancement', 'easy', 'documentation'])),
+    ).toBe(false); // Only 3 beginner labels
   });
 
   it('should handle string labels', () => {
@@ -508,9 +490,7 @@ describe('isLabelFarming', () => {
   });
 
   it('should be case-insensitive', () => {
-    expect(isLabelFarming(makeItem([
-      'Good First Issue', 'HACKTOBERFEST', 'Easy', 'Beginner', 'Starter',
-    ]))).toBe(true);
+    expect(isLabelFarming(makeItem(['Good First Issue', 'HACKTOBERFEST', 'Easy', 'Beginner', 'Starter']))).toBe(true);
   });
 });
 
@@ -571,7 +551,7 @@ describe('detectLabelFarmingRepos', () => {
     repository_url: `https://api.github.com/repos/${repo}`,
     updated_at: '2026-01-01T00:00:00Z',
     title: opts.title || 'Some issue',
-    labels: (opts.labels || []).map(name => ({ name })),
+    labels: (opts.labels || []).map((name) => ({ name })),
   });
 
   it('should flag repo with single issue having 5+ beginner labels', () => {
@@ -666,11 +646,11 @@ describe('calculateRepoQualityBonus', () => {
   });
 
   it('should handle exact boundary values', () => {
-    expect(calculateRepoQualityBonus(50, 0)).toBe(3);    // exactly 50 stars
-    expect(calculateRepoQualityBonus(500, 0)).toBe(5);   // exactly 500 stars
-    expect(calculateRepoQualityBonus(5000, 0)).toBe(8);  // exactly 5000 stars
-    expect(calculateRepoQualityBonus(0, 50)).toBe(2);    // exactly 50 forks
-    expect(calculateRepoQualityBonus(0, 500)).toBe(4);   // exactly 500 forks
+    expect(calculateRepoQualityBonus(50, 0)).toBe(3); // exactly 50 stars
+    expect(calculateRepoQualityBonus(500, 0)).toBe(5); // exactly 500 stars
+    expect(calculateRepoQualityBonus(5000, 0)).toBe(8); // exactly 5000 stars
+    expect(calculateRepoQualityBonus(0, 50)).toBe(2); // exactly 50 forks
+    expect(calculateRepoQualityBonus(0, 500)).toBe(4); // exactly 500 forks
   });
 
   it('should return 0 for zero stars and forks', () => {
@@ -712,16 +692,16 @@ describe('calculateViabilityScore with repoQualityBonus', () => {
     const recent = new Date();
     recent.setDate(recent.getDate() - 1);
     const score = discovery.calculateViabilityScore({
-      repoScore: 10,            // +20
+      repoScore: 10, // +20
       hasExistingPR: false,
       isClaimed: false,
-      clearRequirements: true,   // +15
+      clearRequirements: true, // +15
       hasContributionGuidelines: true, // +10
       issueUpdatedAt: recent.toISOString(), // +15
       closedWithoutMergeCount: 0,
       mergedPRCount: 0,
-      orgHasMergedPRs: true,     // +5
-      repoQualityBonus: 12,      // +12
+      orgHasMergedPRs: true, // +5
+      repoQualityBonus: 12, // +12
     });
     // 50 + 20 + 12 + 15 + 15 + 10 + 5 = 127, clamped to 100
     expect(score).toBe(100);
@@ -730,9 +710,9 @@ describe('calculateViabilityScore with repoQualityBonus', () => {
   it('should combine quality bonus with other bonuses and penalties', () => {
     const score = discovery.calculateViabilityScore({
       ...baseParams,
-      repoQualityBonus: 7,       // +7
-      clearRequirements: true,    // +15
-      isClaimed: true,            // -20
+      repoQualityBonus: 7, // +7
+      clearRequirements: true, // +15
+      isClaimed: true, // -20
     });
     // 50 + 7 + 15 - 20 = 52
     expect(score).toBe(52);
@@ -777,7 +757,7 @@ describe('isDocOnlyIssue (#105)', () => {
     html_url: 'https://github.com/owner/repo/issues/1',
     repository_url: 'https://api.github.com/repos/owner/repo',
     updated_at: '2026-01-01T00:00:00Z',
-    labels: labels.map(name => ({ name })),
+    labels: labels.map((name) => ({ name })),
   });
 
   it('should return true when ALL labels are doc-related', () => {
@@ -978,26 +958,25 @@ describe('aiPolicyBlocklist filtering in searchIssues (#108)', () => {
         issuesAndPullRequests: vi.fn().mockResolvedValue({
           data: {
             total_count: 2,
-            items: [
-              makeSearchItem('blocked/repo', 1),
-              makeSearchItem('allowed/repo', 2),
-            ],
+            items: [makeSearchItem('blocked/repo', 1), makeSearchItem('allowed/repo', 2)],
           },
         }),
       },
       issues: {
-        get: vi.fn().mockImplementation(({ owner, repo, issue_number }: any) => Promise.resolve({
-          data: {
-            id: issue_number,
-            html_url: `https://github.com/${owner}/${repo}/issues/${issue_number}`,
-            title: `Test issue ${issue_number}`,
-            labels: [{ name: 'good first issue' }],
-            created_at: new Date().toISOString(),
-            updated_at: new Date().toISOString(),
-            comments: 0,
-            body: `1. Step one\n2. Step two\nThis should work correctly.\n${'x'.repeat(200)}`,
-          },
-        })),
+        get: vi.fn().mockImplementation(({ owner, repo, issue_number }: any) =>
+          Promise.resolve({
+            data: {
+              id: issue_number,
+              html_url: `https://github.com/${owner}/${repo}/issues/${issue_number}`,
+              title: `Test issue ${issue_number}`,
+              labels: [{ name: 'good first issue' }],
+              created_at: new Date().toISOString(),
+              updated_at: new Date().toISOString(),
+              comments: 0,
+              body: `1. Step one\n2. Step two\nThis should work correctly.\n${'x'.repeat(200)}`,
+            },
+          }),
+        ),
         listEventsForTimeline: vi.fn().mockResolvedValue({ data: [] }),
       },
       repos: {
@@ -1019,7 +998,7 @@ describe('aiPolicyBlocklist filtering in searchIssues (#108)', () => {
 
   it('should filter out issues from blocklisted repos', async () => {
     const candidates = await discovery.searchIssues({ maxResults: 10 });
-    const repos = candidates.map(c => c.issue.repo);
+    const repos = candidates.map((c) => c.issue.repo);
     expect(repos).not.toContain('blocked/repo');
     expect(repos).toContain('allowed/repo');
   });
@@ -1029,7 +1008,7 @@ describe('aiPolicyBlocklist filtering in searchIssues (#108)', () => {
     discovery = new IssueDiscovery('fake-token');
 
     const candidates = await discovery.searchIssues({ maxResults: 10 });
-    const repos = candidates.map(c => c.issue.repo);
+    const repos = candidates.map((c) => c.issue.repo);
     expect(repos).toContain('blocked/repo');
     expect(repos).toContain('allowed/repo');
   });
@@ -1039,7 +1018,7 @@ describe('aiPolicyBlocklist filtering in searchIssues (#108)', () => {
     discovery = new IssueDiscovery('fake-token');
 
     const candidates = await discovery.searchIssues({ maxResults: 10 });
-    const repos = candidates.map(c => c.issue.repo);
+    const repos = candidates.map((c) => c.issue.repo);
     // Neither test repo is in DEFAULT_CONFIG.aiPolicyBlocklist (['matplotlib/matplotlib']), so both pass through
     expect(repos).toContain('blocked/repo');
     expect(repos).toContain('allowed/repo');
@@ -1051,16 +1030,13 @@ describe('aiPolicyBlocklist filtering in searchIssues (#108)', () => {
     mockOctokitInstance.search.issuesAndPullRequests.mockResolvedValue({
       data: {
         total_count: 2,
-        items: [
-          makeSearchItem('matplotlib/matplotlib', 1),
-          makeSearchItem('allowed/repo', 2),
-        ],
+        items: [makeSearchItem('matplotlib/matplotlib', 1), makeSearchItem('allowed/repo', 2)],
       },
     });
     discovery = new IssueDiscovery('fake-token');
 
     const candidates = await discovery.searchIssues({ maxResults: 10 });
-    const repos = candidates.map(c => c.issue.repo);
+    const repos = candidates.map((c) => c.issue.repo);
     expect(repos).not.toContain('matplotlib/matplotlib');
     expect(repos).toContain('allowed/repo');
   });

--- a/src/core/issue-discovery.ts
+++ b/src/core/issue-discovery.ts
@@ -10,14 +10,7 @@ import { getOctokit, checkRateLimit } from './github.js';
 import { getStateManager } from './state.js';
 import { paginateAll } from './pagination.js';
 import { parseGitHubUrl, daysBetween, getDataDir } from './utils.js';
-import {
-  TrackedIssue,
-  IssueVettingResult,
-  ContributionGuidelines,
-  ProjectHealth,
-  RepoScore,
-  DEFAULT_CONFIG,
-} from './types.js';
+import { TrackedIssue, IssueVettingResult, ContributionGuidelines, ProjectHealth, DEFAULT_CONFIG } from './types.js';
 import { ValidationError } from './errors.js';
 
 // Concurrency limit for parallel API calls
@@ -70,8 +63,7 @@ function pruneCache(): void {
 
   // Then, if still over size limit, remove oldest entries
   if (guidelinesCache.size > CACHE_MAX_SIZE) {
-    const entries = Array.from(guidelinesCache.entries())
-      .sort((a, b) => a[1].fetchedAt - b[1].fetchedAt);
+    const entries = Array.from(guidelinesCache.entries()).sort((a, b) => a[1].fetchedAt - b[1].fetchedAt);
 
     const toRemove = entries.slice(0, guidelinesCache.size - CACHE_MAX_SIZE);
     for (const [key] of toRemove) {
@@ -81,12 +73,7 @@ function pruneCache(): void {
 }
 
 /** Labels that indicate documentation-only issues (#105). */
-export const DOC_ONLY_LABELS = new Set([
-  'documentation',
-  'docs',
-  'typo',
-  'spelling',
-]);
+export const DOC_ONLY_LABELS = new Set(['documentation', 'docs', 'typo', 'spelling']);
 
 /**
  * Check if an issue's labels are ALL documentation-related (#105).
@@ -95,13 +82,11 @@ export const DOC_ONLY_LABELS = new Set([
  */
 export function isDocOnlyIssue(item: GitHubSearchItem): boolean {
   if (!item.labels || !Array.isArray(item.labels) || item.labels.length === 0) return false;
-  const labelNames = item.labels.map(l =>
-    (typeof l === 'string' ? l : l.name || '').toLowerCase()
-  );
+  const labelNames = item.labels.map((l) => (typeof l === 'string' ? l : l.name || '').toLowerCase());
   // Filter out empty label names before checking
-  const nonEmptyLabels = labelNames.filter(n => n.length > 0);
+  const nonEmptyLabels = labelNames.filter((n) => n.length > 0);
   if (nonEmptyLabels.length === 0) return false;
-  return nonEmptyLabels.every(n => DOC_ONLY_LABELS.has(n));
+  return nonEmptyLabels.every((n) => DOC_ONLY_LABELS.has(n));
 }
 
 /**
@@ -143,10 +128,8 @@ export const BEGINNER_LABELS = new Set([
 /** Check if a single issue has an excessive number of beginner labels (>= 5). */
 export function isLabelFarming(item: GitHubSearchItem): boolean {
   if (!item.labels || !Array.isArray(item.labels)) return false;
-  const labelNames = item.labels.map(l =>
-    (typeof l === 'string' ? l : l.name || '').toLowerCase()
-  );
-  const beginnerCount = labelNames.filter(n => BEGINNER_LABELS.has(n)).length;
+  const labelNames = item.labels.map((l) => (typeof l === 'string' ? l : l.name || '').toLowerCase());
+  const beginnerCount = labelNames.filter((n) => BEGINNER_LABELS.has(n)).length;
   return beginnerCount >= 5;
 }
 
@@ -156,7 +139,9 @@ export function hasTemplatedTitle(title: string): boolean {
   // Matches "<anything> <category-noun> <number>" where category nouns are typical
   // of mass-created templated issues. This avoids false positives on legitimate titles
   // like "Add support for Python 3" or "Implement RFC 7231" which lack category nouns.
-  return /^.+\s+(question|fact|point|item|task|entry|post|challenge|exercise|example|problem|tip|recipe|snippet)\s+#?\d+$/i.test(title);
+  return /^.+\s+(question|fact|point|item|task|entry|post|challenge|exercise|example|problem|tip|recipe|snippet)\s+#?\d+$/i.test(
+    title,
+  );
 }
 
 /**
@@ -241,12 +226,9 @@ export class IssueDiscovery {
 
     try {
       // Paginate through all starred repos (up to 500 to avoid excessive API calls)
-      const iterator = this.octokit.paginate.iterator(
-        this.octokit.activity.listReposStarredByAuthenticatedUser,
-        {
-          per_page: 100,
-        }
-      );
+      const iterator = this.octokit.paginate.iterator(this.octokit.activity.listReposStarredByAuthenticatedUser, {
+        per_page: 100,
+      });
 
       let pageCount = 0;
       for await (const { data: repos } of iterator) {
@@ -284,13 +266,13 @@ export class IssueDiscovery {
       if (cachedRepos.length === 0) {
         console.warn(
           `[STARRED_REPOS_FETCH_FAILED] Failed to fetch starred repositories from GitHub API. ` +
-          `No cached repos available. Error: ${errorMessage}\n` +
-          `Tip: Ensure your GITHUB_TOKEN has the 'read:user' scope and try again.`
+            `No cached repos available. Error: ${errorMessage}\n` +
+            `Tip: Ensure your GITHUB_TOKEN has the 'read:user' scope and try again.`,
         );
       } else {
         console.warn(
           `[STARRED_REPOS_FETCH_FAILED] Failed to fetch starred repositories from GitHub API. ` +
-          `Using ${cachedRepos.length} cached repos instead. Error: ${errorMessage}`
+            `Using ${cachedRepos.length} cached repos instead. Error: ${errorMessage}`,
         );
       }
       return cachedRepos;
@@ -312,11 +294,13 @@ export class IssueDiscovery {
    * Searches in priority order: merged-PR repos first (no label filter), then starred repos, then general.
    * Filters out issues from low-scoring and excluded repos.
    */
-  async searchIssues(options: {
-    languages?: string[];
-    labels?: string[];
-    maxResults?: number;
-  } = {}): Promise<IssueCandidate[]> {
+  async searchIssues(
+    options: {
+      languages?: string[];
+      labels?: string[];
+      maxResults?: number;
+    } = {},
+  ): Promise<IssueCandidate[]> {
     const config = this.stateManager.getState().config;
     const languages = options.languages || config.languages;
     const labels = options.labels || config.labels;
@@ -333,8 +317,7 @@ export class IssueDiscovery {
       const rateLimit = await checkRateLimit(this.githubToken);
       if (rateLimit.remaining < 5) {
         const resetTime = new Date(rateLimit.resetAt).toLocaleTimeString('en-US', { hour12: false });
-        this.rateLimitWarning =
-          `GitHub search API quota low (${rateLimit.remaining}/${rateLimit.limit} remaining, resets at ${resetTime}). Search may be slow.`;
+        this.rateLimitWarning = `GitHub search API quota low (${rateLimit.remaining}/${rateLimit.limit} remaining, resets at ${resetTime}). Search may be slow.`;
         console.warn(this.rateLimitWarning);
       }
     } catch (error) {
@@ -361,14 +344,14 @@ export class IssueDiscovery {
     const lowScoringRepos = new Set(this.stateManager.getLowScoringRepos(3)); // Score <= 3 is low
 
     // Common filters
-    const trackedUrls = new Set(this.stateManager.getState().activeIssues.map(i => i.url));
+    const trackedUrls = new Set(this.stateManager.getState().activeIssues.map((i) => i.url));
     const excludedRepos = new Set(config.excludeRepos);
     const maxAgeDays = config.maxIssueAgeDays || 90;
     const now = new Date();
 
     // Build query parts
-    const labelQuery = labels.map(l => `label:"${l}"`).join(' ');
-    const langQuery = languages.map(l => `language:${l}`).join(' ');
+    const labelQuery = labels.map((l) => `label:"${l}"`).join(' ');
+    const langQuery = languages.map((l) => `language:${l}`).join(' ');
     // Phase 0 uses a broader query — established contributors don't need beginner labels
     const establishedQuery = `is:issue is:open ${langQuery} no:assignee`;
     // Phases 1+ use label-filtered query for discovery in unfamiliar repos
@@ -378,10 +361,12 @@ export class IssueDiscovery {
     const includeDocIssues = config.includeDocIssues ?? true;
     const aiBlocklisted = new Set(config.aiPolicyBlocklist ?? DEFAULT_CONFIG.aiPolicyBlocklist ?? []);
     if (aiBlocklisted.size > 0) {
-      console.log(`[AI_POLICY_FILTER] Filtering issues from ${aiBlocklisted.size} blocklisted repo(s): ${[...aiBlocklisted].join(', ')}`);
+      console.log(
+        `[AI_POLICY_FILTER] Filtering issues from ${aiBlocklisted.size} blocklisted repo(s): ${[...aiBlocklisted].join(', ')}`,
+      );
     }
     const filterIssues = (items: GitHubSearchItem[]) => {
-      return items.filter(item => {
+      return items.filter((item) => {
         if (trackedUrls.has(item.html_url)) return false;
         const repoFullName = item.repository_url.split('/').slice(-2).join('/');
         if (excludedRepos.has(repoFullName)) return false;
@@ -402,29 +387,26 @@ export class IssueDiscovery {
     // Phase 0: Search repos where user has merged PRs + open-PR repos (highest merge probability)
     // Uses broader query — established contributors don't need "good first issue" labels
     // Merged-PR repos come first, then open-PR repos fill remaining slots (capped at 10 total)
-    const phase0Repos = [
-      ...mergedPRRepos,
-      ...openPRRepos.filter(r => !mergedPRRepoSet.has(r)),
-    ].slice(0, 10);
+    const phase0Repos = [...mergedPRRepos, ...openPRRepos.filter((r) => !mergedPRRepoSet.has(r))].slice(0, 10);
     const phase0RepoSet = new Set(phase0Repos);
 
     if (phase0Repos.length > 0) {
       const mergedInPhase0 = Math.min(mergedPRRepos.length, phase0Repos.length);
       const openInPhase0 = phase0Repos.length - mergedInPhase0;
-      console.log(`Phase 0: Searching issues in ${phase0Repos.length} repos (${mergedInPhase0} merged-PR, ${openInPhase0} open-PR, no label filter)...`);
+      console.log(
+        `Phase 0: Searching issues in ${phase0Repos.length} repos (${mergedInPhase0} merged-PR, ${openInPhase0} open-PR, no label filter)...`,
+      );
 
       // Phase 0a: merged-PR repos (priority: merged_pr)
       const mergedPhase0Repos = phase0Repos.slice(0, mergedInPhase0);
       if (mergedPhase0Repos.length > 0) {
         const remainingNeeded = maxResults - allCandidates.length;
         if (remainingNeeded > 0) {
-          const { candidates: mergedCandidates, allBatchesFailed, rateLimitHit } = await this.searchInRepos(
-            mergedPhase0Repos,
-            establishedQuery,
-            remainingNeeded,
-            'merged_pr',
-            filterIssues
-          );
+          const {
+            candidates: mergedCandidates,
+            allBatchesFailed,
+            rateLimitHit,
+          } = await this.searchInRepos(mergedPhase0Repos, establishedQuery, remainingNeeded, 'merged_pr', filterIssues);
           allCandidates.push(...mergedCandidates);
           if (allBatchesFailed) {
             phase0Error = 'All merged-PR repo batches failed';
@@ -441,13 +423,11 @@ export class IssueDiscovery {
       if (openPhase0Repos.length > 0 && allCandidates.length < maxResults) {
         const remainingNeeded = maxResults - allCandidates.length;
         if (remainingNeeded > 0) {
-          const { candidates: openCandidates, allBatchesFailed, rateLimitHit } = await this.searchInRepos(
-            openPhase0Repos,
-            establishedQuery,
-            remainingNeeded,
-            'starred',
-            filterIssues
-          );
+          const {
+            candidates: openCandidates,
+            allBatchesFailed,
+            rateLimitHit,
+          } = await this.searchInRepos(openPhase0Repos, establishedQuery, remainingNeeded, 'starred', filterIssues);
           allCandidates.push(...openCandidates);
           if (allBatchesFailed) {
             const msg = 'All open-PR repo batches failed';
@@ -463,18 +443,16 @@ export class IssueDiscovery {
 
     // Phase 1: Search starred repos (filter out already-searched Phase 0 repos)
     if (allCandidates.length < maxResults && starredRepos.length > 0) {
-      const reposToSearch = starredRepos.filter(r => !phase0RepoSet.has(r));
+      const reposToSearch = starredRepos.filter((r) => !phase0RepoSet.has(r));
       if (reposToSearch.length > 0) {
         console.log(`Phase 1: Searching issues in ${reposToSearch.length} starred repos...`);
         const remainingNeeded = maxResults - allCandidates.length;
         if (remainingNeeded > 0) {
-          const { candidates: starredCandidates, allBatchesFailed, rateLimitHit } = await this.searchInRepos(
-            reposToSearch.slice(0, 10),
-            baseQuery,
-            remainingNeeded,
-            'starred',
-            filterIssues
-          );
+          const {
+            candidates: starredCandidates,
+            allBatchesFailed,
+            rateLimitHit,
+          } = await this.searchInRepos(reposToSearch.slice(0, 10), baseQuery, remainingNeeded, 'starred', filterIssues);
           allCandidates.push(...starredCandidates);
           if (allBatchesFailed) {
             phase1Error = 'All starred repo batches failed';
@@ -505,38 +483,44 @@ export class IssueDiscovery {
         // Detect and filter label-farming repos (#97)
         const spamRepos = detectLabelFarmingRepos(data.items);
         if (spamRepos.size > 0) {
-          const spamCount = data.items.filter(i =>
-            spamRepos.has(i.repository_url.split('/').slice(-2).join('/'))
+          const spamCount = data.items.filter((i) =>
+            spamRepos.has(i.repository_url.split('/').slice(-2).join('/')),
           ).length;
           console.log(
-            `[SPAM_FILTER] Filtered ${spamCount} issues from ${spamRepos.size} label-farming repos: ${[...spamRepos].join(', ')}`
+            `[SPAM_FILTER] Filtered ${spamCount} issues from ${spamRepos.size} label-farming repos: ${[...spamRepos].join(', ')}`,
           );
         }
 
         // Filter and exclude already-found repos
-        const seenRepos = new Set(allCandidates.map(c => c.issue.repo));
+        const seenRepos = new Set(allCandidates.map((c) => c.issue.repo));
         const itemsToVet = filterIssues(data.items)
-          .filter(item => {
+          .filter((item) => {
             const repoFullName = item.repository_url.split('/').slice(-2).join('/');
             return !spamRepos.has(repoFullName);
           })
-          .filter(item => {
+          .filter((item) => {
             const repoFullName = item.repository_url.split('/').slice(-2).join('/');
             // Skip if already searched in earlier phases
-            return !phase0RepoSet.has(repoFullName) && !starredRepoSet.has(repoFullName) && !seenRepos.has(repoFullName);
+            return (
+              !phase0RepoSet.has(repoFullName) && !starredRepoSet.has(repoFullName) && !seenRepos.has(repoFullName)
+            );
           })
           .slice(0, remainingNeeded * 2);
 
-        const { candidates: results, allFailed: allVetFailed, rateLimitHit: vetRateLimitHit } = await this.vetIssuesParallel(
-          itemsToVet.map(i => i.html_url),
+        const {
+          candidates: results,
+          allFailed: allVetFailed,
+          rateLimitHit: vetRateLimitHit,
+        } = await this.vetIssuesParallel(
+          itemsToVet.map((i) => i.html_url),
           remainingNeeded,
-          'normal'
+          'normal',
         );
 
         // Apply minStars filter to Phase 2 results (#105)
         // Phase 0/1 are exempt — if you've already contributed to or starred a repo, star count is irrelevant.
         const minStars = config.minStars ?? 50;
-        const starFiltered = results.filter(c => {
+        const starFiltered = results.filter((c) => {
           if (c.projectHealth.checkFailed) return true; // Don't penalize repos we couldn't check
           const stars = c.projectHealth.stargazersCount ?? 0;
           return stars >= minStars;
@@ -570,15 +554,13 @@ export class IssueDiscovery {
         phase1Error ? `Phase 1 (starred repos): ${phase1Error}` : null,
         phase2Error ? `Phase 2 (general): ${phase2Error}` : null,
       ].filter(Boolean);
-      const details = phaseErrors.length > 0
-        ? ` ${phaseErrors.join('. ')}.`
-        : '';
+      const details = phaseErrors.length > 0 ? ` ${phaseErrors.join('. ')}.` : '';
       const rateLimitContext = rateLimitHitDuringSearch
         ? ' GitHub API rate limits may have affected results — try again after the rate limit resets.'
         : '';
       throw new ValidationError(
         `No issue candidates found across all search phases.${details}${rateLimitContext} ` +
-        'Try adjusting your search criteria (languages, labels) or check your network connection.'
+          'Try adjusting your search criteria (languages, labels) or check your network connection.',
       );
     }
 
@@ -639,7 +621,7 @@ export class IssueDiscovery {
     baseQuery: string,
     maxResults: number,
     priority: SearchPriority,
-    filterFn: (items: GitHubSearchItem[]) => GitHubSearchItem[]
+    filterFn: (items: GitHubSearchItem[]) => GitHubSearchItem[],
   ): Promise<{ candidates: IssueCandidate[]; allBatchesFailed: boolean; rateLimitHit: boolean }> {
     const candidates: IssueCandidate[] = [];
 
@@ -657,7 +639,7 @@ export class IssueDiscovery {
 
       try {
         // Build repo filter: (repo:a OR repo:b OR repo:c)
-        const repoFilter = batch.map(r => `repo:${r}`).join(' OR ');
+        const repoFilter = batch.map((r) => `repo:${r}`).join(' OR ');
         const batchQuery = `${baseQuery} (${repoFilter})`;
 
         const { data } = await this.octokit.search.issuesAndPullRequests({
@@ -671,9 +653,9 @@ export class IssueDiscovery {
           const filtered = filterFn(data.items);
           const remainingNeeded = maxResults - candidates.length;
           const { candidates: vetted } = await this.vetIssuesParallel(
-            filtered.slice(0, remainingNeeded * 2).map(i => i.html_url),
+            filtered.slice(0, remainingNeeded * 2).map((i) => i.html_url),
             remainingNeeded,
-            priority
+            priority,
           );
           candidates.push(...vetted);
         }
@@ -683,7 +665,10 @@ export class IssueDiscovery {
           rateLimitFailures++;
         }
         const batchRepos = batch.join(', ');
-        console.error(`Error searching issues in batch [${batchRepos}]:`, error instanceof Error ? error.message : error);
+        console.error(
+          `Error searching issues in batch [${batchRepos}]:`,
+          error instanceof Error ? error.message : error,
+        );
       }
     }
 
@@ -692,7 +677,7 @@ export class IssueDiscovery {
     if (allBatchesFailed) {
       console.error(
         `[SEARCH_PHASE_ALL_BATCHES_FAILED] All ${batches.length} batch(es) failed for ${priority} phase. ` +
-        `This may indicate a systemic issue (rate limit, auth, network).`
+          `This may indicate a systemic issue (rate limit, auth, network).`,
       );
     }
 
@@ -719,7 +704,7 @@ export class IssueDiscovery {
   private async vetIssuesParallel(
     urls: string[],
     maxResults: number,
-    priority?: SearchPriority
+    priority?: SearchPriority,
   ): Promise<{ candidates: IssueCandidate[]; allFailed: boolean; rateLimitHit: boolean }> {
     const candidates: IssueCandidate[] = [];
     const pending: Promise<void>[] = [];
@@ -732,7 +717,7 @@ export class IssueDiscovery {
       attemptedCount++;
 
       const task = this.vetIssue(url)
-        .then(candidate => {
+        .then((candidate) => {
           if (candidates.length < maxResults) {
             // Override the priority if provided
             if (priority) {
@@ -741,7 +726,7 @@ export class IssueDiscovery {
             candidates.push(candidate);
           }
         })
-        .catch(error => {
+        .catch((error) => {
           failedVettingCount++;
           if (IssueDiscovery.isRateLimitError(error)) {
             rateLimitFailures++;
@@ -754,9 +739,7 @@ export class IssueDiscovery {
       // Limit concurrency
       if (pending.length >= MAX_CONCURRENT_REQUESTS) {
         // Wait for at least one to complete, then remove it
-        const completed = await Promise.race(
-          pending.map((p, i) => p.then(() => i))
-        );
+        const completed = await Promise.race(pending.map((p, i) => p.then(() => i)));
         pending.splice(completed, 1);
       }
     }
@@ -768,7 +751,7 @@ export class IssueDiscovery {
     if (allFailed) {
       console.error(
         `[VET_ISSUES_ALL_FAILED] All ${attemptedCount} issue(s) failed vetting. ` +
-        `This may indicate a systemic issue (rate limit, auth, network).`
+          `This may indicate a systemic issue (rate limit, auth, network).`,
       );
     }
 
@@ -851,7 +834,7 @@ export class IssueDiscovery {
       number,
       title: ghIssue.title,
       status: 'candidate',
-      labels: ghIssue.labels.map(l => (typeof l === 'string' ? l : l.name || '')),
+      labels: ghIssue.labels.map((l) => (typeof l === 'string' ? l : l.name || '')),
       createdAt: ghIssue.created_at,
       updatedAt: ghIssue.updated_at,
       vetted: true,
@@ -877,7 +860,9 @@ export class IssueDiscovery {
     const config = this.stateManager.getState().config;
     const repoScoreRecord = this.stateManager.getRepoScore(repoFullName);
     if (repoScoreRecord && repoScoreRecord.mergedPRCount > 0) {
-      reasonsToApprove.push(`Trusted project (${repoScoreRecord.mergedPRCount} PR${repoScoreRecord.mergedPRCount > 1 ? 's' : ''} merged)`);
+      reasonsToApprove.push(
+        `Trusted project (${repoScoreRecord.mergedPRCount} PR${repoScoreRecord.mergedPRCount > 1 ? 's' : ''} merged)`,
+      );
     } else if (config.trustedProjects.includes(repoFullName)) {
       reasonsToApprove.push('Trusted project (previous PR merged)');
     }
@@ -887,7 +872,9 @@ export class IssueDiscovery {
       if (repoScoreRecord.closedWithoutMergeCount > 0 && repoScoreRecord.mergedPRCount === 0) {
         reasonsToSkip.push('User has rejected PR(s) in this repo with no successful merges');
       } else if (repoScoreRecord.closedWithoutMergeCount > 0 && repoScoreRecord.mergedPRCount > 0) {
-        vettingResult.notes.push(`Mixed history: ${repoScoreRecord.mergedPRCount} merged, ${repoScoreRecord.closedWithoutMergeCount} closed without merge`);
+        vettingResult.notes.push(
+          `Mixed history: ${repoScoreRecord.mergedPRCount} merged, ${repoScoreRecord.closedWithoutMergeCount} closed without merge`,
+        );
       }
     }
 
@@ -895,8 +882,9 @@ export class IssueDiscovery {
     const orgName = repoFullName.split('/')[0];
     let orgHasMergedPRs = false;
     if (orgName && repoFullName.includes('/')) {
-      orgHasMergedPRs = Object.values(this.stateManager.getState().repoScores)
-        .some(rs => rs.repo && rs.mergedPRCount > 0 && rs.repo.startsWith(orgName + '/') && rs.repo !== repoFullName);
+      orgHasMergedPRs = Object.values(this.stateManager.getState().repoScores).some(
+        (rs) => rs.repo && rs.mergedPRCount > 0 && rs.repo.startsWith(orgName + '/') && rs.repo !== repoFullName,
+      );
     }
     if (orgHasMergedPRs) {
       reasonsToApprove.push(`Org affinity (merged PRs in other ${orgName} repos)`);
@@ -972,25 +960,27 @@ export class IssueDiscovery {
       });
 
       // Also check timeline for linked PRs
-      const timeline = await paginateAll((page) => this.octokit.issues.listEventsForTimeline({
-        owner,
-        repo,
-        issue_number: issueNumber,
-        per_page: 100,
-        page,
-      }));
-
-      const linkedPRs = timeline.filter(
-        (event) => {
-          const e = event as { event?: string; source?: { issue?: { pull_request?: unknown } } };
-          return e.event === 'cross-referenced' && e.source?.issue?.pull_request;
-        }
+      const timeline = await paginateAll((page) =>
+        this.octokit.issues.listEventsForTimeline({
+          owner,
+          repo,
+          issue_number: issueNumber,
+          per_page: 100,
+          page,
+        }),
       );
+
+      const linkedPRs = timeline.filter((event) => {
+        const e = event as { event?: string; source?: { issue?: { pull_request?: unknown } } };
+        return e.event === 'cross-referenced' && e.source?.issue?.pull_request;
+      });
 
       return { passed: data.total_count === 0 && linkedPRs.length === 0 };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
-      console.warn(`[CHECK_NO_EXISTING_PR] Failed to check for existing PRs on ${owner}/${repo}#${issueNumber}: ${errorMessage}. Assuming no existing PR.`);
+      console.warn(
+        `[CHECK_NO_EXISTING_PR] Failed to check for existing PRs on ${owner}/${repo}#${issueNumber}: ${errorMessage}. Assuming no existing PR.`,
+      );
       return { passed: true, inconclusive: true, reason: errorMessage };
     }
   }
@@ -999,7 +989,7 @@ export class IssueDiscovery {
     owner: string,
     repo: string,
     issueNumber: number,
-    commentCount: number
+    commentCount: number,
   ): Promise<CheckResult> {
     if (commentCount === 0) return { passed: true };
 
@@ -1013,7 +1003,7 @@ export class IssueDiscovery {
           issue_number: issueNumber,
           per_page: 100,
         },
-        (response) => response.data
+        (response) => response.data,
       );
 
       // Limit to last 100 comments to avoid excessive processing
@@ -1021,18 +1011,18 @@ export class IssueDiscovery {
 
       // Look for claiming phrases
       const claimPhrases = [
-        'i\'m working on this',
+        "i'm working on this",
         'i am working on this',
-        'i\'ll take this',
+        "i'll take this",
         'i will take this',
         'working on it',
-        'i\'d like to work on',
+        "i'd like to work on",
         'i would like to work on',
         'can i work on',
         'may i work on',
         'assigned to me',
-        'i\'m on it',
-        'i\'ll submit a pr',
+        "i'm on it",
+        "i'll submit a pr",
         'i will submit a pr',
         'working on a fix',
         'working on a pr',
@@ -1040,7 +1030,7 @@ export class IssueDiscovery {
 
       for (const comment of recentComments) {
         const body = (comment.body || '').toLowerCase();
-        if (claimPhrases.some(phrase => body.includes(phrase))) {
+        if (claimPhrases.some((phrase) => body.includes(phrase))) {
           return { passed: false };
         }
       }
@@ -1048,7 +1038,9 @@ export class IssueDiscovery {
       return { passed: true };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
-      console.warn(`[CHECK_NOT_CLAIMED] Failed to check claim status on ${owner}/${repo}#${issueNumber}: ${errorMessage}. Assuming not claimed.`);
+      console.warn(
+        `[CHECK_NOT_CLAIMED] Failed to check claim status on ${owner}/${repo}#${issueNumber}: ${errorMessage}. Assuming not claimed.`,
+      );
       return { passed: true, inconclusive: true, reason: errorMessage };
     }
   }
@@ -1082,7 +1074,9 @@ export class IssueDiscovery {
         }
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
-        console.warn(`[CHECK_CI_STATUS] Failed to check CI status for ${owner}/${repo}: ${errorMessage}. Defaulting to unknown.`);
+        console.warn(
+          `[CHECK_CI_STATUS] Failed to check CI status for ${owner}/${repo}: ${errorMessage}. Defaulting to unknown.`,
+        );
       }
 
       return {
@@ -1113,24 +1107,16 @@ export class IssueDiscovery {
     }
   }
 
-  private async fetchContributionGuidelines(
-    owner: string,
-    repo: string
-  ): Promise<ContributionGuidelines | undefined> {
+  private async fetchContributionGuidelines(owner: string, repo: string): Promise<ContributionGuidelines | undefined> {
     const cacheKey = `${owner}/${repo}`;
 
     // Check cache first
     const cached = guidelinesCache.get(cacheKey);
-    if (cached && (Date.now() - cached.fetchedAt) < CACHE_TTL_MS) {
+    if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
       return cached.guidelines;
     }
 
-    const filesToCheck = [
-      'CONTRIBUTING.md',
-      '.github/CONTRIBUTING.md',
-      'docs/CONTRIBUTING.md',
-      'contributing.md',
-    ];
+    const filesToCheck = ['CONTRIBUTING.md', '.github/CONTRIBUTING.md', 'docs/CONTRIBUTING.md', 'contributing.md'];
 
     for (const file of filesToCheck) {
       try {
@@ -1383,9 +1369,9 @@ ${Object.entries(vettingResult.checks)
 - CI status: ${projectHealth.ciStatus}
 
 ### Recommendation: **${recommendation.toUpperCase()}**
-${reasonsToApprove.length > 0 ? `\n**Reasons to approve:**\n${reasonsToApprove.map(r => `- ${r}`).join('\n')}` : ''}
-${reasonsToSkip.length > 0 ? `\n**Reasons to skip:**\n${reasonsToSkip.map(r => `- ${r}`).join('\n')}` : ''}
-${vettingResult.notes.length > 0 ? `\n**Notes:**\n${vettingResult.notes.map(n => `- ${n}`).join('\n')}` : ''}
+${reasonsToApprove.length > 0 ? `\n**Reasons to approve:**\n${reasonsToApprove.map((r) => `- ${r}`).join('\n')}` : ''}
+${reasonsToSkip.length > 0 ? `\n**Reasons to skip:**\n${reasonsToSkip.map((r) => `- ${r}`).join('\n')}` : ''}
+${vettingResult.notes.length > 0 ? `\n**Notes:**\n${vettingResult.notes.map((n) => `- ${n}`).join('\n')}` : ''}
 `;
   }
 }

--- a/src/core/logger.test.ts
+++ b/src/core/logger.test.ts
@@ -106,7 +106,9 @@ describe('logger', () => {
       loggerModule.enableDebug();
       const err = new Error('boom');
       await expect(
-        loggerModule.timed('mod', 'op', async () => { throw err; })
+        loggerModule.timed('mod', 'op', async () => {
+          throw err;
+        }),
       ).rejects.toThrow('boom');
       expect(consoleErrorSpy).toHaveBeenCalled();
       const output = consoleErrorSpy.mock.calls[0][0] as string;
@@ -117,7 +119,9 @@ describe('logger', () => {
     it('should re-throw on error without logging when debug is disabled', async () => {
       const err = new Error('boom');
       await expect(
-        loggerModule.timed('mod', 'op', async () => { throw err; })
+        loggerModule.timed('mod', 'op', async () => {
+          throw err;
+        }),
       ).rejects.toThrow('boom');
       expect(consoleErrorSpy).not.toHaveBeenCalled();
     });

--- a/src/core/pagination.test.ts
+++ b/src/core/pagination.test.ts
@@ -16,9 +16,7 @@ describe('paginateAll', () => {
     const page1 = Array.from({ length: 100 }, (_, i) => i);
     const page2 = Array.from({ length: 50 }, (_, i) => i + 100);
 
-    const fetchPage = vi.fn()
-      .mockResolvedValueOnce({ data: page1 })
-      .mockResolvedValueOnce({ data: page2 });
+    const fetchPage = vi.fn().mockResolvedValueOnce({ data: page1 }).mockResolvedValueOnce({ data: page2 });
 
     const result = await paginateAll(fetchPage, 100);
 
@@ -56,7 +54,8 @@ describe('paginateAll', () => {
     const page2 = [{ id: 3 }, { id: 4 }];
     const page3 = [{ id: 5 }];
 
-    const fetchPage = vi.fn()
+    const fetchPage = vi
+      .fn()
       .mockResolvedValueOnce({ data: page1 })
       .mockResolvedValueOnce({ data: page2 })
       .mockResolvedValueOnce({ data: page3 });

--- a/src/core/pr-monitor.test.ts
+++ b/src/core/pr-monitor.test.ts
@@ -18,7 +18,14 @@ vi.mock('./state.js', () => ({
 }));
 
 // Import after mocks are set up
-const { PRMonitor, computeDisplayLabel, classifyCICheck, classifyFailingChecks, isBotAuthor, isConditionalChecklistItem } = await import('./pr-monitor.js');
+const {
+  PRMonitor,
+  computeDisplayLabel,
+  classifyCICheck,
+  classifyFailingChecks,
+  isBotAuthor,
+  isConditionalChecklistItem,
+} = await import('./pr-monitor.js');
 const { isAcknowledgmentComment } = await import('./comment-utils.js');
 const { getStateManager } = await import('./state.js');
 
@@ -197,16 +204,16 @@ describe('PRMonitor changes_addressed detection', () => {
   it('should return changes_addressed when commit is newer than maintainer comment', () => {
     const monitor = new PRMonitor('fake-token');
     const result = (monitor as any).determineStatus(
-      'passing',        // ciStatus
-      false,            // hasMergeConflict
-      true,             // hasUnrespondedComment
-      false,            // hasIncompleteChecklist
+      'passing', // ciStatus
+      false, // hasMergeConflict
+      true, // hasUnrespondedComment
+      false, // hasIncompleteChecklist
       'changes_requested', // reviewDecision
-      2,                // daysSinceActivity
-      30,               // dormantThreshold
-      25,               // approachingThreshold
-      '2026-02-08T12:00:00Z',  // latestCommitDate (newer)
-      '2026-02-07T10:00:00Z'   // lastMaintainerCommentDate (older)
+      2, // daysSinceActivity
+      30, // dormantThreshold
+      25, // approachingThreshold
+      '2026-02-08T12:00:00Z', // latestCommitDate (newer)
+      '2026-02-07T10:00:00Z', // lastMaintainerCommentDate (older)
     );
 
     expect(result).toBe('changes_addressed');
@@ -217,14 +224,14 @@ describe('PRMonitor changes_addressed detection', () => {
     const result = (monitor as any).determineStatus(
       'passing',
       false,
-      true,             // hasUnrespondedComment
+      true, // hasUnrespondedComment
       false,
       'changes_requested',
       2,
       30,
       25,
-      '2026-02-06T10:00:00Z',  // latestCommitDate (older)
-      '2026-02-07T10:00:00Z'   // lastMaintainerCommentDate (newer)
+      '2026-02-06T10:00:00Z', // latestCommitDate (older)
+      '2026-02-07T10:00:00Z', // lastMaintainerCommentDate (newer)
     );
 
     expect(result).toBe('needs_response');
@@ -235,14 +242,14 @@ describe('PRMonitor changes_addressed detection', () => {
     const result = (monitor as any).determineStatus(
       'passing',
       false,
-      true,             // hasUnrespondedComment
+      true, // hasUnrespondedComment
       false,
       'changes_requested',
       2,
       30,
       25,
-      undefined,               // latestCommitDate (missing)
-      '2026-02-07T10:00:00Z'  // lastMaintainerCommentDate
+      undefined, // latestCommitDate (missing)
+      '2026-02-07T10:00:00Z', // lastMaintainerCommentDate
     );
 
     expect(result).toBe('needs_response');
@@ -253,15 +260,15 @@ describe('PRMonitor changes_addressed detection', () => {
     const result = (monitor as any).determineStatus(
       'passing',
       false,
-      false,            // hasUnrespondedComment = false
+      false, // hasUnrespondedComment = false
       false,
       'approved',
       2,
       30,
       25,
-      '2026-02-08T12:00:00Z',  // latestCommitDate
-      '2026-02-07T10:00:00Z',  // lastMaintainerCommentDate
-      undefined                 // latestChangesRequestedDate
+      '2026-02-08T12:00:00Z', // latestCommitDate
+      '2026-02-07T10:00:00Z', // lastMaintainerCommentDate
+      undefined, // latestChangesRequestedDate
     );
 
     expect(result).toBe('waiting_on_maintainer');
@@ -278,15 +285,15 @@ describe('PRMonitor needs_changes detection', () => {
     const result = (monitor as any).determineStatus(
       'passing',
       false,
-      false,            // hasUnrespondedComment = false (inline review comments)
+      false, // hasUnrespondedComment = false (inline review comments)
       false,
       'changes_requested',
       2,
       30,
       25,
-      '2026-02-08T06:50:38Z',   // latestCommitDate (before review)
-      undefined,                  // lastMaintainerCommentDate
-      '2026-02-08T11:52:22Z'    // latestChangesRequestedDate (after commit)
+      '2026-02-08T06:50:38Z', // latestCommitDate (before review)
+      undefined, // lastMaintainerCommentDate
+      '2026-02-08T11:52:22Z', // latestChangesRequestedDate (after commit)
     );
 
     expect(result).toBe('needs_changes');
@@ -303,9 +310,9 @@ describe('PRMonitor needs_changes detection', () => {
       2,
       30,
       25,
-      '2026-02-09T10:00:00Z',   // latestCommitDate (after review)
+      '2026-02-09T10:00:00Z', // latestCommitDate (after review)
       undefined,
-      '2026-02-08T11:52:22Z'    // latestChangesRequestedDate (before commit)
+      '2026-02-08T11:52:22Z', // latestChangesRequestedDate (before commit)
     );
 
     expect(result).toBe('changes_addressed');
@@ -322,9 +329,9 @@ describe('PRMonitor needs_changes detection', () => {
       2,
       30,
       25,
-      undefined,                  // latestCommitDate (missing)
+      undefined, // latestCommitDate (missing)
       undefined,
-      '2026-02-08T11:52:22Z'    // latestChangesRequestedDate
+      '2026-02-08T11:52:22Z', // latestChangesRequestedDate
     );
 
     expect(result).toBe('needs_changes');
@@ -343,7 +350,7 @@ describe('PRMonitor needs_changes detection', () => {
       25,
       '2026-02-08T06:50:38Z',
       undefined,
-      undefined                   // latestChangesRequestedDate (missing)
+      undefined, // latestChangesRequestedDate (missing)
     );
 
     // No review date to compare against — fall through to healthy
@@ -357,19 +364,21 @@ describe('PRMonitor determineStatus — remaining paths', () => {
   });
 
   // Helper to call determineStatus with defaults
-  function callDetermineStatus(overrides: Partial<{
-    ciStatus: string;
-    hasMergeConflict: boolean;
-    hasUnrespondedComment: boolean;
-    hasIncompleteChecklist: boolean;
-    reviewDecision: string;
-    daysSinceActivity: number;
-    dormantThreshold: number;
-    approachingThreshold: number;
-    latestCommitDate: string | undefined;
-    lastMaintainerCommentDate: string | undefined;
-    latestChangesRequestedDate: string | undefined;
-  }> = {}) {
+  function callDetermineStatus(
+    overrides: Partial<{
+      ciStatus: string;
+      hasMergeConflict: boolean;
+      hasUnrespondedComment: boolean;
+      hasIncompleteChecklist: boolean;
+      reviewDecision: string;
+      daysSinceActivity: number;
+      dormantThreshold: number;
+      approachingThreshold: number;
+      latestCommitDate: string | undefined;
+      lastMaintainerCommentDate: string | undefined;
+      latestChangesRequestedDate: string | undefined;
+    }> = {},
+  ) {
     const monitor = new PRMonitor('fake-token');
     const defaults = {
       ciStatus: 'passing',
@@ -386,10 +395,17 @@ describe('PRMonitor determineStatus — remaining paths', () => {
     };
     const p = { ...defaults, ...overrides };
     return (monitor as any).determineStatus(
-      p.ciStatus, p.hasMergeConflict, p.hasUnrespondedComment,
-      p.hasIncompleteChecklist, p.reviewDecision, p.daysSinceActivity,
-      p.dormantThreshold, p.approachingThreshold, p.latestCommitDate,
-      p.lastMaintainerCommentDate, p.latestChangesRequestedDate
+      p.ciStatus,
+      p.hasMergeConflict,
+      p.hasUnrespondedComment,
+      p.hasIncompleteChecklist,
+      p.reviewDecision,
+      p.daysSinceActivity,
+      p.dormantThreshold,
+      p.approachingThreshold,
+      p.latestCommitDate,
+      p.lastMaintainerCommentDate,
+      p.latestChangesRequestedDate,
     );
   }
 
@@ -430,24 +446,30 @@ describe('PRMonitor determineStatus — remaining paths', () => {
   });
 
   it('should prioritize needs_response over failing_ci', () => {
-    expect(callDetermineStatus({
-      ciStatus: 'failing',
-      hasUnrespondedComment: true,
-    })).toBe('needs_response');
+    expect(
+      callDetermineStatus({
+        ciStatus: 'failing',
+        hasUnrespondedComment: true,
+      }),
+    ).toBe('needs_response');
   });
 
   it('should prioritize failing_ci over merge_conflict', () => {
-    expect(callDetermineStatus({
-      ciStatus: 'failing',
-      hasMergeConflict: true,
-    })).toBe('failing_ci');
+    expect(
+      callDetermineStatus({
+        ciStatus: 'failing',
+        hasMergeConflict: true,
+      }),
+    ).toBe('failing_ci');
   });
 
   it('should prioritize merge_conflict over incomplete_checklist', () => {
-    expect(callDetermineStatus({
-      hasMergeConflict: true,
-      hasIncompleteChecklist: true,
-    })).toBe('merge_conflict');
+    expect(
+      callDetermineStatus({
+        hasMergeConflict: true,
+        hasIncompleteChecklist: true,
+      }),
+    ).toBe('merge_conflict');
   });
 });
 
@@ -516,11 +538,9 @@ describe('PRMonitor analyzeChecklist', () => {
 
   it('should still flag non-conditional unchecked items alongside conditional ones (#152)', () => {
     const monitor = new PRMonitor('fake-token');
-    const body = [
-      '- [x] Tests included',
-      '- [ ] Documentation updated',
-      '- [ ] Changelog entry (if applicable)',
-    ].join('\n');
+    const body = ['- [x] Tests included', '- [ ] Documentation updated', '- [ ] Changelog entry (if applicable)'].join(
+      '\n',
+    );
     const result = (monitor as any).analyzeChecklist(body);
     expect(result.hasIncompleteChecklist).toBe(true);
     expect(result.checklistStats).toEqual({ checked: 1, total: 3 });
@@ -573,7 +593,7 @@ describe('PRMonitor extractMaintainerActionHints', () => {
     const monitor = new PRMonitor('fake-token');
     const result = (monitor as any).extractMaintainerActionHints(
       'Can you show a screenshot of the before/after?',
-      'review_required'
+      'review_required',
     );
     expect(result).toContain('demo_requested');
   });
@@ -582,7 +602,7 @@ describe('PRMonitor extractMaintainerActionHints', () => {
     const monitor = new PRMonitor('fake-token');
     const result = (monitor as any).extractMaintainerActionHints(
       'Please add test coverage for this feature',
-      'review_required'
+      'review_required',
     );
     expect(result).toContain('tests_requested');
   });
@@ -591,7 +611,7 @@ describe('PRMonitor extractMaintainerActionHints', () => {
     const monitor = new PRMonitor('fake-token');
     const result = (monitor as any).extractMaintainerActionHints(
       'Can you update the documentation for this API change?',
-      'review_required'
+      'review_required',
     );
     expect(result).toContain('docs_requested');
   });
@@ -600,7 +620,7 @@ describe('PRMonitor extractMaintainerActionHints', () => {
     const monitor = new PRMonitor('fake-token');
     const result = (monitor as any).extractMaintainerActionHints(
       'This branch is behind main, could you rebase?',
-      'review_required'
+      'review_required',
     );
     expect(result).toContain('rebase_requested');
   });
@@ -609,7 +629,7 @@ describe('PRMonitor extractMaintainerActionHints', () => {
     const monitor = new PRMonitor('fake-token');
     const result = (monitor as any).extractMaintainerActionHints(
       'Please add test coverage and a screenshot of the changes',
-      'changes_requested'
+      'changes_requested',
     );
     expect(result).toContain('changes_requested');
     expect(result).toContain('tests_requested');
@@ -630,9 +650,7 @@ describe('PRMonitor determineReviewDecision', () => {
 
   it('should return approved when latest review is APPROVED', () => {
     const monitor = new PRMonitor('fake-token');
-    const result = (monitor as any).determineReviewDecision([
-      { state: 'APPROVED', user: { login: 'reviewer1' } },
-    ]);
+    const result = (monitor as any).determineReviewDecision([{ state: 'APPROVED', user: { login: 'reviewer1' } }]);
     expect(result).toBe('approved');
   });
 
@@ -664,9 +682,7 @@ describe('PRMonitor determineReviewDecision', () => {
 
   it('should return review_required for COMMENTED-only reviews', () => {
     const monitor = new PRMonitor('fake-token');
-    const result = (monitor as any).determineReviewDecision([
-      { state: 'COMMENTED', user: { login: 'reviewer1' } },
-    ]);
+    const result = (monitor as any).determineReviewDecision([{ state: 'COMMENTED', user: { login: 'reviewer1' } }]);
     expect(result).toBe('review_required');
   });
 });
@@ -753,7 +769,7 @@ describe('PRMonitor checkUnrespondedComments', () => {
       [{ user: { login: 'testuser' }, body: 'My comment', created_at: '2026-02-07T10:00:00Z' }],
       [],
       [],
-      'testuser'
+      'testuser',
     );
     expect(result.hasUnrespondedComment).toBe(false);
   });
@@ -767,7 +783,7 @@ describe('PRMonitor checkUnrespondedComments', () => {
       ],
       [],
       [],
-      'testuser'
+      'testuser',
     );
     expect(result.hasUnrespondedComment).toBe(true);
     expect(result.lastMaintainerComment?.author).toBe('maintainer');
@@ -782,7 +798,7 @@ describe('PRMonitor checkUnrespondedComments', () => {
       ],
       [],
       [],
-      'testuser'
+      'testuser',
     );
     expect(result.hasUnrespondedComment).toBe(false);
   });
@@ -796,7 +812,7 @@ describe('PRMonitor checkUnrespondedComments', () => {
       ],
       [],
       [],
-      'testuser'
+      'testuser',
     );
     expect(result.hasUnrespondedComment).toBe(false);
   });
@@ -812,7 +828,7 @@ describe('PRMonitor checkUnrespondedComments', () => {
         ],
         [],
         [],
-        'testuser'
+        'testuser',
       );
       expect(result.hasUnrespondedComment).toBe(false);
     }
@@ -828,7 +844,7 @@ describe('PRMonitor checkUnrespondedComments', () => {
       ],
       [],
       [],
-      'testuser'
+      'testuser',
     );
     expect(result.hasUnrespondedComment).toBe(true);
     expect(result.lastMaintainerComment?.author).toBe('maintainer');
@@ -843,7 +859,7 @@ describe('PRMonitor checkUnrespondedComments', () => {
       ],
       [],
       [],
-      'testuser'
+      'testuser',
     );
     expect(result.hasUnrespondedComment).toBe(false);
   });
@@ -852,11 +868,9 @@ describe('PRMonitor checkUnrespondedComments', () => {
     const monitor = new PRMonitor('fake-token');
     const result = (monitor as any).checkUnrespondedComments(
       [],
-      [
-        { user: { login: 'maintainer' }, body: 'Needs changes here', submitted_at: '2026-02-07T12:00:00Z' },
-      ],
+      [{ user: { login: 'maintainer' }, body: 'Needs changes here', submitted_at: '2026-02-07T12:00:00Z' }],
       [],
-      'testuser'
+      'testuser',
     );
     expect(result.hasUnrespondedComment).toBe(true);
     expect(result.lastMaintainerComment?.author).toBe('maintainer');
@@ -866,11 +880,9 @@ describe('PRMonitor checkUnrespondedComments', () => {
     const monitor = new PRMonitor('fake-token');
     const result = (monitor as any).checkUnrespondedComments(
       [],
-      [
-        { user: { login: 'maintainer' }, body: '', submitted_at: '2026-02-07T12:00:00Z' },
-      ],
+      [{ user: { login: 'maintainer' }, body: '', submitted_at: '2026-02-07T12:00:00Z' }],
       [],
-      'testuser'
+      'testuser',
     );
     expect(result.hasUnrespondedComment).toBe(false);
   });
@@ -879,12 +891,10 @@ describe('PRMonitor checkUnrespondedComments', () => {
     const monitor = new PRMonitor('fake-token');
     const longBody = 'x'.repeat(300);
     const result = (monitor as any).checkUnrespondedComments(
-      [
-        { user: { login: 'maintainer' }, body: longBody, created_at: '2026-02-07T12:00:00Z' },
-      ],
+      [{ user: { login: 'maintainer' }, body: longBody, created_at: '2026-02-07T12:00:00Z' }],
       [],
       [],
-      'testuser'
+      'testuser',
     );
     expect(result.lastMaintainerComment?.body.length).toBeLessThanOrEqual(203); // 200 + "..."
   });
@@ -898,7 +908,7 @@ describe('PRMonitor checkUnrespondedComments', () => {
       ],
       [],
       [],
-      'testuser' // lowercase
+      'testuser', // lowercase
     );
     expect(result.hasUnrespondedComment).toBe(true);
   });
@@ -1034,7 +1044,6 @@ describe('PRMonitor getCIStatus auth-gate filtering', () => {
 });
 
 describe('PRMonitor generateDigest', () => {
-
   function makeFetchedPR(overrides: Partial<import('./types.js').FetchedPR> = {}): import('./types.js').FetchedPR {
     return {
       id: 1,
@@ -1097,16 +1106,16 @@ describe('PRMonitor generateDigest', () => {
     const monitor = new PRMonitor('fake-token');
     const digest = monitor.generateDigest(prs);
 
-    expect(digest.prsNeedingResponse.map(p => p.number)).toEqual([1]);
-    expect(digest.ciFailingPRs.map(p => p.number)).toEqual([2]);
-    expect(digest.mergeConflictPRs.map(p => p.number)).toEqual([3]);
-    expect(digest.healthyPRs.map(p => p.number)).toEqual([4, 11]); // healthy + waiting
-    expect(digest.dormantPRs.map(p => p.number)).toEqual([5]);
-    expect(digest.approachingDormant.map(p => p.number)).toEqual([6]);
-    expect(digest.needsChangesPRs.map(p => p.number)).toEqual([7]);
-    expect(digest.changesAddressedPRs.map(p => p.number)).toEqual([8]);
-    expect(digest.waitingOnMaintainerPRs.map(p => p.number)).toEqual([9]);
-    expect(digest.incompleteChecklistPRs.map(p => p.number)).toEqual([10]);
+    expect(digest.prsNeedingResponse.map((p) => p.number)).toEqual([1]);
+    expect(digest.ciFailingPRs.map((p) => p.number)).toEqual([2]);
+    expect(digest.mergeConflictPRs.map((p) => p.number)).toEqual([3]);
+    expect(digest.healthyPRs.map((p) => p.number)).toEqual([4, 11]); // healthy + waiting
+    expect(digest.dormantPRs.map((p) => p.number)).toEqual([5]);
+    expect(digest.approachingDormant.map((p) => p.number)).toEqual([6]);
+    expect(digest.needsChangesPRs.map((p) => p.number)).toEqual([7]);
+    expect(digest.changesAddressedPRs.map((p) => p.number)).toEqual([8]);
+    expect(digest.waitingOnMaintainerPRs.map((p) => p.number)).toEqual([9]);
+    expect(digest.incompleteChecklistPRs.map((p) => p.number)).toEqual([10]);
   });
 
   it('should calculate totalNeedingAttention correctly', () => {
@@ -1391,19 +1400,21 @@ describe('PRMonitor CI failure overrides changes_addressed (Issue #68)', () => {
   });
 
   // Helper to call determineStatus with defaults
-  function callDetermineStatus(overrides: Partial<{
-    ciStatus: string;
-    hasMergeConflict: boolean;
-    hasUnrespondedComment: boolean;
-    hasIncompleteChecklist: boolean;
-    reviewDecision: string;
-    daysSinceActivity: number;
-    dormantThreshold: number;
-    approachingThreshold: number;
-    latestCommitDate: string | undefined;
-    lastMaintainerCommentDate: string | undefined;
-    latestChangesRequestedDate: string | undefined;
-  }> = {}) {
+  function callDetermineStatus(
+    overrides: Partial<{
+      ciStatus: string;
+      hasMergeConflict: boolean;
+      hasUnrespondedComment: boolean;
+      hasIncompleteChecklist: boolean;
+      reviewDecision: string;
+      daysSinceActivity: number;
+      dormantThreshold: number;
+      approachingThreshold: number;
+      latestCommitDate: string | undefined;
+      lastMaintainerCommentDate: string | undefined;
+      latestChangesRequestedDate: string | undefined;
+    }> = {},
+  ) {
     const monitor = new PRMonitor('fake-token');
     const defaults = {
       ciStatus: 'passing',
@@ -1420,64 +1431,83 @@ describe('PRMonitor CI failure overrides changes_addressed (Issue #68)', () => {
     };
     const p = { ...defaults, ...overrides };
     return (monitor as any).determineStatus(
-      p.ciStatus, p.hasMergeConflict, p.hasUnrespondedComment,
-      p.hasIncompleteChecklist, p.reviewDecision, p.daysSinceActivity,
-      p.dormantThreshold, p.approachingThreshold, p.latestCommitDate,
-      p.lastMaintainerCommentDate, p.latestChangesRequestedDate
+      p.ciStatus,
+      p.hasMergeConflict,
+      p.hasUnrespondedComment,
+      p.hasIncompleteChecklist,
+      p.reviewDecision,
+      p.daysSinceActivity,
+      p.dormantThreshold,
+      p.approachingThreshold,
+      p.latestCommitDate,
+      p.lastMaintainerCommentDate,
+      p.latestChangesRequestedDate,
     );
   }
 
   it('should return failing_ci when changes_addressed (comment path) and CI is failing', () => {
-    expect(callDetermineStatus({
-      ciStatus: 'failing',
-      hasUnrespondedComment: true,
-      latestCommitDate: '2026-02-08T12:00:00Z',
-      lastMaintainerCommentDate: '2026-02-07T10:00:00Z',
-    })).toBe('failing_ci');
+    expect(
+      callDetermineStatus({
+        ciStatus: 'failing',
+        hasUnrespondedComment: true,
+        latestCommitDate: '2026-02-08T12:00:00Z',
+        lastMaintainerCommentDate: '2026-02-07T10:00:00Z',
+      }),
+    ).toBe('failing_ci');
   });
 
   it('should return failing_ci when changes_addressed (review path) and CI is failing', () => {
-    expect(callDetermineStatus({
-      ciStatus: 'failing',
-      reviewDecision: 'changes_requested',
-      latestCommitDate: '2026-02-09T10:00:00Z',
-      latestChangesRequestedDate: '2026-02-08T11:52:22Z',
-    })).toBe('failing_ci');
+    expect(
+      callDetermineStatus({
+        ciStatus: 'failing',
+        reviewDecision: 'changes_requested',
+        latestCommitDate: '2026-02-09T10:00:00Z',
+        latestChangesRequestedDate: '2026-02-08T11:52:22Z',
+      }),
+    ).toBe('failing_ci');
   });
 
   it('should still return changes_addressed when CI is passing (comment path regression)', () => {
-    expect(callDetermineStatus({
-      ciStatus: 'passing',
-      hasUnrespondedComment: true,
-      latestCommitDate: '2026-02-08T12:00:00Z',
-      lastMaintainerCommentDate: '2026-02-07T10:00:00Z',
-    })).toBe('changes_addressed');
+    expect(
+      callDetermineStatus({
+        ciStatus: 'passing',
+        hasUnrespondedComment: true,
+        latestCommitDate: '2026-02-08T12:00:00Z',
+        lastMaintainerCommentDate: '2026-02-07T10:00:00Z',
+      }),
+    ).toBe('changes_addressed');
   });
 
   it('should still return changes_addressed when CI is passing (review path regression)', () => {
-    expect(callDetermineStatus({
-      ciStatus: 'passing',
-      reviewDecision: 'changes_requested',
-      latestCommitDate: '2026-02-09T10:00:00Z',
-      latestChangesRequestedDate: '2026-02-08T11:52:22Z',
-    })).toBe('changes_addressed');
+    expect(
+      callDetermineStatus({
+        ciStatus: 'passing',
+        reviewDecision: 'changes_requested',
+        latestCommitDate: '2026-02-09T10:00:00Z',
+        latestChangesRequestedDate: '2026-02-08T11:52:22Z',
+      }),
+    ).toBe('changes_addressed');
   });
 
   it('should still prioritize needs_response over failing_ci', () => {
-    expect(callDetermineStatus({
-      ciStatus: 'failing',
-      hasUnrespondedComment: true,
-      // No commit after maintainer comment → needs_response, not changes_addressed
-    })).toBe('needs_response');
+    expect(
+      callDetermineStatus({
+        ciStatus: 'failing',
+        hasUnrespondedComment: true,
+        // No commit after maintainer comment → needs_response, not changes_addressed
+      }),
+    ).toBe('needs_response');
   });
 
   it('should still prioritize needs_changes over failing_ci', () => {
-    expect(callDetermineStatus({
-      ciStatus: 'failing',
-      reviewDecision: 'changes_requested',
-      latestCommitDate: '2026-02-07T06:50:38Z',
-      latestChangesRequestedDate: '2026-02-08T11:52:22Z',
-    })).toBe('needs_changes');
+    expect(
+      callDetermineStatus({
+        ciStatus: 'failing',
+        reviewDecision: 'changes_requested',
+        latestCommitDate: '2026-02-07T06:50:38Z',
+        latestChangesRequestedDate: '2026-02-08T11:52:22Z',
+      }),
+    ).toBe('needs_changes');
   });
 });
 
@@ -1532,7 +1562,7 @@ describe('isAcknowledgmentComment (Issue #69)', () => {
       ],
       [],
       [],
-      'testuser'
+      'testuser',
     );
     expect(result.hasUnrespondedComment).toBe(false);
     expect(result.lastMaintainerComment).toBeUndefined();
@@ -1544,11 +1574,15 @@ describe('isAcknowledgmentComment (Issue #69)', () => {
       [
         { user: { login: 'testuser' }, body: 'My PR', created_at: '2026-02-07T10:00:00Z' },
         { user: { login: 'maintainer' }, body: 'Thanks, will look at this', created_at: '2026-02-07T11:00:00Z' },
-        { user: { login: 'maintainer' }, body: 'Please fix the linting errors in src/main.ts', created_at: '2026-02-07T12:00:00Z' },
+        {
+          user: { login: 'maintainer' },
+          body: 'Please fix the linting errors in src/main.ts',
+          created_at: '2026-02-07T12:00:00Z',
+        },
       ],
       [],
       [],
-      'testuser'
+      'testuser',
     );
     expect(result.hasUnrespondedComment).toBe(true);
     expect(result.lastMaintainerComment?.author).toBe('maintainer');
@@ -1557,15 +1591,13 @@ describe('isAcknowledgmentComment (Issue #69)', () => {
   it('should detect inline-only COMMENTED reviews as unresponded (#151)', () => {
     const monitor = new PRMonitor('fake-token');
     const result = (monitor as any).checkUnrespondedComments(
-      [
-        { user: { login: 'testuser' }, body: 'My PR', created_at: '2026-02-07T10:00:00Z' },
-      ],
+      [{ user: { login: 'testuser' }, body: 'My PR', created_at: '2026-02-07T10:00:00Z' }],
       [
         // Review with inline comments only (no top-level body)
         { user: { login: 'reviewer' }, body: '', submitted_at: '2026-02-07T12:00:00Z', state: 'COMMENTED' },
       ],
       [],
-      'testuser'
+      'testuser',
     );
     expect(result.hasUnrespondedComment).toBe(true);
     expect(result.lastMaintainerComment?.author).toBe('reviewer');
@@ -1574,14 +1606,10 @@ describe('isAcknowledgmentComment (Issue #69)', () => {
   it('should skip reviews with null/undefined state and no body (#151)', () => {
     const monitor = new PRMonitor('fake-token');
     const result = (monitor as any).checkUnrespondedComments(
-      [
-        { user: { login: 'testuser' }, body: 'My PR', created_at: '2026-02-07T10:00:00Z' },
-      ],
-      [
-        { user: { login: 'reviewer' }, body: '', submitted_at: '2026-02-07T12:00:00Z' },
-      ],
+      [{ user: { login: 'testuser' }, body: 'My PR', created_at: '2026-02-07T10:00:00Z' }],
+      [{ user: { login: 'reviewer' }, body: '', submitted_at: '2026-02-07T12:00:00Z' }],
       [],
-      'testuser'
+      'testuser',
     );
     expect(result.hasUnrespondedComment).toBe(false);
   });
@@ -1589,14 +1617,10 @@ describe('isAcknowledgmentComment (Issue #69)', () => {
   it('should skip CHANGES_REQUESTED reviews with empty body (#151)', () => {
     const monitor = new PRMonitor('fake-token');
     const result = (monitor as any).checkUnrespondedComments(
-      [
-        { user: { login: 'testuser' }, body: 'My PR', created_at: '2026-02-07T10:00:00Z' },
-      ],
-      [
-        { user: { login: 'reviewer' }, body: '', submitted_at: '2026-02-07T12:00:00Z', state: 'CHANGES_REQUESTED' },
-      ],
+      [{ user: { login: 'testuser' }, body: 'My PR', created_at: '2026-02-07T10:00:00Z' }],
+      [{ user: { login: 'reviewer' }, body: '', submitted_at: '2026-02-07T12:00:00Z', state: 'CHANGES_REQUESTED' }],
       [],
-      'testuser'
+      'testuser',
     );
     expect(result.hasUnrespondedComment).toBe(false);
   });
@@ -1610,7 +1634,7 @@ describe('isAcknowledgmentComment (Issue #69)', () => {
         { user: { login: 'testuser' }, body: '', submitted_at: '2026-02-07T12:00:00Z', state: 'COMMENTED' },
       ],
       [],
-      'testuser'
+      'testuser',
     );
     expect(result.hasUnrespondedComment).toBe(false);
   });
@@ -1619,11 +1643,9 @@ describe('isAcknowledgmentComment (Issue #69)', () => {
     const monitor = new PRMonitor('fake-token');
     const result = (monitor as any).checkUnrespondedComments(
       [],
-      [
-        { user: { login: 'reviewer' }, body: '', submitted_at: '2026-02-07T12:00:00Z', state: 'COMMENTED' },
-      ],
+      [{ user: { login: 'reviewer' }, body: '', submitted_at: '2026-02-07T12:00:00Z', state: 'COMMENTED' }],
       [],
-      'testuser'
+      'testuser',
     );
     expect(result.lastMaintainerComment?.body).toBe('(posted inline review comments)');
   });
@@ -1631,14 +1653,10 @@ describe('isAcknowledgmentComment (Issue #69)', () => {
   it('should still skip APPROVED reviews with no body (#151)', () => {
     const monitor = new PRMonitor('fake-token');
     const result = (monitor as any).checkUnrespondedComments(
-      [
-        { user: { login: 'testuser' }, body: 'My PR', created_at: '2026-02-07T10:00:00Z' },
-      ],
-      [
-        { user: { login: 'reviewer' }, body: '', submitted_at: '2026-02-07T12:00:00Z', state: 'APPROVED' },
-      ],
+      [{ user: { login: 'testuser' }, body: 'My PR', created_at: '2026-02-07T10:00:00Z' }],
+      [{ user: { login: 'reviewer' }, body: '', submitted_at: '2026-02-07T12:00:00Z', state: 'APPROVED' }],
       [],
-      'testuser'
+      'testuser',
     );
     expect(result.hasUnrespondedComment).toBe(false);
   });
@@ -1656,7 +1674,7 @@ describe('isAcknowledgmentComment (Issue #69)', () => {
         { user: { login: 'SunsetTechuila' }, body: '', submitted_at: '2026-02-14T05:14:49Z', state: 'COMMENTED' },
       ],
       [],
-      'testuser'
+      'testuser',
     );
     expect(result.hasUnrespondedComment).toBe(true);
     // The most recent maintainer comment should be the inline review, not the older comment
@@ -1698,10 +1716,12 @@ describe('computeDisplayLabel (#79)', () => {
   });
 
   it('should return [Needs Response] with author for needs_response', () => {
-    const { displayLabel, displayDescription } = computeDisplayLabel(makePR({
-      status: 'needs_response',
-      lastMaintainerComment: { author: 'johndoe', body: 'Please fix', createdAt: '2026-02-07T10:00:00Z' },
-    }));
+    const { displayLabel, displayDescription } = computeDisplayLabel(
+      makePR({
+        status: 'needs_response',
+        lastMaintainerComment: { author: 'johndoe', body: 'Please fix', createdAt: '2026-02-07T10:00:00Z' },
+      }),
+    );
     expect(displayLabel).toBe('[Needs Response]');
     expect(displayDescription).toBe('@johndoe commented');
   });
@@ -1712,69 +1732,79 @@ describe('computeDisplayLabel (#79)', () => {
   });
 
   it('should return [CI Failing] with actionable check count', () => {
-    const { displayLabel, displayDescription } = computeDisplayLabel(makePR({
-      status: 'failing_ci',
-      failingCheckNames: ['Build', 'Lint', 'Vercel Deploy'],
-      classifiedChecks: [
-        { name: 'Build', category: 'actionable' },
-        { name: 'Lint', category: 'actionable' },
-        { name: 'Vercel Deploy', category: 'fork_limitation' },
-      ],
-    }));
+    const { displayLabel, displayDescription } = computeDisplayLabel(
+      makePR({
+        status: 'failing_ci',
+        failingCheckNames: ['Build', 'Lint', 'Vercel Deploy'],
+        classifiedChecks: [
+          { name: 'Build', category: 'actionable' },
+          { name: 'Lint', category: 'actionable' },
+          { name: 'Vercel Deploy', category: 'fork_limitation' },
+        ],
+      }),
+    );
     expect(displayLabel).toBe('[CI Failing]');
     expect(displayDescription).toBe('2 checks failed: Build, Lint');
   });
 
   it('should return singular form for exactly 1 actionable check', () => {
-    const { displayDescription } = computeDisplayLabel(makePR({
-      status: 'failing_ci',
-      failingCheckNames: ['Build'],
-      classifiedChecks: [{ name: 'Build', category: 'actionable' }],
-    }));
+    const { displayDescription } = computeDisplayLabel(
+      makePR({
+        status: 'failing_ci',
+        failingCheckNames: ['Build'],
+        classifiedChecks: [{ name: 'Build', category: 'actionable' }],
+      }),
+    );
     expect(displayDescription).toBe('1 check failed: Build');
   });
 
   it('should fall back to failingCheckNames count when all checks are non-actionable', () => {
-    const { displayDescription } = computeDisplayLabel(makePR({
-      status: 'failing_ci',
-      failingCheckNames: ['Vercel Deploy', 'Netlify Build'],
-      classifiedChecks: [
-        { name: 'Vercel Deploy', category: 'fork_limitation' },
-        { name: 'Netlify Build', category: 'fork_limitation' },
-      ],
-    }));
+    const { displayDescription } = computeDisplayLabel(
+      makePR({
+        status: 'failing_ci',
+        failingCheckNames: ['Vercel Deploy', 'Netlify Build'],
+        classifiedChecks: [
+          { name: 'Vercel Deploy', category: 'fork_limitation' },
+          { name: 'Netlify Build', category: 'fork_limitation' },
+        ],
+      }),
+    );
     expect(displayDescription).toBe('2 checks failed');
   });
 
   it('should indicate infrastructure failures when all checks are infrastructure (#145)', () => {
-    const { displayDescription } = computeDisplayLabel(makePR({
-      status: 'failing_ci',
-      failingCheckNames: ['Build', 'Lint'],
-      classifiedChecks: [
-        { name: 'Build', category: 'infrastructure', conclusion: 'cancelled' },
-        { name: 'Lint', category: 'infrastructure', conclusion: 'timed_out' },
-      ],
-    }));
+    const { displayDescription } = computeDisplayLabel(
+      makePR({
+        status: 'failing_ci',
+        failingCheckNames: ['Build', 'Lint'],
+        classifiedChecks: [
+          { name: 'Build', category: 'infrastructure', conclusion: 'cancelled' },
+          { name: 'Lint', category: 'infrastructure', conclusion: 'timed_out' },
+        ],
+      }),
+    );
     expect(displayDescription).toBe('2 checks cancelled/timed out (infrastructure)');
   });
 
   it('should indicate single infrastructure failure (#145)', () => {
-    const { displayDescription } = computeDisplayLabel(makePR({
-      status: 'failing_ci',
-      failingCheckNames: ['Build'],
-      classifiedChecks: [
-        { name: 'Build', category: 'infrastructure', conclusion: 'cancelled' },
-      ],
-    }));
+    const { displayDescription } = computeDisplayLabel(
+      makePR({
+        status: 'failing_ci',
+        failingCheckNames: ['Build'],
+        classifiedChecks: [{ name: 'Build', category: 'infrastructure', conclusion: 'cancelled' }],
+      }),
+    );
     expect(displayDescription).toBe('1 check cancelled/timed out (infrastructure)');
   });
 
   it('should return generic description when no classified checks', () => {
-    const { displayDescription } = computeDisplayLabel(makePR({
-      status: 'failing_ci',
-      failingCheckNames: [],
-      classifiedChecks: [],
-    }));
+    const { displayDescription } = computeDisplayLabel(
+      makePR({
+        status: 'failing_ci',
+        failingCheckNames: [],
+        classifiedChecks: [],
+      }),
+    );
     expect(displayDescription).toBe('One or more CI checks are failing');
   });
 
@@ -1784,67 +1814,83 @@ describe('computeDisplayLabel (#79)', () => {
   });
 
   it('should return [Incomplete Checklist] with stats', () => {
-    const { displayLabel, displayDescription } = computeDisplayLabel(makePR({
-      status: 'incomplete_checklist',
-      checklistStats: { checked: 2, total: 5 },
-    }));
+    const { displayLabel, displayDescription } = computeDisplayLabel(
+      makePR({
+        status: 'incomplete_checklist',
+        checklistStats: { checked: 2, total: 5 },
+      }),
+    );
     expect(displayLabel).toBe('[Incomplete Checklist]');
     expect(displayDescription).toBe('2/5 items checked');
   });
 
   it('should return fallback for incomplete_checklist without stats', () => {
-    const { displayDescription } = computeDisplayLabel(makePR({
-      status: 'incomplete_checklist',
-    }));
+    const { displayDescription } = computeDisplayLabel(
+      makePR({
+        status: 'incomplete_checklist',
+      }),
+    );
     expect(displayDescription).toBe('PR body has unchecked required checkboxes');
   });
 
   it('should return [Missing Files] with file list', () => {
-    const { displayLabel, displayDescription } = computeDisplayLabel(makePR({
-      status: 'missing_required_files',
-      missingRequiredFiles: ['CHANGELOG.md', 'LICENSE'],
-    }));
+    const { displayLabel, displayDescription } = computeDisplayLabel(
+      makePR({
+        status: 'missing_required_files',
+        missingRequiredFiles: ['CHANGELOG.md', 'LICENSE'],
+      }),
+    );
     expect(displayLabel).toBe('[Missing Files]');
     expect(displayDescription).toBe('Missing: CHANGELOG.md, LICENSE');
   });
 
   it('should return fallback for missing_required_files without file list', () => {
-    const { displayDescription } = computeDisplayLabel(makePR({
-      status: 'missing_required_files',
-    }));
+    const { displayDescription } = computeDisplayLabel(
+      makePR({
+        status: 'missing_required_files',
+      }),
+    );
     expect(displayDescription).toBe('Required files are missing');
   });
 
   it('should return [Changes Addressed] with author', () => {
-    const { displayLabel, displayDescription } = computeDisplayLabel(makePR({
-      status: 'changes_addressed',
-      lastMaintainerComment: { author: 'reviewer', body: 'Changes needed', createdAt: '2026-02-07T10:00:00Z' },
-    }));
+    const { displayLabel, displayDescription } = computeDisplayLabel(
+      makePR({
+        status: 'changes_addressed',
+        lastMaintainerComment: { author: 'reviewer', body: 'Changes needed', createdAt: '2026-02-07T10:00:00Z' },
+      }),
+    );
     expect(displayLabel).toBe('[Changes Addressed]');
     expect(displayDescription).toBe('Waiting for @reviewer to re-review');
   });
 
   it('should return fallback for changes_addressed without comment', () => {
-    const { displayDescription } = computeDisplayLabel(makePR({
-      status: 'changes_addressed',
-    }));
+    const { displayDescription } = computeDisplayLabel(
+      makePR({
+        status: 'changes_addressed',
+      }),
+    );
     expect(displayDescription).toBe('Waiting for maintainer re-review');
   });
 
   it('should return [Dormant] with days count', () => {
-    const { displayLabel, displayDescription } = computeDisplayLabel(makePR({
-      status: 'dormant',
-      daysSinceActivity: 45,
-    }));
+    const { displayLabel, displayDescription } = computeDisplayLabel(
+      makePR({
+        status: 'dormant',
+        daysSinceActivity: 45,
+      }),
+    );
     expect(displayLabel).toBe('[Dormant]');
     expect(displayDescription).toBe('No activity for 45 days');
   });
 
   it('should return [Approaching Dormant] with days count', () => {
-    const { displayDescription } = computeDisplayLabel(makePR({
-      status: 'approaching_dormant',
-      daysSinceActivity: 27,
-    }));
+    const { displayDescription } = computeDisplayLabel(
+      makePR({
+        status: 'approaching_dormant',
+        daysSinceActivity: 27,
+      }),
+    );
     expect(displayDescription).toBe('No activity for 27 days');
   });
 
@@ -1862,10 +1908,21 @@ describe('computeDisplayLabel (#79)', () => {
   it('should have an entry for every FetchedPRStatus', () => {
     // Ensure no status is missed — if a new status is added, this test will catch it
     const allStatuses: import('./types.js').FetchedPRStatus[] = [
-      'needs_response', 'failing_ci', 'ci_blocked', 'ci_not_running',
-      'merge_conflict', 'needs_rebase', 'missing_required_files', 'incomplete_checklist',
-      'needs_changes', 'changes_addressed', 'waiting', 'waiting_on_maintainer',
-      'healthy', 'approaching_dormant', 'dormant',
+      'needs_response',
+      'failing_ci',
+      'ci_blocked',
+      'ci_not_running',
+      'merge_conflict',
+      'needs_rebase',
+      'missing_required_files',
+      'incomplete_checklist',
+      'needs_changes',
+      'changes_addressed',
+      'waiting',
+      'waiting_on_maintainer',
+      'healthy',
+      'approaching_dormant',
+      'dormant',
     ];
     for (const status of allStatuses) {
       const result = computeDisplayLabel(makePR({ status }));
@@ -2010,7 +2067,10 @@ describe('classifyFailingChecks (#81, #145)', () => {
   });
 
   it('should use conclusion data for classification (#145)', () => {
-    const conclusions = new Map([['Build', 'cancelled'], ['Tests', 'failure']]);
+    const conclusions = new Map([
+      ['Build', 'cancelled'],
+      ['Tests', 'failure'],
+    ]);
     const result = classifyFailingChecks(['Build', 'Tests'], conclusions);
     expect(result).toEqual([
       { name: 'Build', category: 'infrastructure', conclusion: 'cancelled' },
@@ -2027,7 +2087,9 @@ describe('classifyFailingChecks (#81, #145)', () => {
 
 describe('isConditionalChecklistItem (#152)', () => {
   it('should detect "(if ...)" pattern', () => {
-    expect(isConditionalChecklistItem('- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix)')).toBe(true);
+    expect(isConditionalChecklistItem('- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix)')).toBe(
+      true,
+    );
   });
 
   it('should detect "if applicable"', () => {
@@ -2089,7 +2151,7 @@ describe('fetchUserOpenPRs excludeRepos/excludeOrgs exempts shelved PRs (#175)',
   const makePRDetailMocks = (prUrl: string) => {
     const match = prUrl.match(/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
     if (!match) throw new Error(`Bad URL: ${prUrl}`);
-    const [, owner, repo, num] = match;
+    const [, _owner, _repo, num] = match;
     return {
       pulls: {
         get: vi.fn().mockResolvedValue({
@@ -2275,16 +2337,16 @@ describe('PRMonitor status with inline review after commit (#151)', () => {
   it('should return needs_response when inline review arrives after commit that addressed old comment', () => {
     const monitor = new PRMonitor('fake-token');
     const status = (monitor as any).determineStatus(
-      'passing',                  // ciStatus
-      false,                      // hasMergeConflict
-      true,                       // hasUnrespondedComment (inline review detected)
-      false,                      // hasIncompleteChecklist
-      'review_required',          // reviewDecision
-      1,                          // daysSinceActivity
-      30,                         // dormantThreshold
-      25,                         // approachingThreshold
-      '2026-02-13T06:35:00Z',    // latestCommitDate (before inline review)
-      '2026-02-14T05:14:49Z',    // lastMaintainerCommentDate (inline review)
+      'passing', // ciStatus
+      false, // hasMergeConflict
+      true, // hasUnrespondedComment (inline review detected)
+      false, // hasIncompleteChecklist
+      'review_required', // reviewDecision
+      1, // daysSinceActivity
+      30, // dormantThreshold
+      25, // approachingThreshold
+      '2026-02-13T06:35:00Z', // latestCommitDate (before inline review)
+      '2026-02-14T05:14:49Z', // lastMaintainerCommentDate (inline review)
     );
 
     expect(status).toBe('needs_response');
@@ -2420,9 +2482,7 @@ describe('getCIStatus error handling (#182)', () => {
 
     expect(result).toBeDefined();
     expect(result.status).not.toBe('failing');
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Non-404 error fetching check runs')
-    );
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Non-404 error fetching check runs'));
   });
 
   it('should silently handle 404 from listForRef without logging', async () => {
@@ -2462,9 +2522,7 @@ describe('Maintainer self-reply detection (#199)', () => {
     // Scenario from issue #199: MikeMcQuaid submits review, contributor pushes commit,
     // MikeMcQuaid self-replies to own inline comment
     const result = (monitor as any).checkUnrespondedComments(
-      [
-        { user: { login: 'testuser' }, body: 'My PR', created_at: '2026-02-22T10:00:00Z' },
-      ],
+      [{ user: { login: 'testuser' }, body: 'My PR', created_at: '2026-02-22T10:00:00Z' }],
       [
         // Original review with inline comments
         { user: { login: 'MikeMcQuaid' }, body: '', submitted_at: '2026-02-22T12:00:00Z', state: 'COMMENTED', id: 100 },
@@ -2473,11 +2531,24 @@ describe('Maintainer self-reply detection (#199)', () => {
       ],
       [
         // Original inline comment from the first review
-        { id: 1000, user: { login: 'MikeMcQuaid' }, body: 'Can you see if T.untyped can use T.anything?', created_at: '2026-02-22T12:00:00Z', pull_request_review_id: 100 },
+        {
+          id: 1000,
+          user: { login: 'MikeMcQuaid' },
+          body: 'Can you see if T.untyped can use T.anything?',
+          created_at: '2026-02-22T12:00:00Z',
+          pull_request_review_id: 100,
+        },
         // Self-reply to own comment in the second review
-        { id: 1001, user: { login: 'MikeMcQuaid' }, body: "Unfortunately seems like they can't all be changed", created_at: '2026-02-24T08:29:00Z', in_reply_to_id: 1000, pull_request_review_id: 200 },
+        {
+          id: 1001,
+          user: { login: 'MikeMcQuaid' },
+          body: "Unfortunately seems like they can't all be changed",
+          created_at: '2026-02-24T08:29:00Z',
+          in_reply_to_id: 1000,
+          pull_request_review_id: 200,
+        },
       ],
-      'testuser'
+      'testuser',
     );
 
     // The self-reply review (id=200) should be skipped, but the original review (id=100)
@@ -2504,11 +2575,24 @@ describe('Maintainer self-reply detection (#199)', () => {
       ],
       [
         // Original inline comment
-        { id: 1000, user: { login: 'maintainer' }, body: 'Please fix this', created_at: '2026-02-22T12:00:00Z', pull_request_review_id: 100 },
+        {
+          id: 1000,
+          user: { login: 'maintainer' },
+          body: 'Please fix this',
+          created_at: '2026-02-22T12:00:00Z',
+          pull_request_review_id: 100,
+        },
         // Self-reply
-        { id: 1001, user: { login: 'maintainer' }, body: 'Never mind, looks like this is fine', created_at: '2026-02-24T08:29:00Z', in_reply_to_id: 1000, pull_request_review_id: 200 },
+        {
+          id: 1001,
+          user: { login: 'maintainer' },
+          body: 'Never mind, looks like this is fine',
+          created_at: '2026-02-24T08:29:00Z',
+          in_reply_to_id: 1000,
+          pull_request_review_id: 200,
+        },
       ],
-      'testuser'
+      'testuser',
     );
 
     // Self-reply after user's comment should NOT trigger needs_response
@@ -2518,9 +2602,7 @@ describe('Maintainer self-reply detection (#199)', () => {
   it('should still flag when maintainer replies to DIFFERENT author comment', () => {
     const monitor = new PRMonitor('fake-token');
     const result = (monitor as any).checkUnrespondedComments(
-      [
-        { user: { login: 'testuser' }, body: 'My PR', created_at: '2026-02-22T10:00:00Z' },
-      ],
+      [{ user: { login: 'testuser' }, body: 'My PR', created_at: '2026-02-22T10:00:00Z' }],
       [
         // Review from reviewer-A
         { user: { login: 'reviewer-A' }, body: '', submitted_at: '2026-02-22T12:00:00Z', state: 'COMMENTED', id: 100 },
@@ -2529,11 +2611,24 @@ describe('Maintainer self-reply detection (#199)', () => {
       ],
       [
         // reviewer-A's original comment
-        { id: 1000, user: { login: 'reviewer-A' }, body: 'Looks good to me', created_at: '2026-02-22T12:00:00Z', pull_request_review_id: 100 },
+        {
+          id: 1000,
+          user: { login: 'reviewer-A' },
+          body: 'Looks good to me',
+          created_at: '2026-02-22T12:00:00Z',
+          pull_request_review_id: 100,
+        },
         // reviewer-B replies to reviewer-A's comment (different author = NOT self-reply)
-        { id: 1001, user: { login: 'reviewer-B' }, body: 'Actually I disagree, needs changes', created_at: '2026-02-24T08:00:00Z', in_reply_to_id: 1000, pull_request_review_id: 200 },
+        {
+          id: 1001,
+          user: { login: 'reviewer-B' },
+          body: 'Actually I disagree, needs changes',
+          created_at: '2026-02-24T08:00:00Z',
+          in_reply_to_id: 1000,
+          pull_request_review_id: 200,
+        },
       ],
-      'testuser'
+      'testuser',
     );
 
     expect(result.hasUnrespondedComment).toBe(true);
@@ -2543,9 +2638,7 @@ describe('Maintainer self-reply detection (#199)', () => {
   it('should still flag when review has mix of self-reply and new thread', () => {
     const monitor = new PRMonitor('fake-token');
     const result = (monitor as any).checkUnrespondedComments(
-      [
-        { user: { login: 'testuser' }, body: 'My PR', created_at: '2026-02-22T10:00:00Z' },
-      ],
+      [{ user: { login: 'testuser' }, body: 'My PR', created_at: '2026-02-22T10:00:00Z' }],
       [
         // Original review
         { user: { login: 'maintainer' }, body: '', submitted_at: '2026-02-22T12:00:00Z', state: 'COMMENTED', id: 100 },
@@ -2554,13 +2647,32 @@ describe('Maintainer self-reply detection (#199)', () => {
       ],
       [
         // Original inline comment
-        { id: 1000, user: { login: 'maintainer' }, body: 'Fix this', created_at: '2026-02-22T12:00:00Z', pull_request_review_id: 100 },
+        {
+          id: 1000,
+          user: { login: 'maintainer' },
+          body: 'Fix this',
+          created_at: '2026-02-22T12:00:00Z',
+          pull_request_review_id: 100,
+        },
         // Self-reply in review 200
-        { id: 1001, user: { login: 'maintainer' }, body: 'Update on this', created_at: '2026-02-24T08:00:00Z', in_reply_to_id: 1000, pull_request_review_id: 200 },
+        {
+          id: 1001,
+          user: { login: 'maintainer' },
+          body: 'Update on this',
+          created_at: '2026-02-24T08:00:00Z',
+          in_reply_to_id: 1000,
+          pull_request_review_id: 200,
+        },
         // NEW comment thread in same review 200 (no in_reply_to_id)
-        { id: 1002, user: { login: 'maintainer' }, body: 'Also found another issue here', created_at: '2026-02-24T08:01:00Z', pull_request_review_id: 200 },
+        {
+          id: 1002,
+          user: { login: 'maintainer' },
+          body: 'Also found another issue here',
+          created_at: '2026-02-24T08:01:00Z',
+          pull_request_review_id: 200,
+        },
       ],
-      'testuser'
+      'testuser',
     );
 
     // Mixed review (self-reply + new thread) should still flag
@@ -2577,7 +2689,7 @@ describe('Maintainer self-reply detection (#199)', () => {
         { user: { login: 'reviewer' }, body: '', submitted_at: '2026-02-07T12:00:00Z', state: 'COMMENTED' },
       ],
       [],
-      'testuser'
+      'testuser',
     );
 
     // Without review.id, can't look up inline comments — falls back to synthetic
@@ -2588,13 +2700,17 @@ describe('Maintainer self-reply detection (#199)', () => {
     const monitor = new PRMonitor('fake-token');
     const result = (monitor as any).checkUnrespondedComments(
       [],
+      [{ user: { login: 'reviewer' }, body: '', submitted_at: '2026-02-07T12:00:00Z', state: 'COMMENTED', id: 100 }],
       [
-        { user: { login: 'reviewer' }, body: '', submitted_at: '2026-02-07T12:00:00Z', state: 'COMMENTED', id: 100 },
+        {
+          id: 1000,
+          user: { login: 'reviewer' },
+          body: 'Please add error handling here',
+          created_at: '2026-02-07T12:00:00Z',
+          pull_request_review_id: 100,
+        },
       ],
-      [
-        { id: 1000, user: { login: 'reviewer' }, body: 'Please add error handling here', created_at: '2026-02-07T12:00:00Z', pull_request_review_id: 100 },
-      ],
-      'testuser'
+      'testuser',
     );
 
     expect(result.hasUnrespondedComment).toBe(true);
@@ -2631,7 +2747,13 @@ describe('Maintainer self-reply detection (#199)', () => {
     const monitor = new PRMonitor('fake-token');
     const result = (monitor as any).isAllSelfReplies(200, [
       { id: 1000, user: { login: 'MikeMcQuaid' }, body: 'Original', pull_request_review_id: 100 },
-      { id: 1001, user: { login: 'mikemcquaid' }, body: 'Follow up', in_reply_to_id: 1000, pull_request_review_id: 200 },
+      {
+        id: 1001,
+        user: { login: 'mikemcquaid' },
+        body: 'Follow up',
+        in_reply_to_id: 1000,
+        pull_request_review_id: 200,
+      },
     ]);
     expect(result).toBe(true);
   });
@@ -2888,7 +3010,8 @@ describe('fetchRepoStarCounts (#216)', () => {
   it('should fetch star counts for repos', async () => {
     mockOctokitInstance = {
       repos: {
-        get: vi.fn()
+        get: vi
+          .fn()
           .mockResolvedValueOnce({ data: { stargazers_count: 5000 } })
           .mockResolvedValueOnce({ data: { stargazers_count: 200 } }),
       },
@@ -2911,7 +3034,8 @@ describe('fetchRepoStarCounts (#216)', () => {
   it('should skip repos that fail to fetch (deleted/private)', async () => {
     mockOctokitInstance = {
       repos: {
-        get: vi.fn()
+        get: vi
+          .fn()
           .mockResolvedValueOnce({ data: { stargazers_count: 1000 } })
           .mockRejectedValueOnce(new Error('Not Found')),
       },
@@ -3029,7 +3153,10 @@ describe('review comment fetch error handling (#229)', () => {
   });
 
   it('should degrade gracefully on non-rate-limit 403 (e.g. private repo)', async () => {
-    mockOctokitInstance = makeMocksWithReviewCommentError({ status: 403, message: 'Resource not accessible by integration' });
+    mockOctokitInstance = makeMocksWithReviewCommentError({
+      status: 403,
+      message: 'Resource not accessible by integration',
+    });
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const monitor = new PRMonitor('fake-token');
@@ -3038,9 +3165,7 @@ describe('review comment fetch error handling (#229)', () => {
     // Non-rate-limit 403 should NOT re-throw — PR still returned
     expect(prs).toHaveLength(1);
     expect(prs[0].url).toBe(prUrl);
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('403 fetching review comments'),
-    );
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('403 fetching review comments'));
 
     errorSpy.mockRestore();
   });
@@ -3055,9 +3180,7 @@ describe('review comment fetch error handling (#229)', () => {
     // PR should still be returned — 500 is gracefully degraded
     expect(prs).toHaveLength(1);
     expect(prs[0].url).toBe(prUrl);
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Failed to fetch review comments'),
-    );
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to fetch review comments'));
 
     errorSpy.mockRestore();
   });

--- a/src/core/pr-monitor.ts
+++ b/src/core/pr-monitor.ts
@@ -8,7 +8,19 @@ import { Octokit } from '@octokit/rest';
 import { getOctokit } from './github.js';
 import { getStateManager } from './state.js';
 import { daysBetween, parseGitHubUrl, extractOwnerRepo } from './utils.js';
-import { FetchedPR, FetchedPRStatus, CIStatus, CIStatusResult, ReviewDecision, DailyDigest, MaintainerActionHint, ClosedPR, MergedPR, CIFailureCategory, ClassifiedCheck } from './types.js';
+import {
+  FetchedPR,
+  FetchedPRStatus,
+  CIStatus,
+  CIStatusResult,
+  ReviewDecision,
+  DailyDigest,
+  MaintainerActionHint,
+  ClosedPR,
+  MergedPR,
+  CIFailureCategory,
+  ClassifiedCheck,
+} from './types.js';
 import { isBotAuthor, isAcknowledgmentComment } from './comment-utils.js';
 import { runWorkerPool } from './concurrency.js';
 import { ConfigurationError, ValidationError } from './errors.js';
@@ -100,7 +112,7 @@ export class PRMonitor {
 
     const shelvedUrls = new Set(config.shelvedPRUrls || []);
 
-    const filteredItems = allItems.filter(item => {
+    const filteredItems = allItems.filter((item) => {
       if (!item.pull_request) return false;
       // Skip PRs to repos owned by the user (not OSS contributions)
       const parsed = extractOwnerRepo(item.html_url);
@@ -115,46 +127,53 @@ export class PRMonitor {
       // to stop finding *new* issues there, not hide open PRs already being tracked (#175)
       const isShelved = shelvedUrls.has(item.html_url);
       if (config.excludeRepos.includes(repoFullName) && !isShelved) return false;
-      if (config.excludeOrgs?.some(org => ownerLower === org.toLowerCase()) && !isShelved) return false;
+      if (config.excludeOrgs?.some((org) => ownerLower === org.toLowerCase()) && !isShelved) return false;
       return true;
     });
 
-    debug('pr-monitor', `Filtered to ${filteredItems.length} PRs after excluding own repos, shelved, and excluded orgs/repos`);
+    debug(
+      'pr-monitor',
+      `Filtered to ${filteredItems.length} PRs after excluding own repos, shelved, and excluded orgs/repos`,
+    );
 
     // Fetch detailed info using a worker pool for bounded concurrency.
     await timed('pr-monitor', `Fetch details for ${filteredItems.length} PRs`, async () => {
-      await runWorkerPool(filteredItems, async (item) => {
-        try {
-          debug('pr-monitor', `Fetching details for ${item.html_url}`);
-          const pr = await this.fetchPRDetails(item.html_url);
-          if (pr) prs.push(pr);
-        } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : String(error);
-          warn('pr-monitor', `Error fetching ${item.html_url}: ${errorMessage}`);
-          failures.push({ prUrl: item.html_url, error: errorMessage });
-        }
-      }, MAX_CONCURRENT_REQUESTS);
+      await runWorkerPool(
+        filteredItems,
+        async (item) => {
+          try {
+            debug('pr-monitor', `Fetching details for ${item.html_url}`);
+            const pr = await this.fetchPRDetails(item.html_url);
+            if (pr) prs.push(pr);
+          } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            warn('pr-monitor', `Error fetching ${item.html_url}: ${errorMessage}`);
+            failures.push({ prUrl: item.html_url, error: errorMessage });
+          }
+        },
+        MAX_CONCURRENT_REQUESTS,
+      );
     });
 
     // Sort by days since activity (most urgent first)
     prs.sort((a, b) => {
       // Priority: needs_response > failing_ci > merge_conflict > approaching_dormant > dormant > waiting > healthy
       const statusPriority: Record<FetchedPRStatus, number> = {
-        'needs_response': 0,
-        'needs_changes': 1,
-        'failing_ci': 2,
-        'ci_blocked': 3,
-        'ci_not_running': 4,
-        'merge_conflict': 5,
-        'needs_rebase': 6,
-        'missing_required_files': 7,
-        'incomplete_checklist': 8,
-        'changes_addressed': 9,
-        'approaching_dormant': 10,
-        'dormant': 11,
-        'waiting': 12,
-        'waiting_on_maintainer': 13,
-        'healthy': 14,
+        needs_response: 0,
+        needs_changes: 1,
+        failing_ci: 2,
+        ci_blocked: 3,
+        ci_not_running: 4,
+        merge_conflict: 5,
+        needs_rebase: 6,
+        missing_required_files: 7,
+        incomplete_checklist: 8,
+        changes_addressed: 9,
+        approaching_dormant: 10,
+        dormant: 11,
+        waiting: 12,
+        waiting_on_maintainer: 13,
+        healthy: 14,
       };
       return statusPriority[a.status] - statusPriority[b.status];
     });
@@ -179,32 +198,38 @@ export class PRMonitor {
     // gracefully on failure rather than dropping the entire PR (#199).
     const [prResponse, comments, reviewsResponse, reviewComments] = await Promise.all([
       this.octokit.pulls.get({ owner, repo, pull_number: number }),
-      paginateAll((page) => this.octokit.issues.listComments({ owner, repo, issue_number: number, per_page: 100, page })),
+      paginateAll((page) =>
+        this.octokit.issues.listComments({ owner, repo, issue_number: number, per_page: 100, page }),
+      ),
       this.octokit.pulls.listReviews({ owner, repo, pull_number: number }),
-      paginateAll((page) => this.octokit.pulls.listReviewComments({ owner, repo, pull_number: number, per_page: 100, page }))
-        .catch((err: unknown) => {
-          const status = (err as { status?: number })?.status;
-          // Rate limit errors must propagate — silently swallowing them hides
-          // a systemic problem and produces misleading results (#229).
-          if (status === 429) {
+      paginateAll((page) =>
+        this.octokit.pulls.listReviewComments({ owner, repo, pull_number: number, per_page: 100, page }),
+      ).catch((err: unknown) => {
+        const status = (err as { status?: number })?.status;
+        // Rate limit errors must propagate — silently swallowing them hides
+        // a systemic problem and produces misleading results (#229).
+        if (status === 429) {
+          throw err;
+        }
+        if (status === 403) {
+          const msg = ((err as { message?: string })?.message ?? '').toLowerCase();
+          if (msg.includes('rate limit') || msg.includes('abuse detection')) {
             throw err;
           }
-          if (status === 403) {
-            const msg = ((err as { message?: string })?.message ?? '').toLowerCase();
-            if (msg.includes('rate limit') || msg.includes('abuse detection')) {
-              throw err;
-            }
-            // Non-rate-limit 403 (DMCA, private repo, SSO) — degrade gracefully
-            warn('pr-monitor', `403 fetching review comments for ${owner}/${repo}#${number}: ${msg}`);
-            return { data: [] as Array<any> };
-          }
-          if (status === 404) {
-            debug('pr-monitor', `Review comments 404 for ${owner}/${repo}#${number} (likely no inline comments)`);
-          } else {
-            warn('pr-monitor', `Failed to fetch review comments for ${owner}/${repo}#${number} (status ${status ?? 'unknown'}): self-reply detection will be skipped`);
-          }
+          // Non-rate-limit 403 (DMCA, private repo, SSO) — degrade gracefully
+          warn('pr-monitor', `403 fetching review comments for ${owner}/${repo}#${number}: ${msg}`);
           return [] as Array<any>;
-        }),
+        }
+        if (status === 404) {
+          debug('pr-monitor', `Review comments 404 for ${owner}/${repo}#${number} (likely no inline comments)`);
+        } else {
+          warn(
+            'pr-monitor',
+            `Failed to fetch review comments for ${owner}/${repo}#${number} (status ${status ?? 'unknown'}): self-reply detection will be skipped`,
+          );
+        }
+        return [] as Array<any>;
+      }),
     ]);
 
     const ghPR = prResponse.data;
@@ -221,7 +246,7 @@ export class PRMonitor {
       comments,
       reviews,
       reviewComments,
-      config.githubUsername
+      config.githubUsername,
     );
 
     // Fetch CI status and (conditionally) latest commit date in parallel
@@ -231,8 +256,9 @@ export class PRMonitor {
     const ciPromise = this.getCIStatus(owner, repo, ghPR.head.sha);
     const needCommitDate = hasUnrespondedComment || reviewDecision === 'changes_requested';
     const commitDatePromise = needCommitDate
-      ? this.octokit.repos.getCommit({ owner, repo, ref: ghPR.head.sha })
-          .then(res => res.data.commit.author?.date)
+      ? this.octokit.repos
+          .getCommit({ owner, repo, ref: ghPR.head.sha })
+          .then((res) => res.data.commit.author?.date)
           .catch(() => undefined)
       : Promise.resolve(undefined);
 
@@ -245,10 +271,7 @@ export class PRMonitor {
     const { hasIncompleteChecklist, checklistStats } = this.analyzeChecklist(ghPR.body || '');
 
     // Extract maintainer action hints from comments
-    const maintainerActionHints = this.extractMaintainerActionHints(
-      lastMaintainerComment?.body,
-      reviewDecision
-    );
+    const maintainerActionHints = this.extractMaintainerActionHints(lastMaintainerComment?.body, reviewDecision);
 
     // Calculate days since activity
     const daysSinceActivity = daysBetween(new Date(ghPR.updated_at), new Date());
@@ -268,7 +291,7 @@ export class PRMonitor {
       config.approachingDormantDays,
       latestCommitDate,
       lastMaintainerComment?.createdAt,
-      latestChangesRequestedDate
+      latestChangesRequestedDate,
     );
 
     // Classify failing checks (#81)
@@ -305,8 +328,8 @@ export class PRMonitor {
   private buildFetchedPR(fields: Omit<FetchedPR, 'displayLabel' | 'displayDescription'>): FetchedPR {
     const pr: FetchedPR = {
       ...fields,
-      displayLabel: '',  // computed below
-      displayDescription: '',  // computed below
+      displayLabel: '', // computed below
+      displayDescription: '', // computed below
     };
 
     // Compute display labels (#79) — must happen after status + classifiedChecks are set
@@ -322,9 +345,15 @@ export class PRMonitor {
    */
   private checkUnrespondedComments(
     comments: Array<{ user?: { login?: string } | null; body?: string | null; created_at: string }>,
-    reviews: Array<{ user?: { login?: string } | null; body?: string | null; submitted_at?: string | null; state?: string | null; id?: number }>,
+    reviews: Array<{
+      user?: { login?: string } | null;
+      body?: string | null;
+      submitted_at?: string | null;
+      state?: string | null;
+      id?: number;
+    }>,
     reviewComments: ReviewComment[],
-    username: string
+    username: string,
   ): { hasUnrespondedComment: boolean; lastMaintainerComment?: FetchedPR['lastMaintainerComment'] } {
     // Combine comments and reviews into a timeline
     const timeline: Array<{ author: string; body: string; createdAt: string; isUser: boolean }> = [];
@@ -358,9 +387,10 @@ export class PRMonitor {
       }
 
       // Resolve body: prefer actual text, then inline comment text, then synthetic placeholder
-      const resolvedBody = body
-        || (review.id != null ? this.getInlineCommentBody(review.id, reviewComments) : undefined)
-        || '(posted inline review comments)';
+      const resolvedBody =
+        body ||
+        (review.id != null ? this.getInlineCommentBody(review.id, reviewComments) : undefined) ||
+        '(posted inline review comments)';
 
       timeline.push({
         author,
@@ -416,9 +446,7 @@ export class PRMonitor {
    * Used to filter out informational follow-ups that don't require contributor action (#199).
    */
   private isAllSelfReplies(reviewId: number, reviewComments: ReviewComment[]): boolean {
-    const commentsForReview = reviewComments.filter(
-      c => c.pull_request_review_id === reviewId
-    );
+    const commentsForReview = reviewComments.filter((c) => c.pull_request_review_id === reviewId);
 
     if (commentsForReview.length === 0) return false;
 
@@ -430,7 +458,7 @@ export class PRMonitor {
       }
     }
 
-    return commentsForReview.every(comment => {
+    return commentsForReview.every((comment) => {
       if (!comment.in_reply_to_id) return false; // New thread, not a reply
       const parentAuthor = authorMap.get(comment.in_reply_to_id);
       const commentAuthor = comment.user?.login?.toLowerCase();
@@ -445,9 +473,7 @@ export class PRMonitor {
    * synthetic placeholders (#199).
    */
   private getInlineCommentBody(reviewId: number, reviewComments: ReviewComment[]): string | undefined {
-    return reviewComments
-      .find(c => c.pull_request_review_id === reviewId && c.body?.trim())
-      ?.body?.trim();
+    return reviewComments.find((c) => c.pull_request_review_id === reviewId && c.body?.trim())?.body?.trim();
   }
 
   /**
@@ -464,7 +490,7 @@ export class PRMonitor {
     approachingThreshold: number,
     latestCommitDate?: string,
     lastMaintainerCommentDate?: string,
-    latestChangesRequestedDate?: string
+    latestChangesRequestedDate?: string,
   ): FetchedPRStatus {
     // Priority order: needs_response/needs_changes/changes_addressed > failing_ci > merge_conflict > incomplete_checklist > dormant > approaching_dormant > waiting_on_maintainer > waiting/healthy
 
@@ -529,7 +555,10 @@ export class PRMonitor {
    * Conditional items (containing "if applicable", "(if ...)", etc.) are
    * excluded from the incomplete count (#152).
    */
-  private analyzeChecklist(body: string): { hasIncompleteChecklist: boolean; checklistStats?: FetchedPR['checklistStats'] } {
+  private analyzeChecklist(body: string): {
+    hasIncompleteChecklist: boolean;
+    checklistStats?: FetchedPR['checklistStats'];
+  } {
     if (!body) return { hasIncompleteChecklist: false };
 
     const checkedPattern = /- \[x\]/gi;
@@ -545,9 +574,7 @@ export class PRMonitor {
     if (total === 0) return { hasIncompleteChecklist: false };
 
     // Filter out conditional checklist items that are intentionally unchecked
-    const nonConditionalUnchecked = uncheckedLines.filter(
-      line => !isConditionalChecklistItem(line)
-    );
+    const nonConditionalUnchecked = uncheckedLines.filter((line) => !isConditionalChecklistItem(line));
 
     return {
       hasIncompleteChecklist: nonConditionalUnchecked.length > 0,
@@ -561,7 +588,7 @@ export class PRMonitor {
    */
   private extractMaintainerActionHints(
     commentBody: string | undefined,
-    reviewDecision: ReviewDecision
+    reviewDecision: ReviewDecision,
   ): MaintainerActionHint[] {
     const hints: MaintainerActionHint[] = [];
 
@@ -574,26 +601,47 @@ export class PRMonitor {
     const lower = commentBody.toLowerCase();
 
     // Demo/screenshot requests
-    const demoKeywords = ['screenshot', 'demo', 'recording', 'screen recording', 'before/after', 'before and after', 'gif', 'video', 'screencast', 'show me', 'can you show'];
-    if (demoKeywords.some(kw => lower.includes(kw))) {
+    const demoKeywords = [
+      'screenshot',
+      'demo',
+      'recording',
+      'screen recording',
+      'before/after',
+      'before and after',
+      'gif',
+      'video',
+      'screencast',
+      'show me',
+      'can you show',
+    ];
+    if (demoKeywords.some((kw) => lower.includes(kw))) {
       hints.push('demo_requested');
     }
 
     // Test requests
-    const testKeywords = ['add test', 'test coverage', 'unit test', 'missing test', 'add a test', 'write test', 'needs test', 'need test'];
-    if (testKeywords.some(kw => lower.includes(kw))) {
+    const testKeywords = [
+      'add test',
+      'test coverage',
+      'unit test',
+      'missing test',
+      'add a test',
+      'write test',
+      'needs test',
+      'need test',
+    ];
+    if (testKeywords.some((kw) => lower.includes(kw))) {
       hints.push('tests_requested');
     }
 
     // Documentation requests
     const docKeywords = ['documentation', 'readme', 'jsdoc', 'docstring', 'add docs', 'update docs', 'document this'];
-    if (docKeywords.some(kw => lower.includes(kw))) {
+    if (docKeywords.some((kw) => lower.includes(kw))) {
       hints.push('docs_requested');
     }
 
     // Rebase requests
     const rebaseKeywords = ['rebase', 'merge conflict', 'out of date', 'behind main', 'behind master'];
-    if (rebaseKeywords.some(kw => lower.includes(kw))) {
+    if (rebaseKeywords.some((kw) => lower.includes(kw))) {
       hints.push('rebase_requested');
     }
 
@@ -641,26 +689,27 @@ export class PRMonitor {
    */
   private analyzeCombinedStatus(
     combinedStatus: { state: string; statuses: Array<{ state: string; context: string; description: string | null }> },
-    failingCheckNames: string[]
+    failingCheckNames: string[],
   ): { effectiveCombinedState: string; hasStatuses: boolean } {
     // Filter out authorization-gate statuses (e.g., Vercel "Authorization required to deploy")
     // These are permission gates, not real CI failures
-    const realStatuses = combinedStatus.statuses.filter(s => {
+    const realStatuses = combinedStatus.statuses.filter((s) => {
       const desc = (s.description || '').toLowerCase();
-      return !(s.state === 'failure' && (
-        desc.includes('authorization required') ||
-        desc.includes('authorize')
-      ));
+      return !(s.state === 'failure' && (desc.includes('authorization required') || desc.includes('authorize')));
     });
 
-    const hasRealFailure = realStatuses.some(s => s.state === 'failure' || s.state === 'error');
-    const hasRealPending = realStatuses.some(s => s.state === 'pending');
-    const hasRealSuccess = realStatuses.some(s => s.state === 'success');
-    const effectiveCombinedState = hasRealFailure ? 'failure'
-      : hasRealPending ? 'pending'
-      : hasRealSuccess ? 'success'
-      : realStatuses.length === 0 ? 'success' // All statuses were auth gates; don't inherit original failure
-      : combinedStatus.state;
+    const hasRealFailure = realStatuses.some((s) => s.state === 'failure' || s.state === 'error');
+    const hasRealPending = realStatuses.some((s) => s.state === 'pending');
+    const hasRealSuccess = realStatuses.some((s) => s.state === 'success');
+    const effectiveCombinedState = hasRealFailure
+      ? 'failure'
+      : hasRealPending
+        ? 'pending'
+        : hasRealSuccess
+          ? 'success'
+          : realStatuses.length === 0
+            ? 'success' // All statuses were auth gates; don't inherit original failure
+            : combinedStatus.state;
     const hasStatuses = combinedStatus.statuses.length > 0;
 
     // Collect failing status names from combined status API
@@ -688,9 +737,10 @@ export class PRMonitor {
       failingCheckConclusions: Map<string, string>;
     },
     combinedAnalysis: { effectiveCombinedState: string; hasStatuses: boolean },
-    checkRunCount: number
+    checkRunCount: number,
   ): CIStatusResult {
-    const { hasFailingChecks, hasPendingChecks, hasSuccessfulChecks, failingCheckNames, failingCheckConclusions } = checkRunAnalysis;
+    const { hasFailingChecks, hasPendingChecks, hasSuccessfulChecks, failingCheckNames, failingCheckConclusions } =
+      checkRunAnalysis;
     const { effectiveCombinedState, hasStatuses } = combinedAnalysis;
 
     // Safety net: If we have ANY failing checks, report as failing
@@ -731,7 +781,10 @@ export class PRMonitor {
           if (status === 404) {
             debug('pr-monitor', `Check runs 404 for ${owner}/${repo}@${sha.slice(0, 7)} (no checks configured)`);
           } else {
-            warn('pr-monitor', `Non-404 error fetching check runs for ${owner}/${repo}@${sha.slice(0, 7)}: ${status ?? err}`);
+            warn(
+              'pr-monitor',
+              `Non-404 error fetching check runs for ${owner}/${repo}@${sha.slice(0, 7)}: ${status ?? err}`,
+            );
           }
           return null;
         }),
@@ -743,7 +796,7 @@ export class PRMonitor {
       // Deduplicate check runs by name, keeping only the most recent run per unique name.
       // GitHub returns all historical runs (including re-runs), so without deduplication
       // a superseded failure will incorrectly flag the PR as failing even after a re-run passes.
-      const latestCheckRunsByName = new Map<string, typeof allCheckRuns[0]>();
+      const latestCheckRunsByName = new Map<string, (typeof allCheckRuns)[0]>();
       for (const check of allCheckRuns) {
         const existing = latestCheckRunsByName.get(check.name);
         if (!existing || new Date(check.started_at ?? 0) > new Date(existing.started_at ?? 0)) {
@@ -778,7 +831,9 @@ export class PRMonitor {
   /**
    * Determine review decision from reviews list
    */
-  private determineReviewDecision(reviews: Array<{ state?: string | null; user?: { login?: string } | null }>): ReviewDecision {
+  private determineReviewDecision(
+    reviews: Array<{ state?: string | null; user?: { login?: string } | null }>,
+  ): ReviewDecision {
     if (reviews.length === 0) {
       return 'review_required';
     }
@@ -811,7 +866,7 @@ export class PRMonitor {
    * Used to detect needs_changes status when review feedback is in inline comments.
    */
   private getLatestChangesRequestedDate(
-    reviews: Array<{ state?: string | null; submitted_at?: string | null }>
+    reviews: Array<{ state?: string | null; submitted_at?: string | null }>,
   ): string | undefined {
     let latest: string | undefined;
     for (const review of reviews) {
@@ -1051,7 +1106,9 @@ export class PRMonitor {
           results.set(result.value.repo, result.value.stars);
         } else {
           chunkFailures++;
-          console.error(`[STAR_FETCH] Failed to fetch stars for ${chunk[j]}: ${result.reason instanceof Error ? result.reason.message : result.reason}`);
+          console.error(
+            `[STAR_FETCH] Failed to fetch stars for ${chunk[j]}: ${result.reason instanceof Error ? result.reason.message : result.reason}`,
+          );
         }
       }
       // If entire chunk failed, likely a systemic issue (rate limit, auth, outage) — abort remaining
@@ -1076,7 +1133,10 @@ export class PRMonitor {
     query: string,
     label: string,
     days: number,
-    mapItem: (item: { html_url: string; title: string; closed_at: string | null; pull_request?: { merged_at?: string | null } }, parsed: { owner: string; repo: string; number: number }) => T,
+    mapItem: (
+      item: { html_url: string; title: string; closed_at: string | null; pull_request?: { merged_at?: string | null } },
+      parsed: { owner: string; repo: string; number: number },
+    ) => T,
   ): Promise<T[]> {
     const config = this.stateManager.getState().config;
 
@@ -1114,7 +1174,7 @@ export class PRMonitor {
 
       // Skip excluded repos and orgs
       if (config.excludeRepos.includes(repo)) continue;
-      if (config.excludeOrgs?.some(org => parsed.owner.toLowerCase() === org.toLowerCase())) continue;
+      if (config.excludeOrgs?.some((org) => parsed.owner.toLowerCase() === org.toLowerCase())) continue;
 
       results.push(mapItem(item, { owner: parsed.owner, repo, number: parsed.number }));
     }
@@ -1154,7 +1214,9 @@ export class PRMonitor {
       (item, { repo, number }) => {
         const mergedAt = item.pull_request?.merged_at;
         if (!mergedAt) {
-          console.error(`Warning: merged_at missing for merged PR ${item.html_url}${item.closed_at ? ', falling back to closed_at' : ', no date available'}`);
+          console.error(
+            `Warning: merged_at missing for merged PR ${item.html_url}${item.closed_at ? ', falling back to closed_at' : ', no date available'}`,
+          );
         }
         return {
           url: item.html_url,
@@ -1170,28 +1232,32 @@ export class PRMonitor {
   /**
    * Generate a daily digest from fetched PRs
    */
-  generateDigest(prs: FetchedPR[], recentlyClosedPRs: ClosedPR[] = [], recentlyMergedPRs: MergedPR[] = []): DailyDigest {
+  generateDigest(
+    prs: FetchedPR[],
+    recentlyClosedPRs: ClosedPR[] = [],
+    recentlyMergedPRs: MergedPR[] = [],
+  ): DailyDigest {
     const now = new Date().toISOString();
 
     // Categorize PRs
-    const prsNeedingResponse = prs.filter(pr => pr.status === 'needs_response');
-    const ciFailingPRs = prs.filter(pr => pr.status === 'failing_ci');
-    const mergeConflictPRs = prs.filter(pr => pr.status === 'merge_conflict');
-    const approachingDormant = prs.filter(pr => pr.status === 'approaching_dormant');
-    const dormantPRs = prs.filter(pr => pr.status === 'dormant');
-    const healthyPRs = prs.filter(pr => pr.status === 'healthy' || pr.status === 'waiting');
+    const prsNeedingResponse = prs.filter((pr) => pr.status === 'needs_response');
+    const ciFailingPRs = prs.filter((pr) => pr.status === 'failing_ci');
+    const mergeConflictPRs = prs.filter((pr) => pr.status === 'merge_conflict');
+    const approachingDormant = prs.filter((pr) => pr.status === 'approaching_dormant');
+    const dormantPRs = prs.filter((pr) => pr.status === 'dormant');
+    const healthyPRs = prs.filter((pr) => pr.status === 'healthy' || pr.status === 'waiting');
 
     // Get stats from state manager (historical data from repo scores)
     const stats = this.stateManager.getStats();
 
-    const ciBlockedPRs = prs.filter(pr => pr.status === 'ci_blocked');
-    const ciNotRunningPRs = prs.filter(pr => pr.status === 'ci_not_running');
-    const needsRebasePRs = prs.filter(pr => pr.status === 'needs_rebase');
-    const missingRequiredFilesPRs = prs.filter(pr => pr.status === 'missing_required_files');
-    const incompleteChecklistPRs = prs.filter(pr => pr.status === 'incomplete_checklist');
-    const needsChangesPRs = prs.filter(pr => pr.status === 'needs_changes');
-    const changesAddressedPRs = prs.filter(pr => pr.status === 'changes_addressed');
-    const waitingOnMaintainerPRs = prs.filter(pr => pr.status === 'waiting_on_maintainer');
+    const ciBlockedPRs = prs.filter((pr) => pr.status === 'ci_blocked');
+    const ciNotRunningPRs = prs.filter((pr) => pr.status === 'ci_not_running');
+    const needsRebasePRs = prs.filter((pr) => pr.status === 'needs_rebase');
+    const missingRequiredFilesPRs = prs.filter((pr) => pr.status === 'missing_required_files');
+    const incompleteChecklistPRs = prs.filter((pr) => pr.status === 'incomplete_checklist');
+    const needsChangesPRs = prs.filter((pr) => pr.status === 'needs_changes');
+    const changesAddressedPRs = prs.filter((pr) => pr.status === 'changes_addressed');
+    const waitingOnMaintainerPRs = prs.filter((pr) => pr.status === 'waiting_on_maintainer');
 
     return {
       generatedAt: now,
@@ -1216,7 +1282,14 @@ export class PRMonitor {
       autoUnshelvedPRs: [],
       summary: {
         totalActivePRs: prs.length,
-        totalNeedingAttention: prsNeedingResponse.length + needsChangesPRs.length + ciFailingPRs.length + mergeConflictPRs.length + needsRebasePRs.length + missingRequiredFilesPRs.length + incompleteChecklistPRs.length,
+        totalNeedingAttention:
+          prsNeedingResponse.length +
+          needsChangesPRs.length +
+          ciFailingPRs.length +
+          mergeConflictPRs.length +
+          needsRebasePRs.length +
+          missingRequiredFilesPRs.length +
+          incompleteChecklistPRs.length,
         totalMergedAllTime: stats.mergedPRs,
         mergeRate: parseFloat(stats.mergeRate),
       },
@@ -1287,7 +1360,6 @@ export class PRMonitor {
     this.stateManager.addActivePR(pr);
     return pr;
   }
-
 }
 
 /**
@@ -1297,9 +1369,8 @@ export class PRMonitor {
 const STATUS_DISPLAY: Record<FetchedPRStatus, { label: string; description: (pr: FetchedPR) => string }> = {
   needs_response: {
     label: '[Needs Response]',
-    description: (pr) => pr.lastMaintainerComment
-      ? `@${pr.lastMaintainerComment.author} commented`
-      : 'Maintainer awaiting response',
+    description: (pr) =>
+      pr.lastMaintainerComment ? `@${pr.lastMaintainerComment.author} commented` : 'Maintainer awaiting response',
   },
   needs_changes: {
     label: '[Needs Changes]',
@@ -1309,10 +1380,12 @@ const STATUS_DISPLAY: Record<FetchedPRStatus, { label: string; description: (pr:
     label: '[CI Failing]',
     description: (pr) => {
       const checks = pr.classifiedChecks || [];
-      const actionable = checks.filter(c => c.category === 'actionable');
-      if (actionable.length > 0) return `${actionable.length} check${actionable.length === 1 ? '' : 's'} failed: ${actionable.map(c => c.name).join(', ')}`;
-      const infrastructure = checks.filter(c => c.category === 'infrastructure');
-      if (infrastructure.length > 0) return `${infrastructure.length} check${infrastructure.length === 1 ? '' : 's'} cancelled/timed out (infrastructure)`;
+      const actionable = checks.filter((c) => c.category === 'actionable');
+      if (actionable.length > 0)
+        return `${actionable.length} check${actionable.length === 1 ? '' : 's'} failed: ${actionable.map((c) => c.name).join(', ')}`;
+      const infrastructure = checks.filter((c) => c.category === 'infrastructure');
+      if (infrastructure.length > 0)
+        return `${infrastructure.length} check${infrastructure.length === 1 ? '' : 's'} cancelled/timed out (infrastructure)`;
       const failingNames = pr.failingCheckNames || [];
       if (failingNames.length > 0) return `${failingNames.length} check${failingNames.length === 1 ? '' : 's'} failed`;
       return 'One or more CI checks are failing';
@@ -1336,21 +1409,22 @@ const STATUS_DISPLAY: Record<FetchedPRStatus, { label: string; description: (pr:
   },
   missing_required_files: {
     label: '[Missing Files]',
-    description: (pr) => pr.missingRequiredFiles
-      ? `Missing: ${pr.missingRequiredFiles.join(', ')}`
-      : 'Required files are missing',
+    description: (pr) =>
+      pr.missingRequiredFiles ? `Missing: ${pr.missingRequiredFiles.join(', ')}` : 'Required files are missing',
   },
   incomplete_checklist: {
     label: '[Incomplete Checklist]',
-    description: (pr) => pr.checklistStats
-      ? `${pr.checklistStats.checked}/${pr.checklistStats.total} items checked`
-      : 'PR body has unchecked required checkboxes',
+    description: (pr) =>
+      pr.checklistStats
+        ? `${pr.checklistStats.checked}/${pr.checklistStats.total} items checked`
+        : 'PR body has unchecked required checkboxes',
   },
   changes_addressed: {
     label: '[Changes Addressed]',
-    description: (pr) => pr.lastMaintainerComment
-      ? `Waiting for @${pr.lastMaintainerComment.author} to re-review`
-      : 'Waiting for maintainer re-review',
+    description: (pr) =>
+      pr.lastMaintainerComment
+        ? `Waiting for @${pr.lastMaintainerComment.author} to re-review`
+        : 'Waiting for maintainer re-review',
   },
   waiting: {
     label: '[Waiting]',
@@ -1392,7 +1466,8 @@ export function computeDisplayLabel(pr: FetchedPR): { displayLabel: string; disp
  * Matches patterns like "(if the PR is ...)", "if applicable", "N/A", "optional", etc.
  * Conservative — only skips items with clear conditional language.
  */
-const CONDITIONAL_CHECKLIST_PATTERN = /\(if\s|\bif applicable\b|\bif needed\b|\bif relevant\b|\bonly if\b|\bwhen applicable\b|\(optional\)|- \[ \]\s*optional\b|\bn\/a\b|\bnot applicable\b|\bif required\b|\bif necessary\b/;
+const CONDITIONAL_CHECKLIST_PATTERN =
+  /\(if\s|\bif applicable\b|\bif needed\b|\bif relevant\b|\bonly if\b|\bwhen applicable\b|\(optional\)|- \[ \]\s*optional\b|\bn\/a\b|\bnot applicable\b|\bif required\b|\bif necessary\b/;
 
 export function isConditionalChecklistItem(line: string): boolean {
   return CONDITIONAL_CHECKLIST_PATTERN.test(line.toLowerCase());
@@ -1417,12 +1492,7 @@ const FORK_LIMITATION_PATTERNS: RegExp[] = [
  * Known CI check name patterns that indicate authorization gates (#81).
  * These require maintainer approval and are not real failures.
  */
-const AUTH_GATE_PATTERNS: RegExp[] = [
-  /authoriz/i,
-  /approval/i,
-  /\bcla\b/i,
-  /license\/cla/i,
-];
+const AUTH_GATE_PATTERNS: RegExp[] = [/authoriz/i, /approval/i, /\bcla\b/i, /license\/cla/i];
 
 /**
  * Known CI check name patterns that indicate infrastructure/transient failures (#145).
@@ -1447,16 +1517,16 @@ export function classifyCICheck(name: string, description?: string, conclusion?:
   const nameLower = name.toLowerCase();
 
   // Check name first (more reliable than description)
-  if (AUTH_GATE_PATTERNS.some(p => p.test(nameLower))) return 'auth_gate';
-  if (FORK_LIMITATION_PATTERNS.some(p => p.test(nameLower))) return 'fork_limitation';
-  if (INFRASTRUCTURE_PATTERNS.some(p => p.test(nameLower))) return 'infrastructure';
+  if (AUTH_GATE_PATTERNS.some((p) => p.test(nameLower))) return 'auth_gate';
+  if (FORK_LIMITATION_PATTERNS.some((p) => p.test(nameLower))) return 'fork_limitation';
+  if (INFRASTRUCTURE_PATTERNS.some((p) => p.test(nameLower))) return 'infrastructure';
 
   // Fall through to description only if name was not classified
   if (description) {
     const descLower = description.toLowerCase();
-    if (AUTH_GATE_PATTERNS.some(p => p.test(descLower))) return 'auth_gate';
-    if (FORK_LIMITATION_PATTERNS.some(p => p.test(descLower))) return 'fork_limitation';
-    if (INFRASTRUCTURE_PATTERNS.some(p => p.test(descLower))) return 'infrastructure';
+    if (AUTH_GATE_PATTERNS.some((p) => p.test(descLower))) return 'auth_gate';
+    if (FORK_LIMITATION_PATTERNS.some((p) => p.test(descLower))) return 'fork_limitation';
+    if (INFRASTRUCTURE_PATTERNS.some((p) => p.test(descLower))) return 'infrastructure';
   }
 
   return 'actionable';
@@ -1468,9 +1538,9 @@ export function classifyCICheck(name: string, description?: string, conclusion?:
  */
 export function classifyFailingChecks(
   failingCheckNames: string[],
-  conclusions?: Map<string, string>
+  conclusions?: Map<string, string>,
 ): ClassifiedCheck[] {
-  return failingCheckNames.map(name => {
+  return failingCheckNames.map((name) => {
     const conclusion = conclusions?.get(name);
     return {
       name,

--- a/src/core/state.test.ts
+++ b/src/core/state.test.ts
@@ -90,13 +90,18 @@ describe('StateManager', () => {
 
     it('should mark all PRs as read', () => {
       const pr1 = createMockPR({ hasUnreadComments: true });
-      const pr2 = createMockPR({ id: 456, url: 'https://github.com/owner/repo/pull/2', number: 2, hasUnreadComments: true });
+      const pr2 = createMockPR({
+        id: 456,
+        url: 'https://github.com/owner/repo/pull/2',
+        number: 2,
+        hasUnreadComments: true,
+      });
       stateManager.addActivePR(pr1);
       stateManager.addActivePR(pr2);
       const count = stateManager.markAllPRsAsRead();
       expect(count).toBe(2);
       const state = stateManager.getState();
-      expect(state.activePRs.every(pr => !pr.hasUnreadComments)).toBe(true);
+      expect(state.activePRs.every((pr) => !pr.hasUnreadComments)).toBe(true);
     });
   });
 
@@ -111,7 +116,12 @@ describe('StateManager', () => {
       // So needsResponse is always 0 in getStats()
       // The actual count comes from the fresh fetch in daily command
       const pr1 = createMockPR({ hasUnreadComments: true });
-      const pr2 = createMockPR({ id: 456, url: 'https://github.com/owner/repo/pull/2', number: 2, hasUnreadComments: false });
+      const pr2 = createMockPR({
+        id: 456,
+        url: 'https://github.com/owner/repo/pull/2',
+        number: 2,
+        hasUnreadComments: false,
+      });
       stateManager.addActivePR(pr1);
       stateManager.addActivePR(pr2);
       const stats = stateManager.getStats();
@@ -131,7 +141,7 @@ describe('StateManager', () => {
       stateManager.addTrustedProject('owner/repo');
       stateManager.addTrustedProject('owner/repo');
       const state = stateManager.getState();
-      expect(state.config.trustedProjects.filter(p => p === 'owner/repo')).toHaveLength(1);
+      expect(state.config.trustedProjects.filter((p) => p === 'owner/repo')).toHaveLength(1);
     });
   });
 
@@ -256,12 +266,16 @@ describe('StateManager calculateScore (via updateRepoScore)', () => {
   });
 
   it('should add +1 for responsive signal', () => {
-    stateManager.updateRepoScore('owner/repo', { signals: { isResponsive: true, hasActiveMaintainers: true, hasHostileComments: false } });
+    stateManager.updateRepoScore('owner/repo', {
+      signals: { isResponsive: true, hasActiveMaintainers: true, hasHostileComments: false },
+    });
     expect(stateManager.getRepoScore('owner/repo')!.score).toBe(6);
   });
 
   it('should subtract -2 for hostile signal', () => {
-    stateManager.updateRepoScore('owner/repo', { signals: { hasHostileComments: true, hasActiveMaintainers: true, isResponsive: false } });
+    stateManager.updateRepoScore('owner/repo', {
+      signals: { hasHostileComments: true, hasActiveMaintainers: true, isResponsive: false },
+    });
     expect(stateManager.getRepoScore('owner/repo')!.score).toBe(3);
   });
 
@@ -589,7 +603,7 @@ describe('StateManager event logging', () => {
 
     const dailyChecks = stateManager.getEventsByType('daily_check');
     expect(dailyChecks).toHaveLength(3);
-    expect(dailyChecks.every(e => e.type === 'daily_check')).toBe(true);
+    expect(dailyChecks.every((e) => e.type === 'daily_check')).toBe(true);
 
     const merged = stateManager.getEventsByType('pr_merged');
     expect(merged).toHaveLength(1);
@@ -617,7 +631,9 @@ describe('StateManager event logging', () => {
 
   it('should filter events by date range with getEventsInRange', () => {
     // Manually push events with controlled timestamps to avoid timing issues
-    const state = stateManager.getState() as { events: Array<{ id: string; type: StateEventType; at: string; data: Record<string, unknown> }> };
+    const state = stateManager.getState() as {
+      events: Array<{ id: string; type: StateEventType; at: string; data: Record<string, unknown> }>;
+    };
 
     state.events.push(
       { id: 'evt_1', type: 'daily_check', at: '2024-01-01T00:00:00Z', data: { day: 'jan1' } },
@@ -636,17 +652,11 @@ describe('StateManager event logging', () => {
     expect(rangeEvents[1].data.day).toBe('feb1');
 
     // Range: entire year should include all 4
-    const allEvents = stateManager.getEventsInRange(
-      new Date('2023-12-01T00:00:00Z'),
-      new Date('2024-12-31T00:00:00Z'),
-    );
+    const allEvents = stateManager.getEventsInRange(new Date('2023-12-01T00:00:00Z'), new Date('2024-12-31T00:00:00Z'));
     expect(allEvents).toHaveLength(4);
 
     // Range: before all events should include none
-    const noEvents = stateManager.getEventsInRange(
-      new Date('2023-01-01T00:00:00Z'),
-      new Date('2023-12-31T00:00:00Z'),
-    );
+    const noEvents = stateManager.getEventsInRange(new Date('2023-01-01T00:00:00Z'), new Date('2023-12-31T00:00:00Z'));
     expect(noEvents).toHaveLength(0);
   });
 });

--- a/src/core/state.ts
+++ b/src/core/state.ts
@@ -5,7 +5,19 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { AgentState, INITIAL_STATE, TrackedPR, TrackedIssue, RepoScore, RepoScoreUpdate, StateEvent, StateEventType, DailyDigest, LocalRepoCache, SnoozeInfo } from './types.js';
+import {
+  AgentState,
+  INITIAL_STATE,
+  TrackedPR,
+  TrackedIssue,
+  RepoScore,
+  RepoScoreUpdate,
+  StateEvent,
+  StateEventType,
+  DailyDigest,
+  LocalRepoCache,
+  SnoozeInfo,
+} from './types.js';
 import { getStatePath, getBackupDir, getDataDir } from './utils.js';
 import { ValidationError } from './errors.js';
 
@@ -56,7 +68,11 @@ export function acquireLock(lockPath: string): void {
   }
 
   // Stale lock detected — remove it and try to re-acquire
-  try { fs.unlinkSync(lockPath); } catch { /* already removed */ }
+  try {
+    fs.unlinkSync(lockPath);
+  } catch {
+    /* already removed */
+  }
   try {
     fs.writeFileSync(lockPath, lockData, { flag: 'wx' });
   } catch {
@@ -263,8 +279,9 @@ export class StateManager {
       // Copy backups if they exist
       if (fs.existsSync(LEGACY_BACKUP_DIR)) {
         const newBackupDir = getBackupDir();
-        const backupFiles = fs.readdirSync(LEGACY_BACKUP_DIR)
-          .filter(f => f.startsWith('state-') && f.endsWith('.json'));
+        const backupFiles = fs
+          .readdirSync(LEGACY_BACKUP_DIR)
+          .filter((f) => f.startsWith('state-') && f.endsWith('.json'));
 
         for (const backupFile of backupFiles) {
           const srcPath = path.join(LEGACY_BACKUP_DIR, backupFile);
@@ -392,8 +409,9 @@ export class StateManager {
     }
 
     // Get backup files sorted by name (most recent first, since names include timestamps)
-    const backupFiles = fs.readdirSync(backupDir)
-      .filter(f => f.startsWith('state-') && f.endsWith('.json'))
+    const backupFiles = fs
+      .readdirSync(backupDir)
+      .filter((f) => f.startsWith('state-') && f.endsWith('.json'))
       .sort()
       .reverse();
 
@@ -421,7 +439,7 @@ export class StateManager {
 
           return state;
         }
-      } catch (error) {
+      } catch (_error) {
         // This backup is also corrupted, try the next one
         console.warn(`Backup ${backupFile} is corrupted, trying next...`);
       }
@@ -449,14 +467,13 @@ export class StateManager {
     }
 
     // Base requirements for all versions
-    const hasBaseFields = (
+    const hasBaseFields =
       typeof s.version === 'number' &&
       typeof s.repoScores === 'object' &&
       s.repoScores !== null &&
       Array.isArray(s.events) &&
       typeof s.config === 'object' &&
-      s.config !== null
-    );
+      s.config !== null;
 
     if (!hasBaseFields) return false;
 
@@ -520,8 +537,9 @@ export class StateManager {
   private cleanupBackups(): void {
     const backupDir = getBackupDir();
     try {
-      const files = fs.readdirSync(backupDir)
-        .filter(f => f.startsWith('state-'))
+      const files = fs
+        .readdirSync(backupDir)
+        .filter((f) => f.startsWith('state-'))
         .sort()
         .reverse();
 
@@ -530,7 +548,10 @@ export class StateManager {
         try {
           fs.unlinkSync(path.join(backupDir, file));
         } catch (error) {
-          console.error(`Warning: Could not delete old backup ${file}:`, error instanceof Error ? error.message : error);
+          console.error(
+            `Warning: Could not delete old backup ${file}:`,
+            error instanceof Error ? error.message : error,
+          );
         }
       }
     } catch (error) {
@@ -629,7 +650,7 @@ export class StateManager {
    * @returns All events matching the given type, in chronological order.
    */
   getEventsByType(type: StateEventType): StateEvent[] {
-    return this.state.events.filter(e => e.type === type);
+    return this.state.events.filter((e) => e.type === type);
   }
 
   /**
@@ -639,7 +660,7 @@ export class StateManager {
    * @returns Events whose timestamps fall within [since, until].
    */
   getEventsInRange(since: Date, until: Date = new Date()): StateEvent[] {
-    return this.state.events.filter(e => {
+    return this.state.events.filter((e) => {
       const eventTime = new Date(e.at);
       return eventTime >= since && eventTime <= until;
     });
@@ -655,7 +676,7 @@ export class StateManager {
    */
   addActivePR(pr: TrackedPR): void {
     // Check if already exists
-    const existing = this.state.activePRs.find(p => p.url === pr.url);
+    const existing = this.state.activePRs.find((p) => p.url === pr.url);
     if (existing) {
       console.error(`PR ${pr.url} already tracked`);
       return;
@@ -679,7 +700,7 @@ export class StateManager {
    * @param issue - The issue to begin tracking.
    */
   addIssue(issue: TrackedIssue): void {
-    const existing = this.state.activeIssues.find(i => i.url === issue.url);
+    const existing = this.state.activeIssues.find((i) => i.url === issue.url);
     if (existing) {
       console.error(`Issue ${issue.url} already tracked`);
       return;
@@ -712,8 +733,8 @@ export class StateManager {
    */
   private static matchesExclusion(repo: string, repos: string[], orgs?: string[]): boolean {
     const repoLower = repo.toLowerCase();
-    if (repos.some(r => r.toLowerCase() === repoLower)) return true;
-    if (orgs?.some(o => o.toLowerCase() === repoLower.split('/')[0])) return true;
+    if (repos.some((r) => r.toLowerCase() === repoLower)) return true;
+    if (orgs?.some((o) => o.toLowerCase() === repoLower.split('/')[0])) return true;
     return false;
   }
 
@@ -739,7 +760,7 @@ export class StateManager {
     const matches = (repo: string): boolean => StateManager.matchesExclusion(repo, repos, orgs);
 
     const beforeTrusted = this.state.config.trustedProjects.length;
-    this.state.config.trustedProjects = this.state.config.trustedProjects.filter(p => !matches(p));
+    this.state.config.trustedProjects = this.state.config.trustedProjects.filter((p) => !matches(p));
     const removedTrusted = beforeTrusted - this.state.config.trustedProjects.length;
 
     let removedScoreCount = 0;
@@ -752,7 +773,7 @@ export class StateManager {
 
     if (removedTrusted > 0 || removedScoreCount > 0) {
       console.error(
-        `[CLEANUP] Removed ${removedTrusted} trusted project(s) and ${removedScoreCount} repo score(s) for excluded repos/orgs`
+        `[CLEANUP] Removed ${removedTrusted} trusted project(s) and ${removedScoreCount} repo score(s) for excluded repos/orgs`,
       );
     }
   }
@@ -978,7 +999,7 @@ export class StateManager {
    */
   untrackPR(url: string): boolean {
     // Check active PRs
-    let index = this.state.activePRs.findIndex(p => p.url === url);
+    let index = this.state.activePRs.findIndex((p) => p.url === url);
     if (index !== -1) {
       const pr = this.state.activePRs.splice(index, 1)[0];
       console.error(`Untracked PR: ${pr.repo}#${pr.number}`);
@@ -986,7 +1007,7 @@ export class StateManager {
     }
 
     // Check dormant PRs
-    index = this.state.dormantPRs.findIndex(p => p.url === url);
+    index = this.state.dormantPRs.findIndex((p) => p.url === url);
     if (index !== -1) {
       const pr = this.state.dormantPRs.splice(index, 1)[0];
       console.error(`Untracked dormant PR: ${pr.repo}#${pr.number}`);
@@ -1003,7 +1024,7 @@ export class StateManager {
    * @returns true if the PR was found and updated, false if not in the active list.
    */
   markPRAsRead(url: string): boolean {
-    const pr = this.state.activePRs.find(p => p.url === url);
+    const pr = this.state.activePRs.find((p) => p.url === url);
     if (pr) {
       pr.hasUnreadComments = false;
       pr.activityStatus = 'active';
@@ -1082,7 +1103,9 @@ export class StateManager {
     if (repoScore.lastMergedAt) {
       const lastMergedDate = new Date(repoScore.lastMergedAt);
       if (isNaN(lastMergedDate.getTime())) {
-        console.error(`[SCORE_CALC] Invalid lastMergedAt date for ${repoScore.repo}: "${repoScore.lastMergedAt}". Skipping recency bonus.`);
+        console.error(
+          `[SCORE_CALC] Invalid lastMergedAt date for ${repoScore.repo}: "${repoScore.lastMergedAt}". Skipping recency bonus.`,
+        );
       } else {
         const msPerDay = 1000 * 60 * 60 * 24;
         const daysSince = Math.floor((Date.now() - lastMergedDate.getTime()) / msPerDay);
@@ -1196,9 +1219,9 @@ export class StateManager {
    */
   getReposWithMergedPRs(): string[] {
     return Object.values(this.state.repoScores)
-      .filter(rs => rs.mergedPRCount > 0)
+      .filter((rs) => rs.mergedPRCount > 0)
       .sort((a, b) => b.mergedPRCount - a.mergedPRCount)
-      .map(rs => rs.repo);
+      .map((rs) => rs.repo);
   }
 
   /**
@@ -1210,9 +1233,9 @@ export class StateManager {
    */
   getReposWithOpenPRs(): string[] {
     return Object.values(this.state.repoScores)
-      .filter(rs => rs.mergedPRCount === 0 && rs.closedWithoutMergeCount === 0)
+      .filter((rs) => rs.mergedPRCount === 0 && rs.closedWithoutMergeCount === 0)
       .sort((a, b) => b.score - a.score)
-      .map(rs => rs.repo);
+      .map((rs) => rs.repo);
   }
 
   /**
@@ -1223,9 +1246,9 @@ export class StateManager {
   getHighScoringRepos(minScore?: number): string[] {
     const threshold = minScore ?? this.state.config.minRepoScoreThreshold;
     return Object.values(this.state.repoScores)
-      .filter(rs => rs.score >= threshold)
+      .filter((rs) => rs.score >= threshold)
       .sort((a, b) => b.score - a.score)
-      .map(rs => rs.repo);
+      .map((rs) => rs.repo);
   }
 
   /**
@@ -1236,9 +1259,9 @@ export class StateManager {
   getLowScoringRepos(maxScore?: number): string[] {
     const threshold = maxScore ?? this.state.config.minRepoScoreThreshold;
     return Object.values(this.state.repoScores)
-      .filter(rs => rs.score <= threshold)
+      .filter((rs) => rs.score <= threshold)
       .sort((a, b) => a.score - b.score)
-      .map(rs => rs.repo);
+      .map((rs) => rs.repo);
   }
 
   // === Statistics ===
@@ -1266,9 +1289,7 @@ export class StateManager {
     }
 
     const completed = totalMerged + totalClosed;
-    const mergeRate = completed > 0
-      ? (totalMerged / completed) * 100
-      : 0;
+    const mergeRate = completed > 0 ? (totalMerged / completed) * 100 : 0;
 
     return {
       // v2: These are calculated from fresh GitHub data, not stored locally
@@ -1278,7 +1299,7 @@ export class StateManager {
       mergedPRs: totalMerged,
       closedPRs: totalClosed,
       activeIssues: 0,
-      trustedProjects: this.state.config.trustedProjects.filter(p => !this.isExcluded(p)).length,
+      trustedProjects: this.state.config.trustedProjects.filter((p) => !this.isExcluded(p)).length,
       mergeRate: mergeRate.toFixed(1) + '%',
       totalTracked,
       needsResponse: 0,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -108,11 +108,11 @@ export type FetchedPRStatus =
  * Extracted from comment text by keyword matching.
  */
 export type MaintainerActionHint =
-  | 'demo_requested'       // See extractMaintainerActionHints() in pr-monitor.ts for full keyword list
-  | 'tests_requested'      // See extractMaintainerActionHints() in pr-monitor.ts for full keyword list
-  | 'changes_requested'    // Generic code changes (from review decision)
-  | 'docs_requested'       // See extractMaintainerActionHints() in pr-monitor.ts for full keyword list
-  | 'rebase_requested';    // See extractMaintainerActionHints() in pr-monitor.ts for full keyword list
+  | 'demo_requested' // See extractMaintainerActionHints() in pr-monitor.ts for full keyword list
+  | 'tests_requested' // See extractMaintainerActionHints() in pr-monitor.ts for full keyword list
+  | 'changes_requested' // Generic code changes (from review decision)
+  | 'docs_requested' // See extractMaintainerActionHints() in pr-monitor.ts for full keyword list
+  | 'rebase_requested'; // See extractMaintainerActionHints() in pr-monitor.ts for full keyword list
 
 /**
  * Ephemeral PR data fetched fresh from GitHub on each run (v2 architecture).
@@ -379,13 +379,7 @@ export interface RepoScoreUpdate {
  * - `daily_check` — A daily digest run completed
  * - `comment_posted` — The agent posted a comment on a PR
  */
-export type StateEventType =
-  | 'pr_tracked'
-  | 'pr_merged'
-  | 'pr_closed'
-  | 'pr_dormant'
-  | 'daily_check'
-  | 'comment_posted';
+export type StateEventType = 'pr_tracked' | 'pr_merged' | 'pr_closed' | 'pr_dormant' | 'daily_check' | 'comment_posted';
 
 /** An entry in the state audit log. Events are append-only and used for history tracking. */
 export interface StateEvent {
@@ -601,13 +595,13 @@ export interface AgentConfig {
 
 /** Status of a user's comment thread on a GitHub issue. */
 export type IssueConversationStatus =
-  | 'new_response'      // Maintainer responded after user's last comment
-  | 'waiting'           // Last non-bot commenter is not the user; no substantive (non-acknowledgment) response found
-  | 'acknowledged';     // User was the last non-bot commenter; no action needed
+  | 'new_response' // Maintainer responded after user's last comment
+  | 'waiting' // Last non-bot commenter is not the user; no substantive (non-acknowledgment) response found
+  | 'acknowledged'; // User was the last non-bot commenter; no action needed
 
 /** Base fields shared by all issue conversation states. */
 interface CommentedIssueBase {
-  repo: string;         // "owner/repo"
+  repo: string; // "owner/repo"
   number: number;
   title: string;
   url: string;
@@ -620,7 +614,7 @@ interface CommentedIssueBase {
 export interface CommentedIssueWithResponse extends CommentedIssueBase {
   status: 'new_response';
   lastResponseAuthor: string;
-  lastResponseBody: string;    // Truncated to 200 chars (+ "..." suffix when truncated)
+  lastResponseBody: string; // Truncated to 200 chars (+ "..." suffix when truncated)
   lastResponseAt: string;
 }
 

--- a/src/core/utils.test.ts
+++ b/src/core/utils.test.ts
@@ -78,23 +78,25 @@ describe('parseGitHubUrl', () => {
 
 describe('extractOwnerRepo', () => {
   it('should extract owner and repo from a PR URL', () => {
-    expect(extractOwnerRepo('https://github.com/facebook/react/pull/123'))
-      .toEqual({ owner: 'facebook', repo: 'react' });
+    expect(extractOwnerRepo('https://github.com/facebook/react/pull/123')).toEqual({
+      owner: 'facebook',
+      repo: 'react',
+    });
   });
 
   it('should extract owner and repo from an issue URL', () => {
-    expect(extractOwnerRepo('https://github.com/vercel/next.js/issues/456'))
-      .toEqual({ owner: 'vercel', repo: 'next.js' });
+    expect(extractOwnerRepo('https://github.com/vercel/next.js/issues/456')).toEqual({
+      owner: 'vercel',
+      repo: 'next.js',
+    });
   });
 
   it('should extract from a bare repo URL with trailing slash', () => {
-    expect(extractOwnerRepo('https://github.com/vercel/next.js/'))
-      .toEqual({ owner: 'vercel', repo: 'next.js' });
+    expect(extractOwnerRepo('https://github.com/vercel/next.js/')).toEqual({ owner: 'vercel', repo: 'next.js' });
   });
 
   it('should handle hyphenated and underscored names', () => {
-    expect(extractOwnerRepo('https://github.com/my-org/my_repo/pull/1'))
-      .toEqual({ owner: 'my-org', repo: 'my_repo' });
+    expect(extractOwnerRepo('https://github.com/my-org/my_repo/pull/1')).toEqual({ owner: 'my-org', repo: 'my_repo' });
   });
 
   it('should return null for non-GitHub URLs', () => {
@@ -230,33 +232,22 @@ describe('formatRelativeTime', () => {
 
 describe('byDateDescending', () => {
   it('should sort items by date descending', () => {
-    const items = [
-      { date: '2026-01-01' },
-      { date: '2026-03-01' },
-      { date: '2026-02-01' },
-    ];
-    items.sort(byDateDescending(item => item.date));
-    expect(items.map(i => i.date)).toEqual(['2026-03-01', '2026-02-01', '2026-01-01']);
+    const items = [{ date: '2026-01-01' }, { date: '2026-03-01' }, { date: '2026-02-01' }];
+    items.sort(byDateDescending((item) => item.date));
+    expect(items.map((i) => i.date)).toEqual(['2026-03-01', '2026-02-01', '2026-01-01']);
   });
 
   it('should handle null dates (sort to end)', () => {
-    const items = [
-      { date: null as string | null },
-      { date: '2026-02-01' },
-      { date: '2026-01-01' },
-    ];
-    items.sort(byDateDescending(item => item.date));
+    const items = [{ date: null as string | null }, { date: '2026-02-01' }, { date: '2026-01-01' }];
+    items.sort(byDateDescending((item) => item.date));
     expect(items[0].date).toBe('2026-02-01');
     expect(items[1].date).toBe('2026-01-01');
     expect(items[2].date).toBeNull();
   });
 
   it('should handle undefined dates', () => {
-    const items = [
-      { date: undefined as string | undefined },
-      { date: '2026-01-01' },
-    ];
-    items.sort(byDateDescending(item => item.date));
+    const items = [{ date: undefined as string | undefined }, { date: '2026-01-01' }];
+    items.sort(byDateDescending((item) => item.date));
     expect(items[0].date).toBe('2026-01-01');
     expect(items[1].date).toBeUndefined();
   });
@@ -266,7 +257,7 @@ describe('byDateDescending', () => {
       { date: '2026-01-01', id: 'a' },
       { date: '2026-01-01', id: 'b' },
     ];
-    items.sort(byDateDescending(item => item.date));
+    items.sort(byDateDescending((item) => item.date));
     // Both have same date, order is stable (0 diff)
     expect(items.length).toBe(2);
   });

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -360,10 +360,10 @@ export function requireGitHubToken(): string {
   if (!token) {
     throw new ConfigurationError(
       'GitHub authentication required.\n\n' +
-      'Options:\n' +
-      '  1. Use gh CLI: gh auth login\n' +
-      '  2. Set GITHUB_TOKEN environment variable\n\n' +
-      'The gh CLI is recommended - install from https://cli.github.com'
+        'Options:\n' +
+        '  1. Use gh CLI: gh auth login\n' +
+        '  2. Set GITHUB_TOKEN environment variable\n\n' +
+        'The gh CLI is recommended - install from https://cli.github.com',
     );
   }
 

--- a/src/formatters/json.ts
+++ b/src/formatters/json.ts
@@ -23,7 +23,12 @@ export interface CapacityAssessment {
   reason: string;
 }
 
-export type ActionableIssueType = 'ci_failing' | 'merge_conflict' | 'needs_response' | 'needs_changes' | 'incomplete_checklist';
+export type ActionableIssueType =
+  | 'ci_failing'
+  | 'merge_conflict'
+  | 'needs_response'
+  | 'needs_changes'
+  | 'incomplete_checklist';
 
 export interface ActionableIssue {
   type: ActionableIssueType;


### PR DESCRIPTION
## Summary

Closes #230

Adds linting and formatting infrastructure:

- ESLint v9 flat config with TypeScript support and Prettier integration
- Prettier with single quotes, trailing commas, 120 char width
- Scripts: `npm run lint`, `npm run lint:fix`, `npm run format`, `npm run format:check`
- Lint + format check added to CI pipeline (before type check)
- All existing code auto-formatted and lint-clean (no behavior changes)
- Minor cleanups: removed 5 unused imports, renamed 4 unused vars with _ prefix

## Test plan

- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm run format:check` — all files formatted
- [x] `npm test` — all 622 tests pass
- [x] CI workflow updated with lint + format steps