### PR TITLE
feat: dashboard improvements — filtering, dark mode, search

### DIFF
--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -1223,7 +1223,7 @@ function generateDashboardHtml(
           for (const pr of recentlyMerged) repos.add(pr.repo);
           for (const pr of (digest.recentlyClosedPRs || [])) repos.add(pr.repo);
           for (const pr of autoUnshelvedPRs) repos.add(pr.repo);
-          return Array.from(repos).sort().map(repo => `<option value="${escapeHtml(repo)}">${escapeHtml(repo)}</option>`).join('\\n        ');
+          return Array.from(repos).sort().map(repo => `<option value="${escapeHtml(repo)}">${escapeHtml(repo)}</option>`).join('\n        ');
         })()}
       </select>
       <span class="filter-count" id="filterCount"></span>
@@ -1552,8 +1552,10 @@ function generateDashboardHtml(
       var label = document.getElementById('themeLabel');
 
       function getEffectiveTheme() {
-        var stored = localStorage.getItem('oss-dashboard-theme');
-        if (stored) return stored;
+        try {
+          var stored = localStorage.getItem('oss-dashboard-theme');
+          if (stored === 'light' || stored === 'dark') return stored;
+        } catch (e) { /* localStorage unavailable (private browsing) */ }
         return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
       }
 
@@ -1573,9 +1575,9 @@ function generateDashboardHtml(
       applyTheme(getEffectiveTheme());
 
       toggle.addEventListener('click', function() {
-        var current = html.getAttribute('data-theme') || getEffectiveTheme();
+        var current = html.getAttribute('data-theme');
         var next = current === 'dark' ? 'light' : 'dark';
-        localStorage.setItem('oss-dashboard-theme', next);
+        try { localStorage.setItem('oss-dashboard-theme', next); } catch (e) { /* private browsing */ }
         applyTheme(next);
       });
     })();


### PR DESCRIPTION
## Summary

Closes #241

Comprehensive dashboard UX improvements — all client-side, no server needed:

- **Dark/Light mode** — respects system preference via `prefers-color-scheme`, plus manual toggle button. Persists preference in localStorage.
- **Status filtering** — dropdown with 17 status options filters PR cards by status
- **Repository filtering** — dynamically populated dropdown filters by repo
- **Search** — text input filters PR cards by title (case-insensitive)
- **Filter count** — shows "X of Y items" when filters are active
- **Timestamp** — shows full generation date in header and ISO timestamp in footer

All three filters work conjunctively (AND logic). 340 lines added.

## Test plan

- [x] All 622 tests pass
- [x] TypeScript compiles cleanly
- [x] All JavaScript is embedded inline in generated HTML