### PR TITLE
test: add unit tests for 10 untested command files

### DIFF
--- a/src/commands/comments.test.ts
+++ b/src/commands/comments.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Tests for comments, post, and claim commands
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../core/index.js', () => ({
+  getStateManager: vi.fn(),
+  getOctokit: vi.fn(),
+  parseGitHubUrl: vi.fn(),
+  formatRelativeTime: vi.fn(),
+  getGitHubToken: vi.fn(),
+}));
+
+vi.mock('../formatters/json.js', () => ({
+  outputJson: vi.fn(),
+  outputJsonError: vi.fn(),
+}));
+
+import { getStateManager, getOctokit, parseGitHubUrl, getGitHubToken } from '../core/index.js';
+import { outputJson, outputJsonError } from '../formatters/json.js';
+import { runComments, runPost, runClaim } from './comments.js';
+
+const mockGetStateManager = vi.mocked(getStateManager);
+const mockGetOctokit = vi.mocked(getOctokit);
+const mockParseGitHubUrl = vi.mocked(parseGitHubUrl);
+const mockGetGitHubToken = vi.mocked(getGitHubToken);
+const mockOutputJson = vi.mocked(outputJson);
+const mockOutputJsonError = vi.mocked(outputJsonError);
+
+const TEST_PR_URL = 'https://github.com/owner/repo/pull/42';
+const TEST_ISSUE_URL = 'https://github.com/owner/repo/issues/10';
+
+describe('runComments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetStateManager.mockReturnValue({
+      getState: vi.fn().mockReturnValue({ config: { githubUsername: 'testuser' } }),
+    } as any);
+  });
+
+  it('should exit with error when no GitHub token', async () => {
+    mockGetGitHubToken.mockReturnValue(null as any);
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+
+    await expect(runComments({ prUrl: TEST_PR_URL, json: true })).rejects.toThrow('exit');
+
+    expect(mockOutputJsonError).toHaveBeenCalledWith(expect.stringContaining('GitHub authentication required'));
+    mockExit.mockRestore();
+  });
+
+  it('should exit with error for invalid PR URL', async () => {
+    mockGetGitHubToken.mockReturnValue('ghp_test123');
+    mockParseGitHubUrl.mockReturnValue(null as any);
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+
+    await expect(runComments({ prUrl: 'invalid-url', json: true })).rejects.toThrow('exit');
+
+    expect(mockOutputJsonError).toHaveBeenCalledWith('Invalid PR URL format');
+    mockExit.mockRestore();
+  });
+
+  it('should fetch and return comments in JSON mode', async () => {
+    mockGetGitHubToken.mockReturnValue('ghp_test123');
+    mockParseGitHubUrl.mockReturnValue({ owner: 'owner', repo: 'repo', number: 42, type: 'pull' });
+
+    const mockPullsGet = vi.fn().mockResolvedValue({
+      data: { title: 'Test PR', state: 'open', mergeable: true, head: { ref: 'feature' }, base: { ref: 'main' }, html_url: TEST_PR_URL },
+    });
+    const mockListReviewComments = vi.fn().mockResolvedValue({ data: [] });
+    const mockListComments = vi.fn().mockResolvedValue({ data: [] });
+    const mockListReviews = vi.fn().mockResolvedValue({
+      data: [
+        { user: { login: 'reviewer', type: 'User' }, state: 'APPROVED', body: 'LGTM', submitted_at: '2026-01-15T10:00:00Z' },
+      ],
+    });
+
+    mockGetOctokit.mockReturnValue({
+      pulls: { get: mockPullsGet, listReviewComments: mockListReviewComments, listReviews: mockListReviews },
+      issues: { listComments: mockListComments },
+    } as any);
+
+    await runComments({ prUrl: TEST_PR_URL, json: true });
+
+    expect(mockOutputJson).toHaveBeenCalledWith(expect.objectContaining({
+      pr: expect.objectContaining({ title: 'Test PR', state: 'open' }),
+      reviews: [{ user: 'reviewer', state: 'APPROVED', body: 'LGTM', submittedAt: '2026-01-15T10:00:00Z' }],
+      summary: { reviewCount: 1, inlineCommentCount: 0, discussionCommentCount: 0 },
+    }));
+  });
+
+  it('should filter out own comments', async () => {
+    mockGetGitHubToken.mockReturnValue('ghp_test123');
+    mockParseGitHubUrl.mockReturnValue({ owner: 'owner', repo: 'repo', number: 42, type: 'pull' });
+
+    const mockPullsGet = vi.fn().mockResolvedValue({
+      data: { title: 'Test PR', state: 'open', mergeable: true, head: { ref: 'feature' }, base: { ref: 'main' }, html_url: TEST_PR_URL },
+    });
+    const mockListReviewComments = vi.fn().mockResolvedValue({ data: [] });
+    const mockListComments = vi.fn().mockResolvedValue({
+      data: [
+        { user: { login: 'testuser', type: 'User' }, body: 'My own comment', created_at: '2026-01-15T10:00:00Z' },
+        { user: { login: 'other', type: 'User' }, body: 'Other comment', created_at: '2026-01-15T11:00:00Z' },
+      ],
+    });
+    const mockListReviews = vi.fn().mockResolvedValue({ data: [] });
+
+    mockGetOctokit.mockReturnValue({
+      pulls: { get: mockPullsGet, listReviewComments: mockListReviewComments, listReviews: mockListReviews },
+      issues: { listComments: mockListComments },
+    } as any);
+
+    await runComments({ prUrl: TEST_PR_URL, json: true });
+
+    const outputData = mockOutputJson.mock.calls[0][0] as any;
+    expect(outputData.issueComments).toHaveLength(1);
+    expect(outputData.issueComments[0].user).toBe('other');
+  });
+});
+
+describe('runPost', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should exit with error when no GitHub token', async () => {
+    mockGetGitHubToken.mockReturnValue(null as any);
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+
+    await expect(runPost({ url: TEST_PR_URL, message: 'Hello', json: true })).rejects.toThrow('exit');
+
+    expect(mockOutputJsonError).toHaveBeenCalledWith(expect.stringContaining('GitHub authentication required'));
+    mockExit.mockRestore();
+  });
+
+  it('should exit with error when no message provided', async () => {
+    mockGetGitHubToken.mockReturnValue('ghp_test123');
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+
+    await expect(runPost({ url: TEST_PR_URL, json: true })).rejects.toThrow('exit');
+
+    expect(mockOutputJsonError).toHaveBeenCalledWith('No message provided');
+    mockExit.mockRestore();
+  });
+
+  it('should exit with error for invalid URL', async () => {
+    mockGetGitHubToken.mockReturnValue('ghp_test123');
+    mockParseGitHubUrl.mockReturnValue(null as any);
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+
+    await expect(runPost({ url: 'bad-url', message: 'Hello', json: true })).rejects.toThrow('exit');
+
+    expect(mockOutputJsonError).toHaveBeenCalledWith('Invalid GitHub URL format');
+    mockExit.mockRestore();
+  });
+
+  it('should post a comment and output JSON', async () => {
+    mockGetGitHubToken.mockReturnValue('ghp_test123');
+    mockParseGitHubUrl.mockReturnValue({ owner: 'owner', repo: 'repo', number: 42, type: 'pull' });
+
+    const mockCreateComment = vi.fn().mockResolvedValue({
+      data: { html_url: 'https://github.com/owner/repo/pull/42#issuecomment-1' },
+    });
+    mockGetOctokit.mockReturnValue({
+      issues: { createComment: mockCreateComment },
+    } as any);
+    const mockMarkPRAsRead = vi.fn().mockReturnValue(true);
+    mockGetStateManager.mockReturnValue({
+      markPRAsRead: mockMarkPRAsRead,
+      save: vi.fn(),
+    } as any);
+
+    await runPost({ url: TEST_PR_URL, message: 'Thanks!', json: true });
+
+    expect(mockCreateComment).toHaveBeenCalledWith({
+      owner: 'owner',
+      repo: 'repo',
+      issue_number: 42,
+      body: 'Thanks!',
+    });
+    expect(mockOutputJson).toHaveBeenCalledWith({
+      commentUrl: 'https://github.com/owner/repo/pull/42#issuecomment-1',
+      url: TEST_PR_URL,
+    });
+  });
+});
+
+describe('runClaim', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should exit with error when no GitHub token', async () => {
+    mockGetGitHubToken.mockReturnValue(null as any);
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+
+    await expect(runClaim({ issueUrl: TEST_ISSUE_URL, json: true })).rejects.toThrow('exit');
+
+    expect(mockOutputJsonError).toHaveBeenCalledWith(expect.stringContaining('GitHub authentication required'));
+    mockExit.mockRestore();
+  });
+
+  it('should exit with error for non-issue URL', async () => {
+    mockGetGitHubToken.mockReturnValue('ghp_test123');
+    mockParseGitHubUrl.mockReturnValue({ owner: 'owner', repo: 'repo', number: 42, type: 'pull' });
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+
+    await expect(runClaim({ issueUrl: TEST_PR_URL, json: true })).rejects.toThrow('exit');
+
+    expect(mockOutputJsonError).toHaveBeenCalledWith('Invalid issue URL format (must be an issue, not a PR)');
+    mockExit.mockRestore();
+  });
+
+  it('should claim an issue and track it', async () => {
+    mockGetGitHubToken.mockReturnValue('ghp_test123');
+    mockParseGitHubUrl.mockReturnValue({ owner: 'owner', repo: 'repo', number: 10, type: 'issues' });
+
+    const mockCreateComment = vi.fn().mockResolvedValue({
+      data: { html_url: 'https://github.com/owner/repo/issues/10#issuecomment-1' },
+    });
+    mockGetOctokit.mockReturnValue({
+      issues: { createComment: mockCreateComment },
+    } as any);
+    const mockAddIssue = vi.fn();
+    const mockSave = vi.fn();
+    mockGetStateManager.mockReturnValue({
+      addIssue: mockAddIssue,
+      save: mockSave,
+    } as any);
+
+    await runClaim({ issueUrl: TEST_ISSUE_URL, json: true });
+
+    expect(mockCreateComment).toHaveBeenCalled();
+    expect(mockAddIssue).toHaveBeenCalledWith(expect.objectContaining({
+      url: TEST_ISSUE_URL,
+      repo: 'owner/repo',
+      number: 10,
+      status: 'claimed',
+    }));
+    expect(mockSave).toHaveBeenCalled();
+    expect(mockOutputJson).toHaveBeenCalledWith({
+      commentUrl: 'https://github.com/owner/repo/issues/10#issuecomment-1',
+      issueUrl: TEST_ISSUE_URL,
+    });
+  });
+});

--- a/src/commands/config.test.ts
+++ b/src/commands/config.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for config command
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../core/index.js', () => ({
+  getStateManager: vi.fn(),
+}));
+
+vi.mock('../formatters/json.js', () => ({
+  outputJson: vi.fn(),
+  outputJsonError: vi.fn(),
+}));
+
+import { getStateManager } from '../core/index.js';
+import { outputJson, outputJsonError } from '../formatters/json.js';
+import { runConfig } from './config.js';
+
+const mockGetStateManager = vi.mocked(getStateManager);
+const mockOutputJson = vi.mocked(outputJson);
+const mockOutputJsonError = vi.mocked(outputJsonError);
+
+const DEFAULT_CONFIG = {
+  githubUsername: 'testuser',
+  maxActivePRs: 10,
+  dormantThresholdDays: 30,
+  approachingDormantDays: 25,
+  languages: ['typescript', 'javascript'],
+  labels: ['good first issue', 'help wanted'],
+  excludeRepos: [],
+  excludeOrgs: [],
+  setupComplete: true,
+};
+
+describe('runConfig', () => {
+  const mockSave = vi.fn();
+  const mockUpdateConfig = vi.fn();
+  const mockCleanupExcludedData = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetStateManager.mockReturnValue({
+      getState: vi.fn().mockReturnValue({ config: { ...DEFAULT_CONFIG } }),
+      updateConfig: mockUpdateConfig,
+      cleanupExcludedData: mockCleanupExcludedData,
+      save: mockSave,
+    } as any);
+  });
+
+  it('should show current config in JSON mode when no key specified', async () => {
+    await runConfig({ json: true });
+
+    expect(mockOutputJson).toHaveBeenCalledWith({ config: DEFAULT_CONFIG });
+  });
+
+  it('should set username config', async () => {
+    await runConfig({ key: 'username', value: 'newuser', json: true });
+
+    expect(mockUpdateConfig).toHaveBeenCalledWith({ githubUsername: 'newuser' });
+    expect(mockSave).toHaveBeenCalled();
+    expect(mockOutputJson).toHaveBeenCalledWith({ success: true, key: 'username', value: 'newuser' });
+  });
+
+  it('should add a language', async () => {
+    await runConfig({ key: 'add-language', value: 'python', json: true });
+
+    expect(mockUpdateConfig).toHaveBeenCalledWith({
+      languages: ['typescript', 'javascript', 'python'],
+    });
+    expect(mockSave).toHaveBeenCalled();
+  });
+
+  it('should not add duplicate language', async () => {
+    await runConfig({ key: 'add-language', value: 'typescript', json: true });
+
+    expect(mockUpdateConfig).not.toHaveBeenCalled();
+    expect(mockSave).toHaveBeenCalled();
+  });
+
+  it('should add a label', async () => {
+    await runConfig({ key: 'add-label', value: 'bug', json: true });
+
+    expect(mockUpdateConfig).toHaveBeenCalledWith({
+      labels: ['good first issue', 'help wanted', 'bug'],
+    });
+    expect(mockSave).toHaveBeenCalled();
+  });
+
+  it('should exclude a repo with valid format', async () => {
+    await runConfig({ key: 'exclude-repo', value: 'owner/repo', json: true });
+
+    expect(mockUpdateConfig).toHaveBeenCalledWith({
+      excludeRepos: ['owner/repo'],
+    });
+    expect(mockCleanupExcludedData).toHaveBeenCalledWith(['owner/repo'], []);
+    expect(mockSave).toHaveBeenCalled();
+  });
+
+  it('should exit with error for invalid repo format in exclude-repo', async () => {
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+
+    await expect(runConfig({ key: 'exclude-repo', value: 'invalid', json: true })).rejects.toThrow('exit');
+
+    expect(mockOutputJsonError).toHaveBeenCalledWith(expect.stringContaining('Invalid repo format'));
+    mockExit.mockRestore();
+  });
+
+  it('should exclude an org', async () => {
+    await runConfig({ key: 'exclude-org', value: 'facebook', json: true });
+
+    expect(mockUpdateConfig).toHaveBeenCalledWith({
+      excludeOrgs: ['facebook'],
+    });
+    expect(mockCleanupExcludedData).toHaveBeenCalledWith([], ['facebook']);
+    expect(mockSave).toHaveBeenCalled();
+  });
+
+  it('should exit with error for invalid org name with slash', async () => {
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+
+    await expect(runConfig({ key: 'exclude-org', value: 'owner/repo', json: true })).rejects.toThrow('exit');
+
+    expect(mockOutputJsonError).toHaveBeenCalledWith(expect.stringContaining('Invalid org name'));
+    mockExit.mockRestore();
+  });
+
+  it('should exit with error for unknown config key', async () => {
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+
+    await expect(runConfig({ key: 'unknown-key', value: 'val', json: true })).rejects.toThrow('exit');
+
+    expect(mockOutputJsonError).toHaveBeenCalledWith('Unknown config key: unknown-key');
+    mockExit.mockRestore();
+  });
+
+  it('should exit with error when value is missing', async () => {
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+
+    await expect(runConfig({ key: 'username', json: true })).rejects.toThrow('exit');
+
+    expect(mockOutputJsonError).toHaveBeenCalledWith('Value required');
+    mockExit.mockRestore();
+  });
+});

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for init command
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockTrackPR = vi.fn();
+
+vi.mock('../core/index.js', () => {
+  const MockPRMonitor = vi.fn(function (this: any) {
+    this.trackPR = mockTrackPR;
+  });
+  return {
+    getStateManager: vi.fn(),
+    PRMonitor: MockPRMonitor,
+    getOctokit: vi.fn(),
+    getGitHubToken: vi.fn(),
+  };
+});
+
+vi.mock('../formatters/json.js', () => ({
+  outputJson: vi.fn(),
+  outputJsonError: vi.fn(),
+}));
+
+import { getStateManager, getOctokit, getGitHubToken } from '../core/index.js';
+import { outputJson, outputJsonError } from '../formatters/json.js';
+import { runInit } from './init.js';
+
+const mockGetStateManager = vi.mocked(getStateManager);
+const mockGetGitHubToken = vi.mocked(getGitHubToken);
+const mockGetOctokit = vi.mocked(getOctokit);
+const mockOutputJson = vi.mocked(outputJson);
+const mockOutputJsonError = vi.mocked(outputJsonError);
+
+describe('runInit', () => {
+  const mockSave = vi.fn();
+  const mockUpdateConfig = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetStateManager.mockReturnValue({
+      updateConfig: mockUpdateConfig,
+      save: mockSave,
+    } as any);
+  });
+
+  it('should exit with error when no GitHub token is available', async () => {
+    mockGetGitHubToken.mockReturnValue(null as any);
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+
+    await expect(runInit({ username: 'testuser', json: true })).rejects.toThrow('exit');
+
+    expect(mockOutputJsonError).toHaveBeenCalledWith(expect.stringContaining('GitHub authentication required'));
+    mockExit.mockRestore();
+  });
+
+  it('should import open PRs for a user', async () => {
+    mockGetGitHubToken.mockReturnValue('ghp_test123');
+    const mockSearch = vi.fn().mockResolvedValue({
+      data: {
+        total_count: 2,
+        items: [
+          {
+            html_url: 'https://github.com/owner/repo/pull/1',
+            pull_request: { url: 'https://api.github.com/repos/owner/repo/pulls/1' },
+          },
+          {
+            html_url: 'https://github.com/owner/repo/pull/2',
+            pull_request: { url: 'https://api.github.com/repos/owner/repo/pulls/2' },
+          },
+        ],
+      },
+    });
+    mockGetOctokit.mockReturnValue({
+      search: { issuesAndPullRequests: mockSearch },
+    } as any);
+    mockTrackPR
+      .mockResolvedValueOnce({ repo: 'owner/repo', number: 1, title: 'First PR' })
+      .mockResolvedValueOnce({ repo: 'owner/repo', number: 2, title: 'Second PR' });
+
+    await runInit({ username: 'testuser', json: true });
+
+    expect(mockUpdateConfig).toHaveBeenCalledWith({ githubUsername: 'testuser' });
+    expect(mockTrackPR).toHaveBeenCalledTimes(2);
+    expect(mockSave).toHaveBeenCalled();
+    expect(mockOutputJson).toHaveBeenCalledWith({
+      username: 'testuser',
+      totalFound: 2,
+      imported: [
+        { repo: 'owner/repo', number: 1, title: 'First PR' },
+        { repo: 'owner/repo', number: 2, title: 'Second PR' },
+      ],
+      errors: [],
+    });
+  });
+
+  it('should handle errors when tracking individual PRs', async () => {
+    mockGetGitHubToken.mockReturnValue('ghp_test123');
+    const mockSearch = vi.fn().mockResolvedValue({
+      data: {
+        total_count: 1,
+        items: [
+          {
+            html_url: 'https://github.com/owner/repo/pull/1',
+            pull_request: { url: 'https://api.github.com/repos/owner/repo/pulls/1' },
+          },
+        ],
+      },
+    });
+    mockGetOctokit.mockReturnValue({
+      search: { issuesAndPullRequests: mockSearch },
+    } as any);
+    mockTrackPR.mockRejectedValueOnce(new Error('API rate limit exceeded'));
+
+    await runInit({ username: 'testuser', json: true });
+
+    expect(mockOutputJson).toHaveBeenCalledWith({
+      username: 'testuser',
+      totalFound: 1,
+      imported: [],
+      errors: [{ url: 'https://github.com/owner/repo/pull/1', error: 'API rate limit exceeded' }],
+    });
+  });
+
+  it('should skip items without pull_request property', async () => {
+    mockGetGitHubToken.mockReturnValue('ghp_test123');
+    const mockSearch = vi.fn().mockResolvedValue({
+      data: {
+        total_count: 1,
+        items: [
+          { html_url: 'https://github.com/owner/repo/issues/5' },
+        ],
+      },
+    });
+    mockGetOctokit.mockReturnValue({
+      search: { issuesAndPullRequests: mockSearch },
+    } as any);
+
+    await runInit({ username: 'testuser', json: true });
+
+    expect(mockTrackPR).not.toHaveBeenCalled();
+    expect(mockOutputJson).toHaveBeenCalledWith({
+      username: 'testuser',
+      totalFound: 1,
+      imported: [],
+      errors: [],
+    });
+  });
+});

--- a/src/commands/read.test.ts
+++ b/src/commands/read.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for read command
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../core/index.js', () => ({
+  getStateManager: vi.fn(),
+}));
+
+vi.mock('../formatters/json.js', () => ({
+  outputJson: vi.fn(),
+  outputJsonError: vi.fn(),
+}));
+
+import { getStateManager } from '../core/index.js';
+import { outputJson, outputJsonError } from '../formatters/json.js';
+import { runRead } from './read.js';
+
+const mockGetStateManager = vi.mocked(getStateManager);
+const mockOutputJson = vi.mocked(outputJson);
+const mockOutputJsonError = vi.mocked(outputJsonError);
+
+const TEST_PR_URL = 'https://github.com/owner/repo/pull/42';
+
+describe('runRead', () => {
+  const mockSave = vi.fn();
+  const mockMarkPRAsRead = vi.fn();
+  const mockMarkAllPRsAsRead = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetStateManager.mockReturnValue({
+      markPRAsRead: mockMarkPRAsRead,
+      markAllPRsAsRead: mockMarkAllPRsAsRead,
+      save: mockSave,
+    } as any);
+  });
+
+  it('should mark a specific PR as read', async () => {
+    mockMarkPRAsRead.mockReturnValue(true);
+
+    await runRead({ prUrl: TEST_PR_URL, json: true });
+
+    expect(mockMarkPRAsRead).toHaveBeenCalledWith(TEST_PR_URL);
+    expect(mockSave).toHaveBeenCalled();
+    expect(mockOutputJson).toHaveBeenCalledWith({ marked: true, url: TEST_PR_URL });
+  });
+
+  it('should not save when PR is not found or already read', async () => {
+    mockMarkPRAsRead.mockReturnValue(false);
+
+    await runRead({ prUrl: TEST_PR_URL, json: true });
+
+    expect(mockSave).not.toHaveBeenCalled();
+    expect(mockOutputJson).toHaveBeenCalledWith({ marked: false, url: TEST_PR_URL });
+  });
+
+  it('should mark all PRs as read with --all flag', async () => {
+    mockMarkAllPRsAsRead.mockReturnValue(5);
+
+    await runRead({ all: true, json: true });
+
+    expect(mockMarkAllPRsAsRead).toHaveBeenCalled();
+    expect(mockSave).toHaveBeenCalled();
+    expect(mockOutputJson).toHaveBeenCalledWith({ markedAsRead: 5, all: true });
+  });
+
+  it('should exit with error when neither prUrl nor --all is provided', async () => {
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+
+    await expect(runRead({ json: true })).rejects.toThrow('exit');
+
+    expect(mockOutputJsonError).toHaveBeenCalledWith('PR URL or --all flag required');
+    mockExit.mockRestore();
+  });
+
+  it('should output text when marking all PRs as read without JSON', async () => {
+    mockMarkAllPRsAsRead.mockReturnValue(3);
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runRead({ all: true, json: false });
+
+    expect(consoleSpy).toHaveBeenCalled();
+    const allOutput = consoleSpy.mock.calls.map(c => c[0]).join('\n');
+    expect(allOutput).toContain('Marked 3 PRs as read');
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/commands/search.test.ts
+++ b/src/commands/search.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for search command
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSearchIssues = vi.fn();
+const mockFormatCandidate = vi.fn();
+let mockRateLimitWarning: string | null = null;
+
+vi.mock('../core/index.js', () => {
+  const MockIssueDiscovery = vi.fn(function (this: any) {
+    this.searchIssues = mockSearchIssues;
+    this.formatCandidate = mockFormatCandidate;
+    Object.defineProperty(this, 'rateLimitWarning', {
+      get: () => mockRateLimitWarning,
+    });
+  });
+  return {
+    IssueDiscovery: MockIssueDiscovery,
+    getGitHubToken: vi.fn(),
+    getStateManager: vi.fn(),
+    DEFAULT_CONFIG: {
+      aiPolicyBlocklist: ['matplotlib/matplotlib'],
+    },
+  };
+});
+
+vi.mock('../formatters/json.js', () => ({
+  outputJson: vi.fn(),
+  outputJsonError: vi.fn(),
+}));
+
+import { getGitHubToken, getStateManager } from '../core/index.js';
+import { outputJson, outputJsonError } from '../formatters/json.js';
+import { runSearch } from './search.js';
+
+const mockGetGitHubToken = vi.mocked(getGitHubToken);
+const mockGetStateManager = vi.mocked(getStateManager);
+const mockOutputJson = vi.mocked(outputJson);
+const mockOutputJsonError = vi.mocked(outputJsonError);
+
+describe('runSearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRateLimitWarning = null;
+    mockGetStateManager.mockReturnValue({
+      getState: vi.fn().mockReturnValue({
+        config: {
+          excludeRepos: ['excluded/repo'],
+          aiPolicyBlocklist: ['matplotlib/matplotlib'],
+        },
+      }),
+      getRepoScore: vi.fn().mockReturnValue(null),
+    } as any);
+  });
+
+  it('should exit with error when no GitHub token is available', async () => {
+    mockGetGitHubToken.mockReturnValue(null as any);
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+
+    await expect(runSearch({ maxResults: 10, json: true })).rejects.toThrow('exit');
+
+    expect(mockOutputJsonError).toHaveBeenCalledWith(expect.stringContaining('GitHub authentication required'));
+    mockExit.mockRestore();
+  });
+
+  it('should search and return candidates in JSON mode', async () => {
+    mockGetGitHubToken.mockReturnValue('ghp_test123');
+    mockSearchIssues.mockResolvedValue([
+      {
+        issue: { repo: 'owner/repo', number: 5, title: 'Fix bug', url: 'https://github.com/owner/repo/issues/5', labels: ['bug'] },
+        recommendation: 'approve',
+        reasonsToApprove: ['Active maintainers'],
+        reasonsToSkip: [],
+        searchPriority: 'high',
+        viabilityScore: 85,
+      },
+    ]);
+
+    await runSearch({ maxResults: 10, json: true });
+
+    expect(mockSearchIssues).toHaveBeenCalledWith({ maxResults: 10 });
+    expect(mockOutputJson).toHaveBeenCalledWith(expect.objectContaining({
+      candidates: expect.arrayContaining([
+        expect.objectContaining({
+          issue: { repo: 'owner/repo', number: 5, title: 'Fix bug', url: 'https://github.com/owner/repo/issues/5', labels: ['bug'] },
+          recommendation: 'approve',
+        }),
+      ]),
+      excludedRepos: ['excluded/repo'],
+      aiPolicyBlocklist: ['matplotlib/matplotlib'],
+    }));
+  });
+
+  it('should include repo score when available', async () => {
+    mockGetGitHubToken.mockReturnValue('ghp_test123');
+    mockSearchIssues.mockResolvedValue([
+      {
+        issue: { repo: 'scored/repo', number: 1, title: 'Issue', url: 'https://github.com/scored/repo/issues/1', labels: [] },
+        recommendation: 'approve',
+        reasonsToApprove: [],
+        reasonsToSkip: [],
+        searchPriority: 'medium',
+        viabilityScore: 70,
+      },
+    ]);
+    mockGetStateManager.mockReturnValue({
+      getState: vi.fn().mockReturnValue({
+        config: { excludeRepos: [], aiPolicyBlocklist: [] },
+      }),
+      getRepoScore: vi.fn().mockReturnValue({
+        score: 8,
+        mergedPRCount: 3,
+        closedWithoutMergeCount: 1,
+        signals: { isResponsive: true },
+        lastMergedAt: '2026-01-10T00:00:00Z',
+      }),
+    } as any);
+
+    await runSearch({ maxResults: 5, json: true });
+
+    const outputData = mockOutputJson.mock.calls[0][0] as any;
+    expect(outputData.candidates[0].repoScore).toEqual({
+      score: 8,
+      mergedPRCount: 3,
+      closedWithoutMergeCount: 1,
+      isResponsive: true,
+      lastMergedAt: '2026-01-10T00:00:00Z',
+    });
+  });
+
+  it('should include rate limit warning when present', async () => {
+    mockGetGitHubToken.mockReturnValue('ghp_test123');
+    mockSearchIssues.mockResolvedValue([]);
+    mockRateLimitWarning = 'Rate limit is low';
+
+    await runSearch({ maxResults: 10, json: true });
+
+    const outputData = mockOutputJson.mock.calls[0][0] as any;
+    expect(outputData.rateLimitWarning).toBe('Rate limit is low');
+  });
+
+  it('should handle empty results in text mode', async () => {
+    mockGetGitHubToken.mockReturnValue('ghp_test123');
+    mockSearchIssues.mockResolvedValue([]);
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runSearch({ maxResults: 10, json: false });
+
+    expect(consoleSpy).toHaveBeenCalled();
+    const allOutput = consoleSpy.mock.calls.map(c => c[0]).join('\n');
+    expect(allOutput).toContain('No matching issues found');
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/commands/setup.test.ts
+++ b/src/commands/setup.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for setup and check-setup commands
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../core/index.js', () => ({
+  getStateManager: vi.fn(),
+  DEFAULT_CONFIG: {
+    aiPolicyBlocklist: ['matplotlib/matplotlib'],
+  },
+}));
+
+vi.mock('../formatters/json.js', () => ({
+  outputJson: vi.fn(),
+}));
+
+import { getStateManager } from '../core/index.js';
+import { outputJson } from '../formatters/json.js';
+import { runSetup, runCheckSetup } from './setup.js';
+
+const mockGetStateManager = vi.mocked(getStateManager);
+const mockOutputJson = vi.mocked(outputJson);
+
+const DEFAULT_CONFIG = {
+  githubUsername: 'testuser',
+  maxActivePRs: 10,
+  dormantThresholdDays: 30,
+  approachingDormantDays: 25,
+  languages: ['typescript', 'javascript'],
+  labels: ['good first issue', 'help wanted'],
+  setupComplete: true,
+  aiPolicyBlocklist: ['matplotlib/matplotlib'],
+};
+
+describe('runSetup', () => {
+  const mockSave = vi.fn();
+  const mockUpdateConfig = vi.fn();
+  const mockMarkSetupComplete = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetStateManager.mockReturnValue({
+      getState: vi.fn().mockReturnValue({ config: { ...DEFAULT_CONFIG } }),
+      updateConfig: mockUpdateConfig,
+      markSetupComplete: mockMarkSetupComplete,
+      save: mockSave,
+    } as any);
+  });
+
+  it('should show setup status when already complete in JSON mode', async () => {
+    await runSetup({ json: true });
+
+    expect(mockOutputJson).toHaveBeenCalledWith(expect.objectContaining({
+      setupComplete: true,
+      config: expect.objectContaining({
+        githubUsername: 'testuser',
+        maxActivePRs: 10,
+      }),
+    }));
+  });
+
+  it('should show setup prompts when setup is incomplete in JSON mode', async () => {
+    mockGetStateManager.mockReturnValue({
+      getState: vi.fn().mockReturnValue({ config: { ...DEFAULT_CONFIG, setupComplete: false } }),
+      updateConfig: mockUpdateConfig,
+      save: mockSave,
+    } as any);
+
+    await runSetup({ json: true });
+
+    expect(mockOutputJson).toHaveBeenCalledWith(expect.objectContaining({
+      setupRequired: true,
+      prompts: expect.arrayContaining([
+        expect.objectContaining({ setting: 'username' }),
+        expect.objectContaining({ setting: 'maxActivePRs' }),
+      ]),
+    }));
+  });
+
+  it('should show setup prompts when --reset is used', async () => {
+    await runSetup({ reset: true, json: true });
+
+    expect(mockOutputJson).toHaveBeenCalledWith(expect.objectContaining({
+      setupRequired: true,
+    }));
+  });
+
+  it('should apply --set settings correctly', async () => {
+    await runSetup({ set: ['username=newuser', 'maxActivePRs=5'], json: true });
+
+    expect(mockUpdateConfig).toHaveBeenCalledWith({ githubUsername: 'newuser' });
+    expect(mockUpdateConfig).toHaveBeenCalledWith({ maxActivePRs: 5 });
+    expect(mockSave).toHaveBeenCalled();
+    expect(mockOutputJson).toHaveBeenCalledWith(expect.objectContaining({
+      success: true,
+      settings: expect.objectContaining({
+        username: 'newuser',
+        maxActivePRs: '5',
+      }),
+    }));
+  });
+
+  it('should handle languages setting with comma-separated values', async () => {
+    await runSetup({ set: ['languages=python,rust,go'], json: true });
+
+    expect(mockUpdateConfig).toHaveBeenCalledWith({ languages: ['python', 'rust', 'go'] });
+    expect(mockSave).toHaveBeenCalled();
+  });
+
+  it('should handle complete=true setting', async () => {
+    await runSetup({ set: ['complete=true'], json: true });
+
+    expect(mockMarkSetupComplete).toHaveBeenCalled();
+    expect(mockSave).toHaveBeenCalled();
+  });
+
+  it('should handle showHealthCheck=false', async () => {
+    await runSetup({ set: ['showHealthCheck=false'], json: true });
+
+    expect(mockUpdateConfig).toHaveBeenCalledWith({ showHealthCheck: false });
+  });
+
+  it('should handle squashByDefault with ask value', async () => {
+    await runSetup({ set: ['squashByDefault=ask'], json: true });
+
+    expect(mockUpdateConfig).toHaveBeenCalledWith({ squashByDefault: 'ask' });
+  });
+
+  it('should handle includeDocIssues setting', async () => {
+    await runSetup({ set: ['includeDocIssues=true'], json: true });
+
+    expect(mockUpdateConfig).toHaveBeenCalledWith({ includeDocIssues: true });
+  });
+
+  it('should filter invalid aiPolicyBlocklist entries', async () => {
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await runSetup({ set: ['aiPolicyBlocklist=valid/repo,invalid-entry'], json: false });
+
+    expect(mockUpdateConfig).toHaveBeenCalledWith({ aiPolicyBlocklist: ['valid/repo'] });
+    consoleSpy.mockRestore();
+  });
+});
+
+describe('runCheckSetup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should report setup complete in JSON mode', async () => {
+    mockGetStateManager.mockReturnValue({
+      isSetupComplete: vi.fn().mockReturnValue(true),
+      getState: vi.fn().mockReturnValue({ config: { githubUsername: 'testuser' } }),
+    } as any);
+
+    await runCheckSetup({ json: true });
+
+    expect(mockOutputJson).toHaveBeenCalledWith({
+      setupComplete: true,
+      username: 'testuser',
+    });
+  });
+
+  it('should report setup incomplete in JSON mode', async () => {
+    mockGetStateManager.mockReturnValue({
+      isSetupComplete: vi.fn().mockReturnValue(false),
+      getState: vi.fn().mockReturnValue({ config: { githubUsername: '' } }),
+    } as any);
+
+    await runCheckSetup({ json: true });
+
+    expect(mockOutputJson).toHaveBeenCalledWith({
+      setupComplete: false,
+      username: '',
+    });
+  });
+
+  it('should output text when setup is complete', async () => {
+    mockGetStateManager.mockReturnValue({
+      isSetupComplete: vi.fn().mockReturnValue(true),
+      getState: vi.fn().mockReturnValue({ config: { githubUsername: 'testuser' } }),
+    } as any);
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runCheckSetup({ json: false });
+
+    const allOutput = consoleSpy.mock.calls.map(c => c[0]).join('\n');
+    expect(allOutput).toContain('SETUP_COMPLETE');
+    expect(allOutput).toContain('username=testuser');
+    consoleSpy.mockRestore();
+  });
+
+  it('should output SETUP_INCOMPLETE when not complete', async () => {
+    mockGetStateManager.mockReturnValue({
+      isSetupComplete: vi.fn().mockReturnValue(false),
+      getState: vi.fn().mockReturnValue({ config: { githubUsername: '' } }),
+    } as any);
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runCheckSetup({ json: false });
+
+    const allOutput = consoleSpy.mock.calls.map(c => c[0]).join('\n');
+    expect(allOutput).toContain('SETUP_INCOMPLETE');
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/commands/snooze.test.ts
+++ b/src/commands/snooze.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for snooze/unsnooze commands
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../core/index.js', () => ({
+  getStateManager: vi.fn(),
+}));
+
+vi.mock('../formatters/json.js', () => ({
+  outputJson: vi.fn(),
+  outputJsonError: vi.fn(),
+}));
+
+vi.mock('./validation.js', () => ({
+  PR_URL_PATTERN: /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+$/,
+  validateGitHubUrl: vi.fn(),
+}));
+
+import { getStateManager } from '../core/index.js';
+import { outputJson, outputJsonError } from '../formatters/json.js';
+import { validateGitHubUrl } from './validation.js';
+import { runSnooze, runUnsnooze } from './snooze.js';
+
+const mockGetStateManager = vi.mocked(getStateManager);
+const mockOutputJson = vi.mocked(outputJson);
+const mockOutputJsonError = vi.mocked(outputJsonError);
+const mockValidateGitHubUrl = vi.mocked(validateGitHubUrl);
+
+const TEST_PR_URL = 'https://github.com/owner/repo/pull/42';
+
+describe('runSnooze', () => {
+  const mockSave = vi.fn();
+  const mockSnoozePR = vi.fn();
+  const mockGetSnoozeInfo = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockValidateGitHubUrl.mockImplementation(() => {});
+    mockGetStateManager.mockReturnValue({
+      snoozePR: mockSnoozePR,
+      getSnoozeInfo: mockGetSnoozeInfo,
+      save: mockSave,
+    } as any);
+  });
+
+  it('should snooze a PR with default duration', async () => {
+    mockSnoozePR.mockReturnValue(true);
+    mockGetSnoozeInfo.mockReturnValue({ expiresAt: '2026-01-22T00:00:00Z' });
+
+    await runSnooze({ prUrl: TEST_PR_URL, reason: 'flaky CI', json: true });
+
+    expect(mockSnoozePR).toHaveBeenCalledWith(TEST_PR_URL, 'flaky CI', 7);
+    expect(mockSave).toHaveBeenCalled();
+    expect(mockOutputJson).toHaveBeenCalledWith({
+      snoozed: true,
+      url: TEST_PR_URL,
+      days: 7,
+      reason: 'flaky CI',
+      expiresAt: '2026-01-22T00:00:00Z',
+    });
+  });
+
+  it('should snooze a PR with custom duration', async () => {
+    mockSnoozePR.mockReturnValue(true);
+    mockGetSnoozeInfo.mockReturnValue({ expiresAt: '2026-01-17T00:00:00Z' });
+
+    await runSnooze({ prUrl: TEST_PR_URL, reason: 'upstream issue', days: 3, json: true });
+
+    expect(mockSnoozePR).toHaveBeenCalledWith(TEST_PR_URL, 'upstream issue', 3);
+  });
+
+  it('should report already snoozed without saving', async () => {
+    mockSnoozePR.mockReturnValue(false);
+    mockGetSnoozeInfo.mockReturnValue({ expiresAt: '2026-01-22T00:00:00Z' });
+
+    await runSnooze({ prUrl: TEST_PR_URL, reason: 'flaky CI', json: true });
+
+    expect(mockSave).not.toHaveBeenCalled();
+    expect(mockOutputJson).toHaveBeenCalledWith(expect.objectContaining({ snoozed: false }));
+  });
+
+  it('should reject non-positive snooze duration', async () => {
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+
+    await expect(runSnooze({ prUrl: TEST_PR_URL, reason: 'test', days: 0, json: true })).rejects.toThrow('exit');
+
+    expect(mockOutputJsonError).toHaveBeenCalledWith('Snooze duration must be a positive number of days.');
+    mockExit.mockRestore();
+  });
+
+  it('should reject negative snooze duration', async () => {
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+
+    await expect(runSnooze({ prUrl: TEST_PR_URL, reason: 'test', days: -5, json: true })).rejects.toThrow('exit');
+
+    expect(mockOutputJsonError).toHaveBeenCalledWith('Snooze duration must be a positive number of days.');
+    mockExit.mockRestore();
+  });
+});
+
+describe('runUnsnooze', () => {
+  const mockSave = vi.fn();
+  const mockUnsnoozePR = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockValidateGitHubUrl.mockImplementation(() => {});
+    mockGetStateManager.mockReturnValue({
+      unsnoozePR: mockUnsnoozePR,
+      save: mockSave,
+    } as any);
+  });
+
+  it('should unsnooze a PR and save state', async () => {
+    mockUnsnoozePR.mockReturnValue(true);
+
+    await runUnsnooze({ prUrl: TEST_PR_URL, json: true });
+
+    expect(mockUnsnoozePR).toHaveBeenCalledWith(TEST_PR_URL);
+    expect(mockSave).toHaveBeenCalled();
+    expect(mockOutputJson).toHaveBeenCalledWith({ unsnoozed: true, url: TEST_PR_URL });
+  });
+
+  it('should not save state when PR was not snoozed', async () => {
+    mockUnsnoozePR.mockReturnValue(false);
+
+    await runUnsnooze({ prUrl: TEST_PR_URL, json: true });
+
+    expect(mockSave).not.toHaveBeenCalled();
+    expect(mockOutputJson).toHaveBeenCalledWith({ unsnoozed: false, url: TEST_PR_URL });
+  });
+});

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for status command
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../core/index.js', () => ({
+  getStateManager: vi.fn(),
+}));
+
+vi.mock('../formatters/json.js', () => ({
+  outputJson: vi.fn(),
+}));
+
+import { getStateManager } from '../core/index.js';
+import { outputJson } from '../formatters/json.js';
+import { runStatus } from './status.js';
+
+const mockGetStateManager = vi.mocked(getStateManager);
+const mockOutputJson = vi.mocked(outputJson);
+
+describe('runStatus', () => {
+  const mockStats = {
+    activePRs: 3,
+    dormantPRs: 1,
+    mergedPRs: 5,
+    closedPRs: 2,
+    activeIssues: 0,
+    trustedProjects: 1,
+    mergeRate: '71%',
+    needsResponse: 1,
+  };
+
+  const mockActivePRs = [
+    { repo: 'owner/repo', number: 1, title: 'Fix bug', hasUnreadComments: true },
+    { repo: 'owner/repo', number: 2, title: 'Add feature', hasUnreadComments: false },
+  ];
+
+  const mockDormantPRs = [
+    { repo: 'other/repo', number: 10, title: 'Old PR', hasUnreadComments: false },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetStateManager.mockReturnValue({
+      getStats: vi.fn().mockReturnValue(mockStats),
+      getState: vi.fn().mockReturnValue({
+        activePRs: mockActivePRs,
+        dormantPRs: mockDormantPRs,
+        lastRunAt: '2026-01-15T10:00:00Z',
+      }),
+    } as any);
+  });
+
+  it('should output status in JSON mode', async () => {
+    await runStatus({ json: true });
+
+    expect(mockOutputJson).toHaveBeenCalledWith({
+      stats: mockStats,
+      activePRs: mockActivePRs,
+      dormantPRs: mockDormantPRs,
+      lastRunAt: '2026-01-15T10:00:00Z',
+    });
+  });
+
+  it('should output text mode without error', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runStatus({ json: false });
+
+    expect(consoleSpy).toHaveBeenCalled();
+    const allOutput = consoleSpy.mock.calls.map(c => c[0]).join('\n');
+    expect(allOutput).toContain('Active PRs: 3');
+    expect(allOutput).toContain('Dormant PRs: 1');
+    expect(allOutput).toContain('Merge Rate: 71%');
+    consoleSpy.mockRestore();
+  });
+
+  it('should exclude totalTracked from JSON output', async () => {
+    mockGetStateManager.mockReturnValue({
+      getStats: vi.fn().mockReturnValue({ ...mockStats, totalTracked: 11 }),
+      getState: vi.fn().mockReturnValue({
+        activePRs: [],
+        dormantPRs: [],
+        lastRunAt: '2026-01-15T10:00:00Z',
+      }),
+    } as any);
+
+    await runStatus({ json: true });
+
+    const outputData = mockOutputJson.mock.calls[0][0] as any;
+    expect(outputData.stats.totalTracked).toBeUndefined();
+  });
+
+  it('should handle empty PR lists', async () => {
+    mockGetStateManager.mockReturnValue({
+      getStats: vi.fn().mockReturnValue({ ...mockStats, activePRs: 0, dormantPRs: 0 }),
+      getState: vi.fn().mockReturnValue({
+        activePRs: [],
+        dormantPRs: [],
+        lastRunAt: '',
+      }),
+    } as any);
+
+    await runStatus({ json: true });
+
+    const outputData = mockOutputJson.mock.calls[0][0] as any;
+    expect(outputData.activePRs).toEqual([]);
+    expect(outputData.dormantPRs).toEqual([]);
+  });
+});

--- a/src/commands/track.test.ts
+++ b/src/commands/track.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for track/untrack commands
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockTrackPR = vi.fn();
+
+vi.mock('../core/index.js', () => {
+  const MockPRMonitor = vi.fn(function (this: any) {
+    this.trackPR = mockTrackPR;
+  });
+  return {
+    getStateManager: vi.fn(),
+    PRMonitor: MockPRMonitor,
+    getGitHubToken: vi.fn(),
+  };
+});
+
+vi.mock('../formatters/json.js', () => ({
+  outputJson: vi.fn(),
+  outputJsonError: vi.fn(),
+}));
+
+import { getStateManager, getGitHubToken } from '../core/index.js';
+import { outputJson, outputJsonError } from '../formatters/json.js';
+import { runTrack, runUntrack } from './track.js';
+
+const mockGetStateManager = vi.mocked(getStateManager);
+const mockGetGitHubToken = vi.mocked(getGitHubToken);
+const mockOutputJson = vi.mocked(outputJson);
+const mockOutputJsonError = vi.mocked(outputJsonError);
+
+const TEST_PR_URL = 'https://github.com/owner/repo/pull/42';
+
+describe('runTrack', () => {
+  const mockSave = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetStateManager.mockReturnValue({
+      save: mockSave,
+    } as any);
+  });
+
+  it('should exit with error when no GitHub token is available', async () => {
+    mockGetGitHubToken.mockReturnValue(null as any);
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+
+    await expect(runTrack({ prUrl: TEST_PR_URL, json: true })).rejects.toThrow('exit');
+
+    expect(mockOutputJsonError).toHaveBeenCalledWith(expect.stringContaining('GitHub authentication required'));
+    mockExit.mockRestore();
+  });
+
+  it('should track a PR and save state', async () => {
+    mockGetGitHubToken.mockReturnValue('ghp_test123');
+    const trackedPR = { repo: 'owner/repo', number: 42, title: 'Test PR' };
+    mockTrackPR.mockResolvedValue(trackedPR);
+
+    await runTrack({ prUrl: TEST_PR_URL, json: true });
+
+    expect(mockTrackPR).toHaveBeenCalledWith(TEST_PR_URL);
+    expect(mockSave).toHaveBeenCalled();
+    expect(mockOutputJson).toHaveBeenCalledWith({ pr: trackedPR });
+  });
+
+  it('should output text when not in JSON mode', async () => {
+    mockGetGitHubToken.mockReturnValue('ghp_test123');
+    const trackedPR = { repo: 'owner/repo', number: 42, title: 'Test PR' };
+    mockTrackPR.mockResolvedValue(trackedPR);
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runTrack({ prUrl: TEST_PR_URL, json: false });
+
+    expect(consoleSpy).toHaveBeenCalled();
+    const allOutput = consoleSpy.mock.calls.map(c => c[0]).join('\n');
+    expect(allOutput).toContain('owner/repo#42');
+    consoleSpy.mockRestore();
+  });
+});
+
+describe('runUntrack', () => {
+  const mockSave = vi.fn();
+  const mockUntrackPR = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetStateManager.mockReturnValue({
+      untrackPR: mockUntrackPR,
+      save: mockSave,
+    } as any);
+  });
+
+  it('should untrack a PR and save state when PR exists', async () => {
+    mockUntrackPR.mockReturnValue(true);
+
+    await runUntrack({ prUrl: TEST_PR_URL, json: true });
+
+    expect(mockUntrackPR).toHaveBeenCalledWith(TEST_PR_URL);
+    expect(mockSave).toHaveBeenCalled();
+    expect(mockOutputJson).toHaveBeenCalledWith({ removed: true, url: TEST_PR_URL });
+  });
+
+  it('should not save state when PR was not tracked', async () => {
+    mockUntrackPR.mockReturnValue(false);
+
+    await runUntrack({ prUrl: TEST_PR_URL, json: true });
+
+    expect(mockSave).not.toHaveBeenCalled();
+    expect(mockOutputJson).toHaveBeenCalledWith({ removed: false, url: TEST_PR_URL });
+  });
+});

--- a/src/commands/vet.test.ts
+++ b/src/commands/vet.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for vet command
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockVetIssue = vi.fn();
+const mockFormatCandidate = vi.fn();
+
+vi.mock('../core/index.js', () => {
+  const MockIssueDiscovery = vi.fn(function (this: any) {
+    this.vetIssue = mockVetIssue;
+    this.formatCandidate = mockFormatCandidate;
+  });
+  return {
+    IssueDiscovery: MockIssueDiscovery,
+    getGitHubToken: vi.fn(),
+  };
+});
+
+vi.mock('../formatters/json.js', () => ({
+  outputJson: vi.fn(),
+  outputJsonError: vi.fn(),
+}));
+
+import { getGitHubToken } from '../core/index.js';
+import { outputJson, outputJsonError } from '../formatters/json.js';
+import { runVet } from './vet.js';
+
+const mockGetGitHubToken = vi.mocked(getGitHubToken);
+const mockOutputJson = vi.mocked(outputJson);
+const mockOutputJsonError = vi.mocked(outputJsonError);
+
+const TEST_ISSUE_URL = 'https://github.com/owner/repo/issues/5';
+
+describe('runVet', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should exit with error when no GitHub token', async () => {
+    mockGetGitHubToken.mockReturnValue(null as any);
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+
+    await expect(runVet({ issueUrl: TEST_ISSUE_URL, json: true })).rejects.toThrow('exit');
+
+    expect(mockOutputJsonError).toHaveBeenCalledWith(expect.stringContaining('GitHub authentication required'));
+    mockExit.mockRestore();
+  });
+
+  it('should vet an issue and output JSON result', async () => {
+    mockGetGitHubToken.mockReturnValue('ghp_test123');
+    const candidate = {
+      issue: { repo: 'owner/repo', number: 5, title: 'Fix bug', url: TEST_ISSUE_URL, labels: ['bug'] },
+      recommendation: 'approve' as const,
+      reasonsToApprove: ['Active maintainers', 'Good first issue label'],
+      reasonsToSkip: [],
+      projectHealth: { stars: 1000, openIssues: 50 },
+      vettingResult: { isViable: true },
+    };
+    mockVetIssue.mockResolvedValue(candidate);
+
+    await runVet({ issueUrl: TEST_ISSUE_URL, json: true });
+
+    expect(mockVetIssue).toHaveBeenCalledWith(TEST_ISSUE_URL);
+    expect(mockOutputJson).toHaveBeenCalledWith({
+      issue: { repo: 'owner/repo', number: 5, title: 'Fix bug', url: TEST_ISSUE_URL, labels: ['bug'] },
+      recommendation: 'approve',
+      reasonsToApprove: ['Active maintainers', 'Good first issue label'],
+      reasonsToSkip: [],
+      projectHealth: { stars: 1000, openIssues: 50 },
+      vettingResult: { isViable: true },
+    });
+  });
+
+  it('should output formatted text in non-JSON mode', async () => {
+    mockGetGitHubToken.mockReturnValue('ghp_test123');
+    const candidate = {
+      issue: { repo: 'owner/repo', number: 5, title: 'Fix bug', url: TEST_ISSUE_URL, labels: [] },
+      recommendation: 'skip' as const,
+      reasonsToApprove: [],
+      reasonsToSkip: ['Inactive project'],
+      projectHealth: {},
+      vettingResult: { isViable: false },
+    };
+    mockVetIssue.mockResolvedValue(candidate);
+    mockFormatCandidate.mockReturnValue('Formatted output');
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runVet({ issueUrl: TEST_ISSUE_URL, json: false });
+
+    expect(mockFormatCandidate).toHaveBeenCalledWith(candidate);
+    expect(consoleSpy).toHaveBeenCalledWith('Formatted output');
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #227

Adds unit tests for all 10 previously untested command files:

| File | Tests | Coverage |
|------|-------|----------|
| `config.test.ts` | 11 | Show/set config, add-language, add-label, exclude-repo/org, invalid input |
| `init.test.ts` | 4 | Token check, import PRs, tracking errors, skip non-PR items |
| `status.test.ts` | 4 | JSON/text output, stats computation, empty lists |
| `track.test.ts` | 5 | Track/untrack PRs, token check, save state |
| `snooze.test.ts` | 7 | Snooze with default/custom duration, unsnooze, validation |
| `read.test.ts` | 5 | Mark single/all PRs read, not found, missing args |
| `search.test.ts` | 5 | Search flow, repo scoring, rate limits, empty results |
| `comments.test.ts` | 11 | Fetch/post/claim, token checks, URL validation, filtering |
| `setup.test.ts` | 14 | Complete status, prompts, reset, settings, health check |
| `vet.test.ts` | 3 | Token check, JSON/text output |

**69 new tests total**, bringing the suite from 622 to 691.

## Test plan

- [x] All 691 tests pass
- [x] Tests mock external dependencies consistently with existing patterns
- [x] Both JSON and text output paths covered
- [x] Error paths tested (missing token, invalid input, not found)