### PR TITLE
Remove src/ from package files and add types to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/cli.d.ts",
       "import": "./dist/cli.js",
       "require": "./dist/cli.bundle.cjs"
     },
@@ -56,7 +57,6 @@
     "hooks/",
     "skills/",
     "dist/",
-    "src/",
     "LICENSE",
     "README.md",
     "CHANGELOG.md"


### PR DESCRIPTION
## Summary
- Remove `"src/"` from `files` array to reduce npm package size
- Add `"types"` condition to `exports` field for TypeScript resolution

Closes #281
Closes #282