### PR TITLE
Add CI coverage thresholds to prevent regression

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,12 @@ export default defineConfig({
       reporter: ['text', 'text-summary'],
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/**/*.e2e.test.ts'],
+      thresholds: {
+        statements: 50,
+        branches: 40,
+        functions: 55,
+        lines: 50,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary
- Add coverage thresholds to `vitest.config.ts`: statements 50%, branches 40%, functions 55%, lines 50%
- Thresholds set conservatively below current numbers (~5-7pp headroom)
- Enforced during `npm run test:coverage`

Closes #273