### PR TITLE
Add macOS CI runner to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,17 @@ permissions:
 
 jobs:
   ci:
-    name: Node ${{ matrix.node-version }}
-    runs-on: ubuntu-latest
+    name: Node ${{ matrix.node-version }} / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         node-version: [20, 22, 24]
+        include:
+          - os: macos-latest
+            node-version: 22
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- Add `macos-latest` with Node 22 to CI matrix (1 additional job)
- Keep ubuntu-latest with Node [20, 22, 24] unchanged
- Job names now include OS for clear GitHub Actions UI

Closes #279