### PR TITLE
Re-add automated npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,10 +28,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build bundle
-        run: npm run bundle
+      - name: Run tests
+        run: npm test
+
+      - name: Build
+        run: npm run build && npm run bundle
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
+        run: npm publish --provenance --access public --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `.github/workflows/npm-publish.yml` triggered on GitHub release creation
- Skips pre-releases, uses Node 22, builds bundle before publish
- Uses `NPM_TOKEN` secret with npm provenance attestation

Closes #278