### PR TITLE
Add tests for cli.ts entry point

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -59,9 +59,6 @@ const mockDebug = vi.mocked(debug);
 // but Commander handles those built-ins before preAction ever fires, so they are
 // never actually matched. They are tested via the length assertion below.
 
-import { readFileSync } from 'fs';
-import { join } from 'path';
-
 function extractLocalOnlyCommandsFromSource(): string[] {
   const src = readFileSync(join(__dirname, 'cli.ts'), 'utf-8');
   const match = src.match(/const LOCAL_ONLY_COMMANDS = \[([\s\S]*?)\];/);
@@ -264,7 +261,7 @@ describe('preAction hook', () => {
 
     await expect(program.parseAsync(['node', 'cli', 'daily'])).rejects.toThrow('process.exit called');
 
-    const errorOutput = consoleErrorSpy.mock.calls.map((c) => c[0]).join('\n');
+    const errorOutput = consoleErrorSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
     expect(errorOutput).toContain('GitHub authentication required');
   });
 


### PR DESCRIPTION
## Summary
- 39 new tests covering `LOCAL_ONLY_COMMANDS` validation, `preAction` hook token-gating, `--debug` flag, version detection, and command registration
- Takes `cli.ts` from 0% to meaningful coverage

Closes #270