### PR TITLE
Add GitHub username validation for search queries

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -5,6 +5,7 @@
 
 import { getStateManager } from '../core/index.js';
 import { outputJson } from '../formatters/json.js';
+import { validateGitHubUsername } from './validation.js';
 
 interface InitOptions {
   username: string;
@@ -12,6 +13,7 @@ interface InitOptions {
 }
 
 export async function runInit(options: InitOptions): Promise<void> {
+  validateGitHubUsername(options.username);
   const stateManager = getStateManager();
 
   if (!options.json) {

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -5,6 +5,7 @@
 
 import { getStateManager, DEFAULT_CONFIG } from '../core/index.js';
 import { outputJson } from '../formatters/json.js';
+import { validateGitHubUsername } from './validation.js';
 
 interface SetupOptions {
   reset?: boolean;
@@ -30,6 +31,7 @@ export async function runSetup(options: SetupOptions): Promise<void> {
 
       switch (key) {
         case 'username':
+          validateGitHubUsername(value);
           stateManager.updateConfig({ githubUsername: value });
           results[key] = value;
           break;

--- a/src/commands/validation.test.ts
+++ b/src/commands/validation.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for shared URL validation patterns (validation.ts).
+ * Tests for shared validation patterns (validation.ts).
  * Command-level state logic is tested in shelve.test.ts, dismiss.test.ts, and state.test.ts.
  */
 
@@ -11,7 +11,9 @@ import {
   validatePRNumber,
   validateMessage,
   validateRepoIdentifier,
+  validateGitHubUsername,
 } from './validation.js';
+import { ValidationError } from '../core/errors.js';
 
 describe('PR_URL_PATTERN', () => {
   it('should match valid PR URLs', () => {
@@ -125,5 +127,82 @@ describe('validateRepoIdentifier', () => {
 
   it('should throw for identifiers with spaces', () => {
     expect(() => validateRepoIdentifier('owner/my repo')).toThrow('Invalid repository format');
+  });
+});
+
+describe('validateGitHubUsername', () => {
+  describe('valid usernames', () => {
+    it('should accept a normal username', () => {
+      expect(validateGitHubUsername('octocat')).toBe('octocat');
+    });
+
+    it('should accept a username with hyphens', () => {
+      expect(validateGitHubUsername('my-cool-name')).toBe('my-cool-name');
+    });
+
+    it('should accept a single character username', () => {
+      expect(validateGitHubUsername('a')).toBe('a');
+    });
+
+    it('should accept a username at the max length of 39 characters', () => {
+      const username = 'a'.repeat(39);
+      expect(validateGitHubUsername(username)).toBe(username);
+    });
+
+    it('should accept a username with numbers', () => {
+      expect(validateGitHubUsername('user123')).toBe('user123');
+    });
+
+    it('should accept a username starting with a number', () => {
+      expect(validateGitHubUsername('123user')).toBe('123user');
+    });
+
+    it('should trim whitespace from the username', () => {
+      expect(validateGitHubUsername('  octocat  ')).toBe('octocat');
+    });
+  });
+
+  describe('invalid usernames', () => {
+    it('should reject an empty string', () => {
+      expect(() => validateGitHubUsername('')).toThrow(ValidationError);
+      expect(() => validateGitHubUsername('')).toThrow('cannot be empty');
+    });
+
+    it('should reject a whitespace-only string', () => {
+      expect(() => validateGitHubUsername('   ')).toThrow(ValidationError);
+      expect(() => validateGitHubUsername('   ')).toThrow('cannot be empty');
+    });
+
+    it('should reject a username longer than 39 characters', () => {
+      const username = 'a'.repeat(40);
+      expect(() => validateGitHubUsername(username)).toThrow(ValidationError);
+      expect(() => validateGitHubUsername(username)).toThrow('at most 39 characters');
+    });
+
+    it('should reject a username starting with a hyphen', () => {
+      expect(() => validateGitHubUsername('-octocat')).toThrow(ValidationError);
+      expect(() => validateGitHubUsername('-octocat')).toThrow('cannot start with a hyphen');
+    });
+
+    it('should reject a username ending with a hyphen', () => {
+      expect(() => validateGitHubUsername('octocat-')).toThrow(ValidationError);
+      expect(() => validateGitHubUsername('octocat-')).toThrow('cannot end with a hyphen');
+    });
+
+    it('should reject a username with consecutive hyphens', () => {
+      expect(() => validateGitHubUsername('octo--cat')).toThrow(ValidationError);
+      expect(() => validateGitHubUsername('octo--cat')).toThrow('consecutive hyphens');
+    });
+
+    it('should reject a username with special characters', () => {
+      expect(() => validateGitHubUsername('octo.cat')).toThrow(ValidationError);
+      expect(() => validateGitHubUsername('octo_cat')).toThrow(ValidationError);
+      expect(() => validateGitHubUsername('octo@cat')).toThrow(ValidationError);
+      expect(() => validateGitHubUsername('octo cat')).toThrow(ValidationError);
+    });
+
+    it('should reject a username with special characters with the right message', () => {
+      expect(() => validateGitHubUsername('octo.cat')).toThrow('alphanumeric characters and hyphens');
+    });
   });
 });

--- a/src/commands/validation.ts
+++ b/src/commands/validation.ts
@@ -1,7 +1,8 @@
 /**
- * Shared URL validation patterns and helpers for CLI commands.
+ * Shared validation patterns and helpers for CLI commands.
  */
 
+import { ValidationError } from '../core/errors.js';
 import { outputJsonError } from '../formatters/json.js';
 
 /** Matches GitHub PR URLs: https://github.com/owner/repo/pull/123 */
@@ -79,4 +80,54 @@ export function validateRepoIdentifier(repo: string): string {
     throw new Error(`Invalid repository format: "${repo}". Expected "owner/repo".`);
   }
   return repo;
+}
+
+/** Maximum allowed GitHub username length */
+const MAX_USERNAME_LENGTH = 39;
+/** Pattern for valid GitHub username characters (alphanumeric and hyphens) */
+const USERNAME_CHARS_PATTERN = /^[a-zA-Z0-9-]+$/;
+/** Pattern for consecutive hyphens */
+const CONSECUTIVE_HYPHENS_PATTERN = /--/;
+
+/**
+ * Validate a GitHub username against GitHub's username rules.
+ * Throws a ValidationError if the username is invalid.
+ *
+ * Rules:
+ * - Must not be empty
+ * - Maximum 39 characters
+ * - Only alphanumeric characters and hyphens
+ * - Cannot start or end with a hyphen
+ * - Cannot contain consecutive hyphens
+ */
+export function validateGitHubUsername(username: string): string {
+  if (!username || username.trim().length === 0) {
+    throw new ValidationError('GitHub username cannot be empty.');
+  }
+
+  const trimmed = username.trim();
+
+  if (trimmed.length > MAX_USERNAME_LENGTH) {
+    throw new ValidationError(
+      `GitHub username must be at most ${MAX_USERNAME_LENGTH} characters (got ${trimmed.length}).`,
+    );
+  }
+
+  if (!USERNAME_CHARS_PATTERN.test(trimmed)) {
+    throw new ValidationError('GitHub username can only contain alphanumeric characters and hyphens.');
+  }
+
+  if (trimmed.startsWith('-')) {
+    throw new ValidationError('GitHub username cannot start with a hyphen.');
+  }
+
+  if (trimmed.endsWith('-')) {
+    throw new ValidationError('GitHub username cannot end with a hyphen.');
+  }
+
+  if (CONSECUTIVE_HYPHENS_PATTERN.test(trimmed)) {
+    throw new ValidationError('GitHub username cannot contain consecutive hyphens.');
+  }
+
+  return trimmed;
 }


### PR DESCRIPTION
## Summary
- Add validateGitHubUsername() enforcing GitHub username rules (max 39 chars, no consecutive/leading/trailing hyphens)
- Applied at entry points: init and setup commands
- Includes validation tests

Closes #274