### PR TITLE
Remove redundant auth checks from command files

### DIFF
--- a/src/commands/comments.test.ts
+++ b/src/commands/comments.test.ts
@@ -39,18 +39,6 @@ describe('runComments', () => {
     } as any);
   });
 
-  it('should exit with error when no GitHub token', async () => {
-    mockGetGitHubToken.mockReturnValue(null as any);
-    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
-      throw new Error('exit');
-    });
-
-    await expect(runComments({ prUrl: TEST_PR_URL, json: true })).rejects.toThrow('exit');
-
-    expect(mockOutputJsonError).toHaveBeenCalledWith(expect.stringContaining('GitHub authentication required'));
-    mockExit.mockRestore();
-  });
-
   it('should exit with error for invalid PR URL', async () => {
     mockGetGitHubToken.mockReturnValue('ghp_test123');
     mockParseGitHubUrl.mockReturnValue(null as any);
@@ -148,18 +136,6 @@ describe('runPost', () => {
     vi.clearAllMocks();
   });
 
-  it('should exit with error when no GitHub token', async () => {
-    mockGetGitHubToken.mockReturnValue(null as any);
-    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
-      throw new Error('exit');
-    });
-
-    await expect(runPost({ url: TEST_PR_URL, message: 'Hello', json: true })).rejects.toThrow('exit');
-
-    expect(mockOutputJsonError).toHaveBeenCalledWith(expect.stringContaining('GitHub authentication required'));
-    mockExit.mockRestore();
-  });
-
   it('should exit with error when no message provided', async () => {
     mockGetGitHubToken.mockReturnValue('ghp_test123');
     const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
@@ -227,18 +203,6 @@ describe('runPost', () => {
 describe('runClaim', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-  });
-
-  it('should exit with error when no GitHub token', async () => {
-    mockGetGitHubToken.mockReturnValue(null as any);
-    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
-      throw new Error('exit');
-    });
-
-    await expect(runClaim({ issueUrl: TEST_ISSUE_URL, json: true })).rejects.toThrow('exit');
-
-    expect(mockOutputJsonError).toHaveBeenCalledWith(expect.stringContaining('GitHub authentication required'));
-    mockExit.mockRestore();
   });
 
   it('should exit with error for non-issue URL', async () => {

--- a/src/commands/comments.ts
+++ b/src/commands/comments.ts
@@ -30,19 +30,8 @@ interface ClaimOptions {
 export async function runComments(options: CommentsOptions): Promise<void> {
   validateUrl(options.prUrl);
 
-  const token = getGitHubToken();
-  if (!token) {
-    if (options.json) {
-      outputJsonError('GitHub authentication required. Run "gh auth login" or set GITHUB_TOKEN.');
-    } else {
-      console.error('Error: GitHub authentication required.');
-      console.error('');
-      console.error('Options:');
-      console.error('  1. Use gh CLI: gh auth login');
-      console.error('  2. Set GITHUB_TOKEN environment variable');
-    }
-    process.exit(1);
-  }
+  // Token is guaranteed by the preAction hook in cli.ts for non-LOCAL_ONLY_COMMANDS.
+  const token = getGitHubToken()!;
 
   const stateManager = getStateManager();
   const octokit = getOctokit(token);
@@ -206,19 +195,8 @@ export async function runComments(options: CommentsOptions): Promise<void> {
 export async function runPost(options: PostOptions): Promise<void> {
   validateUrl(options.url);
 
-  const token = getGitHubToken();
-  if (!token) {
-    if (options.json) {
-      outputJsonError('GitHub authentication required. Run "gh auth login" or set GITHUB_TOKEN.');
-    } else {
-      console.error('Error: GitHub authentication required.');
-      console.error('');
-      console.error('Options:');
-      console.error('  1. Use gh CLI: gh auth login');
-      console.error('  2. Set GITHUB_TOKEN environment variable');
-    }
-    process.exit(1);
-  }
+  // Token is guaranteed by the preAction hook in cli.ts for non-LOCAL_ONLY_COMMANDS.
+  const token = getGitHubToken()!;
 
   let message = options.message;
 
@@ -302,19 +280,8 @@ export async function runPost(options: PostOptions): Promise<void> {
 export async function runClaim(options: ClaimOptions): Promise<void> {
   validateUrl(options.issueUrl);
 
-  const token = getGitHubToken();
-  if (!token) {
-    if (options.json) {
-      outputJsonError('GitHub authentication required. Run "gh auth login" or set GITHUB_TOKEN.');
-    } else {
-      console.error('Error: GitHub authentication required.');
-      console.error('');
-      console.error('Options:');
-      console.error('  1. Use gh CLI: gh auth login');
-      console.error('  2. Set GITHUB_TOKEN environment variable');
-    }
-    process.exit(1);
-  }
+  // Token is guaranteed by the preAction hook in cli.ts for non-LOCAL_ONLY_COMMANDS.
+  const token = getGitHubToken()!;
 
   // Default claim message or custom
   const message = options.message || "Hi! I'd like to work on this issue. Could you assign it to me?";

--- a/src/commands/daily-orchestration.test.ts
+++ b/src/commands/daily-orchestration.test.ts
@@ -902,22 +902,6 @@ describe('runDaily()', () => {
     consoleSpy.mockRestore();
   });
 
-  it('outputs JSON error and exits when no GitHub token in JSON mode', async () => {
-    vi.mocked(getGitHubToken).mockReturnValue(null);
-
-    await expect(runDaily({ json: true })).rejects.toThrow('process.exit called');
-    expect(outputJsonError).toHaveBeenCalledWith(expect.stringContaining('GitHub authentication required'));
-  });
-
-  it('outputs console error and exits when no GitHub token in non-JSON mode', async () => {
-    vi.mocked(getGitHubToken).mockReturnValue(null);
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-    await expect(runDaily({ json: false })).rejects.toThrow('process.exit called');
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Error: GitHub authentication required'));
-    consoleSpy.mockRestore();
-  });
-
   it('outputs JSON error and exits on unexpected throw in JSON mode', async () => {
     vi.mocked(getGitHubToken).mockReturnValue('test-token');
     mockFetchUserOpenPRs.mockRejectedValue(new Error('Unexpected API failure'));

--- a/src/commands/daily.ts
+++ b/src/commands/daily.ts
@@ -48,24 +48,8 @@ interface DailyOptions {
 }
 
 export async function runDaily(options: DailyOptions): Promise<void> {
-  const token = getGitHubToken();
-  if (!token) {
-    if (options.json) {
-      outputJsonError(
-        'GitHub authentication required. Install GitHub CLI (https://cli.github.com/) and run "gh auth login", or set GITHUB_TOKEN.',
-      );
-    } else {
-      console.error('Error: GitHub authentication required.');
-      console.error('');
-      console.error('Option 1 (Recommended): Install and authenticate GitHub CLI');
-      console.error('  Install: https://cli.github.com/');
-      console.error('  Then run: gh auth login');
-      console.error('');
-      console.error('Option 2: Set GITHUB_TOKEN environment variable');
-      console.error('  export GITHUB_TOKEN="your-github-token-here"');
-    }
-    process.exit(1);
-  }
+  // Token is guaranteed by the preAction hook in cli.ts for non-LOCAL_ONLY_COMMANDS.
+  const token = getGitHubToken()!;
 
   try {
     await runDailyInner(token, options);

--- a/src/commands/search.test.ts
+++ b/src/commands/search.test.ts
@@ -28,17 +28,15 @@ vi.mock('../core/index.js', () => {
 
 vi.mock('../formatters/json.js', () => ({
   outputJson: vi.fn(),
-  outputJsonError: vi.fn(),
 }));
 
 import { getGitHubToken, getStateManager } from '../core/index.js';
-import { outputJson, outputJsonError } from '../formatters/json.js';
+import { outputJson } from '../formatters/json.js';
 import { runSearch } from './search.js';
 
 const mockGetGitHubToken = vi.mocked(getGitHubToken);
 const mockGetStateManager = vi.mocked(getStateManager);
 const mockOutputJson = vi.mocked(outputJson);
-const mockOutputJsonError = vi.mocked(outputJsonError);
 
 describe('runSearch', () => {
   beforeEach(() => {
@@ -53,18 +51,6 @@ describe('runSearch', () => {
       }),
       getRepoScore: vi.fn().mockReturnValue(null),
     } as any);
-  });
-
-  it('should exit with error when no GitHub token is available', async () => {
-    mockGetGitHubToken.mockReturnValue(null as any);
-    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
-      throw new Error('exit');
-    });
-
-    await expect(runSearch({ maxResults: 10, json: true })).rejects.toThrow('exit');
-
-    expect(mockOutputJsonError).toHaveBeenCalledWith(expect.stringContaining('GitHub authentication required'));
-    mockExit.mockRestore();
   });
 
   it('should search and return candidates in JSON mode', async () => {

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -4,7 +4,7 @@
  */
 
 import { IssueDiscovery, getGitHubToken, getStateManager, DEFAULT_CONFIG } from '../core/index.js';
-import { outputJson, outputJsonError, type SearchOutput } from '../formatters/json.js';
+import { outputJson, type SearchOutput } from '../formatters/json.js';
 
 interface SearchOptions {
   maxResults: number;
@@ -12,19 +12,8 @@ interface SearchOptions {
 }
 
 export async function runSearch(options: SearchOptions): Promise<void> {
-  const token = getGitHubToken();
-  if (!token) {
-    if (options.json) {
-      outputJsonError('GitHub authentication required. Run "gh auth login" or set GITHUB_TOKEN.');
-    } else {
-      console.error('Error: GitHub authentication required.');
-      console.error('');
-      console.error('Options:');
-      console.error('  1. Use gh CLI: gh auth login');
-      console.error('  2. Set GITHUB_TOKEN environment variable');
-    }
-    process.exit(1);
-  }
+  // Token is guaranteed by the preAction hook in cli.ts for non-LOCAL_ONLY_COMMANDS.
+  const token = getGitHubToken()!;
 
   const discovery = new IssueDiscovery(token);
 

--- a/src/commands/vet.test.ts
+++ b/src/commands/vet.test.ts
@@ -20,34 +20,20 @@ vi.mock('../core/index.js', () => {
 
 vi.mock('../formatters/json.js', () => ({
   outputJson: vi.fn(),
-  outputJsonError: vi.fn(),
 }));
 
 import { getGitHubToken } from '../core/index.js';
-import { outputJson, outputJsonError } from '../formatters/json.js';
+import { outputJson } from '../formatters/json.js';
 import { runVet } from './vet.js';
 
 const mockGetGitHubToken = vi.mocked(getGitHubToken);
 const mockOutputJson = vi.mocked(outputJson);
-const mockOutputJsonError = vi.mocked(outputJsonError);
 
 const TEST_ISSUE_URL = 'https://github.com/owner/repo/issues/5';
 
 describe('runVet', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-  });
-
-  it('should exit with error when no GitHub token', async () => {
-    mockGetGitHubToken.mockReturnValue(null as any);
-    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
-      throw new Error('exit');
-    });
-
-    await expect(runVet({ issueUrl: TEST_ISSUE_URL, json: true })).rejects.toThrow('exit');
-
-    expect(mockOutputJsonError).toHaveBeenCalledWith(expect.stringContaining('GitHub authentication required'));
-    mockExit.mockRestore();
   });
 
   it('should vet an issue and output JSON result', async () => {

--- a/src/commands/vet.ts
+++ b/src/commands/vet.ts
@@ -4,7 +4,7 @@
  */
 
 import { IssueDiscovery, getGitHubToken } from '../core/index.js';
-import { outputJson, outputJsonError } from '../formatters/json.js';
+import { outputJson } from '../formatters/json.js';
 import { validateUrl } from './validation.js';
 
 interface VetOptions {
@@ -15,19 +15,8 @@ interface VetOptions {
 export async function runVet(options: VetOptions): Promise<void> {
   validateUrl(options.issueUrl);
 
-  const token = getGitHubToken();
-  if (!token) {
-    if (options.json) {
-      outputJsonError('GitHub authentication required. Run "gh auth login" or set GITHUB_TOKEN.');
-    } else {
-      console.error('Error: GitHub authentication required.');
-      console.error('');
-      console.error('Options:');
-      console.error('  1. Use gh CLI: gh auth login');
-      console.error('  2. Set GITHUB_TOKEN environment variable');
-    }
-    process.exit(1);
-  }
+  // Token is guaranteed by the preAction hook in cli.ts for non-LOCAL_ONLY_COMMANDS.
+  const token = getGitHubToken()!;
 
   const discovery = new IssueDiscovery(token);
 


### PR DESCRIPTION
## Summary
- Remove redundant `if (!token)` guards from command files (already enforced by preAction hook in cli.ts)
- Remove obsolete "no token" tests
- Preserve auth checks in startup.ts and dashboard.ts

Closes #265