### PR TITLE
test: add E2E tests for daily and search CLI commands

### DIFF
--- a/src/commands/daily.e2e.test.ts
+++ b/src/commands/daily.e2e.test.ts
@@ -1,0 +1,157 @@
+/**
+ * E2E smoke tests for the daily --json command.
+ * Runs the bundled CLI binary and validates JSON output.
+ *
+ * The daily command requires GitHub authentication. Tests validate:
+ * - Auth error behavior when no token is available (always runs)
+ * - Full JSON envelope and data structure when a token IS available
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const execFileAsync = promisify(execFile);
+
+const BUNDLE_PATH = path.resolve(__dirname, '../../dist/cli.bundle.cjs');
+const BUNDLE_EXISTS = fs.existsSync(BUNDLE_PATH);
+const TEST_HOME = '/tmp/oss-autopilot-e2e-daily-test-' + process.pid;
+
+/**
+ * Check whether a real GitHub token is available for authenticated tests.
+ * Uses GITHUB_TOKEN env var only (gh CLI may not be available in CI).
+ */
+const HAS_GITHUB_TOKEN = !!process.env.GITHUB_TOKEN;
+
+async function runDaily(
+  env?: Record<string, string>,
+): Promise<{ stdout: string; stderr: string; json: any; exitCode: number | null }> {
+  let exitCode: number | null = 0;
+  let signal: string | null = null;
+
+  const result = await execFileAsync('node', [BUNDLE_PATH, 'daily', '--json'], {
+    timeout: 30000,
+    env: { ...process.env, ...env, HOME: TEST_HOME },
+    cwd: TEST_HOME,
+  }).catch((err: any) => {
+    exitCode = err.code ?? null;
+    signal = err.signal ?? null;
+    return {
+      stdout: (err.stdout as string) || '',
+      stderr: (err.stderr as string) || '',
+      message: err.message ?? '',
+    };
+  });
+
+  let json: any;
+  try {
+    json = JSON.parse(result.stdout);
+  } catch (parseError) {
+    console.warn(
+      `[E2E] Failed to parse CLI stdout as JSON (exit=${exitCode}, signal=${signal}):\n` +
+        `parse error: ${parseError instanceof Error ? parseError.message : parseError}\n` +
+        `stdout: ${result.stdout.slice(0, 500) || '(empty)'}\nstderr: ${result.stderr.slice(0, 500) || '(empty)'}`,
+    );
+    json = null;
+  }
+
+  return { stdout: result.stdout, stderr: result.stderr, json, exitCode };
+}
+
+describe.skipIf(!BUNDLE_EXISTS)('daily --json E2E', () => {
+  beforeAll(() => {
+    fs.mkdirSync(TEST_HOME, { recursive: true });
+  });
+
+  afterAll(() => {
+    fs.rmSync(TEST_HOME, { recursive: true, force: true });
+  });
+
+  it('should exit with an auth error when no GitHub token is available', async () => {
+    const { stderr, exitCode } = await runDaily({ GITHUB_TOKEN: '', PATH: process.env.PATH || '' });
+    // The preAction hook writes to stderr and calls process.exit(1)
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain('GitHub authentication required');
+  });
+
+  describe.skipIf(!HAS_GITHUB_TOKEN)('with GitHub token', () => {
+    it('should output valid JSON', async () => {
+      const { json } = await runDaily();
+      expect(json, 'CLI should return parseable JSON output').not.toBeNull();
+      expect(typeof json).toBe('object');
+    });
+
+    it('should include success and data fields in the envelope', async () => {
+      const { json } = await runDaily();
+      expect(json, 'CLI should return parseable JSON output').not.toBeNull();
+      expect(json).toHaveProperty('success', true);
+      expect(json).toHaveProperty('data');
+      expect(json).toHaveProperty('timestamp');
+    });
+
+    it('should include digest, capacity, and summary in data', async () => {
+      const { json } = await runDaily();
+      expect(json, 'CLI should return parseable JSON output').not.toBeNull();
+      const data = json.data;
+      expect(data).toHaveProperty('digest');
+      expect(data).toHaveProperty('capacity');
+      expect(data).toHaveProperty('summary');
+      expect(data).toHaveProperty('briefSummary');
+      expect(data).toHaveProperty('actionableIssues');
+      expect(data).toHaveProperty('actionMenu');
+      expect(data).toHaveProperty('repoGroups');
+      expect(data).toHaveProperty('failures');
+    });
+
+    it('should return capacity with expected fields', async () => {
+      const { json } = await runDaily();
+      expect(json, 'CLI should return parseable JSON output').not.toBeNull();
+      const { capacity } = json.data;
+      expect(typeof capacity.hasCapacity).toBe('boolean');
+      expect(typeof capacity.activePRCount).toBe('number');
+      expect(typeof capacity.maxActivePRs).toBe('number');
+      expect(typeof capacity.shelvedPRCount).toBe('number');
+      expect(typeof capacity.criticalIssueCount).toBe('number');
+      expect(typeof capacity.reason).toBe('string');
+    });
+
+    it('should return digest with summary fields', async () => {
+      const { json } = await runDaily();
+      expect(json, 'CLI should return parseable JSON output').not.toBeNull();
+      const { digest } = json.data;
+      expect(digest).toHaveProperty('summary');
+      expect(typeof digest.summary.totalActivePRs).toBe('number');
+      expect(typeof digest.summary.totalNeedingAttention).toBe('number');
+      expect(typeof digest.summary.totalMergedAllTime).toBe('number');
+      expect(typeof digest.summary.mergeRate).toBe('number');
+    });
+
+    it('should return actionMenu with items and context', async () => {
+      const { json } = await runDaily();
+      expect(json, 'CLI should return parseable JSON output').not.toBeNull();
+      const { actionMenu } = json.data;
+      expect(Array.isArray(actionMenu.items)).toBe(true);
+      expect(actionMenu).toHaveProperty('context');
+      expect(typeof actionMenu.context.hasActionableIssues).toBe('boolean');
+      expect(typeof actionMenu.context.actionableCount).toBe('number');
+      expect(typeof actionMenu.context.hasCapacity).toBe('boolean');
+    });
+
+    it('should return arrays for actionableIssues, repoGroups, and failures', async () => {
+      const { json } = await runDaily();
+      expect(json, 'CLI should return parseable JSON output').not.toBeNull();
+      expect(Array.isArray(json.data.actionableIssues)).toBe(true);
+      expect(Array.isArray(json.data.repoGroups)).toBe(true);
+      expect(Array.isArray(json.data.failures)).toBe(true);
+    });
+
+    it('should complete within 30 seconds', async () => {
+      const start = Date.now();
+      await runDaily();
+      const duration = Date.now() - start;
+      expect(duration).toBeLessThan(30000);
+    });
+  });
+});

--- a/src/commands/search.e2e.test.ts
+++ b/src/commands/search.e2e.test.ts
@@ -1,0 +1,138 @@
+/**
+ * E2E smoke tests for the search --json command.
+ * Runs the bundled CLI binary and validates JSON output.
+ *
+ * The search command requires GitHub authentication. Tests validate:
+ * - Auth error behavior when no token is available (always runs)
+ * - Full JSON envelope and data structure when a token IS available
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const execFileAsync = promisify(execFile);
+
+const BUNDLE_PATH = path.resolve(__dirname, '../../dist/cli.bundle.cjs');
+const BUNDLE_EXISTS = fs.existsSync(BUNDLE_PATH);
+const TEST_HOME = '/tmp/oss-autopilot-e2e-search-test-' + process.pid;
+
+/**
+ * Check whether a real GitHub token is available for authenticated tests.
+ * Uses GITHUB_TOKEN env var only (gh CLI may not be available in CI).
+ */
+const HAS_GITHUB_TOKEN = !!process.env.GITHUB_TOKEN;
+
+async function runSearch(
+  args: string[] = [],
+  env?: Record<string, string>,
+): Promise<{ stdout: string; stderr: string; json: any; exitCode: number | null }> {
+  let exitCode: number | null = 0;
+  let signal: string | null = null;
+
+  const result = await execFileAsync('node', [BUNDLE_PATH, 'search', '--json', ...args], {
+    timeout: 30000,
+    env: { ...process.env, ...env, HOME: TEST_HOME },
+    cwd: TEST_HOME,
+  }).catch((err: any) => {
+    exitCode = err.code ?? null;
+    signal = err.signal ?? null;
+    return {
+      stdout: (err.stdout as string) || '',
+      stderr: (err.stderr as string) || '',
+      message: err.message ?? '',
+    };
+  });
+
+  let json: any;
+  try {
+    json = JSON.parse(result.stdout);
+  } catch (parseError) {
+    console.warn(
+      `[E2E] Failed to parse CLI stdout as JSON (exit=${exitCode}, signal=${signal}):\n` +
+        `parse error: ${parseError instanceof Error ? parseError.message : parseError}\n` +
+        `stdout: ${result.stdout.slice(0, 500) || '(empty)'}\nstderr: ${result.stderr.slice(0, 500) || '(empty)'}`,
+    );
+    json = null;
+  }
+
+  return { stdout: result.stdout, stderr: result.stderr, json, exitCode };
+}
+
+describe.skipIf(!BUNDLE_EXISTS)('search --json E2E', () => {
+  beforeAll(() => {
+    fs.mkdirSync(TEST_HOME, { recursive: true });
+  });
+
+  afterAll(() => {
+    fs.rmSync(TEST_HOME, { recursive: true, force: true });
+  });
+
+  it('should exit with an auth error when no GitHub token is available', async () => {
+    const { stderr, exitCode } = await runSearch([], { GITHUB_TOKEN: '', PATH: process.env.PATH || '' });
+    // The preAction hook writes to stderr and calls process.exit(1)
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain('GitHub authentication required');
+  });
+
+  describe.skipIf(!HAS_GITHUB_TOKEN)('with GitHub token', () => {
+    it('should output valid JSON', async () => {
+      const { json } = await runSearch(['1']);
+      expect(json, 'CLI should return parseable JSON output').not.toBeNull();
+      expect(typeof json).toBe('object');
+    });
+
+    it('should include success and data fields in the envelope', async () => {
+      const { json } = await runSearch(['1']);
+      expect(json, 'CLI should return parseable JSON output').not.toBeNull();
+      expect(json).toHaveProperty('success', true);
+      expect(json).toHaveProperty('data');
+      expect(json).toHaveProperty('timestamp');
+    });
+
+    it('should include candidates and excludedRepos in data', async () => {
+      const { json } = await runSearch(['1']);
+      expect(json, 'CLI should return parseable JSON output').not.toBeNull();
+      const data = json.data;
+      expect(Array.isArray(data.candidates)).toBe(true);
+      expect(Array.isArray(data.excludedRepos)).toBe(true);
+      expect(Array.isArray(data.aiPolicyBlocklist)).toBe(true);
+    });
+
+    it('should return candidates with expected structure when results exist', async () => {
+      const { json } = await runSearch(['1']);
+      expect(json, 'CLI should return parseable JSON output').not.toBeNull();
+      const { candidates } = json.data;
+      // May be empty if no issues match the configured languages/labels, so only validate structure if non-empty
+      if (candidates.length > 0) {
+        const candidate = candidates[0];
+        expect(candidate).toHaveProperty('issue');
+        expect(typeof candidate.issue.repo).toBe('string');
+        expect(typeof candidate.issue.number).toBe('number');
+        expect(typeof candidate.issue.title).toBe('string');
+        expect(typeof candidate.issue.url).toBe('string');
+        expect(Array.isArray(candidate.issue.labels)).toBe(true);
+        expect(candidate).toHaveProperty('recommendation');
+        expect(['approve', 'skip', 'needs_review']).toContain(candidate.recommendation);
+        expect(Array.isArray(candidate.reasonsToApprove)).toBe(true);
+        expect(Array.isArray(candidate.reasonsToSkip)).toBe(true);
+        expect(typeof candidate.viabilityScore).toBe('number');
+      }
+    });
+
+    it('should respect the count argument', async () => {
+      const { json } = await runSearch(['2']);
+      expect(json, 'CLI should return parseable JSON output').not.toBeNull();
+      expect(json.data.candidates.length).toBeLessThanOrEqual(2);
+    });
+
+    it('should complete within 30 seconds', async () => {
+      const start = Date.now();
+      await runSearch(['1']);
+      const duration = Date.now() - start;
+      expect(duration).toBeLessThan(30000);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `daily.e2e.test.ts` — E2E smoke tests for the `daily --json` CLI command
- Add `search.e2e.test.ts` — E2E smoke tests for the `search --json` CLI command
- Both commands require GitHub auth, so tests are split into always-run auth-error validation and conditionally-run full JSON structure validation (via `describe.skipIf(!HAS_GITHUB_TOKEN)`)

Both test files follow the established E2E pattern from `startup.e2e.test.ts`, `config.e2e.test.ts`, and `status.e2e.test.ts`.

Closes #272

## Test plan

- [x] `npx vitest run src/commands/daily.e2e.test.ts` — passes (auth error test runs, authenticated tests skip without token)
- [x] `npx vitest run src/commands/search.e2e.test.ts` — passes (auth error test runs, authenticated tests skip without token)
- [x] `npm test` — all existing tests pass (3 pre-existing failures in `status.e2e.test.ts` are unrelated)