### PR TITLE
feat: add offline mode for dashboard and status commands

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -87,8 +87,9 @@ program
   .command('status')
   .description('Show current status and stats')
   .option('--json', 'Output as JSON')
+  .option('--offline', 'Use cached data only (no GitHub API calls)')
   .action(async (options) => {
-    await runStatus({ json: options.json });
+    await runStatus({ json: options.json, offline: options.offline });
   });
 
 // Search command
@@ -212,8 +213,9 @@ program
   .description('Generate HTML stats dashboard')
   .option('--open', 'Open in browser')
   .option('--json', 'Output as JSON')
+  .option('--offline', 'Use cached data only (no GitHub API calls)')
   .action(async (options) => {
-    await runDashboard({ open: options.open, json: options.json });
+    await runDashboard({ open: options.open, json: options.json, offline: options.offline });
   });
 
 // Parse issue list command (#82)

--- a/src/commands/dashboard.test.ts
+++ b/src/commands/dashboard.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Tests for dashboard command (offline mode)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('fs', () => ({
+  writeFileSync: vi.fn(),
+  chmodSync: vi.fn(),
+  existsSync: vi.fn().mockReturnValue(true),
+  mkdirSync: vi.fn(),
+}));
+
+vi.mock('child_process', () => ({
+  execFile: vi.fn(),
+  execFileSync: vi.fn(),
+}));
+
+vi.mock('../core/index.js', () => ({
+  getStateManager: vi.fn(),
+  getDashboardPath: vi.fn().mockReturnValue('/tmp/dashboard.html'),
+  PRMonitor: vi.fn(),
+  IssueConversationMonitor: vi.fn(),
+  getGitHubToken: vi.fn(),
+}));
+
+vi.mock('../formatters/json.js', () => ({
+  outputJson: vi.fn(),
+}));
+
+vi.mock('./daily.js', () => ({
+  toShelvedPRRef: vi.fn((pr: any) => ({
+    number: pr.number,
+    url: pr.url,
+    title: pr.title,
+    repo: pr.repo,
+    daysSinceActivity: pr.daysSinceActivity,
+    status: pr.status,
+  })),
+}));
+
+import { getStateManager, getGitHubToken } from '../core/index.js';
+import { outputJson } from '../formatters/json.js';
+import { runDashboard } from './dashboard.js';
+import type { DailyDigest } from '../core/types.js';
+
+const mockGetStateManager = vi.mocked(getStateManager);
+const mockGetGitHubToken = vi.mocked(getGitHubToken);
+const mockOutputJson = vi.mocked(outputJson);
+
+const makeMockDigest = (generatedAt: string): DailyDigest => ({
+  generatedAt,
+  openPRs: [],
+  prsNeedingResponse: [],
+  ciFailingPRs: [],
+  ciBlockedPRs: [],
+  ciNotRunningPRs: [],
+  mergeConflictPRs: [],
+  needsRebasePRs: [],
+  missingRequiredFilesPRs: [],
+  incompleteChecklistPRs: [],
+  needsChangesPRs: [],
+  changesAddressedPRs: [],
+  waitingOnMaintainerPRs: [],
+  approachingDormant: [],
+  dormantPRs: [],
+  healthyPRs: [],
+  recentlyClosedPRs: [],
+  recentlyMergedPRs: [],
+  shelvedPRs: [],
+  autoUnshelvedPRs: [],
+  summary: {
+    totalActivePRs: 0,
+    totalNeedingAttention: 0,
+    totalMergedAllTime: 3,
+    mergeRate: 75.0,
+  },
+});
+
+describe('runDashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetGitHubToken.mockReturnValue(null);
+  });
+
+  describe('offline mode', () => {
+    it('should use cached digest in JSON mode when --offline is set', async () => {
+      const mockDigest = makeMockDigest('2026-01-15T09:30:00Z');
+      mockGetStateManager.mockReturnValue({
+        getState: vi.fn().mockReturnValue({
+          lastDigest: mockDigest,
+          lastDigestAt: '2026-01-15T09:30:00Z',
+          lastRunAt: '2026-01-15T10:00:00Z',
+          repoScores: {},
+          config: { shelvedPRUrls: [], approachingDormantDays: 25 },
+        }),
+        getStats: vi.fn(),
+      } as any);
+
+      await runDashboard({ json: true, offline: true });
+
+      expect(mockOutputJson).toHaveBeenCalledTimes(1);
+      const outputData = mockOutputJson.mock.calls[0][0] as any;
+      expect(outputData.offline).toBe(true);
+      expect(outputData.lastUpdated).toBe('2026-01-15T09:30:00Z');
+      expect(outputData.stats).toBeDefined();
+    });
+
+    it('should show error when no cached data exists in JSON mode', async () => {
+      mockGetStateManager.mockReturnValue({
+        getState: vi.fn().mockReturnValue({
+          lastDigest: undefined,
+          lastRunAt: '2026-01-15T10:00:00Z',
+          repoScores: {},
+          config: {},
+        }),
+        getStats: vi.fn(),
+      } as any);
+
+      await runDashboard({ json: true, offline: true });
+
+      expect(mockOutputJson).toHaveBeenCalledTimes(1);
+      const outputData = mockOutputJson.mock.calls[0][0] as any;
+      expect(outputData.error).toBe('No cached data found. Run without --offline first.');
+      expect(outputData.offline).toBe(true);
+    });
+
+    it('should show error when no cached data exists in text mode', async () => {
+      mockGetStateManager.mockReturnValue({
+        getState: vi.fn().mockReturnValue({
+          lastDigest: undefined,
+          lastRunAt: '2026-01-15T10:00:00Z',
+          repoScores: {},
+          config: {},
+        }),
+        getStats: vi.fn(),
+      } as any);
+
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await runDashboard({ json: false, offline: true });
+
+      const allErrorOutput = consoleErrorSpy.mock.calls.map((c) => c[0]).join('\n');
+      expect(allErrorOutput).toContain('No cached data found. Run without --offline first.');
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should not call getGitHubToken when --offline is set', async () => {
+      mockGetStateManager.mockReturnValue({
+        getState: vi.fn().mockReturnValue({
+          lastDigest: makeMockDigest('2026-01-15T09:30:00Z'),
+          lastDigestAt: '2026-01-15T09:30:00Z',
+          lastRunAt: '2026-01-15T10:00:00Z',
+          repoScores: {},
+          config: { shelvedPRUrls: [], approachingDormantDays: 25 },
+        }),
+        getStats: vi.fn(),
+      } as any);
+
+      await runDashboard({ json: true, offline: true });
+
+      expect(mockGetGitHubToken).not.toHaveBeenCalled();
+    });
+
+    it('should not include offline fields when --offline is not set', async () => {
+      const mockDigest = makeMockDigest('2026-01-15T09:30:00Z');
+      mockGetStateManager.mockReturnValue({
+        getState: vi.fn().mockReturnValue({
+          lastDigest: mockDigest,
+          lastDigestAt: '2026-01-15T09:30:00Z',
+          lastRunAt: '2026-01-15T10:00:00Z',
+          repoScores: {},
+          config: { shelvedPRUrls: [], approachingDormantDays: 25 },
+        }),
+        getStats: vi.fn(),
+      } as any);
+
+      await runDashboard({ json: true });
+
+      expect(mockOutputJson).toHaveBeenCalledTimes(1);
+      const outputData = mockOutputJson.mock.calls[0][0] as any;
+      expect(outputData.offline).toBeUndefined();
+      expect(outputData.lastUpdated).toBeUndefined();
+    });
+
+    it('should fall back to lastRunAt when generatedAt and lastDigestAt are missing', async () => {
+      const digest = makeMockDigest('');
+      // Clear generatedAt to test fallback
+      (digest as any).generatedAt = '';
+      mockGetStateManager.mockReturnValue({
+        getState: vi.fn().mockReturnValue({
+          lastDigest: digest,
+          lastDigestAt: undefined,
+          lastRunAt: '2026-01-15T10:00:00Z',
+          repoScores: {},
+          config: { shelvedPRUrls: [], approachingDormantDays: 25 },
+        }),
+        getStats: vi.fn(),
+      } as any);
+
+      await runDashboard({ json: true, offline: true });
+
+      const outputData = mockOutputJson.mock.calls[0][0] as any;
+      expect(outputData.offline).toBe(true);
+      expect(outputData.lastUpdated).toBe('2026-01-15T10:00:00Z');
+    });
+  });
+});

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -28,16 +28,30 @@ import type {
 interface DashboardOptions {
   open?: boolean;
   json?: boolean;
+  offline?: boolean;
 }
 
 export async function runDashboard(options: DashboardOptions): Promise<void> {
   const stateManager = getStateManager();
-  const token = getGitHubToken();
+  const token = options.offline ? null : getGitHubToken();
   let digest: DailyDigest | undefined;
   let commentedIssues: CommentedIssue[] = [];
 
-  // If we have a token, fetch fresh data
-  if (token) {
+  // In offline mode, skip all GitHub API calls
+  if (options.offline) {
+    const state = stateManager.getState();
+    digest = state.lastDigest;
+    if (!digest) {
+      if (options.json) {
+        outputJson({ error: 'No cached data found. Run without --offline first.', offline: true });
+      } else {
+        console.error('No cached data found. Run without --offline first.');
+      }
+      return;
+    }
+    const lastUpdated = digest.generatedAt || state.lastDigestAt || state.lastRunAt;
+    console.error(`Offline mode: using cached data from ${lastUpdated}`);
+  } else if (token) {
     console.error('Fetching fresh data from GitHub...');
     try {
       const prMonitor = new PRMonitor(token);
@@ -183,7 +197,7 @@ export async function runDashboard(options: DashboardOptions): Promise<void> {
 
   if (options.json) {
     const issueResponses = commentedIssues.filter((i): i is CommentedIssueWithResponse => i.status === 'new_response');
-    outputJson({
+    const jsonData: Record<string, unknown> = {
       stats,
       prsByRepo,
       topRepos: topRepos.map(([repo, data]) => ({ repo, ...data })),
@@ -191,7 +205,12 @@ export async function runDashboard(options: DashboardOptions): Promise<void> {
       activePRs: digest.openPRs || [],
       commentedIssues,
       issueResponses,
-    });
+    };
+    if (options.offline) {
+      jsonData.offline = true;
+      jsonData.lastUpdated = digest.generatedAt || state.lastDigestAt || state.lastRunAt;
+    }
+    outputJson(jsonData);
     return;
   }
 
@@ -203,7 +222,12 @@ export async function runDashboard(options: DashboardOptions): Promise<void> {
   fs.writeFileSync(dashboardPath, html, { mode: 0o644 });
   fs.chmodSync(dashboardPath, 0o644);
 
-  console.log(`\n📊 Dashboard generated: ${dashboardPath}`);
+  if (options.offline) {
+    const lastUpdated = digest.generatedAt || state.lastDigestAt || state.lastRunAt;
+    console.log(`\n📊 Dashboard generated (offline, cached data from ${lastUpdated}): ${dashboardPath}`);
+  } else {
+    console.log(`\n📊 Dashboard generated: ${dashboardPath}`);
+  }
 
   if (options.open) {
     // Use platform-specific open command - path is hardcoded, not user input

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -75,4 +75,58 @@ describe('runStatus', () => {
     const outputData = mockOutputJson.mock.calls[0][0] as any;
     expect(outputData.stats.totalTracked).toBeUndefined();
   });
+
+  describe('offline mode', () => {
+    it('should include offline and lastUpdated in JSON output when --offline is set', async () => {
+      mockGetStateManager.mockReturnValue({
+        getStats: vi.fn().mockReturnValue(mockStats),
+        getState: vi.fn().mockReturnValue({
+          lastRunAt: '2026-01-15T10:00:00Z',
+          lastDigestAt: '2026-01-15T09:30:00Z',
+        }),
+      } as any);
+
+      await runStatus({ json: true, offline: true });
+
+      const outputData = mockOutputJson.mock.calls[0][0] as any;
+      expect(outputData.offline).toBe(true);
+      expect(outputData.lastUpdated).toBe('2026-01-15T09:30:00Z');
+    });
+
+    it('should fall back to lastRunAt when lastDigestAt is not set', async () => {
+      await runStatus({ json: true, offline: true });
+
+      const outputData = mockOutputJson.mock.calls[0][0] as any;
+      expect(outputData.offline).toBe(true);
+      expect(outputData.lastUpdated).toBe('2026-01-15T10:00:00Z');
+    });
+
+    it('should not include offline fields when --offline is not set', async () => {
+      await runStatus({ json: true });
+
+      const outputData = mockOutputJson.mock.calls[0][0] as any;
+      expect(outputData.offline).toBeUndefined();
+      expect(outputData.lastUpdated).toBeUndefined();
+    });
+
+    it('should show offline message in text mode', async () => {
+      mockGetStateManager.mockReturnValue({
+        getStats: vi.fn().mockReturnValue(mockStats),
+        getState: vi.fn().mockReturnValue({
+          lastRunAt: '2026-01-15T10:00:00Z',
+          lastDigestAt: '2026-01-15T09:30:00Z',
+        }),
+      } as any);
+
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      await runStatus({ json: false, offline: true });
+
+      const allOutput = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
+      expect(allOutput).toContain('Last Updated: 2026-01-15T09:30:00Z');
+      expect(allOutput).toContain('Offline mode: showing cached data');
+      expect(allOutput).not.toContain('Last Run:');
+      consoleSpy.mockRestore();
+    });
+  });
 });

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -8,6 +8,7 @@ import { outputJson, type StatusOutput } from '../formatters/json.js';
 
 interface StatusOptions {
   json?: boolean;
+  offline?: boolean;
 }
 
 export async function runStatus(options: StatusOptions): Promise<void> {
@@ -15,13 +16,22 @@ export async function runStatus(options: StatusOptions): Promise<void> {
   const stats = stateManager.getStats();
   const state = stateManager.getState();
 
+  // Status always reads from local state (no API calls), so offline mode
+  // simply adds metadata about cache freshness.
+  const lastUpdated = state.lastDigestAt || state.lastRunAt;
+
   if (options.json) {
     // Extract only the stats we want to output (exclude totalTracked)
     const { totalTracked: _totalTracked, ...outputStats } = stats as typeof stats & { totalTracked?: number };
-    outputJson<StatusOutput>({
+    const output: StatusOutput = {
       stats: outputStats,
       lastRunAt: state.lastRunAt,
-    });
+    };
+    if (options.offline) {
+      output.offline = true;
+      output.lastUpdated = lastUpdated;
+    }
+    outputJson<StatusOutput>(output);
   } else {
     // Simple console output
     console.log('\n📊 OSS Status\n');
@@ -29,7 +39,12 @@ export async function runStatus(options: StatusOptions): Promise<void> {
     console.log(`Closed PRs: ${stats.closedPRs}`);
     console.log(`Merge Rate: ${stats.mergeRate}`);
     console.log(`Needs Response: ${stats.needsResponse}`);
-    console.log(`\nLast Run: ${state.lastRunAt || 'Never'}`);
+    if (options.offline) {
+      console.log(`\nLast Updated: ${lastUpdated || 'Never'}`);
+      console.log('(Offline mode: showing cached data)');
+    } else {
+      console.log(`\nLast Run: ${state.lastRunAt || 'Never'}`);
+    }
     console.log('\nRun with --json for structured output');
   }
 }

--- a/src/formatters/json.ts
+++ b/src/formatters/json.ts
@@ -90,6 +90,8 @@ export interface StatusOutput {
     needsResponse: number;
   };
   lastRunAt: string;
+  offline?: boolean;
+  lastUpdated?: string;
 }
 
 export interface SearchOutput {


### PR DESCRIPTION
Closes #296

## Summary

- Adds `--offline` flag to the `dashboard` and `status` CLI commands
- When `--offline` is passed, all GitHub API calls are skipped and data is read from cached `~/.oss-autopilot/state.json` and the last-generated digest
- Shows the timestamp of cached data via `lastUpdated` so users know how stale it is
- Gracefully errors with "No cached data found. Run without --offline first." when no cached data exists
- `--json` output includes `offline: true` and `lastUpdated: <ISO timestamp>` fields when in offline mode
- Adds comprehensive test coverage for offline paths in both commands (10 new tests)

## Test plan

- [x] `npx tsc --noEmit` passes with no errors
- [x] `npm test` passes (869 tests, 0 failures)
- [ ] Manual: `npm start -- status --offline --json` shows `offline: true` and `lastUpdated` fields
- [ ] Manual: `npm start -- dashboard --offline --json` shows cached data with offline metadata
- [ ] Manual: `npm start -- dashboard --offline` generates HTML dashboard from cache with timestamp
- [ ] Manual: `npm start -- status --offline` shows "Last Updated" and "(Offline mode: showing cached data)"
- [ ] Manual: With no prior data, `npm start -- dashboard --offline --json` returns helpful error