### PR TITLE
refactor: break up dashboard.ts into focused modules

### DIFF
--- a/src/commands/dashboard-data.ts
+++ b/src/commands/dashboard-data.ts
@@ -4,20 +4,9 @@
  * Separates data concerns from template generation and command orchestration.
  */
 
-import {
-  getStateManager,
-  PRMonitor,
-  IssueConversationMonitor,
-} from '../core/index.js';
+import { getStateManager, PRMonitor, IssueConversationMonitor } from '../core/index.js';
 import { toShelvedPRRef } from './daily.js';
-import type {
-  FetchedPR,
-  DailyDigest,
-  AgentState,
-  ClosedPR,
-  MergedPR,
-  CommentedIssue,
-} from '../core/types.js';
+import type { DailyDigest, AgentState, ClosedPR, MergedPR, CommentedIssue } from '../core/types.js';
 
 export interface DashboardFetchResult {
   digest: DailyDigest;
@@ -77,18 +66,12 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
   try {
     stateManager.setMonthlyMergedCounts(monthlyCounts);
   } catch (error) {
-    console.error(
-      '[DASHBOARD] Failed to store monthly merged counts:',
-      error instanceof Error ? error.message : error,
-    );
+    console.error('[DASHBOARD] Failed to store monthly merged counts:', error instanceof Error ? error.message : error);
   }
   try {
     stateManager.setMonthlyClosedCounts(monthlyClosedCounts);
   } catch (error) {
-    console.error(
-      '[DASHBOARD] Failed to store monthly closed counts:',
-      error instanceof Error ? error.message : error,
-    );
+    console.error('[DASHBOARD] Failed to store monthly closed counts:', error instanceof Error ? error.message : error);
   }
   try {
     const combinedOpenedCounts: Record<string, number> = { ...openedFromMerged };
@@ -103,10 +86,7 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
     }
     stateManager.setMonthlyOpenedCounts(combinedOpenedCounts);
   } catch (error) {
-    console.error(
-      '[DASHBOARD] Failed to store monthly opened counts:',
-      error instanceof Error ? error.message : error,
-    );
+    console.error('[DASHBOARD] Failed to store monthly opened counts:', error instanceof Error ? error.message : error);
   }
 
   const digest = prMonitor.generateDigest(prs, recentlyClosedPRs, recentlyMergedPRs);

--- a/src/commands/dashboard-templates.ts
+++ b/src/commands/dashboard-templates.ts
@@ -4,12 +4,7 @@
  * Pure functions with no side effects — all data is passed in as arguments.
  */
 
-import type {
-  FetchedPR,
-  DailyDigest,
-  AgentState,
-  CommentedIssueWithResponse,
-} from '../core/types.js';
+import type { FetchedPR, DailyDigest, AgentState, CommentedIssueWithResponse } from '../core/types.js';
 
 export interface DashboardStats {
   activePRs: number;

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -6,11 +6,7 @@
 
 import * as fs from 'fs';
 import { execFile } from 'child_process';
-import {
-  getStateManager,
-  getDashboardPath,
-  getGitHubToken,
-} from '../core/index.js';
+import { getStateManager, getDashboardPath, getGitHubToken } from '../core/index.js';
 import { outputJson } from '../formatters/json.js';
 import type {
   CommentedIssue,


### PR DESCRIPTION
## Summary

- Decompose the 1,975-line `dashboard.ts` monolith into three focused modules:
  - `dashboard.ts` (134 lines) — thin orchestrator: command logic, file I/O, browser open
  - `dashboard-data.ts` (180 lines) — data fetching from GitHub, PR grouping, stats computation
  - `dashboard-templates.ts` (1,734 lines) — HTML/CSS/JS template strings, `escapeHtml()`, `buildDashboardStats()`, `generateDashboardHtml()`
- Each module is independently importable and testable
- Visual output is identical — pure code movement, no behavioral changes

Closes #262

## Test plan

- [x] `npx tsc --noEmit` passes with zero errors
- [x] `npm test` passes all 859 tests with zero regressions
- [x] Existing mocks in `cli.test.ts` and `startup.test.ts` work unchanged (they mock `runDashboard` and `writeDashboardFromState` which remain exported from `dashboard.ts`)
- [ ] Verify dashboard HTML output is visually identical by running `npm start -- dashboard --open`