### PR TITLE
fix: add missing isFromMaintainer property and type imports

### DIFF
--- a/src/commands/daily.ts
+++ b/src/commands/daily.ts
@@ -30,6 +30,7 @@ import {
   type CommentedIssue,
   type CommentedIssueWithResponse,
   type PRCheckFailure,
+  type RepoGroup,
 } from '../core/index.js';
 import {
   outputJson,
@@ -38,6 +39,9 @@ import {
   compactActionableIssues,
   compactRepoGroups,
   type DailyOutput,
+  type CapacityAssessment,
+  type ActionableIssue,
+  type ActionMenu,
 } from '../formatters/json.js';
 
 // Re-export domain functions so existing consumers (tests, dashboard, startup)

--- a/src/commands/dashboard.test.ts
+++ b/src/commands/dashboard.test.ts
@@ -705,6 +705,7 @@ describe('dashboard', () => {
           lastResponseAuthor: 'maintainer',
           lastResponseBody: 'Thanks for the PR!',
           lastResponseAt: '2026-01-14T00:00:00Z',
+          isFromMaintainer: true,
         };
 
         const digest = makeDigest();
@@ -1079,6 +1080,7 @@ describe('dashboard', () => {
         lastResponseAuthor: 'maintainer',
         lastResponseBody: 'Great idea! Would you like to submit a PR?',
         lastResponseAt: '2026-01-14T00:00:00Z',
+        isFromMaintainer: true,
       };
 
       const digest = makeDigest();
@@ -1128,6 +1130,7 @@ describe('dashboard', () => {
           lastResponseAuthor: 'a',
           lastResponseBody: 'ok',
           lastResponseAt: '2026-01-14T00:00:00Z',
+          isFromMaintainer: true,
         },
         {
           repo: 'owner/repo',
@@ -1141,6 +1144,7 @@ describe('dashboard', () => {
           lastResponseAuthor: 'b',
           lastResponseBody: 'yes',
           lastResponseAt: '2026-01-14T00:00:00Z',
+          isFromMaintainer: true,
         },
       ];
 


### PR DESCRIPTION
## Summary
- Add `isFromMaintainer` to `CommentedIssueWithResponse` test objects in `dashboard.test.ts` (required after PR #328 added the property to the type)
- Import missing types (`CapacityAssessment`, `ActionableIssue`, `ActionMenu`, `RepoGroup`) in `daily.ts` (needed after PR #329 extracted `DailyCheckResult` interface but left type imports behind)

Fixes CI type check failures on the release PR #321.

## Test plan
- [x] `npx tsc --noEmit` passes cleanly
- [x] All 1776 tests pass