### PR TITLE
fix: remove unused fetchRepoStarCountsImpl import

### DIFF
--- a/src/core/pr-monitor.ts
+++ b/src/core/pr-monitor.ts
@@ -45,7 +45,6 @@ import { computeDisplayLabel } from './display-utils.js';
 import {
   fetchUserMergedPRCounts as fetchUserMergedPRCountsImpl,
   fetchUserClosedPRCounts as fetchUserClosedPRCountsImpl,
-  fetchRepoStarCounts as fetchRepoStarCountsImpl,
   fetchRecentlyClosedPRs as fetchRecentlyClosedPRsImpl,
   fetchRecentlyMergedPRs as fetchRecentlyMergedPRsImpl,
 } from './github-stats.js';


### PR DESCRIPTION
## Summary
- Remove unused `fetchRepoStarCountsImpl` import from `pr-monitor.ts`
- The inline implementation with HTTP caching was correctly kept during the PR #333 merge conflict resolution, making the extracted module import unused

Fixes lint error on release PR #321.

## Test plan
- [x] `npx eslint src/` — 0 errors
- [x] 207 pr-monitor tests pass