### PR TITLE
fix: remove legacy data path references from agents

### DIFF
--- a/agents/contribution-strategist.md
+++ b/agents/contribution-strategist.md
@@ -74,10 +74,7 @@ This returns:
    - User preferences (languages, labels)
    - Repository relationship scores
 
-   **Fallback (if CLI fails — tell the user: "The oss-autopilot CLI failed: [error]. Falling back to local data."):** Read from `.claude/oss-autopilot/`. If local data is also missing, STOP and report both errors to the user — do NOT improvise a workaround.
-   - `pr-history.md` - Past merged/closed PRs
-   - `tracked-prs.md` - Current active PRs
-   - `config.md` - User preferences
+   **Fallback (if CLI fails):** Tell the user: "The oss-autopilot CLI failed: [error]." Then try `gh` CLI commands to fetch the same data directly from GitHub. If that also fails, STOP and report both errors to the user — do NOT improvise a workaround.
 
 2. **Fetch GitHub Profile Data**
    ```bash

--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -183,11 +183,11 @@ The `aiPolicyBlocklist` field is included in CLI search JSON output. If you disc
    - `scoring`: Explanation of why each issue was scored
 
 3. **For Manual Context (when needed)**
-   Read from `.claude/oss-autopilot/`:
-   - `config.md` - Preferred languages, labels
-   - `tracked-prs.md` - Current open PRs (check for dormant ones)
-   - `pr-history.md` - Merged/closed PRs (successful relationships)
-   - `repo-scores.md` - Cached repo evaluations
+   Use `status --json` CLI output which includes:
+   - User preferences (languages, labels)
+   - Current open PRs with health indicators
+   - PR history (merged/closed PRs with success rates)
+   - Cached repo evaluation scores
 
 **Fallback Search (if CLI search fails — follow Fallback protocol above: inform the user, then try gh. If gh also fails, STOP and report both errors):**
 
@@ -333,7 +333,7 @@ Evaluate:
 
 ### 5. Repository Health Check
 
-Check if we have cached repo scores in `repo-scores.md`
+Check if we have cached repo scores via `status --json`.
 If not or stale, quick-assess:
 ```bash
 gh repo view OWNER/REPO --json description,stargazerCount,updatedAt,openIssues

--- a/agents/repo-evaluator.md
+++ b/agents/repo-evaluator.md
@@ -197,19 +197,17 @@ Rate 1-10 based on weighted factors:
 
 **Caching:**
 
-Repository scores are automatically cached in the CLI state (`data/state.json`).
+Repository scores are automatically cached in `~/.oss-autopilot/state.json`.
 
 To check existing cached scores:
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/dist/cli.bundle.cjs" status --json
+GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/dist/cli.bundle.cjs" status --json
 ```
 
 The CLI automatically:
 - Updates repo scores when PRs are merged/closed
 - Tracks response times and merge rates
 - Expires cache entries after 7 days
-
-**Note:** The legacy `.claude/oss-autopilot/repo-scores.md` file may also contain cached scores but the CLI's `data/state.json` is the authoritative source.
 
 **Red Flags to Highlight:**
 - No commits in 60+ days


### PR DESCRIPTION
## Summary
- Removes references to `.claude/oss-autopilot/pr-history.md`, `tracked-prs.md`, and `repo-scores.md` from three agents
- Updates fallback guidance to use `gh` CLI instead of non-existent local files
- Fixes `data/state.json` path in repo-evaluator to `~/.oss-autopilot/state.json`
- Aligns agents with v2 "Fresh Fetch" architecture where PRs are fetched from GitHub API, not stored locally

## Affected agents
- `contribution-strategist.md` — removed legacy file fallback
- `repo-evaluator.md` — fixed state path, removed legacy note
- `issue-scout.md` — replaced local file references with CLI output

## Test plan
- [x] Verified no legacy path references remain in agents/ directory
- [x] All tests pass (87/88 — pre-existing dist/cli.test.js failure)

Closes #346