### PR TITLE
fix: change default file permissions from 0o644 to 0o600 in atomicWriteFileSync

### DIFF
--- a/src/core/state.ts
+++ b/src/core/state.ts
@@ -110,7 +110,7 @@ export function releaseLock(lockPath: string): void {
  */
 export function atomicWriteFileSync(filePath: string, data: string, mode?: number): void {
   const tmpPath = filePath + '.tmp';
-  fs.writeFileSync(tmpPath, data, { mode: mode ?? 0o644 });
+  fs.writeFileSync(tmpPath, data, { mode: mode ?? 0o600 });
   fs.renameSync(tmpPath, filePath);
   // Ensure permissions are correct (rename preserves the tmp file's mode,
   // but on some systems the mode from writeFileSync is masked by umask)


### PR DESCRIPTION
## Summary
- Changes the default mode in `atomicWriteFileSync` from `0o644` (world-readable) to `0o600` (user-only)
- All existing callers already pass `0o600` explicitly — this fixes the default for defense-in-depth
- Consistent with `http-cache.ts` which already uses `0o600`

## Test plan
- [x] All tests pass (87/88 — pre-existing dist/cli.test.js failure)
- [x] Verified all `atomicWriteFileSync` callers still work correctly

Closes #357