### PR TITLE
fix: replace Record<string, any> with Record<string, unknown> in issue-conversation.ts

### DIFF
--- a/src/core/issue-conversation.ts
+++ b/src/core/issue-conversation.ts
@@ -200,7 +200,7 @@ export class IssueConversationMonitor {
         body: comment.body || '',
         createdAt: comment.created_at,
         isUser: author.toLowerCase() === username.toLowerCase(),
-        authorAssociation: (comment as Record<string, any>).author_association || '',
+        authorAssociation: String((comment as Record<string, unknown>).author_association ?? ''),
       });
     }
 


### PR DESCRIPTION
## Summary
- Replaces the last `any` type in production code with `Record<string, unknown>`
- Uses `String()` coercion with `??` fallback for type-safe access to the untyped `author_association` field

## Test plan
- [x] All tests pass (87/88 — pre-existing dist/cli.test.js failure)

Closes #363