### PR TITLE
fix: respect 'any' language preference in CLI search

### DIFF
--- a/src/core/issue-discovery.ts
+++ b/src/core/issue-discovery.ts
@@ -357,11 +357,13 @@ export class IssueDiscovery {
 
     // Build query parts
     const labelQuery = labels.map((l) => `label:"${l}"`).join(' ');
-    const langQuery = languages.map((l) => `language:${l}`).join(' ');
+    // When languages includes 'any', omit the language filter entirely
+    const isAnyLanguage = languages.some((l) => l.toLowerCase() === 'any');
+    const langQuery = isAnyLanguage ? '' : languages.map((l) => `language:${l}`).join(' ');
     // Phase 0 uses a broader query — established contributors don't need beginner labels
-    const establishedQuery = `is:issue is:open ${langQuery} no:assignee`;
+    const establishedQuery = `is:issue is:open ${langQuery} no:assignee`.replace(/  +/g, ' ').trim();
     // Phases 1+ use label-filtered query for discovery in unfamiliar repos
-    const baseQuery = `is:issue is:open ${labelQuery} ${langQuery} no:assignee`;
+    const baseQuery = `is:issue is:open ${labelQuery} ${langQuery} no:assignee`.replace(/  +/g, ' ').trim();
 
     // Helper to filter issues
     const includeDocIssues = config.includeDocIssues ?? true;


### PR DESCRIPTION
## Summary
- When languages config includes `any`, omit the `language:` filter from GitHub search queries entirely
- Previously `any` was passed through as `language:any` which is not a valid GitHub search filter
- Cleans up double spaces in queries when language filter is omitted

## Test plan
- [x] All tests pass (87/88 — pre-existing dist/cli.test.js failure)
- [x] Verified query construction produces clean queries without double spaces

Closes #350