### PR TITLE
feat: add Phase 3 search for actively maintained repos (#349)

### DIFF
--- a/src/core/issue-discovery.test.ts
+++ b/src/core/issue-discovery.test.ts
@@ -1286,10 +1286,9 @@ describe('Phase 3: actively maintained repos (#349)', () => {
       },
     });
 
-    // We need to intercept Phase 3 call specifically. Since vetIssue also calls search,
-    // we use mockImplementation to check the query and return Phase 3 results when
+    // Intercept Phase 3 call specifically. Since vetIssue also calls search,
+    // use mockImplementation to check the query and return Phase 3 results when
     // the query includes 'archived:false'.
-    const defaultImpl = mockOctokitInstance.search.issuesAndPullRequests.getMockImplementation();
     mockOctokitInstance.search.issuesAndPullRequests.mockImplementation((params: any) => {
       if (params?.q?.includes('archived:false')) {
         return Promise.resolve({
@@ -1323,8 +1322,19 @@ describe('Phase 3: actively maintained repos (#349)', () => {
       .mockResolvedValueOnce({ data: { total_count: 0, items: [] } }) // Phase 2
       .mockRejectedValueOnce(new Error('Network error')); // Phase 3
 
-    // Should throw since both phases returned nothing
-    await expect(discovery.searchIssues({ maxResults: 5 })).rejects.toThrow('No issue candidates found');
+    // Should throw with Phase 3 error details included
+    await expect(discovery.searchIssues({ maxResults: 5 })).rejects.toThrow(
+      /Phase 3 \(maintained repos\): Network error/,
+    );
+  });
+
+  it('should return empty array when Phase 3 hits rate limit', async () => {
+    mockOctokitInstance.search.issuesAndPullRequests
+      .mockResolvedValueOnce({ data: { total_count: 0, items: [] } }) // Phase 2
+      .mockRejectedValueOnce(Object.assign(new Error('rate limit exceeded'), { status: 403 })); // Phase 3
+
+    const candidates = await discovery.searchIssues({ maxResults: 5 });
+    expect(candidates).toEqual([]);
   });
 
   it('should use stars and pushed qualifiers in Phase 3 query', async () => {

--- a/src/core/issue-discovery.ts
+++ b/src/core/issue-discovery.ts
@@ -588,16 +588,23 @@ export class IssueDiscovery {
 
         // Filter spam, already-found repos, and already-searched repos
         const spamRepos = detectLabelFarmingRepos(data.items);
+        if (spamRepos.size > 0) {
+          const spamCount = data.items.filter((i) =>
+            spamRepos.has(i.repository_url.split('/').slice(-2).join('/')),
+          ).length;
+          console.log(
+            `[SPAM_FILTER] Filtered ${spamCount} issues from ${spamRepos.size} label-farming repos: ${[...spamRepos].join(', ')}`,
+          );
+        }
         const seenRepos = new Set(allCandidates.map((c) => c.issue.repo));
         const itemsToVet = filterIssues(data.items)
           .filter((item) => {
             const repoFullName = item.repository_url.split('/').slice(-2).join('/');
-            return !spamRepos.has(repoFullName);
-          })
-          .filter((item) => {
-            const repoFullName = item.repository_url.split('/').slice(-2).join('/');
             return (
-              !phase0RepoSet.has(repoFullName) && !starredRepoSet.has(repoFullName) && !seenRepos.has(repoFullName)
+              !spamRepos.has(repoFullName) &&
+              !phase0RepoSet.has(repoFullName) &&
+              !starredRepoSet.has(repoFullName) &&
+              !seenRepos.has(repoFullName)
             );
           })
           .slice(0, remainingNeeded * 2);
@@ -612,14 +619,26 @@ export class IssueDiscovery {
           'normal',
         );
 
-        allCandidates.push(...results);
+        // Apply minStars filter (same as Phase 2, #105)
+        const minStars = config.minStars ?? 50;
+        const starFiltered = results.filter((c) => {
+          if (c.projectHealth.checkFailed) return true;
+          const stars = c.projectHealth.stargazersCount ?? 0;
+          return stars >= minStars;
+        });
+        const starFilteredCount = results.length - starFiltered.length;
+        if (starFilteredCount > 0) {
+          console.log(`[STAR_FILTER] Filtered ${starFilteredCount} Phase 3 candidates below ${minStars} stars`);
+        }
+
+        allCandidates.push(...starFiltered);
         if (allVetFailed) {
           phase3Error = 'all vetting failed';
         }
         if (vetRateLimitHit) {
           rateLimitHitDuringSearch = true;
         }
-        console.log(`Found ${results.length} candidates from maintained-repo search`);
+        console.log(`Found ${starFiltered.length} candidates from maintained-repo search`);
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
         phase3Error = errorMessage;


### PR DESCRIPTION
## Summary

- Adds Strategy D (Phase 3) to issue discovery that searches actively maintained repos (50+ stars, pushed within 30 days, not archived)
- Fills the gap between existing strategies by casting a wider net focused on repo health and merge likelihood
- Uses label-free query to catch repos that Phase 2 misses (which requires `good first issue` labels)
- Runs only when earlier phases haven't filled `maxResults`, skipping repos already found

Closes #349

## Test plan

- [x] Added 5 new tests for Phase 3 behavior
- [x] Tests verify: Phase 3 runs when needed, skipped when full, excludes duplicates, handles errors, uses correct query params
- [x] All 1255 tests pass (5 new)