### PR TITLE
feat: add SBOM generation to release workflow (#359)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 permissions:
-  contents: read
+  contents: write # write required for gh release upload (SBOM attachment)
   id-token: write
 
 jobs:
@@ -38,3 +38,43 @@ jobs:
         run: npm publish --provenance --access public --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  sbom:
+    name: Attach SBOM to release
+    needs: publish
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.release.prerelease }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate SBOM
+        run: npx @cyclonedx/cyclonedx-npm@4.1.2 --output-file sbom.json
+
+      - name: Validate SBOM
+        run: |
+          if [ ! -s sbom.json ]; then
+            echo "::error::SBOM file is missing or empty"
+            exit 1
+          fi
+          if ! jq -e '.bomFormat == "CycloneDX"' sbom.json > /dev/null 2>&1; then
+            echo "::error::SBOM file is not valid CycloneDX format"
+            exit 1
+          fi
+          echo "SBOM validated: $(jq -r '.components | length') components found"
+
+      - name: Attach SBOM to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: gh release upload "$TAG_NAME" sbom.json --clobber


### PR DESCRIPTION
## Summary

- Adds CycloneDX SBOM (Software Bill of Materials) generation as a separate job in the npm-publish workflow
- SBOM is generated after successful npm publish and attached as a release asset
- Pinned `@cyclonedx/cyclonedx-npm@4.1.2` to prevent supply-chain risks from unpinned npx
- Validates SBOM is non-empty and valid CycloneDX format before uploading
- Separate job ensures SBOM failure doesn't mask a successful npm publish

## Design Decisions

- **Single location**: SBOM lives only in `npm-publish.yml` (not `release.yml`) since npm-publish runs for ALL releases and already has `npm ci`
- **Separate job**: `sbom` job depends on `publish` job — if SBOM generation fails, the publish job still shows green
- **Validation**: Checks file is non-empty and has `bomFormat: CycloneDX` before uploading
- **Permissions**: `contents: write` escalation (from `read`) is documented with an inline comment

Closes #359

## Test plan

- [ ] Verify workflow YAML is valid (no syntax errors)
- [ ] Verify SBOM job only runs after publish succeeds (`needs: publish`)
- [ ] Verify `--clobber` flag makes upload idempotent
- [ ] Verify validation step catches empty/malformed SBOM files