### PR TITLE
feat: add /oss-help quick reference command (#360)

### DIFF
--- a/commands/oss-help.md
+++ b/commands/oss-help.md
@@ -1,0 +1,58 @@
+---
+name: oss-help
+description: "Quick reference card for OSS Autopilot commands, agents, and workflows"
+allowed-tools: Read
+---
+
+# OSS Autopilot Quick Reference
+
+Print this reference card for the user. Do NOT run any commands — just display the information below.
+
+---
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/oss` | **Daily check** — fetches open PRs, shows status dashboard, suggests actions (respond to reviews, fix CI, rebase, find new issues) |
+| `/oss-search` | **Find issues** — multi-strategy search across GitHub for contributable issues matching your language/label preferences |
+| `/setup-oss` | **Configure** — set GitHub username, languages, labels, PR limits, and other preferences |
+| `/oss-help` | **This card** — quick reference for all plugin capabilities |
+
+## Agents
+
+These agents activate automatically when relevant, or you can ask for them directly:
+
+| Agent | When to Use |
+|-------|-------------|
+| **pr-responder** | "Help me respond to comments on my PR" — drafts professional replies to maintainer feedback |
+| **pr-health-checker** | "Why is my PR failing CI?" — diagnoses CI failures, merge conflicts, stale reviews, and performs rebases |
+| **pr-compliance-checker** | "Check if my PR is ready" — validates against opensource.guide best practices before submission |
+| **issue-scout** | "Find me issues to work on" — searches, vets, and helps claim good contribution opportunities |
+| **repo-evaluator** | "Is this repo worth contributing to?" — analyzes maintainer responsiveness and project health |
+| **contribution-strategist** | "How am I doing?" — analyzes contribution patterns and provides strategic advice |
+| **pre-commit-reviewer** | "Review my changes before I push" — checks diffs for bugs, style issues, and dead code |
+
+## Typical Workflow
+
+```
+1. /oss              → See what needs attention
+2. Pick an action    → Respond to review, fix CI, rebase
+3. /oss-search       → Find new issues when you have capacity
+4. Claim an issue    → Work on it → Submit PR
+5. /oss              → Monitor PR until merged
+```
+
+## Skill
+
+The **oss-contribution** skill provides best practices for:
+- Writing PR descriptions and commit messages
+- Responding to maintainer feedback
+- Following repository contribution guidelines
+- Open source etiquette (claiming issues, draft PRs, etc.)
+
+## Configuration
+
+Settings are stored in `~/.oss-autopilot/state.json`. Run `/setup-oss` to reconfigure.
+
+Key settings: GitHub username, max active PRs, dormant threshold, preferred languages, issue labels, squash preference.

--- a/commands/setup-oss.md
+++ b/commands/setup-oss.md
@@ -183,7 +183,8 @@ Show summary:
 - X open PRs imported
 
 ### Next Steps
-Run `/oss` to check your PRs and find new contribution opportunities.
+- Run `/oss` to check your PRs and find new contribution opportunities
+- Run `/oss-help` for a full reference card of commands and agents
 ```
 
 **Note:** The `squashByDefault` and `repoOverrides` settings are stored in the config frontmatter. Per-repo squash overrides can be added manually:
@@ -462,7 +463,8 @@ Show summary:
 - X open PRs imported
 
 ### Next Steps
-Run `/oss` to check your PRs and find new contribution opportunities.
+- Run `/oss` to check your PRs and find new contribution opportunities
+- Run `/oss-help` for a full reference card of commands and agents
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Adds `/oss-help` command that prints a reference card of all available commands, agents, and workflows
- Updates `/setup-oss` completion message to mention `/oss-help` for discoverability
- Read-only command (no tools needed beyond Read) — just displays formatted information

Closes #360

## Test plan

- [ ] Verify `/oss-help` displays the reference card correctly
- [ ] Verify all 4 commands and 7 agents are accurately listed
- [ ] Verify `/setup-oss` completion message mentions `/oss-help`