### PR TITLE
feat: add cross-references between all 7 agents (#361)

### DIFF
--- a/agents/contribution-strategist.md
+++ b/agents/contribution-strategist.md
@@ -249,3 +249,8 @@ For documentation-only contributions:
 - Celebrate wins, no matter how small
 - Recognize that sustainable pace matters
 - Never suggest AI attribution in contributions
+
+**Related Agents:**
+- Based on strategic recommendations, suggest **issue-scout** to find aligned issues (e.g., "Based on your patterns, let me find issues in your strongest repos")
+- For evaluating a recommended repo before committing, suggest **repo-evaluator** for detailed health analysis
+- If the user has PRs that need attention, **pr-health-checker** can diagnose and resolve blockers

--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -489,3 +489,8 @@ If user asks "What about issues in [repo with dormant PR]?":
 - Don't over-commit to timeline
 - Track all claimed issues for follow-up
 - Always explain your repo recommendations - transparency builds trust
+
+**Related Agents:**
+- For deeper repository analysis before committing to a contribution, suggest the user run **repo-evaluator** (e.g., "Want me to do a deeper health analysis of this repo before you invest time?")
+- After the user claims an issue and submits a PR, **pr-health-checker** can monitor CI and merge readiness
+- For strategic guidance on which repos to focus on long-term, **contribution-strategist** can analyze patterns and recommend alignment

--- a/agents/pr-compliance-checker.md
+++ b/agents/pr-compliance-checker.md
@@ -308,3 +308,8 @@ When score is below 90, offer to help fix issues:
 
 If AI attribution is found and the repository does NOT require it, flag this as an issue:
 > "Found AI attribution in [location]. Unless this repository requires disclosure of AI tool usage, remove this to avoid unnecessary attention and keep contributions appearing as solely from the user."
+
+**Related Agents:**
+- For code-level quality review before pushing, suggest **pre-commit-reviewer** to catch bugs and style issues
+- If CI is failing or the PR has merge conflicts, suggest **pr-health-checker** to diagnose and resolve
+- To find new contribution opportunities after a successful PR, suggest **issue-scout** to search for aligned issues

--- a/agents/pr-health-checker.md
+++ b/agents/pr-health-checker.md
@@ -368,3 +368,8 @@ Before any push (regular commits, post-rebase force-pushes, or CI fix commits):
 1. Run the project's code review tooling on the diff
 2. Fix any issues found
 3. Only push after the review is clean
+
+**Related Agents:**
+- After fixing CI or resolving conflicts, suggest running **pre-commit-reviewer** before pushing (e.g., "Changes look good — want me to review them before pushing?")
+- If the PR needs a response to maintainer comments, hand off to **pr-responder** for drafting replies
+- For PRs in repos with unknown health, suggest **repo-evaluator** to understand maintainer responsiveness patterns

--- a/agents/pr-responder.md
+++ b/agents/pr-responder.md
@@ -235,3 +235,8 @@ GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/dist/cli.bundle.cjs" p
 gh pr comment OWNER/REPO#NUMBER --body "Your approved response message"
 ```
 If `gh` also fails, STOP and report both errors to the user.
+
+**Related Agents:**
+- If the PR has CI failures or merge conflicts mentioned in review comments, suggest **pr-health-checker** to diagnose and fix before responding
+- Before pushing code changes in response to feedback, suggest **pre-commit-reviewer** to verify quality
+- To validate the PR meets contribution standards after addressing feedback, suggest **pr-compliance-checker**

--- a/agents/pre-commit-reviewer.md
+++ b/agents/pre-commit-reviewer.md
@@ -223,3 +223,8 @@ Then use AskUserQuestion:
 4. **Don't over-flag** — only report issues that a maintainer would actually care about
 5. **No AI attribution** — never suggest adding AI attribution to commits or code
 6. **Read only what's needed** — don't read the entire codebase, focus on changed files and their immediate context
+
+**Related Agents:**
+- After a clean review, **pr-health-checker** can verify CI status and merge readiness before pushing
+- If the changes are in response to maintainer feedback, **pr-responder** can help draft a reply explaining the updates
+- Before final submission, **pr-compliance-checker** can validate the PR against repository contribution standards

--- a/agents/repo-evaluator.md
+++ b/agents/repo-evaluator.md
@@ -224,3 +224,8 @@ The CLI automatically:
 - Multiple maintainers
 - Clear contribution guidelines
 - Welcoming first-timer labels
+
+**Related Agents:**
+- After evaluating a repo, suggest **issue-scout** to find specific issues to work on (e.g., "This repo looks healthy! Want me to find good issues here?")
+- The repo evaluation integrates with **issue-scout**'s scoring system — cached scores from this agent boost issue rankings
+- For strategic repo selection aligned with career goals, **contribution-strategist** can provide broader context


### PR DESCRIPTION
## Summary

- Adds a "Related Agents" section to all 7 agents with contextual hand-off suggestions
- Creates bidirectional references so users can discover the full agent network from any entry point
- Each agent suggests 3 related agents with example prompts showing when to use them

## Cross-reference map

| Agent | References |
|-------|-----------|
| issue-scout | repo-evaluator, pr-health-checker, contribution-strategist |
| repo-evaluator | issue-scout, contribution-strategist |
| pr-health-checker | pre-commit-reviewer, pr-responder, repo-evaluator |
| contribution-strategist | issue-scout, repo-evaluator, pr-health-checker |
| pr-responder | pr-health-checker, pre-commit-reviewer, pr-compliance-checker |
| pre-commit-reviewer | pr-health-checker, pr-responder, pr-compliance-checker |
| pr-compliance-checker | pre-commit-reviewer, pr-health-checker, issue-scout |

Closes #361

## Test plan

- [ ] Verify all 7 agents have "Related Agents" sections
- [ ] Verify all agent names are correct and exist
- [ ] Verify cross-references are bidirectional where appropriate