### PR TITLE
fix: document curated issue list file format (#364)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,31 @@ Settings live in `.claude/oss-autopilot/config.md` (YAML frontmatter). Run `/set
 
 PR tracking state is stored separately in `~/.oss-autopilot/state.json`.
 
+### Curated Issue List
+
+You can maintain a markdown file of pre-researched issues. Set the path during `/setup-oss` or via `setup --set issueListPath=PATH`. The parser recognizes:
+
+- **GitHub URLs** in list items (issues or PRs)
+- **Section headings** (`#`, `##`, `###`) as tier labels
+- **Checkboxes** (`[x]`), **strikethrough** (`~~text~~`), or the word **Done** to mark completed items
+
+Example file:
+
+```markdown
+## Pursue (High Priority)
+- https://github.com/facebook/react/issues/12345 — Fix useEffect cleanup order
+- https://github.com/vercel/next.js/issues/67890 — Add streaming support for app router
+
+## Maybe (Worth Investigating)
+- https://github.com/expressjs/express/issues/111 — Update error handling docs
+
+## Completed
+- [x] https://github.com/nodejs/node/issues/222 — Fix stream backpressure (Done)
+- ~~https://github.com/vitejs/vite/issues/333 — HMR race condition~~
+```
+
+The `/oss-search` command can add vetted issues to this file automatically. Issues from your curated list get a +2 score bonus during search.
+
 ## Tips
 
 **Start small:** Set `maxActivePRs` to 3-5 when starting out. Fewer active PRs with fast responses beats many stale ones.

--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -101,6 +101,8 @@ If the TypeScript CLI command fails (non-zero exit, error output, or missing bun
 
 **Curated Issue List Awareness:**
 
+The curated issue list is a markdown file of pre-researched issues. The parser extracts GitHub URLs from list items, uses headings as tier labels, and marks items as completed via checkboxes (`[x]`), strikethrough (`~~`), or "Done". See README for full format specification.
+
 When dispatched with an issue from the user's curated list (indicated by `Source: curated-list` in the dispatch prompt):
 
 1. **Apply a +2 score bonus** to the issue's base score. The user has already pre-vetted this issue, so it starts with higher confidence.


### PR DESCRIPTION
## Summary

- Add "Curated Issue List" section to README with format specification and example
- Add brief format note to issue-scout agent where it references curated lists
- Documents: GitHub URLs, heading-based tiers, checkbox/strikethrough/Done completion markers

Closes #364

## Test plan

- [ ] Verify README example matches what the parser actually supports
- [ ] Verify issue-scout reference is accurate