### PR TITLE
refactor: parallelize comment fetching and use splitRepo utility

### DIFF
--- a/packages/core/src/commands/comments.ts
+++ b/packages/core/src/commands/comments.ts
@@ -44,38 +44,36 @@ export async function runComments(options: CommentsOptions): Promise<CommentsOut
   // Get PR details
   const { data: pr } = await octokit.pulls.get({ owner, repo, pull_number });
 
-  // Get review comments (inline code comments)
-  const reviewComments = await paginateAll((page) =>
-    octokit.pulls.listReviewComments({
-      owner,
-      repo,
-      pull_number,
-      per_page: 100,
-      page,
-    }),
-  );
-
-  // Get issue comments (general PR discussion)
-  const issueComments = await paginateAll((page) =>
-    octokit.issues.listComments({
-      owner,
-      repo,
-      issue_number: pull_number,
-      per_page: 100,
-      page,
-    }),
-  );
-
-  // Get reviews
-  const reviews = await paginateAll((page) =>
-    octokit.pulls.listReviews({
-      owner,
-      repo,
-      pull_number,
-      per_page: 100,
-      page,
-    }),
-  );
+  // Fetch review comments, issue comments, and reviews in parallel
+  const [reviewComments, issueComments, reviews] = await Promise.all([
+    paginateAll((page) =>
+      octokit.pulls.listReviewComments({
+        owner,
+        repo,
+        pull_number,
+        per_page: 100,
+        page,
+      }),
+    ),
+    paginateAll((page) =>
+      octokit.issues.listComments({
+        owner,
+        repo,
+        issue_number: pull_number,
+        per_page: 100,
+        page,
+      }),
+    ),
+    paginateAll((page) =>
+      octokit.pulls.listReviews({
+        owner,
+        repo,
+        pull_number,
+        per_page: 100,
+        page,
+      }),
+    ),
+  ]);
 
   // Filter out own comments, optionally show bots
   const username = stateManager.getState().config.githubUsername;

--- a/packages/mcp-server/src/resources.test.ts
+++ b/packages/mcp-server/src/resources.test.ts
@@ -35,6 +35,10 @@ vi.mock('@oss-autopilot/core/commands', () => ({
 }));
 
 vi.mock('@oss-autopilot/core', () => ({
+  splitRepo: (fullName: string) => {
+    const [owner, repo] = fullName.split('/');
+    return { owner, repo };
+  },
   getStateManager: vi.fn().mockReturnValue({
     getState: vi.fn().mockReturnValue({
       lastDigest: {

--- a/packages/mcp-server/src/resources.ts
+++ b/packages/mcp-server/src/resources.ts
@@ -7,7 +7,7 @@
 import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { runStatus, runConfig } from '@oss-autopilot/core/commands';
-import { getStateManager } from '@oss-autopilot/core';
+import { getStateManager, splitRepo } from '@oss-autopilot/core';
 import { errorMessage } from './tools.js';
 
 /** Build a standard MCP resource response with a single JSON content entry. */
@@ -103,7 +103,7 @@ export function registerResources(server: McpServer): void {
           const openPRs = getStateManager().getState().lastDigest?.openPRs ?? [];
           return {
             resources: openPRs.map((pr) => {
-              const [owner, repo] = pr.repo.split('/');
+              const { owner, repo } = splitRepo(pr.repo);
               return {
                 uri: `oss://pr/${owner}/${repo}/${pr.number}`,
                 name: `${pr.repo}#${pr.number}`,


### PR DESCRIPTION
## Summary
- Parallelize 3 sequential GitHub API calls in `runComments()` using `Promise.all` — reduces wall-clock latency for comment fetching
- Replace inline `pr.repo.split('/')` with existing `splitRepo()` utility from `@oss-autopilot/core` in MCP server resources
- Update test mock to include `splitRepo` export

## Test plan
- [ ] All existing tests pass (103 MCP server tests, 1237 core tests)
- [ ] Lint and format clean
- [ ] CI green