### PR TITLE
refactor: remove dead fetchRecentPRs and unused fetchRepoStarCounts

### DIFF
--- a/packages/core/src/core/github-stats.ts
+++ b/packages/core/src/core/github-stats.ts
@@ -6,7 +6,6 @@
 import { Octokit } from '@octokit/rest';
 import { extractOwnerRepo, parseGitHubUrl } from './utils.js';
 import { ClosedPR, MergedPR } from './types.js';
-import { ValidationError } from './errors.js';
 import { debug, warn } from './logger.js';
 
 const MODULE = 'github-stats';
@@ -196,59 +195,6 @@ export async function fetchUserClosedPRCounts(
 
   debug(MODULE, `Found ${fetched} closed (unmerged) PRs across ${repos.size} repos`);
   return { repos, monthlyCounts, monthlyOpenedCounts, dailyActivityCounts };
-}
-
-/**
- * Fetch GitHub star counts for a list of repositories.
- * Used to populate stargazersCount in repo scores for dashboard filtering by minStars.
- * Fetches concurrently with per-repo error isolation (missing/private repos are skipped).
- */
-export async function fetchRepoStarCounts(octokit: Octokit, repos: string[]): Promise<Map<string, number>> {
-  if (repos.length === 0) return new Map();
-
-  debug(MODULE, `Fetching star counts for ${repos.length} repos...`);
-  const results = new Map<string, number>();
-
-  // Fetch in parallel chunks to avoid overwhelming the API
-  const chunkSize = 10;
-  for (let i = 0; i < repos.length; i += chunkSize) {
-    const chunk = repos.slice(i, i + chunkSize);
-    const settled = await Promise.allSettled(
-      chunk.map(async (repo) => {
-        const parts = repo.split('/');
-        if (parts.length !== 2 || !parts[0] || !parts[1]) {
-          throw new ValidationError(`Malformed repo identifier: "${repo}"`);
-        }
-        const [owner, name] = parts;
-        const { data } = await octokit.repos.get({ owner, repo: name });
-        return { repo, stars: data.stargazers_count };
-      }),
-    );
-    let chunkFailures = 0;
-    for (let j = 0; j < settled.length; j++) {
-      const result = settled[j];
-      if (result.status === 'fulfilled') {
-        results.set(result.value.repo, result.value.stars);
-      } else {
-        chunkFailures++;
-        warn(
-          MODULE,
-          `Failed to fetch stars for ${chunk[j]}: ${result.reason instanceof Error ? result.reason.message : result.reason}`,
-        );
-      }
-    }
-    // If entire chunk failed, likely a systemic issue (rate limit, auth, outage) — abort remaining
-    if (chunkFailures === chunk.length && chunk.length > 0) {
-      const remaining = repos.length - i - chunkSize;
-      if (remaining > 0) {
-        warn(MODULE, `Entire chunk failed, aborting remaining ${remaining} repos`);
-      }
-      break;
-    }
-  }
-
-  debug(MODULE, `Fetched star counts for ${results.size}/${repos.length} repos`);
-  return results;
 }
 
 /**

--- a/packages/core/src/core/pr-monitor.ts
+++ b/packages/core/src/core/pr-monitor.ts
@@ -600,64 +600,6 @@ export class PRMonitor {
   }
 
   /**
-   * Shared helper: search for recent PRs and filter out own repos, excluded repos/orgs.
-   * Returns parsed search results that pass all filters.
-   */
-  private async fetchRecentPRs<T>(
-    query: string,
-    label: string,
-    days: number,
-    mapItem: (
-      item: { html_url: string; title: string; closed_at: string | null; pull_request?: { merged_at?: string | null } },
-      parsed: { owner: string; repo: string; number: number },
-    ) => T,
-  ): Promise<T[]> {
-    const config = this.stateManager.getState().config;
-
-    if (!config.githubUsername) {
-      warn(MODULE, `Skipping recently ${label} PRs fetch: no githubUsername configured. Run /setup-oss to configure.`);
-      return [];
-    }
-
-    const sinceDate = new Date();
-    sinceDate.setDate(sinceDate.getDate() - days);
-    const since = sinceDate.toISOString().split('T')[0]; // YYYY-MM-DD
-
-    debug(MODULE, `Fetching recently ${label} PRs for @${config.githubUsername} (since ${since})...`);
-
-    const { data } = await this.octokit.search.issuesAndPullRequests({
-      q: query.replace('{username}', config.githubUsername).replace('{since}', since),
-      sort: 'updated',
-      order: 'desc',
-      per_page: 100,
-    });
-
-    const results: T[] = [];
-
-    for (const item of data.items) {
-      const parsed = parseGitHubUrl(item.html_url);
-      if (!parsed) {
-        warn(MODULE, `Could not parse GitHub URL from API response: ${item.html_url}`);
-        continue;
-      }
-
-      const repo = `${parsed.owner}/${parsed.repo}`;
-
-      // Skip own repos
-      if (parsed.owner.toLowerCase() === config.githubUsername.toLowerCase()) continue;
-
-      // Skip excluded repos and orgs
-      if (config.excludeRepos.includes(repo)) continue;
-      if (config.excludeOrgs?.some((org) => parsed.owner.toLowerCase() === org.toLowerCase())) continue;
-
-      results.push(mapItem(item, { owner: parsed.owner, repo, number: parsed.number }));
-    }
-
-    debug(MODULE, `Found ${results.length} recently ${label} PRs`);
-    return results;
-  }
-
-  /**
    * Fetch PRs closed without merge in the last N days.
    * Delegates to github-stats module.
    */


### PR DESCRIPTION
Closes #435

## Summary
- Remove dead private `fetchRecentPRs` method from PRMonitor (~55 lines) — never called, public methods delegate to github-stats.ts instead
- Remove dead standalone `fetchRepoStarCounts` from github-stats.ts (~48 lines) — never imported, the PRMonitor instance method with HttpCache is what's used
- Remove unused `ValidationError` import from github-stats.ts

## Test plan
- [x] All 1340 tests pass (1237 core + 103 MCP server)
- [x] Lint clean
- [x] Verified no remaining references to removed code