### PR TITLE
refactor: extract errorMessage() and getHttpStatusCode() helpers

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -12,6 +12,7 @@
 
 import { Command } from 'commander';
 import { getGitHubTokenAsync, enableDebug, debug, formatRelativeTime } from './core/index.js';
+import { errorMessage } from './core/errors.js';
 import { outputJson, outputJsonError } from './formatters/json.js';
 
 /** Print local repos in human-readable format */
@@ -26,7 +27,7 @@ function printRepos(repos: Record<string, { path: string; currentBranch: string 
 
 /** Shared error handler for CLI action catch blocks. */
 function handleCommandError(err: unknown, json?: boolean): never {
-  const msg = err instanceof Error ? err.message : String(err);
+  const msg = errorMessage(err);
   if (json) {
     outputJsonError(msg);
   } else {

--- a/packages/core/src/commands/check-integration.ts
+++ b/packages/core/src/commands/check-integration.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
 import { execFileSync } from 'child_process';
 import type { CheckIntegrationOutput, NewFileInfo } from '../formatters/json.js';
 import { debug } from '../core/index.js';
+import { errorMessage } from '../core/errors.js';
 
 interface CheckIntegrationOptions {
   base: string;
@@ -92,7 +93,7 @@ export async function runCheckIntegration(options: CheckIntegrationOptions): Pro
     }).trim();
     newFiles = output ? output.split('\n').filter(Boolean) : [];
   } catch (error) {
-    const msg = error instanceof Error ? error.message : String(error);
+    const msg = errorMessage(error);
     throw new Error(`Failed to run git diff: ${msg}`, { cause: error });
   }
 
@@ -155,9 +156,9 @@ export async function runCheckIntegration(options: CheckIntegrationOptions): Pro
       } catch (error: unknown) {
         // git grep exit code 1 = no matches (expected), exit code 2+ = real error
         const exitCode =
-          error && typeof error === 'object' && 'status' in error ? (error as { status: number }).status : null;
-        if (exitCode !== null && exitCode !== 1) {
-          const msg = error instanceof Error ? error.message : String(error);
+          error && typeof error === 'object' && 'status' in error ? (error as { status: unknown }).status : undefined;
+        if (exitCode !== undefined && exitCode !== 1) {
+          const msg = errorMessage(error);
           debug('check-integration', `git grep failed for "${pattern}": ${msg}`);
         }
       }

--- a/packages/core/src/commands/daily.ts
+++ b/packages/core/src/commands/daily.ts
@@ -31,6 +31,7 @@ import {
   type PRCheckFailure,
   type RepoGroup,
 } from '../core/index.js';
+import { errorMessage } from '../core/errors.js';
 import {
   deduplicateDigest,
   compactActionableIssues,
@@ -125,15 +126,15 @@ async function fetchPRData(prMonitor: PRMonitor, token: string): Promise<Fetched
       prMonitor.fetchUserMergedPRCounts(),
       prMonitor.fetchUserClosedPRCounts(),
       prMonitor.fetchRecentlyClosedPRs().catch((err): ClosedPR[] => {
-        console.error(`Warning: Failed to fetch recently closed PRs: ${err instanceof Error ? err.message : err}`);
+        console.error(`Warning: Failed to fetch recently closed PRs: ${errorMessage(err)}`);
         return [];
       }),
       prMonitor.fetchRecentlyMergedPRs().catch((err): MergedPR[] => {
-        console.error(`Warning: Failed to fetch recently merged PRs: ${err instanceof Error ? err.message : err}`);
+        console.error(`Warning: Failed to fetch recently merged PRs: ${errorMessage(err)}`);
         return [];
       }),
       issueMonitor.fetchCommentedIssues().catch((error) => {
-        const msg = error instanceof Error ? error.message : String(error);
+        const msg = errorMessage(error);
         if (msg.includes('No GitHub username configured')) {
           console.error(`[DAILY] Issue conversation tracking requires setup: ${msg}`);
         } else {
@@ -210,10 +211,7 @@ async function updateRepoScores(
       stateManager.updateRepoScore(repo, { mergedPRCount: count, lastMergedAt: lastMergedAt || undefined });
     } catch (error) {
       mergedCountFailures++;
-      console.error(
-        `[DAILY] Failed to update merged count for ${repo}:`,
-        error instanceof Error ? error.message : error,
-      );
+      console.error(`[DAILY] Failed to update merged count for ${repo}:`, errorMessage(error));
     }
   }
   if (mergedCountFailures === mergedCounts.size && mergedCounts.size > 0) {
@@ -237,10 +235,7 @@ async function updateRepoScores(
       stateManager.updateRepoScore(repo, { closedWithoutMergeCount: count });
     } catch (error) {
       closedCountFailures++;
-      console.error(
-        `[DAILY] Failed to update closed count for ${repo}:`,
-        error instanceof Error ? error.message : error,
-      );
+      console.error(`[DAILY] Failed to update closed count for ${repo}:`, errorMessage(error));
     }
   }
   if (closedCountFailures === closedCounts.size && closedCounts.size > 0) {
@@ -259,7 +254,7 @@ async function updateRepoScores(
       stateManager.updateRepoScore(repo, { signals });
     } catch (error) {
       signalUpdateFailures++;
-      console.error(`[DAILY] Failed to update signals for ${repo}:`, error instanceof Error ? error.message : error);
+      console.error(`[DAILY] Failed to update signals for ${repo}:`, errorMessage(error));
     }
   }
   if (signalUpdateFailures === repoSignals.size && repoSignals.size > 0) {
@@ -274,7 +269,7 @@ async function updateRepoScores(
   try {
     starCounts = await prMonitor.fetchRepoStarCounts(allRepos);
   } catch (error) {
-    console.error('[DAILY] Failed to fetch repo star counts:', error instanceof Error ? error.message : error);
+    console.error('[DAILY] Failed to fetch repo star counts:', errorMessage(error));
     console.error(
       '[DAILY] Dashboard minStars filter will use cached star counts (or be skipped for repos without cached data).',
     );
@@ -286,7 +281,7 @@ async function updateRepoScores(
       stateManager.updateRepoScore(repo, { stargazersCount: stars });
     } catch (error) {
       starUpdateFailures++;
-      console.error(`[DAILY] Failed to update star count for ${repo}:`, error instanceof Error ? error.message : error);
+      console.error(`[DAILY] Failed to update star count for ${repo}:`, errorMessage(error));
     }
   }
   if (starUpdateFailures === starCounts.size && starCounts.size > 0) {
@@ -300,7 +295,7 @@ async function updateRepoScores(
       stateManager.addTrustedProject(repo);
     } catch (error) {
       trustSyncFailures++;
-      console.error(`[DAILY] Failed to sync trusted project ${repo}:`, error instanceof Error ? error.message : error);
+      console.error(`[DAILY] Failed to sync trusted project ${repo}:`, errorMessage(error));
     }
   }
   if (trustSyncFailures === mergedCounts.size && mergedCounts.size > 0) {
@@ -328,13 +323,13 @@ function updateAnalytics(
   try {
     stateManager.setMonthlyMergedCounts(monthlyCounts);
   } catch (error) {
-    console.error('[DAILY] Failed to store monthly merged counts:', error instanceof Error ? error.message : error);
+    console.error('[DAILY] Failed to store monthly merged counts:', errorMessage(error));
   }
 
   try {
     stateManager.setMonthlyClosedCounts(monthlyClosedCounts);
   } catch (error) {
-    console.error('[DAILY] Failed to store monthly closed counts:', error instanceof Error ? error.message : error);
+    console.error('[DAILY] Failed to store monthly closed counts:', errorMessage(error));
   }
 
   try {
@@ -352,10 +347,7 @@ function updateAnalytics(
     }
     stateManager.setMonthlyOpenedCounts(combinedOpenedCounts);
   } catch (error) {
-    console.error(
-      '[DAILY] Failed to compute/store monthly opened counts:',
-      error instanceof Error ? error.message : error,
-    );
+    console.error('[DAILY] Failed to compute/store monthly opened counts:', errorMessage(error));
   }
 }
 
@@ -384,7 +376,7 @@ function partitionPRs(
       stateManager.save();
     }
   } catch (error) {
-    console.error('[DAILY] Failed to expire/persist snoozes:', error instanceof Error ? error.message : error);
+    console.error('[DAILY] Failed to expire/persist snoozes:', errorMessage(error));
   }
 
   // Partition PRs into active vs shelved, auto-unshelving when maintainers engage

--- a/packages/core/src/commands/dashboard-data.ts
+++ b/packages/core/src/commands/dashboard-data.ts
@@ -5,6 +5,7 @@
  */
 
 import { getStateManager, PRMonitor, IssueConversationMonitor } from '../core/index.js';
+import { errorMessage } from '../core/errors.js';
 import { toShelvedPRRef } from './daily.js';
 import type { DailyDigest, AgentState, ClosedPR, MergedPR, CommentedIssue } from '../core/types.js';
 
@@ -27,17 +28,17 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
     await Promise.all([
       prMonitor.fetchUserOpenPRs(),
       prMonitor.fetchRecentlyClosedPRs().catch((err): ClosedPR[] => {
-        console.error(`Warning: Failed to fetch recently closed PRs: ${err instanceof Error ? err.message : err}`);
+        console.error(`Warning: Failed to fetch recently closed PRs: ${errorMessage(err)}`);
         return [];
       }),
       prMonitor.fetchRecentlyMergedPRs().catch((err): MergedPR[] => {
-        console.error(`Warning: Failed to fetch recently merged PRs: ${err instanceof Error ? err.message : err}`);
+        console.error(`Warning: Failed to fetch recently merged PRs: ${errorMessage(err)}`);
         return [];
       }),
       prMonitor.fetchUserMergedPRCounts(),
       prMonitor.fetchUserClosedPRCounts(),
       issueMonitor.fetchCommentedIssues().catch((error) => {
-        const msg = error instanceof Error ? error.message : String(error);
+        const msg = errorMessage(error);
         if (msg.includes('No GitHub username configured')) {
           console.error(`[DASHBOARD] Issue conversation tracking requires setup: ${msg}`);
         } else {
@@ -66,12 +67,12 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
   try {
     stateManager.setMonthlyMergedCounts(monthlyCounts);
   } catch (error) {
-    console.error('[DASHBOARD] Failed to store monthly merged counts:', error instanceof Error ? error.message : error);
+    console.error('[DASHBOARD] Failed to store monthly merged counts:', errorMessage(error));
   }
   try {
     stateManager.setMonthlyClosedCounts(monthlyClosedCounts);
   } catch (error) {
-    console.error('[DASHBOARD] Failed to store monthly closed counts:', error instanceof Error ? error.message : error);
+    console.error('[DASHBOARD] Failed to store monthly closed counts:', errorMessage(error));
   }
   try {
     const combinedOpenedCounts: Record<string, number> = { ...openedFromMerged };
@@ -86,7 +87,7 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
     }
     stateManager.setMonthlyOpenedCounts(combinedOpenedCounts);
   } catch (error) {
-    console.error('[DASHBOARD] Failed to store monthly opened counts:', error instanceof Error ? error.message : error);
+    console.error('[DASHBOARD] Failed to store monthly opened counts:', errorMessage(error));
   }
 
   const digest = prMonitor.generateDigest(prs, recentlyClosedPRs, recentlyMergedPRs);

--- a/packages/core/src/commands/dashboard-server.ts
+++ b/packages/core/src/commands/dashboard-server.ts
@@ -10,6 +10,7 @@ import * as http from 'http';
 import * as fs from 'fs';
 import * as path from 'path';
 import { getStateManager, getGitHubToken } from '../core/index.js';
+import { errorMessage } from '../core/errors.js';
 import { fetchDashboardData, computePRsByRepo, computeTopRepos, getMonthlyData } from './dashboard-data.js';
 import { buildDashboardStats } from './dashboard-templates.js';
 import type { DashboardStats } from './dashboard-templates.js';
@@ -257,7 +258,7 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
       stateManager.save();
     } catch (error) {
       console.error('Action failed:', body.action, body.url, error);
-      sendError(res, 500, `Action failed: ${error instanceof Error ? error.message : String(error)}`);
+      sendError(res, 500, `Action failed: ${errorMessage(error)}`);
       return;
     }
 
@@ -286,7 +287,7 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
       sendJson(res, 200, cachedJsonData);
     } catch (error) {
       console.error('Dashboard refresh failed:', error);
-      sendError(res, 500, `Refresh failed: ${error instanceof Error ? error.message : String(error)}`);
+      sendError(res, 500, `Refresh failed: ${errorMessage(error)}`);
     }
   }
 

--- a/packages/core/src/commands/dashboard.ts
+++ b/packages/core/src/commands/dashboard.ts
@@ -8,6 +8,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { execFile } from 'child_process';
 import { getStateManager, getDashboardPath, getGitHubToken } from '../core/index.js';
+import { errorMessage } from '../core/errors.js';
 import { outputJson } from '../formatters/json.js';
 import type { CommentedIssue, CommentedIssueWithResponse, DailyDigest } from '../core/types.js';
 import { fetchDashboardData, computePRsByRepo, computeTopRepos, getMonthlyData } from './dashboard-data.js';
@@ -46,7 +47,7 @@ export async function runDashboard(options: DashboardOptions): Promise<void> {
       digest = result.digest;
       commentedIssues = result.commentedIssues;
     } catch (error) {
-      console.error('Failed to fetch fresh data:', error instanceof Error ? error.message : error);
+      console.error('Failed to fetch fresh data:', errorMessage(error));
       console.error('Falling back to cached data (issue conversations unavailable)...');
       digest = stateManager.getState().lastDigest;
     }

--- a/packages/core/src/commands/local-repos.ts
+++ b/packages/core/src/commands/local-repos.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { execFileSync } from 'child_process';
 import { getStateManager, debug } from '../core/index.js';
+import { errorMessage } from '../core/errors.js';
 import type { LocalReposOutput, LocalRepoInfo } from '../formatters/json.js';
 
 interface LocalReposOptions {
@@ -135,7 +136,7 @@ export async function runLocalRepos(options: LocalReposOptions): Promise<LocalRe
     stateManager.setLocalRepoCache({ repos, scanPaths, cachedAt });
     stateManager.save();
   } catch (error) {
-    const msg = error instanceof Error ? error.message : String(error);
+    const msg = errorMessage(error);
     debug('local-repos', `Failed to cache scan results: ${msg}`);
   }
 

--- a/packages/core/src/commands/parse-list.ts
+++ b/packages/core/src/commands/parse-list.ts
@@ -6,6 +6,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import type { ParseIssueListOutput, ParsedIssueItem } from '../formatters/json.js';
+import { errorMessage } from '../core/errors.js';
 
 interface ParseListOptions {
   filePath: string;
@@ -115,7 +116,7 @@ export async function runParseList(options: ParseListOptions): Promise<ParseIssu
   try {
     content = fs.readFileSync(filePath, 'utf-8');
   } catch (error) {
-    const msg = error instanceof Error ? error.message : String(error);
+    const msg = errorMessage(error);
     throw new Error(`Failed to read file: ${msg}`, { cause: error });
   }
 

--- a/packages/core/src/commands/startup.ts
+++ b/packages/core/src/commands/startup.ts
@@ -11,6 +11,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { execFile } from 'child_process';
 import { getStateManager, getGitHubToken } from '../core/index.js';
+import { errorMessage } from '../core/errors.js';
 import { type StartupOutput, type IssueListInfo } from '../formatters/json.js';
 import { executeDailyCheck } from './daily.js';
 import { writeDashboardFromState } from './dashboard.js';
@@ -20,7 +21,7 @@ function getVersion(): string {
     const pkgPath = path.join(path.dirname(process.argv[1]), '..', 'package.json');
     return JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).version;
   } catch (error) {
-    console.error('[STARTUP] Failed to detect CLI version:', error instanceof Error ? error.message : error);
+    console.error('[STARTUP] Failed to detect CLI version:', errorMessage(error));
     return '0.0.0';
   }
 }
@@ -78,7 +79,7 @@ export function detectIssueList(): IssueListInfo | undefined {
         source = 'configured';
       }
     } catch (error) {
-      console.error('[STARTUP] Failed to read config:', error instanceof Error ? error.message : error);
+      console.error('[STARTUP] Failed to read config:', errorMessage(error));
     }
   }
 
@@ -102,10 +103,7 @@ export function detectIssueList(): IssueListInfo | undefined {
     const { availableCount, completedCount } = countIssueListItems(content);
     return { path: issueListPath, source, availableCount, completedCount };
   } catch (error) {
-    console.error(
-      `[STARTUP] Failed to read issue list at ${issueListPath}:`,
-      error instanceof Error ? error.message : error,
-    );
+    console.error(`[STARTUP] Failed to read issue list at ${issueListPath}:`, errorMessage(error));
     return { path: issueListPath, source, availableCount: 0, completedCount: 0 };
   }
 }
@@ -164,7 +162,7 @@ export async function runStartup(): Promise<StartupOutput> {
       dashboardOpened = true;
     }
   } catch (error) {
-    console.error('[STARTUP] Dashboard generation failed:', error instanceof Error ? error.message : error);
+    console.error('[STARTUP] Dashboard generation failed:', errorMessage(error));
   }
 
   // Append dashboard status to brief summary (only startup opens the browser, not daily)

--- a/packages/core/src/core/errors.test.ts
+++ b/packages/core/src/core/errors.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { OssAutopilotError, ConfigurationError, ValidationError } from './errors.js';
+import { OssAutopilotError, ConfigurationError, ValidationError, errorMessage, getHttpStatusCode } from './errors.js';
 
 describe('Custom Error Hierarchy', () => {
   describe('OssAutopilotError', () => {
@@ -69,5 +69,62 @@ describe('Custom Error Hierarchy', () => {
       expect(configErr).not.toBeInstanceOf(ValidationError);
       expect(validationErr).not.toBeInstanceOf(ConfigurationError);
     });
+  });
+});
+
+describe('errorMessage', () => {
+  it('extracts message from Error instances', () => {
+    expect(errorMessage(new Error('something broke'))).toBe('something broke');
+  });
+
+  it('extracts message from custom error subclasses', () => {
+    expect(errorMessage(new ValidationError('bad input'))).toBe('bad input');
+  });
+
+  it('converts string to string', () => {
+    expect(errorMessage('string error')).toBe('string error');
+  });
+
+  it('converts null to "null"', () => {
+    expect(errorMessage(null)).toBe('null');
+  });
+
+  it('converts undefined to "undefined"', () => {
+    expect(errorMessage(undefined)).toBe('undefined');
+  });
+
+  it('converts number to string', () => {
+    expect(errorMessage(42)).toBe('42');
+  });
+});
+
+describe('getHttpStatusCode', () => {
+  it('extracts numeric status from error-like objects', () => {
+    expect(getHttpStatusCode({ status: 404 })).toBe(404);
+    expect(getHttpStatusCode({ status: 500, message: 'fail' })).toBe(500);
+  });
+
+  it('returns undefined for non-numeric status', () => {
+    expect(getHttpStatusCode({ status: 'not a number' })).toBeUndefined();
+  });
+
+  it('returns undefined for NaN and Infinity status', () => {
+    expect(getHttpStatusCode({ status: NaN })).toBeUndefined();
+    expect(getHttpStatusCode({ status: Infinity })).toBeUndefined();
+  });
+
+  it('returns undefined for objects without status', () => {
+    expect(getHttpStatusCode(new Error('no status'))).toBeUndefined();
+    expect(getHttpStatusCode({ code: 404 })).toBeUndefined();
+  });
+
+  it('returns undefined for null and undefined', () => {
+    expect(getHttpStatusCode(null)).toBeUndefined();
+    expect(getHttpStatusCode(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for primitives', () => {
+    expect(getHttpStatusCode('string')).toBeUndefined();
+    expect(getHttpStatusCode(42)).toBeUndefined();
   });
 });

--- a/packages/core/src/core/errors.ts
+++ b/packages/core/src/core/errors.ts
@@ -36,3 +36,22 @@ export class ValidationError extends OssAutopilotError {
     this.name = 'ValidationError';
   }
 }
+
+/**
+ * Extract a human-readable message from an unknown error value.
+ */
+export function errorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+/**
+ * Safely extract an HTTP status code from an unknown error (e.g. Octokit errors).
+ * Returns undefined if the error doesn't have a numeric `status` property.
+ */
+export function getHttpStatusCode(error: unknown): number | undefined {
+  if (error && typeof error === 'object' && 'status' in error) {
+    const status = (error as { status: unknown }).status;
+    return typeof status === 'number' && Number.isFinite(status) ? status : undefined;
+  }
+  return undefined;
+}

--- a/packages/core/src/core/http-cache.ts
+++ b/packages/core/src/core/http-cache.ts
@@ -15,6 +15,7 @@ import * as path from 'path';
 import * as crypto from 'crypto';
 import { getCacheDir } from './utils.js';
 import { debug } from './logger.js';
+import { getHttpStatusCode } from './errors.js';
 
 const MODULE = 'http-cache';
 
@@ -290,8 +291,5 @@ export async function cachedRequest<T>(
  * Octokit throws a RequestError with status 304 for conditional requests.
  */
 function isNotModifiedError(err: unknown): boolean {
-  if (err && typeof err === 'object' && 'status' in err) {
-    return (err as { status: number }).status === 304;
-  }
-  return false;
+  return getHttpStatusCode(err) === 304;
 }

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -39,6 +39,7 @@ export {
   requireGitHubToken,
   resetGitHubTokenCache,
 } from './utils.js';
+export { OssAutopilotError, ConfigurationError, ValidationError, errorMessage, getHttpStatusCode } from './errors.js';
 export { enableDebug, isDebugEnabled, debug, warn, timed } from './logger.js';
 export { HttpCache, getHttpCache, resetHttpCache, cachedRequest, type CacheEntry } from './http-cache.js';
 export {

--- a/packages/core/src/core/issue-conversation.ts
+++ b/packages/core/src/core/issue-conversation.ts
@@ -14,7 +14,7 @@ import { getStateManager } from './state.js';
 import { daysBetween, splitRepo, extractOwnerRepo } from './utils.js';
 import { runWorkerPool } from './concurrency.js';
 import type { CommentedIssue, IssueConversationStatus } from './types.js';
-import { ConfigurationError } from './errors.js';
+import { ConfigurationError, errorMessage } from './errors.js';
 import { debug, warn } from './logger.js';
 
 const MODULE = 'issue-conversation';
@@ -135,7 +135,7 @@ export class IssueConversationMonitor {
             });
           }
         } catch (error) {
-          const msg = error instanceof Error ? error.message : String(error);
+          const msg = errorMessage(error);
           failures.push({ issueUrl: item.html_url, error: msg });
           warn(MODULE, `Error analyzing issue ${item.html_url}: ${msg}`);
         }

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -14,7 +14,7 @@ import { getOctokit, checkRateLimit } from './github.js';
 import { getStateManager } from './state.js';
 import { daysBetween, getDataDir } from './utils.js';
 import { DEFAULT_CONFIG, type SearchPriority, type IssueCandidate } from './types.js';
-import { ValidationError } from './errors.js';
+import { ValidationError, errorMessage, getHttpStatusCode } from './errors.js';
 import { warn } from './logger.js';
 import { type GitHubSearchItem, isDocOnlyIssue, detectLabelFarmingRepos, applyPerRepoCap } from './issue-filtering.js';
 import { IssueVetter } from './issue-vetting.js';
@@ -99,21 +99,21 @@ export class IssueDiscovery {
       return starredRepos;
     } catch (error) {
       const cachedRepos = this.stateManager.getStarredRepos();
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      warn(MODULE, 'Error fetching starred repos:', errorMessage);
+      const errMsg = errorMessage(error);
+      warn(MODULE, 'Error fetching starred repos:', errMsg);
 
       if (cachedRepos.length === 0) {
         warn(
           MODULE,
           `Failed to fetch starred repositories from GitHub API. ` +
-            `No cached repos available. Error: ${errorMessage}\n` +
+            `No cached repos available. Error: ${errMsg}\n` +
             `Tip: Ensure your GITHUB_TOKEN has the 'read:user' scope and try again.`,
         );
       } else {
         warn(
           MODULE,
           `Failed to fetch starred repositories from GitHub API. ` +
-            `Using ${cachedRepos.length} cached repos instead. Error: ${errorMessage}`,
+            `Using ${cachedRepos.length} cached repos instead. Error: ${errMsg}`,
         );
       }
       return cachedRepos;
@@ -164,11 +164,11 @@ export class IssueDiscovery {
       }
     } catch (error) {
       // Fail fast on auth errors — no point searching with a bad token
-      if ((error as { status?: number })?.status === 401) {
+      if (getHttpStatusCode(error) === 401) {
         throw error;
       }
       // Non-fatal: proceed with search for transient/network errors
-      warn(MODULE, 'Could not check rate limit:', error instanceof Error ? error.message : error);
+      warn(MODULE, 'Could not check rate limit:', errorMessage(error));
     }
 
     // Get merged-PR repos (highest merge probability)
@@ -383,12 +383,12 @@ export class IssueDiscovery {
         }
         console.log(`Found ${starFiltered.length} candidates from general search`);
       } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        phase2Error = errorMessage;
+        const errMsg = errorMessage(error);
+        phase2Error = errMsg;
         if (IssueVetter.isRateLimitError(error)) {
           rateLimitHitDuringSearch = true;
         }
-        warn(MODULE, `Error in general issue search: ${errorMessage}`);
+        warn(MODULE, `Error in general issue search: ${errMsg}`);
       }
     }
 
@@ -475,12 +475,12 @@ export class IssueDiscovery {
         }
         console.log(`Found ${starFiltered.length} candidates from maintained-repo search`);
       } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        phase3Error = errorMessage;
+        const errMsg = errorMessage(error);
+        phase3Error = errMsg;
         if (IssueVetter.isRateLimitError(error)) {
           rateLimitHitDuringSearch = true;
         }
-        warn(MODULE, `Error in maintained-repo search: ${errorMessage}`);
+        warn(MODULE, `Error in maintained-repo search: ${errMsg}`);
       }
     }
 
@@ -598,11 +598,7 @@ export class IssueDiscovery {
           rateLimitFailures++;
         }
         const batchRepos = batch.join(', ');
-        warn(
-          MODULE,
-          `Error searching issues in batch [${batchRepos}]:`,
-          error instanceof Error ? error.message : error,
-        );
+        warn(MODULE, `Error searching issues in batch [${batchRepos}]:`, errorMessage(error));
       }
     }
 

--- a/packages/core/src/core/issue-vetting.ts
+++ b/packages/core/src/core/issue-vetting.ts
@@ -16,7 +16,7 @@ import {
   type SearchPriority,
   type IssueCandidate,
 } from './types.js';
-import { ValidationError } from './errors.js';
+import { ValidationError, errorMessage, getHttpStatusCode } from './errors.js';
 import { warn } from './logger.js';
 import { getHttpCache, cachedRequest } from './http-cache.js';
 import { getStateManager } from './state.js';
@@ -300,7 +300,7 @@ export class IssueVetter {
           if (IssueVetter.isRateLimitError(error)) {
             rateLimitFailures++;
           }
-          warn(MODULE, `Error vetting issue ${url}:`, error instanceof Error ? error.message : error);
+          warn(MODULE, `Error vetting issue ${url}:`, errorMessage(error));
         });
 
       pending.push(task);
@@ -330,10 +330,10 @@ export class IssueVetter {
 
   /** Check if an error is a GitHub rate limit error (429 or rate-limit 403). */
   static isRateLimitError(error: unknown): boolean {
-    const status = (error as { status?: number })?.status;
+    const status = getHttpStatusCode(error);
     if (status === 429) return true;
     if (status === 403) {
-      const msg = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+      const msg = errorMessage(error).toLowerCase();
       return msg.includes('rate limit');
     }
     return false;
@@ -365,12 +365,12 @@ export class IssueVetter {
 
       return { passed: data.total_count === 0 && linkedPRs.length === 0 };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errMsg = errorMessage(error);
       warn(
         MODULE,
-        `Failed to check for existing PRs on ${owner}/${repo}#${issueNumber}: ${errorMessage}. Assuming no existing PR.`,
+        `Failed to check for existing PRs on ${owner}/${repo}#${issueNumber}: ${errMsg}. Assuming no existing PR.`,
       );
-      return { passed: true, inconclusive: true, reason: errorMessage };
+      return { passed: true, inconclusive: true, reason: errMsg };
     }
   }
 
@@ -387,8 +387,8 @@ export class IssueVetter {
       });
       return data.total_count;
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      warn(MODULE, `Could not check merged PRs in ${owner}/${repo}: ${errorMessage}. Defaulting to 0.`);
+      const errMsg = errorMessage(error);
+      warn(MODULE, `Could not check merged PRs in ${owner}/${repo}: ${errMsg}. Defaulting to 0.`);
       return 0;
     }
   }
@@ -440,12 +440,9 @@ export class IssueVetter {
 
       return { passed: true };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      warn(
-        MODULE,
-        `Failed to check claim status on ${owner}/${repo}#${issueNumber}: ${errorMessage}. Assuming not claimed.`,
-      );
-      return { passed: true, inconclusive: true, reason: errorMessage };
+      const errMsg = errorMessage(error);
+      warn(MODULE, `Failed to check claim status on ${owner}/${repo}#${issueNumber}: ${errMsg}. Assuming not claimed.`);
+      return { passed: true, inconclusive: true, reason: errMsg };
     }
   }
 
@@ -487,8 +484,8 @@ export class IssueVetter {
           ciStatus = 'passing'; // Assume passing if workflows exist
         }
       } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        warn(MODULE, `Failed to check CI status for ${owner}/${repo}: ${errorMessage}. Defaulting to unknown.`);
+        const errMsg = errorMessage(error);
+        warn(MODULE, `Failed to check CI status for ${owner}/${repo}: ${errMsg}. Defaulting to unknown.`);
       }
 
       return {
@@ -503,8 +500,8 @@ export class IssueVetter {
         forksCount: repoData.forks_count,
       };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      warn(MODULE, `Error checking project health for ${owner}/${repo}: ${errorMessage}`);
+      const errMsg = errorMessage(error);
+      warn(MODULE, `Error checking project health for ${owner}/${repo}: ${errMsg}`);
       return {
         repo: `${owner}/${repo}`,
         lastCommitAt: '',
@@ -514,7 +511,7 @@ export class IssueVetter {
         ciStatus: 'unknown',
         isActive: false,
         checkFailed: true,
-        failureReason: errorMessage,
+        failureReason: errMsg,
       };
     }
   }

--- a/packages/core/src/core/pr-monitor.ts
+++ b/packages/core/src/core/pr-monitor.ts
@@ -26,7 +26,7 @@ import {
   DetermineStatusInput,
 } from './types.js';
 import { runWorkerPool } from './concurrency.js';
-import { ConfigurationError, ValidationError } from './errors.js';
+import { ConfigurationError, ValidationError, errorMessage, getHttpStatusCode } from './errors.js';
 import { paginateAll } from './pagination.js';
 import { debug, warn, timed } from './logger.js';
 import { getHttpCache, cachedRequest } from './http-cache.js';
@@ -162,9 +162,9 @@ export class PRMonitor {
             const pr = await this.fetchPRDetails(item.html_url);
             if (pr) prs.push(pr);
           } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
-            warn('pr-monitor', `Error fetching ${item.html_url}: ${errorMessage}`);
-            failures.push({ prUrl: item.html_url, error: errorMessage });
+            const errMsg = errorMessage(error);
+            warn('pr-monitor', `Error fetching ${item.html_url}: ${errMsg}`);
+            failures.push({ prUrl: item.html_url, error: errMsg });
           }
         },
         MAX_CONCURRENT_REQUESTS,
@@ -221,14 +221,14 @@ export class PRMonitor {
       paginateAll((page) =>
         this.octokit.pulls.listReviewComments({ owner, repo, pull_number: number, per_page: 100, page }),
       ).catch((err: unknown) => {
-        const status = (err as { status?: number })?.status;
+        const status = getHttpStatusCode(err);
         // Rate limit errors must propagate — silently swallowing them hides
         // a systemic problem and produces misleading results (#229).
         if (status === 429) {
           throw err;
         }
         if (status === 403) {
-          const msg = ((err as { message?: string })?.message ?? '').toLowerCase();
+          const msg = errorMessage(err).toLowerCase();
           if (msg.includes('rate limit') || msg.includes('abuse detection')) {
             throw err;
           }
@@ -453,7 +453,7 @@ export class PRMonitor {
         this.octokit.repos.getCombinedStatusForRef({ owner, repo, ref: sha }),
         // 404 is expected for repos without check runs configured; log other errors for debugging
         this.octokit.checks.listForRef({ owner, repo, ref: sha }).catch((err: unknown) => {
-          const status = (err as { status?: number })?.status;
+          const status = getHttpStatusCode(err);
           if (status === 404) {
             debug('pr-monitor', `Check runs 404 for ${owner}/${repo}@${sha.slice(0, 7)} (no checks configured)`);
           } else {
@@ -487,8 +487,8 @@ export class PRMonitor {
 
       return mergeStatuses(checkRunAnalysis, combinedAnalysis, checkRuns.length);
     } catch (error) {
-      const statusCode = (error as { status?: number }).status;
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const statusCode = getHttpStatusCode(error);
+      const errMsg = errorMessage(error);
 
       if (statusCode === 401) {
         warn('pr-monitor', `CI check failed for ${owner}/${repo}: Invalid token`);
@@ -499,7 +499,7 @@ export class PRMonitor {
         debug('pr-monitor', `CI check 404 for ${owner}/${repo} (no CI configured)`);
         return { status: 'unknown', failingCheckNames: [], failingCheckConclusions: new Map() };
       } else {
-        warn('pr-monitor', `Failed to check CI for ${owner}/${repo}@${sha.slice(0, 7)}: ${errorMessage}`);
+        warn('pr-monitor', `Failed to check CI for ${owner}/${repo}@${sha.slice(0, 7)}: ${errMsg}`);
       }
       return { status: 'unknown', failingCheckNames: [], failingCheckConclusions: new Map() };
     }
@@ -579,10 +579,7 @@ export class PRMonitor {
           results.set(result.value.repo, result.value.stars);
         } else {
           chunkFailures++;
-          warn(
-            MODULE,
-            `Failed to fetch stars for ${chunk[j]}: ${result.reason instanceof Error ? result.reason.message : result.reason}`,
-          );
+          warn(MODULE, `Failed to fetch stars for ${chunk[j]}: ${errorMessage(result.reason)}`);
         }
       }
       // If entire chunk failed, likely a systemic issue (rate limit, auth, outage) — abort remaining

--- a/packages/core/src/core/state.ts
+++ b/packages/core/src/core/state.ts
@@ -18,7 +18,7 @@ import {
   SnoozeInfo,
 } from './types.js';
 import { getStatePath, getBackupDir, getDataDir } from './utils.js';
-import { ValidationError } from './errors.js';
+import { ValidationError, errorMessage } from './errors.js';
 import { debug, warn } from './logger.js';
 
 const MODULE = 'state';
@@ -313,8 +313,7 @@ export class StateManager {
       debug(MODULE, 'Migration complete!');
       return true;
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      warn(MODULE, `Failed to migrate state: ${errorMessage}`);
+      warn(MODULE, `Failed to migrate state: ${errorMessage(error)}`);
 
       // Clean up partial migration to avoid inconsistent state
       const newStatePath = getStatePath();
@@ -544,11 +543,11 @@ export class StateManager {
         try {
           fs.unlinkSync(path.join(backupDir, file));
         } catch (error) {
-          warn(MODULE, `Could not delete old backup ${file}:`, error instanceof Error ? error.message : error);
+          warn(MODULE, `Could not delete old backup ${file}:`, errorMessage(error));
         }
       }
     } catch (error) {
-      warn(MODULE, 'Could not clean up backups:', error instanceof Error ? error.message : error);
+      warn(MODULE, 'Could not clean up backups:', errorMessage(error));
     }
   }
 

--- a/packages/mcp-server/src/prompts.ts
+++ b/packages/mcp-server/src/prompts.ts
@@ -10,7 +10,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { runDaily, runComments, runSearch } from '@oss-autopilot/core/commands';
-import { errorMessage } from './tools.js';
+import { errorMessage } from '@oss-autopilot/core';
 
 /** Build a single-message prompt result with a user text message. */
 function userMessage(text: string) {

--- a/packages/mcp-server/src/resources.ts
+++ b/packages/mcp-server/src/resources.ts
@@ -8,7 +8,7 @@ import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { runStatus, runConfig } from '@oss-autopilot/core/commands';
 import { getStateManager, splitRepo } from '@oss-autopilot/core';
-import { errorMessage } from './tools.js';
+import { errorMessage } from '@oss-autopilot/core';
 
 /** Build a standard MCP resource response with a single JSON content entry. */
 function resourceContent(uri: URL, data: unknown) {

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -31,11 +31,7 @@ import {
   runSnooze,
   runUnsnooze,
 } from '@oss-autopilot/core/commands';
-
-/** Extract a human-readable message from an unknown error. */
-export function errorMessage(e: unknown): string {
-  return e instanceof Error ? e.message : String(e);
-}
+import { errorMessage } from '@oss-autopilot/core';
 
 /** Standard MCP text content result. */
 function ok(data: unknown) {


### PR DESCRIPTION
## Summary
- Extracts `errorMessage(e: unknown): string` and `getHttpStatusCode(error: unknown): number | undefined` into `core/errors.ts`
- Replaces 28+ inline `error instanceof Error ? err.message : String(err)` patterns across 19 source files
- Adds `Number.isFinite` guard to reject NaN/Infinity status codes
- Updates MCP server (`prompts.ts`, `resources.ts`) to import `errorMessage` directly from `@oss-autopilot/core`
- Adds 12 unit tests for both helpers covering edge cases (null, undefined, NaN, Infinity, non-Error objects)

## Test plan
- [x] All 1,249 core tests pass
- [x] All 103 MCP server tests pass (including stdio transport)
- [x] Zero remaining inline error message patterns in `packages/core/src/`
- [x] TypeScript compiles cleanly across all packages

Closes #439