### PR TITLE
refactor: extract isOwnRepo() helper for skip-own-repos filter

### DIFF
--- a/packages/core/src/core/github-stats.ts
+++ b/packages/core/src/core/github-stats.ts
@@ -4,7 +4,7 @@
  */
 
 import { Octokit } from '@octokit/rest';
-import { extractOwnerRepo, parseGitHubUrl } from './utils.js';
+import { extractOwnerRepo, parseGitHubUrl, isOwnRepo } from './utils.js';
 import { ClosedPR, MergedPR } from './types.js';
 import { debug, warn } from './logger.js';
 
@@ -74,7 +74,7 @@ async function fetchUserPRCounts<R>(
       const repo = `${owner}/${parsed.repo}`;
 
       // Skip own repos (PRs to your own repos aren't OSS contributions)
-      if (owner.toLowerCase() === githubUsername.toLowerCase()) continue;
+      if (isOwnRepo(owner, githubUsername)) continue;
 
       // Note: excludeRepos/excludeOrgs are intentionally NOT filtered here.
       // Those filters control issue discovery/search, not historical statistics.
@@ -201,7 +201,7 @@ export async function fetchRecentPRs<T>(
     const repo = `${parsed.owner}/${parsed.repo}`;
 
     // Skip own repos
-    if (parsed.owner.toLowerCase() === config.githubUsername.toLowerCase()) continue;
+    if (isOwnRepo(parsed.owner, config.githubUsername)) continue;
 
     // Skip excluded repos and orgs
     if (config.excludeRepos.includes(repo)) continue;

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -27,6 +27,7 @@ export {
   parseGitHubUrl,
   daysBetween,
   splitRepo,
+  isOwnRepo,
   getDataDir,
   getStatePath,
   getBackupDir,

--- a/packages/core/src/core/issue-conversation.ts
+++ b/packages/core/src/core/issue-conversation.ts
@@ -11,7 +11,7 @@ import { getOctokit } from './github.js';
 import { isBotAuthor, isAcknowledgmentComment } from './comment-utils.js';
 import { paginateAll } from './pagination.js';
 import { getStateManager } from './state.js';
-import { daysBetween, splitRepo, extractOwnerRepo } from './utils.js';
+import { daysBetween, splitRepo, extractOwnerRepo, isOwnRepo } from './utils.js';
 import { runWorkerPool } from './concurrency.js';
 import type { CommentedIssue, IssueConversationStatus } from './types.js';
 import { ConfigurationError, errorMessage } from './errors.js';
@@ -96,7 +96,7 @@ export class IssueConversationMonitor {
       const repoFullName = `${owner}/${repo}`;
 
       // Skip issues in user-owned repos (we only care about contributing to others' projects)
-      if (owner.toLowerCase() === username.toLowerCase()) continue;
+      if (isOwnRepo(owner, username)) continue;
 
       // Skip user-authored issues
       if (item.user?.login?.toLowerCase() === username.toLowerCase()) continue;

--- a/packages/core/src/core/utils.ts
+++ b/packages/core/src/core/utils.ts
@@ -261,6 +261,14 @@ export function splitRepo(repoFullName: string): { owner: string; repo: string }
 }
 
 /**
+ * Case-insensitive check whether a repo owner matches the given GitHub username.
+ * Used to skip a user's own repos (PRs to your own repos aren't OSS contributions).
+ */
+export function isOwnRepo(owner: string, username: string): boolean {
+  return owner.toLowerCase() === username.toLowerCase();
+}
+
+/**
  * Formats a timestamp as a human-readable relative time string.
  *
  * Returns minutes for < 1 hour, hours for < 1 day, days for < 30 days,


### PR DESCRIPTION
## Summary
- Extracts `isOwnRepo(owner, username)` helper into `utils.ts` for case-insensitive owner-vs-username comparison
- Replaces 3 inline `owner.toLowerCase() === username.toLowerCase()` occurrences in `github-stats.ts` and `issue-conversation.ts`
- Exported from core barrel for external consumers

## Test plan
- [x] All 1,249 core tests pass
- [x] All 103 MCP server tests pass

Closes #441