### PR TITLE
test: add unit tests for dashboard-templates.ts

### DIFF
--- a/packages/core/src/commands/dashboard-templates.test.ts
+++ b/packages/core/src/commands/dashboard-templates.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  escapeHtml,
-  buildDashboardStats,
-  generateDashboardHtml,
-  type DashboardStats,
-} from './dashboard-templates.js';
+import { escapeHtml, buildDashboardStats, generateDashboardHtml, type DashboardStats } from './dashboard-templates.js';
 import type {
   FetchedPR,
   DailyDigest,
@@ -122,9 +117,7 @@ describe('escapeHtml', () => {
   });
 
   it('escapes angle brackets', () => {
-    expect(escapeHtml('<script>alert("xss")</script>')).toBe(
-      '&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;',
-    );
+    expect(escapeHtml('<script>alert("xss")</script>')).toBe('&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;');
   });
 
   it('escapes double quotes', () => {
@@ -267,15 +260,17 @@ describe('buildDashboardStats', () => {
 
 describe('generateDashboardHtml', () => {
   /** Shorthand that defaults every argument so tests only supply what they care about. */
-  function renderHtml(options: {
-    stats?: DashboardStats;
-    monthly?: Record<string, number>;
-    monthlyClosed?: Record<string, number>;
-    monthlyOpened?: Record<string, number>;
-    digest?: DailyDigest;
-    state?: AgentState;
-    issueResponses?: CommentedIssueWithResponse[];
-  } = {}): string {
+  function renderHtml(
+    options: {
+      stats?: DashboardStats;
+      monthly?: Record<string, number>;
+      monthlyClosed?: Record<string, number>;
+      monthlyOpened?: Record<string, number>;
+      digest?: DailyDigest;
+      state?: AgentState;
+      issueResponses?: CommentedIssueWithResponse[];
+    } = {},
+  ): string {
     return generateDashboardHtml(
       options.stats ?? makeStats(),
       options.monthly ?? {},


### PR DESCRIPTION
## Summary
- Add 40 tests for `packages/core/src/commands/dashboard-templates.ts` covering `escapeHtml`, `buildDashboardStats`, and `generateDashboardHtml`
- XSS tests use both negative (raw payload absent) and positive (escaped version present) assertions to prevent false passes
- Tests verify rendering for all major PR status categories: needs-response, CI failing, merge conflict, shelved, merged, closed, waiting-on-maintainer, needs-changes, missing-required-files, auto-unshelved, and issue responses
- Includes edge cases: empty digest, null/undefined fields, title truncation, shelved PR filtering from active list

## Test plan
- [x] All 40 new tests pass
- [x] Full suite (1,458 tests) passes
- [x] Factory helpers use correct type-accurate enum values (`'passing'` not `'success'`, `'failing_ci'` not `'ci_failing'`, lowercase `'approved'`/`'changes_requested'`)
- [x] Two rounds of pr-review-toolkit review (code-reviewer, silent-failure-hunter, code-simplifier) — all findings addressed

Closes #453