### PR TITLE
fix: include CHANGES_REQUESTED reviews with empty body in timeline

### DIFF
--- a/packages/core/src/core/pr-monitor.test.ts
+++ b/packages/core/src/core/pr-monitor.test.ts
@@ -475,6 +475,30 @@ describe('PRMonitor determineStatus — remaining paths', () => {
       }),
     ).toBe('merge_conflict');
   });
+
+  it('should return needs_response when CHANGES_REQUESTED review is after commit (#431)', () => {
+    // Scenario: commit at 14:00, CHANGES_REQUESTED review at 14:02,
+    // but lastMaintainerCommentDate points to an older comment (12:00)
+    expect(
+      callDetermineStatus({
+        hasUnrespondedComment: true,
+        latestCommitDate: '2026-03-01T14:00:00Z',
+        lastMaintainerCommentDate: '2026-02-28T12:00:00Z', // stale — older comment
+        latestChangesRequestedDate: '2026-03-01T14:02:00Z', // after commit
+      }),
+    ).toBe('needs_response');
+  });
+
+  it('should return changes_addressed when commit is after both comment and review (#431)', () => {
+    expect(
+      callDetermineStatus({
+        hasUnrespondedComment: true,
+        latestCommitDate: '2026-03-02T10:00:00Z', // after everything
+        lastMaintainerCommentDate: '2026-03-01T12:00:00Z',
+        latestChangesRequestedDate: '2026-03-01T14:02:00Z', // before commit
+      }),
+    ).toBe('changes_addressed');
+  });
 });
 
 describe('PRMonitor analyzeChecklist', () => {
@@ -1547,14 +1571,42 @@ describe('isAcknowledgmentComment (Issue #69)', () => {
     expect(result.hasUnrespondedComment).toBe(false);
   });
 
-  it('should skip CHANGES_REQUESTED reviews with empty body (#151)', () => {
+  it('should include CHANGES_REQUESTED reviews with empty body as actionable (#431)', () => {
     const result = checkUnrespondedComments(
       [{ user: { login: 'testuser' }, body: 'My PR', created_at: '2026-02-07T10:00:00Z' }],
       [{ user: { login: 'reviewer' }, body: '', submitted_at: '2026-02-07T12:00:00Z', state: 'CHANGES_REQUESTED' }],
       [],
       'testuser',
     );
-    expect(result.hasUnrespondedComment).toBe(false);
+    expect(result.hasUnrespondedComment).toBe(true);
+    expect(result.lastMaintainerComment?.author).toBe('reviewer');
+  });
+
+  it('should resolve inline comment body for CHANGES_REQUESTED reviews (#431)', () => {
+    const result = checkUnrespondedComments(
+      [{ user: { login: 'testuser' }, body: 'My PR', created_at: '2026-02-07T10:00:00Z' }],
+      [
+        {
+          user: { login: 'reviewer' },
+          body: '',
+          submitted_at: '2026-02-07T12:00:00Z',
+          state: 'CHANGES_REQUESTED',
+          id: 100,
+        },
+      ],
+      [
+        {
+          id: 1,
+          user: { login: 'reviewer' },
+          body: 'Fix this method',
+          created_at: '2026-02-07T12:00:00Z',
+          pull_request_review_id: 100,
+        },
+      ],
+      'testuser',
+    );
+    expect(result.hasUnrespondedComment).toBe(true);
+    expect(result.lastMaintainerComment?.body).toBe('Fix this method');
   });
 
   it('should ignore user own COMMENTED reviews (#151)', () => {
@@ -1570,6 +1622,20 @@ describe('isAcknowledgmentComment (Issue #69)', () => {
     expect(result.hasUnrespondedComment).toBe(false);
   });
 
+  it('should ignore user own CHANGES_REQUESTED reviews (#431)', () => {
+    const result = checkUnrespondedComments(
+      [],
+      [
+        // User's own CHANGES_REQUESTED review — should not trigger needs_response
+        // (GitHub normally prevents this, but defense-in-depth)
+        { user: { login: 'testuser' }, body: '', submitted_at: '2026-02-07T12:00:00Z', state: 'CHANGES_REQUESTED' },
+      ],
+      [],
+      'testuser',
+    );
+    expect(result.hasUnrespondedComment).toBe(false);
+  });
+
   it('should use synthetic body for inline-only COMMENTED reviews (#151)', () => {
     const result = checkUnrespondedComments(
       [],
@@ -1578,6 +1644,16 @@ describe('isAcknowledgmentComment (Issue #69)', () => {
       'testuser',
     );
     expect(result.lastMaintainerComment?.body).toBe('(posted inline review comments)');
+  });
+
+  it('should use specific synthetic body for inline-only CHANGES_REQUESTED reviews (#431)', () => {
+    const result = checkUnrespondedComments(
+      [],
+      [{ user: { login: 'reviewer' }, body: '', submitted_at: '2026-02-07T12:00:00Z', state: 'CHANGES_REQUESTED' }],
+      [],
+      'testuser',
+    );
+    expect(result.lastMaintainerComment?.body).toBe('(requested changes via inline review comments)');
   });
 
   it('should still skip APPROVED reviews with no body (#151)', () => {

--- a/packages/core/src/core/pr-monitor.ts
+++ b/packages/core/src/core/pr-monitor.ts
@@ -381,6 +381,11 @@ export class PRMonitor {
       // If the contributor pushed a commit after the maintainer's comment,
       // the changes have been addressed — waiting for maintainer re-review
       if (latestCommitDate && lastMaintainerCommentDate && latestCommitDate > lastMaintainerCommentDate) {
+        // Safety net (#431): if a CHANGES_REQUESTED review was submitted after
+        // the commit, the maintainer still expects changes — don't mask it
+        if (latestChangesRequestedDate && latestCommitDate < latestChangesRequestedDate) {
+          return 'needs_response';
+        }
         if (ciStatus === 'failing') return 'failing_ci';
         return 'changes_addressed';
       }

--- a/packages/core/src/core/review-analysis.ts
+++ b/packages/core/src/core/review-analysis.ts
@@ -140,11 +140,11 @@ export function checkUnrespondedComments(
   for (const review of reviews) {
     if (!review.submitted_at) continue;
     const body = (review.body || '').trim();
-    // Include COMMENTED reviews even without body text — they indicate
-    // inline review comments were posted and may need a response (#151).
-    // Skip other empty-body reviews (APPROVED, CHANGES_REQUESTED, DISMISSED)
-    // as those are state changes without comment text.
-    if (!body && review.state !== 'COMMENTED') continue;
+    // Include COMMENTED and CHANGES_REQUESTED reviews even without body text —
+    // they indicate inline review comments were posted and need a response (#151, #431).
+    // CHANGES_REQUESTED with only inline comments is actionable maintainer feedback.
+    // Skip other empty-body reviews (APPROVED, DISMISSED) as those are state changes.
+    if (!body && review.state !== 'COMMENTED' && review.state !== 'CHANGES_REQUESTED') continue;
     const author = review.user?.login || 'unknown';
 
     // For inline-only COMMENTED reviews, skip pure self-replies (#199)
@@ -158,7 +158,9 @@ export function checkUnrespondedComments(
     const resolvedBody =
       body ||
       (review.id != null ? getInlineCommentBody(review.id, reviewComments) : undefined) ||
-      '(posted inline review comments)';
+      (review.state === 'CHANGES_REQUESTED'
+        ? '(requested changes via inline review comments)'
+        : '(posted inline review comments)');
 
     timeline.push({
       author,


### PR DESCRIPTION
## Summary

Fixes #431.

- **Include empty-body CHANGES_REQUESTED reviews in timeline filter** — Reviews where all feedback is in inline comments were silently excluded, causing the PR to appear healthy when it actually needed a response
- **Add safety net in `determineStatus`** — Prevents `changes_addressed` from masking a `CHANGES_REQUESTED` review posted after the contributor's commit
- **Differentiate synthetic placeholder text** — `CHANGES_REQUESTED` reviews now show "(requested changes via inline review comments)" instead of the generic "(posted inline review comments)"
- **Defense-in-depth test** — Verifies that user's own `CHANGES_REQUESTED` reviews don't trigger false positives

## Test plan

- [x] All 1,545 tests pass (1,442 core + 103 mcp-server)
- [x] New test: empty-body CHANGES_REQUESTED included as actionable
- [x] New test: inline comment body resolved for CHANGES_REQUESTED
- [x] New test: `needs_response` when CHANGES_REQUESTED after commit
- [x] New test: `changes_addressed` when commit after both comment and review
- [x] New test: user's own CHANGES_REQUESTED ignored (defense-in-depth)
- [x] New test: specific synthetic placeholder for CHANGES_REQUESTED
- [x] TypeScript compiles cleanly, Prettier clean