### PR TITLE
fix: dismiss command accepts PR URLs and filters them from actionable items

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -696,21 +696,21 @@ program
 
 // Dismiss command
 program
-  .command('dismiss <issue-url>')
-  .description('Dismiss issue reply notifications (resurfaces on new activity)')
+  .command('dismiss <url>')
+  .description('Dismiss notifications for an issue or PR (resurfaces on new activity)')
   .option('--json', 'Output as JSON')
-  .action(async (issueUrl, options) => {
+  .action(async (url, options) => {
     try {
       const { runDismiss } = await import('./commands/dismiss.js');
-      const data = await runDismiss({ issueUrl });
+      const data = await runDismiss({ url });
       if (options.json) {
         outputJson(data);
       } else if (data.dismissed) {
-        console.log(`Dismissed: ${issueUrl}`);
-        console.log('Issue reply notifications are now muted.');
+        console.log(`Dismissed: ${url}`);
+        console.log('Notifications are now muted.');
         console.log('New responses after this point will resurface automatically.');
       } else {
-        console.log('Issue is already dismissed.');
+        console.log('Already dismissed.');
       }
     } catch (err) {
       handleCommandError(err, options.json);
@@ -719,20 +719,20 @@ program
 
 // Undismiss command
 program
-  .command('undismiss <issue-url>')
-  .description('Undismiss an issue (re-enable reply notifications)')
+  .command('undismiss <url>')
+  .description('Undismiss an issue or PR (re-enable notifications)')
   .option('--json', 'Output as JSON')
-  .action(async (issueUrl, options) => {
+  .action(async (url, options) => {
     try {
       const { runUndismiss } = await import('./commands/dismiss.js');
-      const data = await runUndismiss({ issueUrl });
+      const data = await runUndismiss({ url });
       if (options.json) {
         outputJson(data);
       } else if (data.undismissed) {
-        console.log(`Undismissed: ${issueUrl}`);
-        console.log('Issue reply notifications are active again.');
+        console.log(`Undismissed: ${url}`);
+        console.log('Notifications are active again.');
       } else {
-        console.log('Issue was not dismissed.');
+        console.log('Was not dismissed.');
       }
     } catch (err) {
       handleCommandError(err, options.json);

--- a/packages/core/src/commands/daily-orchestration.test.ts
+++ b/packages/core/src/commands/daily-orchestration.test.ts
@@ -561,6 +561,43 @@ describe('executeDailyCheck() — snoozed PR filtering', () => {
 });
 
 // ---------------------------------------------------------------------------
+// executeDailyCheck() — dismissed PR URL filtering (#416)
+// ---------------------------------------------------------------------------
+
+describe('executeDailyCheck() — dismissed PR URL filtering (#416)', () => {
+  it('excludes dismissed PR URLs from actionableIssues', async () => {
+    const dismissedPR = makePR({ repo: 'owner/repo', number: 1, status: 'needs_response' });
+    const activePR = makePR({ repo: 'owner/repo', number: 2, status: 'needs_response' });
+    mockFetchUserOpenPRs.mockResolvedValue({ prs: [dismissedPR, activePR], failures: [] });
+    mockGenerateDigest.mockReturnValue(makeDigest([dismissedPR, activePR]));
+    mockIsPRShelved.mockReturnValue(false);
+
+    mockGetState.mockReturnValue(
+      makeDefaultState({
+        config: {
+          setupComplete: true,
+          githubUsername: 'testuser',
+          maxActivePRs: 10,
+          languages: [],
+          labels: [],
+          excludeRepos: [],
+          trustedProjects: [],
+          shelvedPRUrls: [],
+          dismissedIssues: { [dismissedPR.url]: '2026-01-01T00:00:00Z' },
+          snoozedPRs: {},
+        },
+      }),
+    );
+
+    const result = await executeDailyCheck('test-token');
+
+    const needsResponseIssues = result.actionableIssues.filter((i) => i.type === 'needs_response');
+    expect(needsResponseIssues).toHaveLength(1);
+    expect(needsResponseIssues[0].prUrl).toBe(activePR.url);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // executeDailyCheck() — JSON output shape
 // ---------------------------------------------------------------------------
 

--- a/packages/core/src/commands/daily.ts
+++ b/packages/core/src/commands/daily.ts
@@ -473,7 +473,10 @@ function generateDigestOutput(
   const snoozedUrls = new Set(
     Object.keys(stateManager.getState().config.snoozedPRs ?? {}).filter((url) => stateManager.isSnoozed(url)),
   );
-  const actionableIssues = collectActionableIssues(activePRs, snoozedUrls);
+  // Filter dismissed PR URLs from actionable issues (#416)
+  const dismissedUrls = new Set(Object.keys(stateManager.getState().config.dismissedIssues ?? {}));
+  const nonDismissedPRs = activePRs.filter((pr) => !dismissedUrls.has(pr.url));
+  const actionableIssues = collectActionableIssues(nonDismissedPRs, snoozedUrls);
   digest.summary.totalNeedingAttention = actionableIssues.length;
   const briefSummary = formatBriefSummary(digest, actionableIssues.length, issueResponses.length);
   const actionMenu = computeActionMenu(actionableIssues, capacity, filteredCommentedIssues);

--- a/packages/core/src/commands/dismiss.test.ts
+++ b/packages/core/src/commands/dismiss.test.ts
@@ -3,34 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { ISSUE_URL_PATTERN } from './dismiss.js';
-
-describe('ISSUE_URL_PATTERN', () => {
-  it.each([
-    ['https://github.com/owner/repo/issues/123', 'standard URL'],
-    ['https://github.com/my-org/my-repo/issues/1', 'hyphenated names'],
-    ['https://github.com/owner/repo.js/issues/42', 'dotted repo name'],
-    ['https://github.com/my_org/my_repo/issues/7', 'underscored names'],
-    ['https://github.com/owner/repo/issues/99999', 'large issue number'],
-  ])('should match %s (%s)', (url) => {
-    expect(ISSUE_URL_PATTERN.test(url)).toBe(true);
-  });
-
-  it.each([
-    ['https://github.com/owner/repo/pull/123', 'PR URL'],
-    ['https://gitlab.com/owner/repo/issues/1', 'non-GitHub host'],
-    ['http://github.com/owner/repo/issues/1', 'HTTP (non-HTTPS)'],
-    ['https://github.com/owner/repo/issues/123/', 'trailing slash'],
-    ['https://github.com/owner/repo/issues/123?q=test', 'query parameters'],
-    ['https://github.com/owner/repo/issues/123#comment', 'fragment identifier'],
-    ['https://github.com/owner/repo/issues/', 'missing issue number'],
-    ['https://github.com/owner/repo', 'bare repo URL'],
-    ['', 'empty string'],
-    ['https://github.com/owner/repo/issues/123/timeline', 'extra path segments'],
-  ])('should reject %s (%s)', (url) => {
-    expect(ISSUE_URL_PATTERN.test(url)).toBe(false);
-  });
-});
+// Pattern tests are in validation.test.ts (canonical home for URL patterns)
 
 // Mock getStateManager for command-level tests
 vi.mock('../core/index.js', () => ({
@@ -43,6 +16,7 @@ import { runDismiss, runUndismiss } from './dismiss.js';
 const mockGetStateManager = vi.mocked(getStateManager);
 
 const TEST_ISSUE_URL = 'https://github.com/owner/repo/issues/1';
+const TEST_PR_URL = 'https://github.com/owner/repo/pull/42';
 
 describe('runDismiss', () => {
   const mockSave = vi.fn();
@@ -58,16 +32,25 @@ describe('runDismiss', () => {
 
   it('should dismiss an issue and save state', async () => {
     mockDismissIssue.mockReturnValue(true);
-    const result = await runDismiss({ issueUrl: TEST_ISSUE_URL });
+    const result = await runDismiss({ url: TEST_ISSUE_URL });
 
     expect(mockDismissIssue).toHaveBeenCalledWith(TEST_ISSUE_URL, expect.any(String));
     expect(mockSave).toHaveBeenCalled();
     expect(result).toEqual({ dismissed: true, url: TEST_ISSUE_URL });
   });
 
+  it('should dismiss a PR URL and save state (#416)', async () => {
+    mockDismissIssue.mockReturnValue(true);
+    const result = await runDismiss({ url: TEST_PR_URL });
+
+    expect(mockDismissIssue).toHaveBeenCalledWith(TEST_PR_URL, expect.any(String));
+    expect(mockSave).toHaveBeenCalled();
+    expect(result).toEqual({ dismissed: true, url: TEST_PR_URL });
+  });
+
   it('should not save state when issue is already dismissed', async () => {
     mockDismissIssue.mockReturnValue(false);
-    const result = await runDismiss({ issueUrl: TEST_ISSUE_URL });
+    const result = await runDismiss({ url: TEST_ISSUE_URL });
 
     expect(mockSave).not.toHaveBeenCalled();
     expect(result).toEqual({ dismissed: false, url: TEST_ISSUE_URL });
@@ -88,16 +71,25 @@ describe('runUndismiss', () => {
 
   it('should undismiss an issue and save state', async () => {
     mockUndismissIssue.mockReturnValue(true);
-    const result = await runUndismiss({ issueUrl: TEST_ISSUE_URL });
+    const result = await runUndismiss({ url: TEST_ISSUE_URL });
 
     expect(mockUndismissIssue).toHaveBeenCalledWith(TEST_ISSUE_URL);
     expect(mockSave).toHaveBeenCalled();
     expect(result).toEqual({ undismissed: true, url: TEST_ISSUE_URL });
   });
 
+  it('should undismiss a PR URL and save state (#416)', async () => {
+    mockUndismissIssue.mockReturnValue(true);
+    const result = await runUndismiss({ url: TEST_PR_URL });
+
+    expect(mockUndismissIssue).toHaveBeenCalledWith(TEST_PR_URL);
+    expect(mockSave).toHaveBeenCalled();
+    expect(result).toEqual({ undismissed: true, url: TEST_PR_URL });
+  });
+
   it('should not save state when issue was not dismissed', async () => {
     mockUndismissIssue.mockReturnValue(false);
-    const result = await runUndismiss({ issueUrl: TEST_ISSUE_URL });
+    const result = await runUndismiss({ url: TEST_ISSUE_URL });
 
     expect(mockSave).not.toHaveBeenCalled();
     expect(result).toEqual({ undismissed: false, url: TEST_ISSUE_URL });

--- a/packages/core/src/commands/dismiss.ts
+++ b/packages/core/src/commands/dismiss.ts
@@ -1,11 +1,11 @@
 /**
  * Dismiss/Undismiss commands
- * Manages dismissing issue reply notifications without posting a comment.
- * Dismissed issues resurface automatically when new responses arrive after the dismiss timestamp.
+ * Manages dismissing issue and PR notifications without posting a comment.
+ * Dismissed URLs resurface automatically when new responses arrive after the dismiss timestamp.
  */
 
 import { getStateManager } from '../core/index.js';
-import { ISSUE_URL_PATTERN, validateGitHubUrl, validateUrl } from './validation.js';
+import { ISSUE_OR_PR_URL_PATTERN, validateGitHubUrl, validateUrl } from './validation.js';
 
 export interface DismissOutput {
   dismissed: boolean;
@@ -17,33 +17,33 @@ export interface UndismissOutput {
   url: string;
 }
 
-// Re-export for backward compatibility with tests
-export { ISSUE_URL_PATTERN };
+// Re-export for tests
+export { ISSUE_OR_PR_URL_PATTERN };
 
-export async function runDismiss(options: { issueUrl: string }): Promise<DismissOutput> {
-  validateUrl(options.issueUrl);
-  validateGitHubUrl(options.issueUrl, ISSUE_URL_PATTERN, 'issue');
+export async function runDismiss(options: { url: string }): Promise<DismissOutput> {
+  validateUrl(options.url);
+  validateGitHubUrl(options.url, ISSUE_OR_PR_URL_PATTERN, 'issue or PR');
 
   const stateManager = getStateManager();
-  const added = stateManager.dismissIssue(options.issueUrl, new Date().toISOString());
+  const added = stateManager.dismissIssue(options.url, new Date().toISOString());
 
   if (added) {
     stateManager.save();
   }
 
-  return { dismissed: added, url: options.issueUrl };
+  return { dismissed: added, url: options.url };
 }
 
-export async function runUndismiss(options: { issueUrl: string }): Promise<UndismissOutput> {
-  validateUrl(options.issueUrl);
-  validateGitHubUrl(options.issueUrl, ISSUE_URL_PATTERN, 'issue');
+export async function runUndismiss(options: { url: string }): Promise<UndismissOutput> {
+  validateUrl(options.url);
+  validateGitHubUrl(options.url, ISSUE_OR_PR_URL_PATTERN, 'issue or PR');
 
   const stateManager = getStateManager();
-  const removed = stateManager.undismissIssue(options.issueUrl);
+  const removed = stateManager.undismissIssue(options.url);
 
   if (removed) {
     stateManager.save();
   }
 
-  return { undismissed: removed, url: options.issueUrl };
+  return { undismissed: removed, url: options.url };
 }

--- a/packages/core/src/commands/validation.test.ts
+++ b/packages/core/src/commands/validation.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect } from 'vitest';
 import {
   PR_URL_PATTERN,
   ISSUE_URL_PATTERN,
+  ISSUE_OR_PR_URL_PATTERN,
   validateUrl,
   validatePRNumber,
   validateMessage,
@@ -43,6 +44,28 @@ describe('ISSUE_URL_PATTERN', () => {
     expect(ISSUE_URL_PATTERN.test('https://github.com/owner/repo/pull/123')).toBe(false);
     expect(ISSUE_URL_PATTERN.test('https://github.com/owner/repo/issues/')).toBe(false);
     expect(ISSUE_URL_PATTERN.test('not-a-url')).toBe(false);
+  });
+});
+
+describe('ISSUE_OR_PR_URL_PATTERN (#416)', () => {
+  it.each([
+    ['https://github.com/owner/repo/issues/123', 'issue URL'],
+    ['https://github.com/owner/repo/pull/123', 'PR URL'],
+    ['https://github.com/my-org/my-repo/pull/1', 'hyphenated PR'],
+    ['https://github.com/owner/repo.js/pull/42', 'dotted repo PR'],
+  ])('should match %s (%s)', (url) => {
+    expect(ISSUE_OR_PR_URL_PATTERN.test(url)).toBe(true);
+  });
+
+  it.each([
+    ['https://gitlab.com/owner/repo/pull/1', 'non-GitHub host'],
+    ['http://github.com/owner/repo/pull/1', 'HTTP (non-HTTPS)'],
+    ['https://github.com/owner/repo/pull/123/', 'trailing slash'],
+    ['https://github.com/owner/repo/pulls', 'pulls listing'],
+    ['https://github.com/owner/repo', 'bare repo URL'],
+    ['', 'empty string'],
+  ])('should reject %s (%s)', (url) => {
+    expect(ISSUE_OR_PR_URL_PATTERN.test(url)).toBe(false);
   });
 });
 
@@ -147,6 +170,15 @@ describe('validateGitHubUrl', () => {
   it('should include expected format in error message', () => {
     expect(() => validateGitHubUrl('bad-url', PR_URL_PATTERN, 'PR')).toThrow(
       'Expected format: https://github.com/owner/repo/pull/123',
+    );
+  });
+
+  it('should throw with combined format for issue or PR (#416)', () => {
+    expect(() => validateGitHubUrl('bad-url', ISSUE_OR_PR_URL_PATTERN, 'issue or PR')).toThrow(
+      'Invalid issue or PR URL',
+    );
+    expect(() => validateGitHubUrl('bad-url', ISSUE_OR_PR_URL_PATTERN, 'issue or PR')).toThrow(
+      'Expected format: https://github.com/owner/repo/issues/123 or https://github.com/owner/repo/pull/123',
     );
   });
 });

--- a/packages/core/src/commands/validation.ts
+++ b/packages/core/src/commands/validation.ts
@@ -10,6 +10,9 @@ export const PR_URL_PATTERN = /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+$/
 /** Matches GitHub issue URLs: https://github.com/owner/repo/issues/123 */
 export const ISSUE_URL_PATTERN = /^https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/\d+$/;
 
+/** Matches GitHub issue or PR URLs: /issues/123 or /pull/123 */
+export const ISSUE_OR_PR_URL_PATTERN = /^https:\/\/github\.com\/[^/]+\/[^/]+\/(issues|pull)\/\d+$/;
+
 /** Maximum allowed URL length */
 const MAX_URL_LENGTH = 2048;
 /** Maximum allowed PR/issue number */
@@ -22,12 +25,15 @@ const REPO_PATTERN = /^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/;
 /**
  * Validate a GitHub URL against a pattern. Throws if invalid.
  */
-export function validateGitHubUrl(url: string, pattern: RegExp, entityType: 'PR' | 'issue'): void {
+export function validateGitHubUrl(url: string, pattern: RegExp, entityType: 'PR' | 'issue' | 'issue or PR'): void {
   if (pattern.test(url)) return;
 
-  const example =
-    entityType === 'PR' ? 'https://github.com/owner/repo/pull/123' : 'https://github.com/owner/repo/issues/123';
-  throw new ValidationError(`Invalid ${entityType} URL: ${url}. Expected format: ${example}`);
+  const examples: Record<string, string> = {
+    PR: 'https://github.com/owner/repo/pull/123',
+    issue: 'https://github.com/owner/repo/issues/123',
+    'issue or PR': 'https://github.com/owner/repo/issues/123 or https://github.com/owner/repo/pull/123',
+  };
+  throw new ValidationError(`Invalid ${entityType} URL: ${url}. Expected format: ${examples[entityType]}`);
 }
 
 /**

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -301,26 +301,26 @@ export function registerTools(server: McpServer): void {
     wrapTool(runUnshelve),
   );
 
-  // 18. dismiss — Dismiss an issue
+  // 18. dismiss — Dismiss an issue or PR
   server.registerTool(
     'dismiss',
     {
-      description: 'Dismiss a GitHub issue so it no longer appears in search results.',
+      description: 'Dismiss a GitHub issue or PR so it no longer appears in notifications.',
       inputSchema: {
-        issueUrl: z.string().describe('Full GitHub issue URL to dismiss'),
+        url: z.string().describe('Full GitHub issue or PR URL to dismiss'),
       },
       annotations: { readOnlyHint: false, destructiveHint: false },
     },
     wrapTool(runDismiss),
   );
 
-  // 19. undismiss — Undismiss an issue
+  // 19. undismiss — Undismiss an issue or PR
   server.registerTool(
     'undismiss',
     {
-      description: 'Undismiss a previously dismissed issue, allowing it to appear in search results again.',
+      description: 'Undismiss a previously dismissed issue or PR, re-enabling notifications.',
       inputSchema: {
-        issueUrl: z.string().describe('Full GitHub issue URL to undismiss'),
+        url: z.string().describe('Full GitHub issue or PR URL to undismiss'),
       },
       annotations: { readOnlyHint: false, destructiveHint: false },
     },


### PR DESCRIPTION
## Summary

Fixes #416.

- **Accept both issue and PR URLs** — New `ISSUE_OR_PR_URL_PATTERN` validates `/issues/123` and `/pull/123` formats
- **Wire dismissed PR URLs into daily digest** — Dismissed PR URLs are now filtered from `collectActionableIssues`, preventing them from resurfacing in the "Needs Response" list
- **Rename `issueUrl` to `url`** — Updated parameter names throughout the dismiss command chain for consistency
- **Update MCP server descriptions** — Tool descriptions now mention both issues and PRs
- **Consolidate pattern tests** — URL pattern tests moved to `validation.test.ts` as their canonical home

## Test plan

- [x] All 1,544 tests pass (1,441 core + 103 mcp-server)
- [x] New test: `ISSUE_OR_PR_URL_PATTERN` matches PR URLs, rejects invalid formats
- [x] New test: `runDismiss` accepts PR URLs
- [x] New test: `runUndismiss` accepts PR URLs
- [x] New test: `validateGitHubUrl` with `'issue or PR'` entity type
- [x] New test: dismissed PR URLs excluded from `actionableIssues` in daily digest
- [x] Prettier clean, TypeScript clean