### PR TITLE
fix: remove dead code, extract Phase 2/3 helper, and add error path tests

### DIFF
--- a/packages/core/src/commands/daily-orchestration.test.ts
+++ b/packages/core/src/commands/daily-orchestration.test.ts
@@ -260,8 +260,6 @@ describe('executeDailyCheck()', () => {
     expect(result).toHaveProperty('commentedIssues');
     expect(result).toHaveProperty('repoGroups');
     expect(result).toHaveProperty('failures');
-    expect(Array.isArray(result.updates)).toBe(true);
-    expect(result.updates).toHaveLength(0);
   });
 
   it('returns empty failures when all PRs fetch successfully', async () => {

--- a/packages/core/src/commands/daily.ts
+++ b/packages/core/src/commands/daily.ts
@@ -64,7 +64,6 @@ export {
  */
 export interface DailyCheckResult {
   digest: DailyDigest;
-  updates: unknown[];
   capacity: CapacityAssessment;
   summary: string;
   briefSummary: string;
@@ -484,7 +483,6 @@ function generateDigestOutput(
 
   return {
     digest,
-    updates: [],
     capacity,
     summary,
     briefSummary,
@@ -508,7 +506,6 @@ function generateDigestOutput(
 function toDailyOutput(result: DailyCheckResult): DailyOutput {
   return {
     digest: deduplicateDigest(result.digest),
-    updates: result.updates,
     capacity: result.capacity,
     summary: result.summary,
     briefSummary: result.briefSummary,

--- a/packages/core/src/commands/search.test.ts
+++ b/packages/core/src/commands/search.test.ts
@@ -147,4 +147,11 @@ describe('runSearch', () => {
 
     expect(result.candidates).toEqual([]);
   });
+
+  it('should propagate errors from searchIssues (#414)', async () => {
+    mockRequireGitHubToken.mockReturnValue('ghp_test123');
+    mockSearchIssues.mockRejectedValue(new Error('API rate limit exceeded'));
+
+    await expect(runSearch({ maxResults: 5 })).rejects.toThrow('API rate limit exceeded');
+  });
 });

--- a/packages/core/src/commands/startup.test.ts
+++ b/packages/core/src/commands/startup.test.ts
@@ -304,7 +304,6 @@ describe('runStartup behavior', () => {
           totalNeedingAttention: 0,
         },
       },
-      updates: [],
       capacity: {
         hasCapacity: true,
         activePRCount: totalActivePRs,

--- a/packages/core/src/commands/track.test.ts
+++ b/packages/core/src/commands/track.test.ts
@@ -57,6 +57,16 @@ describe('runTrack', () => {
 
     await expect(runTrack({ prUrl: 'bad-url' })).rejects.toThrow('Invalid PR URL');
   });
+
+  it('should propagate API errors from octokit (#414)', async () => {
+    mockGetOctokit.mockReturnValue({
+      pulls: {
+        get: vi.fn().mockRejectedValue(new Error('Not Found')),
+      },
+    } as any);
+
+    await expect(runTrack({ prUrl: TEST_PR_URL })).rejects.toThrow('Not Found');
+  });
 });
 
 describe('runUntrack', () => {

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -131,6 +131,63 @@ export class IssueDiscovery {
   }
 
   /**
+   * Shared pipeline for Phases 2 and 3: spam-filter, repo-exclusion, vetting, and star-count filter.
+   * Extracts the common logic so each phase only needs to supply search results and context.
+   */
+  private async filterVetAndScore(
+    items: GitHubSearchItem[],
+    filterIssues: (items: GitHubSearchItem[]) => GitHubSearchItem[],
+    excludedRepoSets: Set<string>[],
+    remainingNeeded: number,
+    minStars: number,
+    phaseLabel: string,
+  ): Promise<{ candidates: IssueCandidate[]; allVetFailed: boolean; rateLimitHit: boolean }> {
+    const spamRepos = detectLabelFarmingRepos(items);
+    if (spamRepos.size > 0) {
+      const spamCount = items.filter((i) => spamRepos.has(i.repository_url.split('/').slice(-2).join('/'))).length;
+      debug(
+        MODULE,
+        `[SPAM_FILTER] Filtered ${spamCount} issues from ${spamRepos.size} label-farming repos: ${[...spamRepos].join(', ')}`,
+      );
+    }
+
+    const itemsToVet = filterIssues(items)
+      .filter((item) => {
+        const repoFullName = item.repository_url.split('/').slice(-2).join('/');
+        if (spamRepos.has(repoFullName)) return false;
+        return excludedRepoSets.every((s) => !s.has(repoFullName));
+      })
+      .slice(0, remainingNeeded * 2);
+
+    if (itemsToVet.length === 0) {
+      debug(MODULE, `[${phaseLabel}] All ${items.length} items filtered before vetting`);
+      return { candidates: [], allVetFailed: false, rateLimitHit: false };
+    }
+
+    const {
+      candidates: results,
+      allFailed: allVetFailed,
+      rateLimitHit,
+    } = await this.vetter.vetIssuesParallel(
+      itemsToVet.map((i) => i.html_url),
+      remainingNeeded,
+      'normal',
+    );
+
+    const starFiltered = results.filter((c) => {
+      if (c.projectHealth.checkFailed) return true;
+      const stars = c.projectHealth.stargazersCount ?? 0;
+      return stars >= minStars;
+    });
+    const starFilteredCount = results.length - starFiltered.length;
+    if (starFilteredCount > 0) {
+      debug(MODULE, `[STAR_FILTER] Filtered ${starFilteredCount} ${phaseLabel} candidates below ${minStars} stars`);
+    }
+
+    return { candidates: starFiltered, allVetFailed, rateLimitHit };
+  }
+
+  /**
    * Search for issues matching our criteria.
    * Searches in priority order: merged-PR repos first (no label filter), then starred repos,
    * then general search, then actively maintained repos (#349).
@@ -147,6 +204,7 @@ export class IssueDiscovery {
     const languages = options.languages || config.languages;
     const labels = options.labels || config.labels;
     const maxResults = options.maxResults || 10;
+    const minStars = config.minStars ?? 50;
 
     const allCandidates: IssueCandidate[] = [];
     let phase0Error: string | null = null;
@@ -326,56 +384,19 @@ export class IssueDiscovery {
 
         info(MODULE, `Found ${data.total_count} issues in general search, processing top ${data.items.length}...`);
 
-        // Detect and filter label-farming repos (#97)
-        const spamRepos = detectLabelFarmingRepos(data.items);
-        if (spamRepos.size > 0) {
-          const spamCount = data.items.filter((i) =>
-            spamRepos.has(i.repository_url.split('/').slice(-2).join('/')),
-          ).length;
-          debug(
-            MODULE,
-            `[SPAM_FILTER] Filtered ${spamCount} issues from ${spamRepos.size} label-farming repos: ${[...spamRepos].join(', ')}`,
-          );
-        }
-
-        // Filter and exclude already-found repos
         const seenRepos = new Set(allCandidates.map((c) => c.issue.repo));
-        const itemsToVet = filterIssues(data.items)
-          .filter((item) => {
-            const repoFullName = item.repository_url.split('/').slice(-2).join('/');
-            return !spamRepos.has(repoFullName);
-          })
-          .filter((item) => {
-            const repoFullName = item.repository_url.split('/').slice(-2).join('/');
-            // Skip if already searched in earlier phases
-            return (
-              !phase0RepoSet.has(repoFullName) && !starredRepoSet.has(repoFullName) && !seenRepos.has(repoFullName)
-            );
-          })
-          .slice(0, remainingNeeded * 2);
-
         const {
-          candidates: results,
-          allFailed: allVetFailed,
+          candidates: starFiltered,
+          allVetFailed,
           rateLimitHit: vetRateLimitHit,
-        } = await this.vetter.vetIssuesParallel(
-          itemsToVet.map((i) => i.html_url),
+        } = await this.filterVetAndScore(
+          data.items,
+          filterIssues,
+          [phase0RepoSet, starredRepoSet, seenRepos],
           remainingNeeded,
-          'normal',
+          minStars,
+          'Phase 2',
         );
-
-        // Apply minStars filter to Phase 2 results (#105)
-        // Phase 0/1 are exempt — if you've already contributed to or starred a repo, star count is irrelevant.
-        const minStars = config.minStars ?? 50;
-        const starFiltered = results.filter((c) => {
-          if (c.projectHealth.checkFailed) return true; // Don't penalize repos we couldn't check
-          const stars = c.projectHealth.stargazersCount ?? 0;
-          return stars >= minStars;
-        });
-        const starFilteredCount = results.length - starFiltered.length;
-        if (starFilteredCount > 0) {
-          debug(MODULE, `[STAR_FILTER] Filtered ${starFilteredCount} candidates below ${minStars} stars`);
-        }
 
         allCandidates.push(...starFiltered);
         if (allVetFailed) {
@@ -406,9 +427,8 @@ export class IssueDiscovery {
       const thirtyDaysAgo = new Date();
       thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
       const pushedSince = thirtyDaysAgo.toISOString().split('T')[0];
-      const phase3MinStars = config.minStars ?? 50;
       const phase3Query =
-        `is:issue is:open no:assignee ${langQuery} stars:>=${phase3MinStars} pushed:>=${pushedSince} archived:false`
+        `is:issue is:open no:assignee ${langQuery} stars:>=${minStars} pushed:>=${pushedSince} archived:false`
           .replace(/  +/g, ' ')
           .trim();
 
@@ -425,51 +445,19 @@ export class IssueDiscovery {
           `Found ${data.total_count} issues in maintained-repo search, processing top ${data.items.length}...`,
         );
 
-        // Filter spam, already-found repos, and already-searched repos
-        const spamRepos = detectLabelFarmingRepos(data.items);
-        if (spamRepos.size > 0) {
-          const spamCount = data.items.filter((i) =>
-            spamRepos.has(i.repository_url.split('/').slice(-2).join('/')),
-          ).length;
-          debug(
-            MODULE,
-            `[SPAM_FILTER] Filtered ${spamCount} issues from ${spamRepos.size} label-farming repos: ${[...spamRepos].join(', ')}`,
-          );
-        }
         const seenRepos = new Set(allCandidates.map((c) => c.issue.repo));
-        const itemsToVet = filterIssues(data.items)
-          .filter((item) => {
-            const repoFullName = item.repository_url.split('/').slice(-2).join('/');
-            return (
-              !spamRepos.has(repoFullName) &&
-              !phase0RepoSet.has(repoFullName) &&
-              !starredRepoSet.has(repoFullName) &&
-              !seenRepos.has(repoFullName)
-            );
-          })
-          .slice(0, remainingNeeded * 2);
-
         const {
-          candidates: results,
-          allFailed: allVetFailed,
+          candidates: starFiltered,
+          allVetFailed,
           rateLimitHit: vetRateLimitHit,
-        } = await this.vetter.vetIssuesParallel(
-          itemsToVet.map((i) => i.html_url),
+        } = await this.filterVetAndScore(
+          data.items,
+          filterIssues,
+          [phase0RepoSet, starredRepoSet, seenRepos],
           remainingNeeded,
-          'normal',
+          minStars,
+          'Phase 3',
         );
-
-        // Apply minStars filter (same as Phase 2, #105)
-        const minStars = config.minStars ?? 50;
-        const starFiltered = results.filter((c) => {
-          if (c.projectHealth.checkFailed) return true;
-          const stars = c.projectHealth.stargazersCount ?? 0;
-          return stars >= minStars;
-        });
-        const starFilteredCount = results.length - starFiltered.length;
-        if (starFilteredCount > 0) {
-          debug(MODULE, `[STAR_FILTER] Filtered ${starFilteredCount} Phase 3 candidates below ${minStars} stars`);
-        }
 
         allCandidates.push(...starFiltered);
         if (allVetFailed) {

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -129,7 +129,6 @@ export interface CompactRepoGroup {
 
 export interface DailyOutput {
   digest: DailyDigestCompact;
-  updates: unknown[]; // Legacy field, always empty in v2
   capacity: CapacityAssessment;
   summary: string; // Pre-formatted markdown for Claude to display verbatim
   briefSummary: string; // One-liner for action-first flow


### PR DESCRIPTION
## Summary

Addresses issue #414 — dead code removal, code deduplication, and error path testing.

**Items resolved by prior work (verified, no changes needed):**
- Items 1-2 (try/catch for runSearch/runTrack): CLI already wraps every command in `try { ... } catch (err) { handleCommandError(err, options.json); }`
- Item 3 (validateGitHubUrl process.exit): Fixed in PR #464 (issue #416) — now throws `ValidationError`
- Item 4 (dead fetchRecentPRs): No longer exists in pr-monitor.ts (lives in github-stats.ts where it's used)

**Changes in this PR:**
- **Remove legacy `updates` field** — `updates: unknown[]` was always set to `[]` in v2, adding noise to every JSON payload. Removed from `DailyCheckResult`, `DailyOutput`, `generateDigestOutput()`, `toDailyOutput()`, and all tests.
- **Extract `filterVetAndScore()` helper** — Phase 2 and Phase 3 in `IssueDiscovery.searchIssues()` shared ~40 lines of identical logic (spam detection, repo exclusion, vetting, star filtering). Extracted to a private method, reducing duplication and improving readability.
- **Hoist `config.minStars ?? 50`** — Single evaluation shared by Phase 2, Phase 3, and the Phase 3 query builder (was evaluated 3x before).
- **Early return with debug log** — When all items are filtered pre-vetting, logs a debug message and skips the unnecessary `vetIssuesParallel` call.
- **Add error propagation tests** — New tests for `runSearch` (API error) and `runTrack` (octokit error) verifying that errors propagate correctly to the CLI/MCP error handling layers.

## Test plan

- [x] All 1,546 tests pass (1,443 core + 103 mcp-server)
- [x] Prettier clean
- [x] Net -2 lines (92 added, 94 removed)
- [x] 3 review agents (code-reviewer, silent-failure-hunter, code-simplifier) returned clean

Closes #414