### PR TITLE
fix: enhance pre-commit review to catch test quality, naming, and doc accuracy issues

### DIFF
--- a/agents/pre-commit-reviewer.md
+++ b/agents/pre-commit-reviewer.md
@@ -102,6 +102,11 @@ Also look at 2-3 existing files in the same directories as changed files to infe
 - Comment style
 - Test file location and naming patterns
 
+**API naming convention scan:** If the diff adds new public API surface (exported functions, options, CLI flags, config keys), scan existing APIs in the same module for naming patterns:
+- Positive vs negative booleans — if the codebase uses `interactive`, don't introduce `nonInteractive` (double negative)
+- Consistent casing — if existing options use camelCase, don't introduce snake_case
+- Prefix/suffix conventions — if getters use `getX()`, don't introduce `fetchX()` unless that's an established pattern
+
 ## Phase 2.5: Security Scan
 
 Scan the diff for common security issues. This catches problems before they reach CI (where CodeQL provides deeper static analysis).
@@ -139,12 +144,13 @@ Review the diff (from Phase 1) for:
 - **Style mismatches**: Naming inconsistent with repo conventions, wrong indentation, import order
 - **Missing error handling**: Unhandled promise rejections, missing try/catch for I/O
 - **Unnecessary complexity**: Overly nested logic, duplicate code that could be simplified
+- **Truthiness gotchas** (JS/TS only): Flag `!obj.prop` when the intent is to check for `false` specifically but `undefined` would also match; flag `=== false` when `!prop` would suffice and `undefined` is not a concern; flag boolean coercion of values that could be `0`, `""`, or `null` where the intent is only to check for `undefined`
 
 ### Minor (nice to have)
 - **Readability**: Unclear variable names, missing context in complex logic
 - **Consistency**: Mixed patterns within the same file
 
-## Phase 4: Test Coverage Assessment
+## Phase 4: Test Coverage and Quality Assessment
 
 Check if the changes should include tests:
 
@@ -164,6 +170,20 @@ Check if the changes should include tests:
    - Refactoring → existing tests should still pass
    - Config/docs changes → no tests needed
 
+4. **Test assertion strength** — For each new or modified test, ask: "If I broke the feature under test, would this test actually catch it?"
+   - Flag assertions that are too broad (e.g., checking only final output without verifying intermediate states)
+   - Flag test names that claim comprehensive coverage but only check a subset of behavior
+   - Flag tests that would still pass if the feature regressed (e.g., only checking `.toBeDefined()` or `.toBeTruthy()` when a specific value is expected)
+   - Verify that "override" or "disable" tests actually prove the override is working, not just that the code runs without error
+
+## Phase 4.5: Documentation Accuracy
+
+If the diff includes changes to README, docs, JSDoc, or code comments:
+
+1. **Cross-reference claims against code** — For each factual statement (e.g., "X is automatically disabled when Y"), verify that the actual code implements that behavior
+2. **Check option descriptions match defaults** — Don't say "Enable X" for a feature that's on by default; use "Disable X" or "Control whether X is enabled (default: on)"
+3. **Flag stale documentation** — If code behavior changed but docs describing that behavior weren't updated
+
 ## Phase 5: Consolidated Report
 
 Present findings in this format:
@@ -182,11 +202,16 @@ Present findings in this format:
 ### Minor ({count})
 - **{file}:{line}** — {description}
 
-### Test Coverage
+### Test Coverage & Quality
 - {assessment of whether tests are needed and what's missing}
+- {test assertion strength concerns, if any}
+
+### Documentation Accuracy
+- {any doc/README claims that don't match the code, if docs were changed}
 
 ### Convention Alignment
 - {any style/convention mismatches with the target repo}
+- {API naming deviations, if new public API was added}
 ```
 
 If there are NO issues found:

--- a/workflows/pre-commit-review.md
+++ b/workflows/pre-commit-review.md
@@ -107,6 +107,16 @@ Task(pr-review-toolkit:code-reviewer,
    Convention notes: {any CONTRIBUTING.md or lint config findings}
    Changed files: {changed files list}
 
+   Additional checks:
+   - API naming conventions: If new public API surface is added (exports, options, CLI flags),
+     scan existing APIs in the same module for naming patterns. Flag double-negative boolean
+     names (e.g., nonInteractive when the codebase uses positive booleans like interactive).
+   - JS/TS truthiness: Flag !obj.prop when the intent is to check for false specifically
+     but undefined would also match. Flag === false vs !prop inconsistencies.
+   - Documentation accuracy: If docs/README/JSDoc are changed, cross-reference factual claims
+     against the actual code. Flag 'automatically disabled when X' claims that aren't
+     implemented in code.
+
    Diff:
    {git diff output}")
 
@@ -129,11 +139,20 @@ Task(pr-review-toolkit:code-simplifier,
    {git diff output}")
 
 Task(pr-review-toolkit:pr-test-analyzer,
-  "Analyze test coverage for the following code changes. Check if modified code paths
-   have tests, identify gaps, and recommend what tests should be added.
+  "Analyze test coverage and assertion quality for the following code changes.
    Working directory: {local repo path}
    Test directory: {test dir path}
    Changed files: {changed files list}
+
+   Coverage: Check if modified code paths have tests, identify gaps.
+
+   Assertion strength: For each new or modified test, ask 'If I broke the feature under
+   test, would this test actually catch it?' Flag:
+   - Assertions too broad (only checking final output, not intermediate states)
+   - Test names claiming comprehensive coverage but only checking a subset
+   - Tests that would still pass if the feature regressed (e.g., only .toBeDefined()
+     when a specific value is expected)
+   - Override/disable tests that don't prove the override is working, just that code runs
 
    Diff:
    {git diff output}")
@@ -202,11 +221,14 @@ After all agents complete, merge their outputs into a unified report. Deduplicat
 ### Minor ({count}) — Nice to have
 - **{file}:{line}** — {description}
 
-### Test Coverage
-- {assessment from pr-test-analyzer}
+### Test Coverage & Assertion Quality
+- {assessment from pr-test-analyzer, including assertion strength concerns}
+
+### Documentation Accuracy
+- {any doc/README claims that don't match the code, if docs were changed}
 
 ### Convention Alignment
-- {any style/convention mismatches}
+- {any style/convention/naming mismatches}
 ```
 
 If NO issues found across all agents:


### PR DESCRIPTION
## Summary

Addresses issue #432 — pre-commit review agents miss test quality, naming conventions, and doc accuracy issues that maintainers consistently flag.

Adds four targeted review capabilities to both the standalone `pre-commit-reviewer` agent and the parallel workflow's toolkit agent prompts:

- **Test assertion strength** — For each new/modified test, asks "If I broke the feature, would this test catch it?" Flags too-broad assertions (`.toBeDefined()` when a specific value is expected), test names that overclaim coverage, and override tests that don't prove the override works.

- **API naming convention scan** — When new public API surface is added, scans existing APIs for naming patterns. Flags double-negative booleans (`nonInteractive` → should be `interactive`), casing mismatches, and prefix/suffix deviations.

- **Documentation accuracy** — Cross-references README/JSDoc factual claims against actual code. Flags "automatically disabled when X" claims that aren't implemented, option descriptions that don't match defaults, and stale docs when code behavior changes.

- **JS/TS truthiness patterns** — Flags `!obj.prop` when intent is to check for `false` specifically but `undefined` would also match, `=== false` vs `!prop` inconsistencies, and boolean coercion of values that could be `0`, `""`, or `null`.

## Real-world motivation

The ink#888 PR went through 3 rounds of maintainer review, each catching issues these checks would have flagged:
- Round 1: TTY detection truthiness bug (`isTTY === false` vs `!isTTY`) + weak test assertions
- Round 2: Three test quality gaps (assertions too broad to catch regressions)
- Round 3: API naming convention deviation (`nonInteractive` vs `interactive`) + inaccurate README claims

## Test plan

- [x] All 1,546 tests pass (no code changes, only markdown agent/workflow instructions)
- [x] Changes are in 2 files: `agents/pre-commit-reviewer.md` and `workflows/pre-commit-review.md`
- [x] Net +47 lines of review instructions

Closes #432