### PR TITLE
fix: address review findings in pre-commit review instructions

### DIFF
--- a/agents/pre-commit-reviewer.md
+++ b/agents/pre-commit-reviewer.md
@@ -144,7 +144,10 @@ Review the diff (from Phase 1) for:
 - **Style mismatches**: Naming inconsistent with repo conventions, wrong indentation, import order
 - **Missing error handling**: Unhandled promise rejections, missing try/catch for I/O
 - **Unnecessary complexity**: Overly nested logic, duplicate code that could be simplified
-- **Truthiness gotchas** (JS/TS only): Flag `!obj.prop` when the intent is to check for `false` specifically but `undefined` would also match; flag `=== false` when `!prop` would suffice and `undefined` is not a concern; flag boolean coercion of values that could be `0`, `""`, or `null` where the intent is only to check for `undefined`
+- **Truthiness gotchas** (JS/TS only):
+  - Flag `!obj.prop` when the intent is to check for `false` specifically but `undefined` would also match
+  - Flag `=== false` when `!prop` would suffice and `undefined` is not a concern
+  - Flag boolean coercion of values that could be `0`, `""`, or `null` where the intent is only to check for `undefined`
 
 ### Minor (nice to have)
 - **Readability**: Unclear variable names, missing context in complex logic
@@ -182,7 +185,10 @@ If the diff includes changes to README, docs, JSDoc, or code comments:
 
 1. **Cross-reference claims against code** — For each factual statement (e.g., "X is automatically disabled when Y"), verify that the actual code implements that behavior
 2. **Check option descriptions match defaults** — Don't say "Enable X" for a feature that's on by default; use "Disable X" or "Control whether X is enabled (default: on)"
-3. **Flag stale documentation** — If code behavior changed but docs describing that behavior weren't updated
+
+Regardless of whether docs were changed:
+
+3. **Flag stale documentation** — If code behavior changed (new defaults, renamed options, removed features, changed signatures), check whether any docs, README sections, JSDoc, or inline comments on the changed functions describe that behavior and need updating
 
 ## Phase 5: Consolidated Report
 
@@ -207,7 +213,7 @@ Present findings in this format:
 - {test assertion strength concerns, if any}
 
 ### Documentation Accuracy
-- {any doc/README claims that don't match the code, if docs were changed}
+- {any doc/README claims that don't match the code, or stale docs not updated after code changes}
 
 ### Convention Alignment
 - {any style/convention mismatches with the target repo}

--- a/workflows/pre-commit-review.md
+++ b/workflows/pre-commit-review.md
@@ -112,10 +112,14 @@ Task(pr-review-toolkit:code-reviewer,
      scan existing APIs in the same module for naming patterns. Flag double-negative boolean
      names (e.g., nonInteractive when the codebase uses positive booleans like interactive).
    - JS/TS truthiness: Flag !obj.prop when the intent is to check for false specifically
-     but undefined would also match. Flag === false vs !prop inconsistencies.
+     but undefined would also match. Flag === false vs !prop inconsistencies. Flag boolean
+     coercion of values that could be 0, "", or null where the intent is only to check
+     for undefined.
    - Documentation accuracy: If docs/README/JSDoc are changed, cross-reference factual claims
-     against the actual code. Flag 'automatically disabled when X' claims that aren't
-     implemented in code.
+     against the actual code. Check that option descriptions match defaults (don't say
+     "Enable X" for a feature that's on by default). If code behavior changed but docs
+     were NOT changed, flag any docs/JSDoc/comments on the changed functions that describe
+     the old behavior.
 
    Diff:
    {git diff output}")
@@ -221,11 +225,11 @@ After all agents complete, merge their outputs into a unified report. Deduplicat
 ### Minor ({count}) — Nice to have
 - **{file}:{line}** — {description}
 
-### Test Coverage & Assertion Quality
+### Test Coverage & Quality
 - {assessment from pr-test-analyzer, including assertion strength concerns}
 
 ### Documentation Accuracy
-- {any doc/README claims that don't match the code, if docs were changed}
+- {any doc/README claims that don't match the code, or stale docs not updated after code changes}
 
 ### Convention Alignment
 - {any style/convention/naming mismatches}


### PR DESCRIPTION
## Summary
Follow-up to PR #466 (issue #432). The 3-agent review loop caught several issues in the pre-commit review instruction files:

- **HIGH: Stale documentation detection was gated behind conditional** — Phase 4.5's "flag stale documentation" check (item 3) was nested under "If the diff includes changes to docs..." meaning it was silently skipped when code changed but docs were NOT updated — the exact scenario it's designed to catch. Now unconditional with explicit "Regardless of whether docs were changed:" separator.
- **Workflow missing checks** — Added the missing third truthiness scenario (boolean coercion of `0`, `""`, `null`) and two missing doc accuracy checks (option descriptions match defaults, stale docs when code changes) to the workflow's code-reviewer prompt.
- **Terminology inconsistency** — Standardized from three different names ("Test Coverage & Quality", "Test Coverage & Assertion Quality", "Test Coverage and Quality Assessment") to "Test Coverage & Quality" in all report templates.
- **Dense truthiness bullet** — Split from one run-on semicolon-separated bullet into three sub-bullets for readability.

## Test plan
- [x] `pnpm test` — all 1,546 tests pass (markdown-only changes, no code impact)
- [x] Verified both files use consistent section names via grep
- [x] Verified all three doc accuracy checks present in workflow via grep
- [x] Re-ran 3-agent review loop on the fixes — all clean