### PR TITLE
fix: auto-undismiss PRs on new activity and re-throw commit date rate limits

### DIFF
--- a/packages/core/src/commands/daily-orchestration.test.ts
+++ b/packages/core/src/commands/daily-orchestration.test.ts
@@ -562,29 +562,23 @@ describe('executeDailyCheck() — snoozed PR filtering', () => {
 // executeDailyCheck() — dismissed PR URL filtering (#416)
 // ---------------------------------------------------------------------------
 
-describe('executeDailyCheck() — dismissed PR URL filtering (#416)', () => {
-  it('excludes dismissed PR URLs from actionableIssues', async () => {
-    const dismissedPR = makePR({ repo: 'owner/repo', number: 1, status: 'needs_response' });
+describe('executeDailyCheck() — dismissed PR URL filtering (#416, #468)', () => {
+  it('excludes dismissed PR URLs from actionableIssues when no new activity', async () => {
+    // Dismissed AFTER the PR's last activity — should stay dismissed
+    const dismissedPR = makePR({
+      repo: 'owner/repo',
+      number: 1,
+      status: 'needs_response',
+      updatedAt: '2026-01-10T00:00:00Z',
+    });
     const activePR = makePR({ repo: 'owner/repo', number: 2, status: 'needs_response' });
     mockFetchUserOpenPRs.mockResolvedValue({ prs: [dismissedPR, activePR], failures: [] });
     mockGenerateDigest.mockReturnValue(makeDigest([dismissedPR, activePR]));
     mockIsPRShelved.mockReturnValue(false);
 
-    mockGetState.mockReturnValue(
-      makeDefaultState({
-        config: {
-          setupComplete: true,
-          githubUsername: 'testuser',
-          maxActivePRs: 10,
-          languages: [],
-          labels: [],
-          excludeRepos: [],
-          trustedProjects: [],
-          shelvedPRUrls: [],
-          dismissedIssues: { [dismissedPR.url]: '2026-01-01T00:00:00Z' },
-          snoozedPRs: {},
-        },
-      }),
+    // Return dismiss timestamp only for the dismissed PR
+    mockGetIssueDismissedAt.mockImplementation((url: string) =>
+      url === dismissedPR.url ? '2026-01-15T00:00:00Z' : undefined,
     );
 
     const result = await executeDailyCheck('test-token');
@@ -592,6 +586,34 @@ describe('executeDailyCheck() — dismissed PR URL filtering (#416)', () => {
     const needsResponseIssues = result.actionableIssues.filter((i) => i.type === 'needs_response');
     expect(needsResponseIssues).toHaveLength(1);
     expect(needsResponseIssues[0].prUrl).toBe(activePR.url);
+    expect(mockUndismissIssue).not.toHaveBeenCalledWith(dismissedPR.url);
+  });
+
+  it('auto-undismisses PR when new activity arrives after dismiss timestamp (#468)', async () => {
+    // PR updated AFTER dismiss — should auto-undismiss and resurface
+    const dismissedPR = makePR({
+      repo: 'owner/repo',
+      number: 1,
+      status: 'needs_response',
+      updatedAt: '2026-02-01T00:00:00Z',
+    });
+    mockFetchUserOpenPRs.mockResolvedValue({ prs: [dismissedPR], failures: [] });
+    mockGenerateDigest.mockReturnValue(makeDigest([dismissedPR]));
+    mockIsPRShelved.mockReturnValue(false);
+
+    // Return dismiss timestamp for the dismissed PR
+    mockGetIssueDismissedAt.mockImplementation((url: string) =>
+      url === dismissedPR.url ? '2026-01-15T00:00:00Z' : undefined,
+    );
+
+    const result = await executeDailyCheck('test-token');
+
+    // PR should be included (auto-undismissed)
+    const needsResponseIssues = result.actionableIssues.filter((i) => i.type === 'needs_response');
+    expect(needsResponseIssues).toHaveLength(1);
+    expect(needsResponseIssues[0].prUrl).toBe(dismissedPR.url);
+    expect(mockUndismissIssue).toHaveBeenCalledWith(dismissedPR.url);
+    expect(mockSave).toHaveBeenCalled();
   });
 });
 

--- a/packages/core/src/commands/daily.ts
+++ b/packages/core/src/commands/daily.ts
@@ -445,14 +445,16 @@ function generateDigestOutput(
       const responseTime = new Date(issue.lastResponseAt).getTime();
       const dismissTime = new Date(dismissedAt).getTime();
       if (isNaN(responseTime) || isNaN(dismissTime)) {
-        // Invalid timestamp — fail open (include issue to be safe)
+        // Invalid timestamp — fail open (include issue to be safe) without
+        // permanently removing dismiss record (may be a transient data issue)
         console.error(`[DAILY] Invalid timestamp in dismiss check for ${issue.url}, including issue`);
-        stateManager.undismissIssue(issue.url);
-        hasAutoUndismissed = true;
         return true;
       }
       if (responseTime > dismissTime) {
         // New activity after dismiss — auto-undismiss and resurface
+        console.error(
+          `[DAILY] Auto-undismissing issue ${issue.url}: new response at ${issue.lastResponseAt} after dismiss at ${dismissedAt}`,
+        );
         stateManager.undismissIssue(issue.url);
         hasAutoUndismissed = true;
         return true;
@@ -461,9 +463,6 @@ function generateDigestOutput(
     // Still dismissed (last response is at or before dismiss timestamp)
     return false;
   });
-  if (hasAutoUndismissed) {
-    stateManager.save();
-  }
 
   const issueResponses = filteredCommentedIssues.filter(
     (i): i is CommentedIssueWithResponse => i.status === 'new_response',
@@ -472,9 +471,39 @@ function generateDigestOutput(
   const snoozedUrls = new Set(
     Object.keys(stateManager.getState().config.snoozedPRs ?? {}).filter((url) => stateManager.isSnoozed(url)),
   );
-  // Filter dismissed PR URLs from actionable issues (#416)
-  const dismissedUrls = new Set(Object.keys(stateManager.getState().config.dismissedIssues ?? {}));
-  const nonDismissedPRs = activePRs.filter((pr) => !dismissedUrls.has(pr.url));
+  // Filter dismissed PRs: suppress if dismissed after last activity, auto-undismiss if new activity (#416, #468)
+  const nonDismissedPRs = activePRs.filter((pr) => {
+    const dismissedAt = stateManager.getIssueDismissedAt(pr.url);
+    if (!dismissedAt) return true; // Not dismissed — include
+    const activityTime = new Date(pr.updatedAt).getTime();
+    const dismissTime = new Date(dismissedAt).getTime();
+    if (isNaN(activityTime) || isNaN(dismissTime)) {
+      // Invalid timestamp — fail open (include PR to be safe) without
+      // permanently removing dismiss record (may be a transient data issue)
+      console.error(`[DAILY] Invalid timestamp in PR dismiss check for ${pr.url}, including PR`);
+      return true;
+    }
+    if (activityTime > dismissTime) {
+      // New activity after dismiss — auto-undismiss and resurface
+      console.error(
+        `[DAILY] Auto-undismissing PR ${pr.url}: new activity at ${pr.updatedAt} after dismiss at ${dismissedAt}`,
+      );
+      stateManager.undismissIssue(pr.url);
+      hasAutoUndismissed = true;
+      return true;
+    }
+    // Still dismissed (last activity is at or before dismiss timestamp)
+    return false;
+  });
+
+  // Persist auto-undismiss state changes (issue + PR combined into one save)
+  if (hasAutoUndismissed) {
+    try {
+      stateManager.save();
+    } catch (error) {
+      console.error('[DAILY] Failed to persist auto-undismissed state:', errorMessage(error));
+    }
+  }
   const actionableIssues = collectActionableIssues(nonDismissedPRs, snoozedUrls);
   digest.summary.totalNeedingAttention = actionableIssues.length;
   const briefSummary = formatBriefSummary(digest, actionableIssues.length, issueResponses.length);

--- a/packages/core/src/core/pr-monitor.test.ts
+++ b/packages/core/src/core/pr-monitor.test.ts
@@ -3205,3 +3205,115 @@ describe('review comment fetch error handling (#229)', () => {
     errorSpy.mockRestore();
   });
 });
+
+describe('commitDatePromise error handling (#469)', () => {
+  const prUrl = 'https://github.com/owner/repo/pull/1';
+
+  const makeSearchItem = (url: string) => ({
+    html_url: url,
+    title: 'Test PR',
+    pull_request: { html_url: url },
+    created_at: '2026-02-01T00:00:00Z',
+    updated_at: '2026-02-07T00:00:00Z',
+  });
+
+  /** Build mocks where repos.getCommit fails with the given error, and reviews trigger needCommitDate */
+  const makeMocksWithCommitDateError = (error: { status?: number; message?: string }) => {
+    const err = Object.assign(new Error(error.message ?? 'Request failed'), { status: error.status });
+    return {
+      search: {
+        issuesAndPullRequests: vi.fn().mockResolvedValue({
+          data: { total_count: 1, items: [makeSearchItem(prUrl)] },
+        }),
+      },
+      pulls: {
+        get: vi.fn().mockResolvedValue({
+          data: {
+            id: 1,
+            title: 'Test PR',
+            created_at: '2026-02-01T00:00:00Z',
+            updated_at: '2026-02-07T00:00:00Z',
+            head: { sha: 'abc123' },
+            mergeable: true,
+            mergeable_state: 'clean',
+            body: '',
+            draft: false,
+            review_comments: 0,
+            commits: 1,
+          },
+        }),
+        // Return CHANGES_REQUESTED review to trigger needCommitDate
+        listReviews: vi.fn().mockResolvedValue({
+          data: [{ state: 'CHANGES_REQUESTED', user: { login: 'reviewer' }, submitted_at: '2026-02-05T00:00:00Z' }],
+        }),
+        listReviewComments: vi.fn().mockResolvedValue({ data: [] }),
+      },
+      issues: {
+        listComments: vi.fn().mockResolvedValue({ data: [] }),
+      },
+      repos: {
+        getCombinedStatusForRef: vi.fn().mockResolvedValue({
+          data: { state: 'success', statuses: [] },
+        }),
+        getCommit: vi.fn().mockRejectedValue(err),
+      },
+      checks: {
+        listForRef: vi.fn().mockResolvedValue({ data: { check_runs: [] } }),
+      },
+    };
+  };
+
+  beforeEach(() => {
+    vi.mocked(getStateManager).mockReturnValue({
+      getState: () => ({
+        config: {
+          githubUsername: 'testuser',
+          excludeRepos: [],
+          excludeOrgs: [],
+          shelvedPRUrls: [],
+          dormantThresholdDays: 30,
+          approachingDormantDays: 25,
+        },
+      }),
+    } as any);
+  });
+
+  it('should re-throw 429 rate limit error from getCommit (surfaces in failures)', async () => {
+    mockOctokitInstance = makeMocksWithCommitDateError({ status: 429, message: 'rate limit exceeded' });
+
+    const monitor = new PRMonitor('fake-token');
+    const { prs, failures } = await monitor.fetchUserOpenPRs();
+
+    // Rate limit error should propagate and appear in failures
+    expect(prs).toHaveLength(0);
+    expect(failures).toHaveLength(1);
+    expect(failures[0].error).toContain('rate limit exceeded');
+  });
+
+  it('should re-throw 403 rate limit error from getCommit (surfaces in failures)', async () => {
+    mockOctokitInstance = makeMocksWithCommitDateError({ status: 403, message: 'API rate limit exceeded' });
+
+    const monitor = new PRMonitor('fake-token');
+    const { prs, failures } = await monitor.fetchUserOpenPRs();
+
+    expect(prs).toHaveLength(0);
+    expect(failures).toHaveLength(1);
+    expect(failures[0].error).toContain('API rate limit exceeded');
+  });
+
+  it('should degrade gracefully on non-rate-limit errors from getCommit', async () => {
+    mockOctokitInstance = makeMocksWithCommitDateError({ status: 500, message: 'Internal Server Error' });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const monitor = new PRMonitor('fake-token');
+    const { prs } = await monitor.fetchUserOpenPRs();
+
+    // PR should still be returned — non-rate-limit error is gracefully degraded
+    expect(prs).toHaveLength(1);
+    expect(prs[0].url).toBe(prUrl);
+    // Warn path should have been exercised (routes through console.error via logger.warn)
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to fetch commit date'));
+
+    errorSpy.mockRestore();
+  });
+});

--- a/packages/core/src/core/pr-monitor.ts
+++ b/packages/core/src/core/pr-monitor.ts
@@ -276,7 +276,27 @@ export class PRMonitor {
       ? this.octokit.repos
           .getCommit({ owner, repo, ref: ghPR.head.sha })
           .then((res) => res.data.commit.author?.date)
-          .catch(() => undefined)
+          .catch((err: unknown) => {
+            // Rate limit errors must propagate — silently swallowing them produces
+            // misleading status (e.g. needs_changes when changes were addressed) (#469).
+            const status = getHttpStatusCode(err);
+            if (status === 429) throw err;
+            if (status === 403) {
+              const msg = errorMessage(err).toLowerCase();
+              if (msg.includes('rate limit') || msg.includes('abuse detection')) throw err;
+              // Non-rate-limit 403 (DMCA, private repo, SSO) — degrade gracefully
+              warn(
+                'pr-monitor',
+                `403 fetching commit date for ${owner}/${repo}@${ghPR.head.sha.slice(0, 7)}: ${errorMessage(err)}`,
+              );
+              return undefined;
+            }
+            warn(
+              'pr-monitor',
+              `Failed to fetch commit date for ${owner}/${repo}@${ghPR.head.sha.slice(0, 7)}: ${errorMessage(err)}`,
+            );
+            return undefined;
+          })
       : Promise.resolve(undefined);
 
     const [{ status: ciStatus, failingCheckNames, failingCheckConclusions }, latestCommitDate] = await Promise.all([


### PR DESCRIPTION
## Summary

- **#468**: Dismissed PRs now auto-undismiss when `updatedAt` is after the dismiss timestamp, matching the existing issue dismiss auto-resurface logic. Previously dismissed PRs were permanently muted regardless of new maintainer activity.
- **#469**: `commitDatePromise` catch block now re-throws rate limit errors (429 and 403 rate limit), matching the `reviewComments` catch pattern. Previously all errors were silently swallowed, causing incorrect PR status when rate limited.
- Merged issue + PR auto-undismiss saves into one guarded `try/catch` call (avoids redundant disk I/O and prevents save failures from aborting the daily check)
- Invalid-timestamp path now fails open without permanently removing the dismiss record
- Added debug logging for auto-undismiss events

## Test plan

- [x] New test: PR auto-undismiss when activity > dismiss timestamp
- [x] Updated test: dismissed PR stays dismissed when activity <= dismiss timestamp
- [x] New test: 429 rate limit on getCommit propagates to failures
- [x] New test: 403 rate limit on getCommit propagates to failures
- [x] New test: 500 on getCommit degrades gracefully with warning assertion
- [x] All 1,551 tests pass

Closes #468, closes #469