### PR TITLE
fix: remove AskUserQuestion from allowed-tools to restore interactive picker

### DIFF
--- a/agents/contribution-strategist.md
+++ b/agents/contribution-strategist.md
@@ -40,7 +40,7 @@ User wants help with goal-setting.
 
 model: inherit
 color: magenta
-tools: ["Bash", "Read", "Write", "AskUserQuestion", "mcp__*"]
+tools: ["Bash", "Read", "Write", "mcp__*"]
 ---
 
 > **Input validation:** The "AskUserQuestion Validation Protocol" from `commands/oss.md` applies to ALL `AskUserQuestion` calls in this agent. After every call, check for empty/missing answers and fall back to text-based input if the picker auto-completed.

--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -22,7 +22,7 @@ User wants to evaluate a specific issue before investing time.
 
 model: inherit
 color: green
-tools: ["Bash", "Read", "Write", "AskUserQuestion", "mcp__*"]
+tools: ["Bash", "Read", "Write", "mcp__*"]
 ---
 
 > **Input validation:** The "AskUserQuestion Validation Protocol" from `commands/oss.md` applies to ALL `AskUserQuestion` calls in this agent. After every call, check for empty/missing answers and fall back to text-based input if the picker auto-completed.

--- a/agents/pr-compliance-checker.md
+++ b/agents/pr-compliance-checker.md
@@ -31,7 +31,7 @@ User wants pre-submission guidance on PR quality.
 
 model: inherit
 color: orange
-tools: ["Bash", "Read", "Glob", "Grep", "WebFetch", "AskUserQuestion", "mcp__*"]
+tools: ["Bash", "Read", "Glob", "Grep", "WebFetch", "mcp__*"]
 ---
 
 > **Input validation:** The "AskUserQuestion Validation Protocol" from `commands/oss.md` applies to ALL `AskUserQuestion` calls in this agent. After every call, check for empty/missing answers and fall back to text-based input if the picker auto-completed.

--- a/agents/pr-health-checker.md
+++ b/agents/pr-health-checker.md
@@ -31,7 +31,7 @@ Merge conflicts are a health issue this agent handles.
 
 model: inherit
 color: yellow
-tools: ["Bash", "Read", "Write", "Grep", "AskUserQuestion", "mcp__*"]
+tools: ["Bash", "Read", "Write", "Grep", "mcp__*"]
 ---
 
 > **Input validation:** The "AskUserQuestion Validation Protocol" from `commands/oss.md` applies to ALL `AskUserQuestion` calls in this agent. After every call, check for empty/missing answers and fall back to text-based input if the picker auto-completed.

--- a/agents/pr-responder.md
+++ b/agents/pr-responder.md
@@ -22,7 +22,7 @@ User needs help understanding and responding to a specific code review comment.
 
 model: inherit
 color: cyan
-tools: ["Bash", "Read", "Glob", "Grep", "AskUserQuestion", "mcp__*"]
+tools: ["Bash", "Read", "Glob", "Grep", "mcp__*"]
 ---
 
 > **Input validation:** The "AskUserQuestion Validation Protocol" from `commands/oss.md` applies to ALL `AskUserQuestion` calls in this agent. After every call, check for empty/missing answers and fall back to text-based input if the picker auto-completed.

--- a/agents/pre-commit-reviewer.md
+++ b/agents/pre-commit-reviewer.md
@@ -22,7 +22,7 @@ Post-conflict resolution is a critical moment where bugs can be introduced. Revi
 
 model: inherit
 color: red
-tools: ["Bash", "Read", "Glob", "Grep", "AskUserQuestion", "mcp__*"]
+tools: ["Bash", "Read", "Glob", "Grep", "mcp__*"]
 ---
 
 > **Input validation:** The "AskUserQuestion Validation Protocol" from `commands/oss.md` applies to ALL `AskUserQuestion` calls in this agent. After every call, check for empty/missing answers and fall back to text-based input if the picker auto-completed.

--- a/agents/repo-evaluator.md
+++ b/agents/repo-evaluator.md
@@ -22,7 +22,7 @@ User wants to predict maintainer engagement before contributing.
 
 model: inherit
 color: blue
-tools: ["Bash", "Read", "Write", "Glob", "AskUserQuestion", "mcp__*"]
+tools: ["Bash", "Read", "Write", "Glob", "mcp__*"]
 ---
 
 > **Input validation:** The "AskUserQuestion Validation Protocol" from `commands/oss.md` applies to ALL `AskUserQuestion` calls in this agent. After every call, check for empty/missing answers and fall back to text-based input if the picker auto-completed.

--- a/commands/oss-search.md
+++ b/commands/oss-search.md
@@ -1,7 +1,7 @@
 ---
 name: oss-search
 description: "Search for new open source issues to contribute to — parallel multi-strategy search with vetting"
-allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion, Task, mcp__*
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Task, mcp__*
 ---
 
 # OSS Issue Search

--- a/commands/oss.md
+++ b/commands/oss.md
@@ -1,7 +1,7 @@
 ---
 name: oss
 description: "Daily OSS contribution check - uses CLI with --json for structured data"
-allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion, Task, mcp__*
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Task, mcp__*
 ---
 
 # OSS Autopilot Daily Check

--- a/commands/setup-oss.md
+++ b/commands/setup-oss.md
@@ -1,7 +1,7 @@
 ---
 name: setup-oss
 description: Configure OSS autopilot preferences
-allowed-tools: Bash, Write, Read, Glob, AskUserQuestion, mcp__*
+allowed-tools: Bash, Write, Read, Glob, mcp__*
 ---
 
 # OSS Autopilot Setup


### PR DESCRIPTION
## Summary
- Remove `AskUserQuestion` from `allowed-tools` in all command and agent frontmatter files (10 files)
- This fixes the interactive picker never rendering because the permission system auto-approves it when listed in `allowed-tools`

## Test plan
- [x] Verify no remaining `AskUserQuestion` in any `allowed-tools` or `tools:` frontmatter
- [x] All 1500 tests pass
- [x] AskUserQuestion references in workflow/documentation content are preserved (only tool declarations removed)

Fixes #503