### PR TITLE
fix: prevent self-reply filter from silencing maintainer follow-up questions

### DIFF
--- a/packages/core/src/core/review-analysis.test.ts
+++ b/packages/core/src/core/review-analysis.test.ts
@@ -113,6 +113,69 @@ describe('isAllSelfReplies', () => {
     expect(result).toBe(true);
   });
 
+  it('should return false when self-reply contains a question mark (#498)', () => {
+    const result = isAllSelfReplies(200, [
+      {
+        id: 1000,
+        user: { login: 'maintainer' },
+        body: "Shouldn't this be part of the previous condition only?",
+        created_at: '2026-02-07T10:00:00Z',
+        pull_request_review_id: 100,
+      },
+      {
+        id: 1001,
+        user: { login: 'maintainer' },
+        body: 'Could you please elaborate on this?',
+        created_at: '2026-02-25T10:00:00Z',
+        in_reply_to_id: 1000,
+        pull_request_review_id: 200,
+      },
+    ]);
+    expect(result).toBe(false);
+  });
+
+  it('should return false when self-reply has null body (#498)', () => {
+    const result = isAllSelfReplies(200, [
+      {
+        id: 1000,
+        user: { login: 'maintainer' },
+        body: 'Original comment',
+        created_at: '2026-02-07T10:00:00Z',
+        pull_request_review_id: 100,
+      },
+      {
+        id: 1001,
+        user: { login: 'maintainer' },
+        body: null,
+        created_at: '2026-02-07T11:00:00Z',
+        in_reply_to_id: 1000,
+        pull_request_review_id: 200,
+      },
+    ]);
+    expect(result).toBe(false);
+  });
+
+  it('should return true when self-reply has no question mark', () => {
+    const result = isAllSelfReplies(200, [
+      {
+        id: 1000,
+        user: { login: 'maintainer' },
+        body: 'Original comment',
+        created_at: '2026-02-07T10:00:00Z',
+        pull_request_review_id: 100,
+      },
+      {
+        id: 1001,
+        user: { login: 'maintainer' },
+        body: 'Actually, I meant the other file too.',
+        created_at: '2026-02-07T11:00:00Z',
+        in_reply_to_id: 1000,
+        pull_request_review_id: 200,
+      },
+    ]);
+    expect(result).toBe(true);
+  });
+
   it('should be case-insensitive when checking authors', () => {
     const result = isAllSelfReplies(200, [
       {
@@ -222,6 +285,42 @@ describe('checkUnrespondedComments', () => {
     expect(result.hasUnrespondedComment).toBe(true);
     expect(result.lastMaintainerComment?.author).toBe('reviewer');
     expect(result.lastMaintainerComment?.body).toBe('(requested changes via inline review comments)');
+  });
+
+  it('should detect maintainer self-reply with question as needing response (#498)', () => {
+    const reviewComments = [
+      {
+        id: 1000,
+        user: { login: 'stefan6419846' },
+        body: "Shouldn't this be part of the previous condition only?",
+        created_at: '2026-02-08T10:00:00Z',
+        pull_request_review_id: 100,
+      },
+      {
+        id: 1001,
+        user: { login: 'stefan6419846' },
+        body: 'Could you please elaborate on this?',
+        created_at: '2026-02-25T10:00:00Z',
+        in_reply_to_id: 1000,
+        pull_request_review_id: 300,
+      },
+    ];
+    const result = checkUnrespondedComments(
+      [],
+      [
+        {
+          user: { login: 'stefan6419846' },
+          body: '',
+          submitted_at: '2026-02-25T10:00:00Z',
+          state: 'COMMENTED',
+          id: 300,
+        },
+      ],
+      reviewComments,
+      'prauthor',
+    );
+    expect(result.hasUnrespondedComment).toBe(true);
+    expect(result.lastMaintainerComment?.author).toBe('stefan6419846');
   });
 
   it('should be case-insensitive for username matching', () => {

--- a/packages/core/src/core/review-analysis.ts
+++ b/packages/core/src/core/review-analysis.ts
@@ -92,7 +92,14 @@ export function isAllSelfReplies(reviewId: number, reviewComments: ReviewComment
     if (!comment.in_reply_to_id) return false; // New thread, not a reply
     const parentAuthor = authorMap.get(comment.in_reply_to_id);
     const commentAuthor = comment.user?.login?.toLowerCase();
-    return parentAuthor != null && commentAuthor != null && parentAuthor === commentAuthor;
+    if (parentAuthor == null || commentAuthor == null || parentAuthor !== commentAuthor) return false;
+    // A self-reply containing a question mark is likely a follow-up question
+    // directed at the PR author, not an informational addendum (#498).
+    // Null/empty body on a self-reply is anomalous — surface it rather than
+    // silently filtering, since the safe direction is to notify.
+    if (!comment.body) return false;
+    if (comment.body.includes('?')) return false;
+    return true;
   });
 }
 


### PR DESCRIPTION
## Summary
- `isAllSelfReplies()` now checks the comment body for question marks — self-replies containing `?` are treated as follow-up questions rather than informational addendums
- Null/empty body self-replies are surfaced rather than silently filtered (safe direction)
- 4 new tests covering the question-mark heuristic, null body edge case, and end-to-end integration through `checkUnrespondedComments`

## Root cause
The self-reply filter only checked authorship (same person wrote parent and reply) but not intent. A maintainer replying to their own thread to ask "Could you please elaborate?" was silently filtered, causing the PR author to miss follow-up questions.

## Test plan
- [x] 28 review-analysis tests pass (was 24, +4 new)
- [x] Full suite: 1401 tests pass
- [x] PR review toolkit: code-reviewer, silent-failure-hunter, code-simplifier — no critical findings

Fixes #498