### PR TITLE
fix: filter dismissed PRs from dashboard Action Required section

### DIFF
--- a/packages/core/src/commands/dashboard-server.test.ts
+++ b/packages/core/src/commands/dashboard-server.test.ts
@@ -59,6 +59,8 @@ const mockStateManager = {
   unshelvePR: vi.fn().mockReturnValue(true),
   snoozePR: vi.fn().mockReturnValue(true),
   unsnoozePR: vi.fn().mockReturnValue(true),
+  dismissIssue: vi.fn().mockReturnValue(true),
+  undismissIssue: vi.fn().mockReturnValue(false),
 };
 
 // Create a temp dir for PID file tests (needs to exist before mock is evaluated)

--- a/packages/core/src/commands/dashboard-server.ts
+++ b/packages/core/src/commands/dashboard-server.ts
@@ -11,7 +11,13 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { getStateManager, getGitHubToken, getDataDir } from '../core/index.js';
 import { errorMessage, ValidationError } from '../core/errors.js';
-import { validateUrl, validateGitHubUrl, validateMessage, PR_URL_PATTERN } from './validation.js';
+import {
+  validateUrl,
+  validateGitHubUrl,
+  validateMessage,
+  PR_URL_PATTERN,
+  ISSUE_OR_PR_URL_PATTERN,
+} from './validation.js';
 import {
   fetchDashboardData,
   computePRsByRepo,
@@ -56,6 +62,7 @@ interface DashboardJsonData {
   monthlyClosed: Record<string, number>;
   activePRs: FetchedPR[];
   shelvedPRUrls: string[];
+  dismissedUrls: string[];
   recentlyMergedPRs: MergedPR[];
   recentlyClosedPRs: ClosedPR[];
   autoUnshelvedPRs: ShelvedPRRef[];
@@ -66,7 +73,7 @@ interface DashboardJsonData {
 }
 
 interface ActionRequest {
-  action: 'shelve' | 'unshelve' | 'snooze' | 'unsnooze';
+  action: 'shelve' | 'unshelve' | 'snooze' | 'unsnooze' | 'dismiss' | 'undismiss';
   url: string;
   reason?: string;
   days?: number;
@@ -74,7 +81,14 @@ interface ActionRequest {
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
-const VALID_ACTIONS: Set<ActionRequest['action']> = new Set(['shelve', 'unshelve', 'snooze', 'unsnooze']);
+const VALID_ACTIONS: Set<ActionRequest['action']> = new Set([
+  'shelve',
+  'unshelve',
+  'snooze',
+  'unsnooze',
+  'dismiss',
+  'undismiss',
+]);
 
 const MAX_BODY_BYTES = 10_240;
 
@@ -203,6 +217,7 @@ function buildDashboardJson(
     monthlyClosed,
     activePRs: digest.openPRs || [],
     shelvedPRUrls: state.config.shelvedPRUrls || [],
+    dismissedUrls: Object.keys(state.config.dismissedIssues || {}),
     recentlyMergedPRs: digest.recentlyMergedPRs || [],
     recentlyClosedPRs: digest.recentlyClosedPRs || [],
     autoUnshelvedPRs: digest.autoUnshelvedPRs || [],
@@ -348,10 +363,14 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
       return;
     }
 
-    // Validate URL format — same checks as CLI commands
+    // Validate URL format — same checks as CLI commands.
+    // Dismiss/undismiss accepts both PR and issue URLs; other actions are PR-only.
+    const isDismissAction = body.action === 'dismiss' || body.action === 'undismiss';
+    const urlPattern = isDismissAction ? ISSUE_OR_PR_URL_PATTERN : PR_URL_PATTERN;
+    const urlType = isDismissAction ? 'issue or PR' : 'PR';
     try {
       validateUrl(body.url);
-      validateGitHubUrl(body.url, PR_URL_PATTERN, 'PR');
+      validateGitHubUrl(body.url, urlPattern, urlType);
     } catch (err) {
       if (err instanceof ValidationError) {
         sendError(res, 400, err.message);
@@ -388,6 +407,7 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
       switch (body.action) {
         case 'shelve':
           stateManager.shelvePR(body.url);
+          stateManager.undismissIssue(body.url); // prevent dual state
           break;
         case 'unshelve':
           stateManager.unshelvePR(body.url);
@@ -397,6 +417,13 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
           break;
         case 'unsnooze':
           stateManager.unsnoozePR(body.url);
+          break;
+        case 'dismiss':
+          stateManager.dismissIssue(body.url, new Date().toISOString());
+          stateManager.unshelvePR(body.url); // prevent dual state
+          break;
+        case 'undismiss':
+          stateManager.undismissIssue(body.url);
           break;
       }
       stateManager.save();

--- a/packages/dashboard/src/app.tsx
+++ b/packages/dashboard/src/app.tsx
@@ -14,6 +14,7 @@ export function App() {
   const [selectedUrl, setSelectedUrl] = useState<string | null>(null);
 
   const shelvedUrls = useMemo(() => new Set(data?.shelvedPRUrls ?? []), [data?.shelvedPRUrls]);
+  const dismissedUrls = useMemo(() => new Set(data?.dismissedUrls ?? []), [data?.dismissedUrls]);
 
   if (loading && !data) {
     return (
@@ -79,11 +80,18 @@ export function App() {
         <FilterBar filters={filters} onFilterChange={setFilters} repos={repos} statuses={statuses} />
 
         <div class="dashboard-content">
-          <PRList prs={filteredPRs} selectedUrl={selectedUrl} onSelect={setSelectedUrl} shelvedUrls={shelvedUrls} />
+          <PRList
+            prs={filteredPRs}
+            selectedUrl={selectedUrl}
+            onSelect={setSelectedUrl}
+            shelvedUrls={shelvedUrls}
+            dismissedUrls={dismissedUrls}
+          />
           {selectedPR && (
             <PRDetail
               pr={selectedPR}
               isShelved={shelvedUrls.has(selectedPR.url)}
+              isDismissed={dismissedUrls.has(selectedPR.url)}
               onAction={performAction}
               onClose={() => setSelectedUrl(null)}
             />

--- a/packages/dashboard/src/components/action-bar.tsx
+++ b/packages/dashboard/src/components/action-bar.tsx
@@ -4,10 +4,11 @@ import type { FetchedPR, ActionRequest } from '../types';
 interface ActionBarProps {
   pr: FetchedPR;
   isShelved: boolean;
+  isDismissed: boolean;
   onAction: (action: ActionRequest) => Promise<void>;
 }
 
-export function ActionBar({ pr, isShelved, onAction }: ActionBarProps) {
+export function ActionBar({ pr, isShelved, isDismissed, onAction }: ActionBarProps) {
   const [snoozeOpen, setSnoozeOpen] = useState(false);
   const [snoozeReason, setSnoozeReason] = useState('');
   const [snoozeDays, setSnoozeDays] = useState(1);
@@ -43,6 +44,19 @@ export function ActionBar({ pr, isShelved, onAction }: ActionBarProps) {
         }
       >
         {isShelved ? 'Unshelve' : 'Shelve'}
+      </button>
+
+      <button
+        class={`action-btn ${isDismissed ? 'action-btn--unshelve' : 'action-btn--shelve'}`}
+        disabled={busy}
+        onClick={() =>
+          handleAction({
+            action: isDismissed ? 'undismiss' : 'dismiss',
+            url: pr.url,
+          })
+        }
+      >
+        {isDismissed ? 'Undismiss' : 'Dismiss'}
       </button>
 
       {pr.ciStatus === 'failing' && (

--- a/packages/dashboard/src/components/pr-detail.tsx
+++ b/packages/dashboard/src/components/pr-detail.tsx
@@ -5,6 +5,7 @@ import { ActionBar } from './action-bar';
 interface PRDetailProps {
   pr: FetchedPR;
   isShelved: boolean;
+  isDismissed: boolean;
   onAction: (action: ActionRequest) => Promise<void>;
   onClose: () => void;
 }
@@ -50,7 +51,7 @@ function categoryBadge(category: string): string {
   }
 }
 
-export function PRDetail({ pr, isShelved, onAction, onClose }: PRDetailProps) {
+export function PRDetail({ pr, isShelved, isDismissed, onAction, onClose }: PRDetailProps) {
   return (
     <div class="pr-detail">
       <div class="pr-detail-header">
@@ -156,7 +157,7 @@ export function PRDetail({ pr, isShelved, onAction, onClose }: PRDetailProps) {
         </div>
       </div>
 
-      <ActionBar pr={pr} isShelved={isShelved} onAction={onAction} />
+      <ActionBar pr={pr} isShelved={isShelved} isDismissed={isDismissed} onAction={onAction} />
     </div>
   );
 }

--- a/packages/dashboard/src/components/pr-list.tsx
+++ b/packages/dashboard/src/components/pr-list.tsx
@@ -7,6 +7,7 @@ interface PRListProps {
   selectedUrl: string | null;
   onSelect: (url: string) => void;
   shelvedUrls: Set<string>;
+  dismissedUrls: Set<string>;
 }
 
 /** Statuses that belong in the "Action Required" section. */
@@ -74,11 +75,13 @@ function Section({
   );
 }
 
-export function PRList({ prs, selectedUrl, onSelect, shelvedUrls }: PRListProps) {
+export function PRList({ prs, selectedUrl, onSelect, shelvedUrls, dismissedUrls }: PRListProps) {
   const [shelvedOpen, setShelvedOpen] = useState(false);
+  const [dismissedOpen, setDismissedOpen] = useState(false);
 
-  const activePRs = prs.filter((pr) => !shelvedUrls.has(pr.url));
+  const activePRs = prs.filter((pr) => !shelvedUrls.has(pr.url) && !dismissedUrls.has(pr.url));
   const shelvedPRs = prs.filter((pr) => shelvedUrls.has(pr.url));
+  const dismissedPRs = prs.filter((pr) => dismissedUrls.has(pr.url) && !shelvedUrls.has(pr.url));
 
   const sections: SectionDef[] = [
     {
@@ -103,10 +106,29 @@ export function PRList({ prs, selectedUrl, onSelect, shelvedUrls }: PRListProps)
 
   return (
     <div class="pr-list">
-      {sections.length === 0 && shelvedPRs.length === 0 && <p class="pr-list-empty">No PRs to display</p>}
+      {sections.length === 0 && shelvedPRs.length === 0 && dismissedPRs.length === 0 && (
+        <p class="pr-list-empty">No PRs to display</p>
+      )}
       {sections.map((section) => (
         <Section key={section.id} section={section} selectedUrl={selectedUrl} onSelect={onSelect} />
       ))}
+      {dismissedPRs.length > 0 && (
+        <div class="pr-section pr-section--shelved">
+          <h3
+            class="pr-section-header pr-section-header--collapsible"
+            style={{ borderLeftColor: 'var(--text-muted)' }}
+            onClick={() => setDismissedOpen(!dismissedOpen)}
+          >
+            <span class={`pr-section-chevron ${dismissedOpen ? 'pr-section-chevron--open' : ''}`}>&#9656;</span>
+            Dismissed
+            <span class="pr-section-count">{dismissedPRs.length}</span>
+          </h3>
+          {dismissedOpen &&
+            dismissedPRs.map((pr) => (
+              <PRRow key={pr.url} pr={pr} selected={pr.url === selectedUrl} onSelect={onSelect} />
+            ))}
+        </div>
+      )}
       {shelvedPRs.length > 0 && (
         <div class="pr-section pr-section--shelved">
           <h3

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -212,6 +212,7 @@ export interface DashboardData {
   monthlyClosed: Record<string, number>;
   activePRs: FetchedPR[];
   shelvedPRUrls: string[];
+  dismissedUrls: string[];
   recentlyMergedPRs: MergedPR[];
   recentlyClosedPRs: ClosedPR[];
   autoUnshelvedPRs: ShelvedPRRef[];
@@ -222,7 +223,7 @@ export interface DashboardData {
 // -- Action types (for POST /api/action) --
 
 /** Actions a user can take from the dashboard. */
-export type ActionType = 'shelve' | 'unshelve' | 'snooze' | 'unsnooze';
+export type ActionType = 'shelve' | 'unshelve' | 'snooze' | 'unsnooze' | 'dismiss' | 'undismiss';
 
 /** Request body for POST /api/action. */
 export interface ActionRequest {


### PR DESCRIPTION
## Summary
- Dashboard now filters dismissed PRs from the Action Required section, matching CLI behavior
- Added dismiss/undismiss actions to the dashboard API and UI
- Shelve auto-undismisses and dismiss auto-unshelves to prevent confusing dual state
- URL validation uses `ISSUE_OR_PR_URL_PATTERN` for dismiss actions (accepts both PR and issue URLs)

## Changes
- **Server**: `buildDashboardJson()` includes `dismissedUrls`, `VALID_ACTIONS` expanded, action handler supports dismiss/undismiss
- **Client**: `PRList` filters dismissed PRs into collapsible section, `ActionBar` has dismiss/undismiss buttons
- **Types**: `DashboardData.dismissedUrls`, `ActionType` union expanded

## Test plan
- [x] All 1504 tests pass (including dashboard-server tests with updated mocks)
- [x] PR review toolkit: code-reviewer and silent-failure-hunter — addressed HIGH finding (dual state prevention)

Fixes #501