### PR TITLE
fix: return ci_blocked instead of failing_ci for non-actionable CI failures

### DIFF
--- a/packages/core/src/core/display-utils.test.ts
+++ b/packages/core/src/core/display-utils.test.ts
@@ -95,4 +95,24 @@ describe('computeDisplayLabel', () => {
     const result = computeDisplayLabel(makePR({ status: 'needs_changes' }));
     expect(result.displayLabel).toBe('[Needs Changes]');
   });
+
+  it('should return non-actionable description for ci_blocked with classified checks', () => {
+    const result = computeDisplayLabel(
+      makePR({
+        status: 'ci_blocked',
+        classifiedChecks: [
+          { name: 'Facebook Internal - Linter', category: 'infrastructure' },
+          { name: 'Vercel Deploy', category: 'fork_limitation' },
+        ],
+      }),
+    );
+    expect(result.displayLabel).toBe('[CI Blocked]');
+    expect(result.displayDescription).toBe('All failing checks are non-actionable (infrastructure, fork_limitation)');
+  });
+
+  it('should return default ci_blocked description when no classified checks', () => {
+    const result = computeDisplayLabel(makePR({ status: 'ci_blocked' }));
+    expect(result.displayLabel).toBe('[CI Blocked]');
+    expect(result.displayDescription).toBe('CI checks are failing but no action is needed from you');
+  });
 });

--- a/packages/core/src/core/display-utils.ts
+++ b/packages/core/src/core/display-utils.ts
@@ -39,7 +39,14 @@ const STATUS_DISPLAY: Record<FetchedPRStatus, { label: string; description: (pr:
   },
   ci_blocked: {
     label: '[CI Blocked]',
-    description: () => 'CI cannot run (first-time contributor approval needed)',
+    description: (pr) => {
+      const checks = pr.classifiedChecks || [];
+      if (checks.length > 0 && checks.every((c) => c.category !== 'actionable')) {
+        const categories = [...new Set(checks.map((c) => c.category))];
+        return `All failing checks are non-actionable (${categories.join(', ')})`;
+      }
+      return 'CI checks are failing but no action is needed from you';
+    },
   },
   ci_not_running: {
     label: '[CI Not Running]',

--- a/packages/core/src/core/pr-monitor.test.ts
+++ b/packages/core/src/core/pr-monitor.test.ts
@@ -1472,6 +1472,82 @@ describe('PRMonitor CI failure overrides changes_addressed (Issue #68)', () => {
   });
 });
 
+describe('PRMonitor non-actionable CI failures return ci_blocked (Issue #502)', () => {
+  beforeEach(() => {
+    mockOctokitInstance = {};
+  });
+
+  function callDetermineStatus(
+    overrides: Partial<{
+      ciStatus: string;
+      hasMergeConflict: boolean;
+      hasUnrespondedComment: boolean;
+      hasIncompleteChecklist: boolean;
+      reviewDecision: string;
+      daysSinceActivity: number;
+      dormantThreshold: number;
+      approachingThreshold: number;
+      latestCommitDate: string | undefined;
+      lastMaintainerCommentDate: string | undefined;
+      latestChangesRequestedDate: string | undefined;
+      hasActionableCIFailure: boolean;
+    }> = {},
+  ) {
+    const monitor = new PRMonitor('fake-token');
+    const defaults = {
+      ciStatus: 'passing',
+      hasMergeConflict: false,
+      hasUnrespondedComment: false,
+      hasIncompleteChecklist: false,
+      reviewDecision: 'review_required',
+      daysSinceActivity: 2,
+      dormantThreshold: 30,
+      approachingThreshold: 25,
+      latestCommitDate: undefined as string | undefined,
+      lastMaintainerCommentDate: undefined as string | undefined,
+      latestChangesRequestedDate: undefined as string | undefined,
+    };
+    return (monitor as any).determineStatus({ ...defaults, ...overrides });
+  }
+
+  it('should return ci_blocked when CI is failing but no checks are actionable', () => {
+    expect(callDetermineStatus({ ciStatus: 'failing', hasActionableCIFailure: false })).toBe('ci_blocked');
+  });
+
+  it('should return failing_ci when CI is failing and checks are actionable', () => {
+    expect(callDetermineStatus({ ciStatus: 'failing', hasActionableCIFailure: true })).toBe('failing_ci');
+  });
+
+  it('should return changes_addressed (comment path) when CI failing but not actionable', () => {
+    expect(
+      callDetermineStatus({
+        ciStatus: 'failing',
+        hasActionableCIFailure: false,
+        hasUnrespondedComment: true,
+        latestCommitDate: '2026-02-08T12:00:00Z',
+        lastMaintainerCommentDate: '2026-02-07T10:00:00Z',
+      }),
+    ).toBe('changes_addressed');
+  });
+
+  it('should return changes_addressed (review path) when CI failing but not actionable', () => {
+    expect(
+      callDetermineStatus({
+        ciStatus: 'failing',
+        hasActionableCIFailure: false,
+        reviewDecision: 'changes_requested',
+        latestCommitDate: '2026-02-09T10:00:00Z',
+        latestChangesRequestedDate: '2026-02-08T11:52:22Z',
+      }),
+    ).toBe('changes_addressed');
+  });
+
+  it('should default hasActionableCIFailure to true for backward compatibility', () => {
+    // hasActionableCIFailure intentionally omitted — determineStatus defaults it to true
+    expect(callDetermineStatus({ ciStatus: 'failing' })).toBe('failing_ci');
+  });
+});
+
 describe('isAcknowledgmentComment (Issue #69)', () => {
   it('should detect "thanks" as acknowledgment', () => {
     expect(isAcknowledgmentComment('thanks')).toBe(true);

--- a/packages/core/src/core/pr-monitor.ts
+++ b/packages/core/src/core/pr-monitor.ts
@@ -316,7 +316,12 @@ export class PRMonitor {
     // Find the date of the latest changes_requested review (delegated to review-analysis module)
     const latestChangesRequestedDate = getLatestChangesRequestedDate(reviews);
 
+    // Classify failing checks (delegated to ci-analysis module)
+    const classifiedChecks = classifyFailingChecks(failingCheckNames, failingCheckConclusions);
+
     // Determine status
+    const hasActionableCIFailure =
+      ciStatus === 'failing' && classifiedChecks.some((c) => c.category === 'actionable');
     const status = this.determineStatus({
       ciStatus,
       hasMergeConflict,
@@ -329,10 +334,8 @@ export class PRMonitor {
       latestCommitDate,
       lastMaintainerCommentDate: lastMaintainerComment?.createdAt,
       latestChangesRequestedDate,
+      hasActionableCIFailure,
     });
-
-    // Classify failing checks (delegated to ci-analysis module)
-    const classifiedChecks = classifyFailingChecks(failingCheckNames, failingCheckConclusions);
 
     return this.buildFetchedPR({
       id: ghPR.id,
@@ -393,6 +396,7 @@ export class PRMonitor {
       latestCommitDate,
       lastMaintainerCommentDate,
       latestChangesRequestedDate,
+      hasActionableCIFailure = true,
     } = input;
 
     // Priority order: needs_response/needs_changes/changes_addressed > failing_ci > merge_conflict > incomplete_checklist > dormant > approaching_dormant > waiting_on_maintainer > waiting/healthy
@@ -406,7 +410,9 @@ export class PRMonitor {
         if (latestChangesRequestedDate && latestCommitDate < latestChangesRequestedDate) {
           return 'needs_response';
         }
-        if (ciStatus === 'failing') return 'failing_ci';
+        if (ciStatus === 'failing' && hasActionableCIFailure) return 'failing_ci';
+        // Non-actionable CI failures (infrastructure, fork, auth) don't block changes_addressed —
+        // the contributor can't fix them, so the relevant status is "waiting for re-review" (#502)
         return 'changes_addressed';
       }
       return 'needs_response';
@@ -419,12 +425,13 @@ export class PRMonitor {
         return 'needs_changes';
       }
       // Commit is after review — changes have been addressed
-      if (ciStatus === 'failing') return 'failing_ci';
+      if (ciStatus === 'failing' && hasActionableCIFailure) return 'failing_ci';
+      // Non-actionable CI failures don't block changes_addressed (#502)
       return 'changes_addressed';
     }
 
     if (ciStatus === 'failing') {
-      return 'failing_ci';
+      return hasActionableCIFailure ? 'failing_ci' : 'ci_blocked';
     }
 
     if (hasMergeConflict) {

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -62,6 +62,8 @@ export interface DetermineStatusInput {
   latestCommitDate?: string;
   lastMaintainerCommentDate?: string;
   latestChangesRequestedDate?: string;
+  /** True if at least one failing CI check is classified as 'actionable'. */
+  hasActionableCIFailure?: boolean;
 }
 
 /**
@@ -71,8 +73,7 @@ export interface DetermineStatusInput {
  * **Action required (contributor must act):**
  * - `needs_response` — Maintainer commented after the contributor's last activity
  * - `needs_changes` — Reviewer requested changes (via review, not just a comment)
- * - `failing_ci` — One or more CI checks are failing
- * - `ci_blocked` — CI cannot run (e.g., first-time contributor approval needed) *(reserved)*
+ * - `failing_ci` — One or more CI checks are failing (at least one is actionable)
  * - `ci_not_running` — No CI checks have been triggered *(reserved)*
  * - `merge_conflict` — PR has merge conflicts with the base branch
  * - `needs_rebase` — PR branch is significantly behind upstream *(reserved)*
@@ -80,6 +81,7 @@ export interface DetermineStatusInput {
  * - `incomplete_checklist` — PR body has unchecked required checkboxes
  *
  * **Waiting (no action needed right now):**
+ * - `ci_blocked` — All failing CI checks are non-actionable (infrastructure, fork limitation, auth gate)
  * - `changes_addressed` — Contributor pushed commits after reviewer feedback; awaiting re-review
  * - `waiting` — CI is pending or no specific action needed
  * - `waiting_on_maintainer` — PR is approved and CI passes; waiting for maintainer to merge


### PR DESCRIPTION
## Summary

- PRs where ALL failing CI checks are non-actionable (`infrastructure`, `fork_limitation`, `auth_gate`) now get `ci_blocked` status instead of `failing_ci`
- This moves them from **Action Required** to **Waiting on Others** in the dashboard, reducing noise for contributors who can't fix these failures
- When changes have been addressed but CI has non-actionable failures, `changes_addressed` takes priority (contributor is waiting for re-review, not blocked by CI)
- Updated `ci_blocked` display description to dynamically show check categories (e.g., "All failing checks are non-actionable (infrastructure, fork_limitation)")
- Backward-compatible: `hasActionableCIFailure` defaults to `true`, so existing behavior is preserved for callers that don't pass it

### Examples this fixes
- `facebook/yoga#1903`: "Facebook Internal - Linter" fails, all public checks pass → now `ci_blocked` instead of `failing_ci`
- `py-pdf/pypdf#3631`: platform-specific test failure → now `ci_blocked`

## Test plan

- [x] 7 new tests covering all code paths (standalone CI, comment-path, review-path, backward compat, display labels)
- [x] All 1408 existing tests pass
- [x] Verified `ci_blocked` is already in dashboard's WAITING section (no frontend changes needed)

Closes #502