### PR TITLE
fix: replace duplicated dashboard types with core/types imports

### DIFF
--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -30,10 +30,17 @@ fi
 DASHBOARD_INDEX="${PLUGIN_ROOT}/packages/dashboard/dist/index.html"
 DASHBOARD_PKG="${PLUGIN_ROOT}/packages/dashboard/package.json"
 if [ -f "${DASHBOARD_PKG}" ] && { [ ! -f "${DASHBOARD_INDEX}" ] || [ "${DASHBOARD_PKG}" -nt "${DASHBOARD_INDEX}" ]; }; then
-  if (cd "${PLUGIN_ROOT}/packages/dashboard" && npm install --silent 2>/dev/null && npm run build --silent 2>/dev/null); then
+  # Dashboard depends on @oss-autopilot/core types via workspace:* protocol.
+  # Use pnpm if available (required for workspace: resolution), fall back to npm.
+  if command -v pnpm &>/dev/null; then
+    dashboard_build() { cd "${PLUGIN_ROOT}" && pnpm install --silent 2>/dev/null && pnpm --filter @oss-autopilot/core run build --silent 2>/dev/null && pnpm --filter @oss-autopilot/dashboard run build --silent 2>/dev/null; }
+  else
+    dashboard_build() { cd "${PLUGIN_ROOT}/packages/dashboard" && npm install --silent 2>/dev/null && npm run build --silent 2>/dev/null; }
+  fi
+  if (dashboard_build); then
     messages="${messages:+${messages}\n}Dashboard SPA built successfully."
   else
-    messages="${messages:+${messages}\n}Warning: Dashboard SPA build failed. The static HTML fallback will be used. To fix: cd ${PLUGIN_ROOT}/packages/dashboard && npm install && npm run build"
+    messages="${messages:+${messages}\n}Warning: Dashboard SPA build failed. To fix: cd ${PLUGIN_ROOT} && pnpm install && pnpm run build"
   fi
 fi
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -18,6 +18,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@oss-autopilot/core": "workspace:*",
     "chart.js": "^4.4.8",
     "preact": "^10.25.4"
   },

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -1,142 +1,44 @@
 /**
- * Dashboard-specific type definitions.
+ * Dashboard type definitions.
  *
- * These types are duplicated from @oss-autopilot/core to keep the frontend
- * bundle clean — no Node.js dependencies or server-side code gets pulled in.
+ * Shared types are re-exported from @oss-autopilot/core to prevent drift.
+ * Dashboard-specific types (stats, API response shape, actions) are defined here.
  */
 
-// -- Enums and union types --
+import type {
+  FetchedPRStatus,
+  CIStatus,
+  ReviewDecision,
+  CIFailureCategory,
+  MaintainerActionHint,
+  IssueConversationStatus,
+  ClassifiedCheck,
+  ShelvedPRRef,
+  FetchedPR,
+  CommentedIssue,
+  CommentedIssueWithResponse,
+  MergedPR,
+  ClosedPR,
+} from '@oss-autopilot/core/types';
 
-/** Computed status for a FetchedPR, determined by PRMonitor.determineStatus(). */
-export type FetchedPRStatus =
-  | 'needs_response'
-  | 'failing_ci'
-  | 'ci_blocked'
-  | 'ci_not_running'
-  | 'merge_conflict'
-  | 'needs_rebase'
-  | 'missing_required_files'
-  | 'incomplete_checklist'
-  | 'needs_changes'
-  | 'changes_addressed'
-  | 'waiting'
-  | 'waiting_on_maintainer'
-  | 'healthy'
-  | 'approaching_dormant'
-  | 'dormant';
+// Re-export shared types so consumers keep using `import { X } from '../types'`
+export type {
+  FetchedPRStatus,
+  CIStatus,
+  ReviewDecision,
+  CIFailureCategory,
+  MaintainerActionHint,
+  IssueConversationStatus,
+  ClassifiedCheck,
+  ShelvedPRRef,
+  FetchedPR,
+  CommentedIssue,
+  CommentedIssueWithResponse,
+  MergedPR,
+  ClosedPR,
+};
 
-/** CI pipeline status for a PR's latest commit. */
-export type CIStatus = 'passing' | 'failing' | 'pending' | 'unknown';
-
-/** GitHub's pull request review decision. */
-export type ReviewDecision = 'approved' | 'changes_requested' | 'review_required' | 'unknown';
-
-/**
- * Classification of a CI check failure.
- * - actionable: Real test/build failure the contributor should fix
- * - fork_limitation: Failure due to fork permissions (e.g., Vercel deploy)
- * - auth_gate: Authorization/approval gate, not a real failure
- * - infrastructure: Runner timeout, dependency install failure, transient infra issue
- */
-export type CIFailureCategory = 'actionable' | 'fork_limitation' | 'auth_gate' | 'infrastructure';
-
-/**
- * Hints about what a maintainer is asking for in their review comments.
- */
-export type MaintainerActionHint =
-  | 'demo_requested'
-  | 'tests_requested'
-  | 'changes_requested'
-  | 'docs_requested'
-  | 'rebase_requested';
-
-/** Status of a user's comment thread on a GitHub issue. */
-export type IssueConversationStatus = 'new_response' | 'waiting' | 'acknowledged';
-
-// -- Interfaces --
-
-/** A CI check with its failure classification. */
-export interface ClassifiedCheck {
-  name: string;
-  category: CIFailureCategory;
-  conclusion?: string;
-}
-
-/**
- * Lightweight reference for shelved PRs.
- * Contains only the fields needed for display.
- */
-export interface ShelvedPRRef {
-  number: number;
-  url: string;
-  title: string;
-  repo: string;
-  daysSinceActivity: number;
-  status: FetchedPRStatus;
-}
-
-/**
- * Ephemeral PR data fetched fresh from GitHub on each run.
- * This is the primary data type for dashboard PR display.
- */
-export interface FetchedPR {
-  // Identity
-  id: number;
-  url: string;
-  repo: string;
-  number: number;
-  title: string;
-
-  /** Computed status. */
-  status: FetchedPRStatus;
-
-  /** Human-readable status label. E.g., "[CI Failing]", "[Needs Response]". */
-  displayLabel: string;
-  /** Brief description of what's happening. E.g., "3 checks failed". */
-  displayDescription: string;
-
-  // Timestamps
-  createdAt: string;
-  updatedAt: string;
-
-  /** Calendar days since the most recent activity. */
-  daysSinceActivity: number;
-
-  // CI and merge status
-  ciStatus: CIStatus;
-  failingCheckNames: string[];
-  classifiedChecks: ClassifiedCheck[];
-  hasMergeConflict: boolean;
-  reviewDecision: ReviewDecision;
-
-  // Branch freshness
-  commitsBehindUpstream?: number;
-  headRefName?: string;
-  baseRefName?: string;
-
-  localRepoPath?: string;
-
-  missingRequiredFiles?: string[];
-
-  hasUnrespondedComment: boolean;
-  lastMaintainerComment?: {
-    author: string;
-    body: string;
-    createdAt: string;
-  };
-
-  latestCommitDate?: string;
-
-  hasIncompleteChecklist: boolean;
-  checklistStats?: {
-    checked: number;
-    total: number;
-  };
-
-  maintainerActionHints: MaintainerActionHint[];
-}
-
-// -- Dashboard stats --
+// -- Dashboard-specific types --
 
 export interface DashboardStats {
   activePRs: number;
@@ -145,62 +47,6 @@ export interface DashboardStats {
   closedPRs: number;
   mergeRate: string;
 }
-
-// -- Issue conversation types --
-
-/** Base fields shared by all issue conversation states. */
-interface CommentedIssueBase {
-  repo: string;
-  number: number;
-  title: string;
-  url: string;
-  userLastCommentedAt: string;
-  labels: string[];
-  daysSinceUserComment: number;
-}
-
-/** Issue where someone responded after the user's last comment. */
-export interface CommentedIssueWithResponse extends CommentedIssueBase {
-  status: 'new_response';
-  lastResponseAuthor: string;
-  lastResponseBody: string;
-  lastResponseAt: string;
-  isFromMaintainer: boolean;
-}
-
-/** Issue where no substantive maintainer response was found. */
-interface CommentedIssueWithoutResponse extends CommentedIssueBase {
-  status: 'waiting' | 'acknowledged';
-  lastResponseAuthor?: undefined;
-  lastResponseBody?: undefined;
-  lastResponseAt?: undefined;
-}
-
-/** A GitHub issue the user has commented on, with conversation state. */
-export type CommentedIssue = CommentedIssueWithResponse | CommentedIssueWithoutResponse;
-
-// -- Recently merged/closed PR types --
-
-/** Minimal record of a PR that was merged, used in the daily digest. */
-export interface MergedPR {
-  url: string;
-  repo: string;
-  number: number;
-  title: string;
-  mergedAt: string;
-}
-
-/** Minimal record of a PR that was closed without merge. */
-export interface ClosedPR {
-  url: string;
-  repo: string;
-  number: number;
-  title: string;
-  closedAt: string;
-  closedBy?: string;
-}
-
-// -- Dashboard API response --
 
 /** The shape of the GET /api/data response from the dashboard server. */
 export interface DashboardData {
@@ -219,8 +65,6 @@ export interface DashboardData {
   commentedIssues: CommentedIssue[];
   issueResponses: CommentedIssueWithResponse[];
 }
-
-// -- Action types (for POST /api/action) --
 
 /** Actions a user can take from the dashboard. */
 export type ActionType = 'shelve' | 'unshelve' | 'snooze' | 'unsnooze' | 'dismiss' | 'undismiss';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
 
   packages/dashboard:
     dependencies:
+      '@oss-autopilot/core':
+        specifier: workspace:*
+        version: link:../core
       chart.js:
         specifier: ^4.4.8
         version: 4.5.1


### PR DESCRIPTION
## Summary

Closes #490

- Replace ~200 lines of duplicated type definitions in `packages/dashboard/src/types.ts` with re-exports from `@oss-autopilot/core/types`
- Add `@oss-autopilot/core` as a `workspace:*` dependency in the dashboard package
- Fix `hooks/session-start.sh` to use pnpm when available (required for `workspace:*` resolution) and remove stale "static HTML fallback" reference

### How it works

The core `types.ts` has zero Node.js imports — it's pure TypeScript type definitions. Since the dashboard uses `import type`, these compile away entirely at build time with zero runtime bundle impact. The existing CI `typecheck` step (`pnpm -r run typecheck`) catches type drift automatically — if core/types.ts changes in a way that breaks the dashboard's re-exports, CI fails.

### Types shared (13)
`FetchedPRStatus`, `CIStatus`, `ReviewDecision`, `CIFailureCategory`, `MaintainerActionHint`, `IssueConversationStatus`, `ClassifiedCheck`, `ShelvedPRRef`, `FetchedPR`, `CommentedIssue`, `CommentedIssueWithResponse`, `MergedPR`, `ClosedPR`

### Types kept dashboard-local (4)
`DashboardStats`, `DashboardData`, `ActionType`, `ActionRequest`

## Test plan

- [x] `pnpm run typecheck` passes (all workspace packages)
- [x] `pnpm test` passes (1542 tests: 1439 core + 103 MCP)
- [x] Dashboard Vite build succeeds (198KB bundle)
- [x] Verified zero runtime code from core leaks into dashboard bundle (checked for DEFAULT_CONFIG/INITIAL_STATE — not present)
- [x] `bash -n hooks/session-start.sh` syntax check passes
- [x] All dashboard consumer imports unchanged (re-export pattern preserves `../types` import paths)