### PR TITLE
feat: add comprehensive test coverage for Preact SPA dashboard

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -8,7 +8,9 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "exports": {
     "./package.json": "./package.json"
@@ -24,7 +26,10 @@
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.9.4",
+    "@testing-library/preact": "^3.2.4",
+    "jsdom": "^28.1.0",
     "typescript": "^5.9.3",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^4.0.18"
   }
 }

--- a/packages/dashboard/src/app.test.tsx
+++ b/packages/dashboard/src/app.test.tsx
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/preact';
+import { App } from './app';
+import { makePR, makeDashboardData } from './test-helpers';
+import type { DashboardData } from './types';
+
+function mockFetchOk(data: DashboardData) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(data),
+    }),
+  );
+}
+
+function mockFetchError(status: number, body?: { error: string }) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: false,
+      status,
+      json: () => (body ? Promise.resolve(body) : Promise.reject(new Error('no body'))),
+    }),
+  );
+}
+
+describe('App', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows loading state initially', () => {
+    // Never resolve to keep it in loading state
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {})));
+
+    const { container } = render(<App />);
+    expect(container.textContent).toContain('Loading dashboard data...');
+  });
+
+  it('shows error state with retry button on fetch failure', async () => {
+    mockFetchError(500, { error: 'Internal Server Error' });
+
+    const { container } = render(<App />);
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('Failed to load dashboard data');
+    });
+    expect(container.textContent).toContain('Internal Server Error');
+    expect(container.querySelector('.shell-retry')).toBeTruthy();
+  });
+
+  it('renders dashboard with stats when data loads', async () => {
+    const data = makeDashboardData({
+      stats: { activePRs: 3, shelvedPRs: 1, mergedPRs: 10, closedPRs: 2, mergeRate: '83.3%' },
+    });
+    mockFetchOk(data);
+
+    const { container } = render(<App />);
+
+    await waitFor(() => {
+      expect(container.querySelector('.dashboard')).toBeTruthy();
+    });
+    expect(container.textContent).toContain('3 active PRs');
+    expect(container.textContent).toContain('83.3% merge rate');
+  });
+
+  describe('filtering', () => {
+    const prs = [
+      makePR({
+        url: 'https://github.com/a/b/pull/1',
+        repo: 'a/b',
+        number: 1,
+        title: 'Fix auth bug',
+        status: 'failing_ci',
+      }),
+      makePR({
+        url: 'https://github.com/a/b/pull/2',
+        repo: 'a/b',
+        number: 2,
+        title: 'Add feature',
+        status: 'healthy',
+      }),
+      makePR({
+        url: 'https://github.com/c/d/pull/3',
+        repo: 'c/d',
+        number: 3,
+        title: 'Update docs',
+        status: 'healthy',
+      }),
+    ];
+
+    const data = makeDashboardData({ activePRs: prs });
+
+    beforeEach(() => {
+      mockFetchOk(data);
+    });
+
+    it('shows all PRs with no filters', async () => {
+      const { container } = render(<App />);
+
+      await waitFor(() => {
+        expect(container.querySelector('.dashboard')).toBeTruthy();
+      });
+
+      const rows = container.querySelectorAll('.pr-row');
+      expect(rows).toHaveLength(3);
+    });
+
+    it('filters by status', async () => {
+      const { container } = render(<App />);
+
+      await waitFor(() => {
+        expect(container.querySelector('.dashboard')).toBeTruthy();
+      });
+
+      // Change status filter to 'healthy'
+      const statusSelect = container.querySelector('.filter-select') as HTMLSelectElement;
+      fireEvent.change(statusSelect, { target: { value: 'healthy' } });
+
+      const rows = container.querySelectorAll('.pr-row');
+      expect(rows).toHaveLength(2); // "Add feature" and "Update docs"
+    });
+
+    it('filters by repo', async () => {
+      const { container } = render(<App />);
+
+      await waitFor(() => {
+        expect(container.querySelector('.dashboard')).toBeTruthy();
+      });
+
+      // Change repo filter to 'c/d'
+      const selects = container.querySelectorAll('.filter-select');
+      const repoSelect = selects[1] as HTMLSelectElement;
+      fireEvent.change(repoSelect, { target: { value: 'c/d' } });
+
+      const rows = container.querySelectorAll('.pr-row');
+      expect(rows).toHaveLength(1);
+      expect(rows[0].textContent).toContain('Update docs');
+    });
+
+    it('filters by search text (case-insensitive)', async () => {
+      const { container } = render(<App />);
+
+      await waitFor(() => {
+        expect(container.querySelector('.dashboard')).toBeTruthy();
+      });
+
+      const searchInput = container.querySelector('.filter-input') as HTMLInputElement;
+      fireEvent.input(searchInput, { target: { value: 'AUTH' } });
+
+      const rows = container.querySelectorAll('.pr-row');
+      expect(rows).toHaveLength(1);
+      expect(rows[0].textContent).toContain('Fix auth bug');
+    });
+
+    it('combines multiple filters', async () => {
+      const { container } = render(<App />);
+
+      await waitFor(() => {
+        expect(container.querySelector('.dashboard')).toBeTruthy();
+      });
+
+      // Filter by status 'healthy' AND repo 'a/b'
+      const statusSelect = container.querySelector('.filter-select') as HTMLSelectElement;
+      fireEvent.change(statusSelect, { target: { value: 'healthy' } });
+
+      const selects = container.querySelectorAll('.filter-select');
+      const repoSelect = selects[1] as HTMLSelectElement;
+      fireEvent.change(repoSelect, { target: { value: 'a/b' } });
+
+      const rows = container.querySelectorAll('.pr-row');
+      expect(rows).toHaveLength(1);
+      expect(rows[0].textContent).toContain('Add feature');
+    });
+  });
+
+  it('populates filter dropdowns from PR data', async () => {
+    const prs = [
+      makePR({ repo: 'x/y', status: 'healthy' }),
+      makePR({ repo: 'a/b', status: 'failing_ci', url: 'https://github.com/a/b/pull/2' }),
+    ];
+    mockFetchOk(makeDashboardData({ activePRs: prs }));
+
+    const { container } = render(<App />);
+
+    await waitFor(() => {
+      expect(container.querySelector('.dashboard')).toBeTruthy();
+    });
+
+    // Repo select should have 'All Repos' + 2 unique repos (sorted)
+    const selects = container.querySelectorAll('.filter-select');
+    const repoSelect = selects[1] as HTMLSelectElement;
+    const repoOptions = [...repoSelect.options].map((o) => o.value);
+    expect(repoOptions).toEqual(['all', 'a/b', 'x/y']);
+
+    // Status select should have 'All Statuses' + 2 unique statuses (sorted)
+    const statusSelect = selects[0] as HTMLSelectElement;
+    const statusOptions = [...statusSelect.options].map((o) => o.value);
+    expect(statusOptions).toEqual(['all', 'failing_ci', 'healthy']);
+  });
+
+  it('shows error banner with dismiss button when error coexists with data', async () => {
+    const data = makeDashboardData();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(data) })
+      .mockResolvedValueOnce({ ok: false, status: 500, json: () => Promise.resolve({ error: 'Refresh failed' }) });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { container } = render(<App />);
+
+    await waitFor(() => {
+      expect(container.querySelector('.dashboard')).toBeTruthy();
+    });
+
+    // Trigger refresh which will fail
+    const refreshBtn = container.querySelector('.refresh-btn') as HTMLButtonElement;
+    fireEvent.click(refreshBtn);
+
+    await waitFor(() => {
+      expect(container.querySelector('.error-banner')).toBeTruthy();
+    });
+    expect(container.querySelector('.error-banner')?.textContent).toContain('Refresh failed');
+    expect(container.querySelector('.error-banner-dismiss')).toBeTruthy();
+  });
+});

--- a/packages/dashboard/src/components/action-bar.test.tsx
+++ b/packages/dashboard/src/components/action-bar.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/preact';
+import { ActionBar } from './action-bar';
+import { makePR } from '../test-helpers';
+import type { FetchedPR, ActionRequest } from '../types';
+
+interface ActionBarOptions {
+  pr?: FetchedPR;
+  isShelved?: boolean;
+  isDismissed?: boolean;
+  onAction?: (action: ActionRequest) => Promise<void>;
+}
+
+function renderActionBar(options: ActionBarOptions = {}) {
+  const {
+    pr = makePR(),
+    isShelved = false,
+    isDismissed = false,
+    onAction = vi.fn(),
+  } = options;
+
+  return render(
+    <ActionBar pr={pr} isShelved={isShelved} isDismissed={isDismissed} onAction={onAction} />,
+  );
+}
+
+describe('ActionBar', () => {
+  it('renders Shelve button when not shelved', () => {
+    const { container } = renderActionBar();
+    const btn = container.querySelector('.action-btn--shelve');
+    expect(btn?.textContent).toBe('Shelve');
+  });
+
+  it('renders Unshelve button when shelved', () => {
+    const { container } = renderActionBar({ isShelved: true });
+    const btn = container.querySelector('.action-btn--unshelve');
+    expect(btn?.textContent).toBe('Unshelve');
+  });
+
+  it('renders Dismiss button when not dismissed', () => {
+    const { container } = renderActionBar();
+    const buttons = [...container.querySelectorAll('.action-btn')];
+    const dismissBtn = buttons.find((b) => b.textContent === 'Dismiss');
+    expect(dismissBtn).toBeTruthy();
+  });
+
+  it('renders Undismiss button when dismissed', () => {
+    const { container } = renderActionBar({ isDismissed: true });
+    const buttons = [...container.querySelectorAll('.action-btn')];
+    const undismissBtn = buttons.find((b) => b.textContent === 'Undismiss');
+    expect(undismissBtn).toBeTruthy();
+  });
+
+  it('shows snooze controls only when CI is failing', () => {
+    const { container: passingContainer } = renderActionBar({ pr: makePR({ ciStatus: 'passing' }) });
+    expect(passingContainer.querySelector('.action-btn--snooze')).toBeNull();
+
+    const { container: failingContainer } = renderActionBar({ pr: makePR({ ciStatus: 'failing' }) });
+    expect(failingContainer.querySelector('.action-btn--snooze')).toBeTruthy();
+  });
+
+  it('calls onAction with shelve action on button click', async () => {
+    const onAction = vi.fn().mockResolvedValue(undefined);
+    const pr = makePR();
+
+    const { container } = renderActionBar({ pr, onAction });
+
+    const shelveBtn = container.querySelector('.action-btn--shelve') as HTMLButtonElement;
+    fireEvent.click(shelveBtn);
+
+    await waitFor(() => {
+      expect(onAction).toHaveBeenCalledWith({ action: 'shelve', url: pr.url });
+    });
+  });
+
+  it('displays action error when onAction throws', async () => {
+    const onAction = vi.fn().mockRejectedValue(new Error('Network error'));
+
+    const { container } = renderActionBar({ onAction });
+
+    const shelveBtn = container.querySelector('.action-btn--shelve') as HTMLButtonElement;
+    fireEvent.click(shelveBtn);
+
+    await waitFor(() => {
+      expect(container.querySelector('.action-error')?.textContent).toBe('Network error');
+    });
+  });
+
+  it('opens snooze form on "Snooze CI" click', () => {
+    const { container } = renderActionBar({ pr: makePR({ ciStatus: 'failing' }) });
+
+    expect(container.querySelector('.snooze-form')).toBeNull();
+
+    const snoozeBtn = container.querySelector('.action-btn--snooze') as HTMLButtonElement;
+    fireEvent.click(snoozeBtn);
+
+    expect(container.querySelector('.snooze-form')).toBeTruthy();
+  });
+
+  it('submits snooze with reason and days', async () => {
+    const onAction = vi.fn().mockResolvedValue(undefined);
+    const pr = makePR({ ciStatus: 'failing' });
+
+    const { container } = renderActionBar({ pr, onAction });
+
+    fireEvent.click(container.querySelector('.action-btn--snooze') as HTMLButtonElement);
+
+    const reasonInput = container.querySelector('.snooze-input:not(.snooze-input--days)') as HTMLInputElement;
+    fireEvent.input(reasonInput, { target: { value: 'Waiting on dependency update' } });
+
+    const daysInput = container.querySelector('.snooze-input--days') as HTMLInputElement;
+    fireEvent.input(daysInput, { target: { value: '7' } });
+
+    fireEvent.click(container.querySelector('.action-btn--confirm') as HTMLButtonElement);
+
+    await waitFor(() => {
+      expect(onAction).toHaveBeenCalledWith({
+        action: 'snooze',
+        url: pr.url,
+        reason: 'Waiting on dependency update',
+        days: 7,
+      });
+    });
+  });
+
+  it('closes snooze form after successful submission', async () => {
+    const onAction = vi.fn().mockResolvedValue(undefined);
+
+    const { container } = renderActionBar({ pr: makePR({ ciStatus: 'failing' }), onAction });
+
+    fireEvent.click(container.querySelector('.action-btn--snooze') as HTMLButtonElement);
+    expect(container.querySelector('.snooze-form')).toBeTruthy();
+
+    fireEvent.click(container.querySelector('.action-btn--confirm') as HTMLButtonElement);
+
+    await waitFor(() => {
+      expect(container.querySelector('.snooze-form')).toBeNull();
+    });
+  });
+});

--- a/packages/dashboard/src/components/filter-bar.test.tsx
+++ b/packages/dashboard/src/components/filter-bar.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/preact';
+import { FilterBar } from './filter-bar';
+import type { Filters } from './filter-bar';
+
+const defaultFilters: Filters = { status: 'all', repo: 'all', search: '' };
+
+interface FilterBarOptions {
+  filters?: Filters;
+  onFilterChange?: (filters: Filters) => void;
+  repos?: string[];
+  statuses?: string[];
+}
+
+function renderFilterBar(options: FilterBarOptions = {}) {
+  const {
+    filters = defaultFilters,
+    onFilterChange = vi.fn(),
+    repos = [],
+    statuses = [],
+  } = options;
+
+  return {
+    onFilterChange,
+    ...render(
+      <FilterBar filters={filters} onFilterChange={onFilterChange} repos={repos} statuses={statuses} />,
+    ),
+  };
+}
+
+describe('FilterBar', () => {
+  it('renders status select with options', () => {
+    const { container } = renderFilterBar({
+      repos: ['owner/repo'],
+      statuses: ['healthy', 'failing_ci'],
+    });
+
+    const selects = container.querySelectorAll('.filter-select');
+    expect(selects).toHaveLength(2);
+
+    const statusSelect = selects[0] as HTMLSelectElement;
+    expect(statusSelect.options).toHaveLength(3);
+    expect(statusSelect.options[1].textContent).toBe('Healthy');
+    expect(statusSelect.options[2].textContent).toBe('Failing CI');
+  });
+
+  it('renders repo select with options', () => {
+    const { container } = renderFilterBar({
+      repos: ['owner/repo-a', 'owner/repo-b'],
+    });
+
+    const selects = container.querySelectorAll('.filter-select');
+    const repoSelect = selects[1] as HTMLSelectElement;
+    expect(repoSelect.options).toHaveLength(3);
+  });
+
+  it('calls onFilterChange when status changes', () => {
+    const { container, onFilterChange } = renderFilterBar({
+      statuses: ['healthy', 'failing_ci'],
+    });
+
+    const statusSelect = container.querySelector('.filter-select') as HTMLSelectElement;
+    fireEvent.change(statusSelect, { target: { value: 'failing_ci' } });
+
+    expect(onFilterChange).toHaveBeenCalledWith({ ...defaultFilters, status: 'failing_ci' });
+  });
+
+  it('calls onFilterChange when search input changes', () => {
+    const { container, onFilterChange } = renderFilterBar();
+
+    const input = container.querySelector('.filter-input') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'fix bug' } });
+
+    expect(onFilterChange).toHaveBeenCalledWith({ ...defaultFilters, search: 'fix bug' });
+  });
+});

--- a/packages/dashboard/src/components/issue-list.test.tsx
+++ b/packages/dashboard/src/components/issue-list.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/preact';
+import { IssueList } from './issue-list';
+import { makeIssueResponse } from '../test-helpers';
+
+describe('IssueList', () => {
+  it('returns null when no issues', () => {
+    const { container } = render(<IssueList issues={[]} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders issue response items', () => {
+    const issues = [
+      makeIssueResponse({ title: 'Bug report', number: 42, repo: 'org/lib' }),
+      makeIssueResponse({ title: 'Feature request', number: 43, repo: 'org/lib', isFromMaintainer: false }),
+    ];
+
+    const { container } = render(<IssueList issues={issues} />);
+
+    expect(container.textContent).toContain('Issue Responses');
+    expect(container.querySelectorAll('.issue-item')).toHaveLength(2);
+    expect(container.textContent).toContain('org/lib#42');
+    expect(container.textContent).toContain('Bug report');
+  });
+
+  it('shows maintainer badge for maintainer responses', () => {
+    const issues = [makeIssueResponse({ isFromMaintainer: true })];
+
+    const { container } = render(<IssueList issues={issues} />);
+
+    const badge = container.querySelector('.issue-item-badge--maintainer');
+    expect(badge?.textContent).toBe('Maintainer');
+  });
+
+  it('shows community badge for non-maintainer responses', () => {
+    const issues = [makeIssueResponse({ isFromMaintainer: false })];
+
+    const { container } = render(<IssueList issues={issues} />);
+
+    const badge = container.querySelector('.issue-item-badge--community');
+    expect(badge?.textContent).toBe('Community');
+  });
+
+  it('displays response author and body', () => {
+    const issues = [
+      makeIssueResponse({
+        lastResponseAuthor: 'alice',
+        lastResponseBody: 'Great contribution, thanks!',
+      }),
+    ];
+
+    const { container } = render(<IssueList issues={issues} />);
+
+    expect(container.textContent).toContain('@alice');
+    expect(container.textContent).toContain('Great contribution, thanks!');
+  });
+
+  it('displays days since user comment', () => {
+    const issues = [makeIssueResponse({ daysSinceUserComment: 7 })];
+
+    const { container } = render(<IssueList issues={issues} />);
+
+    expect(container.textContent).toContain('7d since your comment');
+  });
+});

--- a/packages/dashboard/src/components/pr-detail.test.tsx
+++ b/packages/dashboard/src/components/pr-detail.test.tsx
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/preact';
+import { PRDetail } from './pr-detail';
+import { makePR } from '../test-helpers';
+import type { FetchedPR, ActionRequest } from '../types';
+
+interface PRDetailOptions {
+  pr?: FetchedPR;
+  isShelved?: boolean;
+  isDismissed?: boolean;
+  onAction?: (action: ActionRequest) => Promise<void>;
+  onClose?: () => void;
+}
+
+function renderPRDetail(options: PRDetailOptions = {}) {
+  const {
+    pr = makePR(),
+    isShelved = false,
+    isDismissed = false,
+    onAction = vi.fn(),
+    onClose = vi.fn(),
+  } = options;
+
+  return {
+    onClose,
+    ...render(<PRDetail pr={pr} isShelved={isShelved} isDismissed={isDismissed} onAction={onAction} onClose={onClose} />),
+  };
+}
+
+describe('PRDetail', () => {
+  it('renders PR title and repo#number link', () => {
+    const { container } = renderPRDetail({
+      pr: makePR({ title: 'Fix edge case', repo: 'org/lib', number: 42 }),
+    });
+
+    expect(container.querySelector('.pr-detail-title')?.textContent).toBe('Fix edge case');
+    expect(container.textContent).toContain('org/lib#42');
+  });
+
+  it('renders status label and description', () => {
+    const { container } = renderPRDetail({
+      pr: makePR({ displayLabel: '[CI Failing]', displayDescription: '3 checks failed' }),
+    });
+
+    expect(container.querySelector('.pr-detail-status')?.textContent).toBe('[CI Failing]');
+    expect(container.querySelector('.pr-detail-description')?.textContent).toBe('3 checks failed');
+  });
+
+  it('calls onClose when close button is clicked', () => {
+    const onClose = vi.fn();
+    const { container } = renderPRDetail({ onClose });
+
+    const closeBtn = container.querySelector('.pr-detail-close') as HTMLButtonElement;
+    fireEvent.click(closeBtn);
+
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ['approved', 'Approved'],
+    ['changes_requested', 'Changes Requested'],
+    ['review_required', 'Review Required'],
+    ['unknown', 'Unknown'],
+  ])('renders review label "%s" as "%s"', (decision, expected) => {
+    const { container } = renderPRDetail({
+      pr: makePR({ reviewDecision: decision as FetchedPR['reviewDecision'] }),
+    });
+
+    const fields = container.querySelectorAll('.pr-detail-field');
+    const reviewField = [...fields].find((f) => f.querySelector('.pr-detail-field-label')?.textContent === 'Review');
+    expect(reviewField?.querySelector('.pr-detail-field-value')?.textContent).toBe(expected);
+  });
+
+  it('renders CI status with capitalized text', () => {
+    const { container } = renderPRDetail({
+      pr: makePR({ ciStatus: 'failing' }),
+    });
+
+    const fields = container.querySelectorAll('.pr-detail-field');
+    const ciField = [...fields].find((f) => f.querySelector('.pr-detail-field-label')?.textContent === 'CI Status');
+    expect(ciField?.querySelector('.pr-detail-field-value')?.textContent).toBe('Failing');
+  });
+
+  it('renders classified checks with category badges when present', () => {
+    const { container } = renderPRDetail({
+      pr: makePR({
+        classifiedChecks: [
+          { name: 'tests', category: 'actionable' },
+          { name: 'deploy', category: 'fork_limitation' },
+        ],
+      }),
+    });
+
+    const checks = container.querySelectorAll('.pr-detail-check');
+    expect(checks).toHaveLength(2);
+    expect(checks[0].querySelector('.pr-detail-check-name')?.textContent).toBe('tests');
+    expect(checks[0].querySelector('.pr-detail-check-badge')?.textContent).toBe('Actionable');
+    expect(checks[1].querySelector('.pr-detail-check-badge')?.textContent).toBe('Fork Limitation');
+  });
+
+  it('does not render checks section when classifiedChecks is empty', () => {
+    const { container } = renderPRDetail({
+      pr: makePR({ classifiedChecks: [] }),
+    });
+
+    expect(container.querySelector('.pr-detail-checks')).toBeNull();
+  });
+
+  it('renders maintainer comment when present', () => {
+    const { container } = renderPRDetail({
+      pr: makePR({
+        lastMaintainerComment: {
+          author: 'alice',
+          body: 'Please add tests',
+          createdAt: '2025-06-10T00:00:00Z',
+        },
+      }),
+    });
+
+    expect(container.querySelector('.pr-detail-comment-author')?.textContent).toBe('@alice');
+    expect(container.querySelector('.pr-detail-comment-body')?.textContent).toBe('Please add tests');
+  });
+
+  it('does not render maintainer comment when absent', () => {
+    const { container } = renderPRDetail({
+      pr: makePR({ lastMaintainerComment: undefined }),
+    });
+
+    expect(container.querySelector('.pr-detail-comment')).toBeNull();
+  });
+
+  it('renders checklist stats when incomplete', () => {
+    const { container } = renderPRDetail({
+      pr: makePR({
+        hasIncompleteChecklist: true,
+        checklistStats: { checked: 2, total: 5 },
+      }),
+    });
+
+    const fields = container.querySelectorAll('.pr-detail-field');
+    const checklistField = [...fields].find(
+      (f) => f.querySelector('.pr-detail-field-label')?.textContent === 'Checklist',
+    );
+    expect(checklistField?.querySelector('.pr-detail-field-value')?.textContent).toBe('2/5 checked');
+  });
+
+  it('does not render checklist when complete', () => {
+    const { container } = renderPRDetail({
+      pr: makePR({ hasIncompleteChecklist: false }),
+    });
+
+    const labels = [...container.querySelectorAll('.pr-detail-field-label')].map((el) => el.textContent);
+    expect(labels).not.toContain('Checklist');
+  });
+
+  it('renders merge conflict indicator when present', () => {
+    const { container } = renderPRDetail({
+      pr: makePR({ hasMergeConflict: true }),
+    });
+
+    const labels = [...container.querySelectorAll('.pr-detail-field-label')].map((el) => el.textContent);
+    expect(labels).toContain('Merge Conflict');
+  });
+
+  it('does not render merge conflict when absent', () => {
+    const { container } = renderPRDetail({
+      pr: makePR({ hasMergeConflict: false }),
+    });
+
+    const labels = [...container.querySelectorAll('.pr-detail-field-label')].map((el) => el.textContent);
+    expect(labels).not.toContain('Merge Conflict');
+  });
+
+  it('renders days since activity', () => {
+    const { container } = renderPRDetail({
+      pr: makePR({ daysSinceActivity: 12 }),
+    });
+
+    const fields = container.querySelectorAll('.pr-detail-field');
+    const activityField = [...fields].find(
+      (f) => f.querySelector('.pr-detail-field-label')?.textContent === 'Days Since Activity',
+    );
+    expect(activityField?.querySelector('.pr-detail-field-value')?.textContent).toBe('12');
+  });
+
+  it('renders embedded ActionBar', () => {
+    const { container } = renderPRDetail();
+    expect(container.querySelector('.action-bar')).toBeTruthy();
+  });
+});

--- a/packages/dashboard/src/components/pr-list.test.tsx
+++ b/packages/dashboard/src/components/pr-list.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/preact';
+import { PRList } from './pr-list';
+import { makePR } from '../test-helpers';
+import type { FetchedPR } from '../types';
+
+interface PRListOptions {
+  prs?: FetchedPR[];
+  selectedUrl?: string | null;
+  onSelect?: (url: string) => void;
+  shelvedUrls?: Set<string>;
+  dismissedUrls?: Set<string>;
+}
+
+function renderPRList(options: PRListOptions = {}) {
+  const {
+    prs = [],
+    selectedUrl = null,
+    onSelect = vi.fn(),
+    shelvedUrls = new Set<string>(),
+    dismissedUrls = new Set<string>(),
+  } = options;
+
+  return render(
+    <PRList
+      prs={prs}
+      selectedUrl={selectedUrl}
+      onSelect={onSelect}
+      shelvedUrls={shelvedUrls}
+      dismissedUrls={dismissedUrls}
+    />,
+  );
+}
+
+describe('PRList', () => {
+  it('renders "No PRs to display" when empty', () => {
+    const { container } = renderPRList();
+    expect(container.textContent).toContain('No PRs to display');
+  });
+
+  it('groups PRs into sections by status', () => {
+    const prs = [
+      makePR({ url: 'https://github.com/o/r/pull/1', status: 'needs_response', number: 1 }),
+      makePR({ url: 'https://github.com/o/r/pull/2', status: 'waiting_on_maintainer', number: 2 }),
+      makePR({ url: 'https://github.com/o/r/pull/3', status: 'healthy', number: 3 }),
+    ];
+
+    const { container } = renderPRList({ prs });
+
+    const sections = container.querySelectorAll('.pr-section-header');
+    const sectionTitles = [...sections].map((el) => el.textContent?.replace(/\d+$/, '').trim());
+    expect(sectionTitles).toContain('Action Required');
+    expect(sectionTitles).toContain('Waiting on Others');
+    expect(sectionTitles).toContain('Healthy / Stale');
+  });
+
+  it('excludes shelved PRs from active sections', () => {
+    const prs = [
+      makePR({ url: 'https://github.com/o/r/pull/1', status: 'healthy', number: 1 }),
+      makePR({ url: 'https://github.com/o/r/pull/2', status: 'healthy', number: 2 }),
+    ];
+
+    const { container } = renderPRList({
+      prs,
+      shelvedUrls: new Set(['https://github.com/o/r/pull/2']),
+    });
+
+    const rows = container.querySelectorAll('.pr-row');
+    expect(rows).toHaveLength(1);
+  });
+
+  it('calls onSelect when a PR row is clicked', () => {
+    const onSelect = vi.fn();
+    const prs = [makePR({ url: 'https://github.com/o/r/pull/1', status: 'healthy' })];
+
+    const { container } = renderPRList({ prs, onSelect });
+
+    const row = container.querySelector('.pr-row') as HTMLElement;
+    fireEvent.click(row);
+
+    expect(onSelect).toHaveBeenCalledWith('https://github.com/o/r/pull/1');
+  });
+
+  it('highlights the selected PR row', () => {
+    const prs = [makePR({ url: 'https://github.com/o/r/pull/1', status: 'healthy' })];
+
+    const { container } = renderPRList({
+      prs,
+      selectedUrl: 'https://github.com/o/r/pull/1',
+    });
+
+    const row = container.querySelector('.pr-row');
+    expect(row?.classList.contains('pr-row--selected')).toBe(true);
+  });
+
+  it('shows shelved section with correct count', () => {
+    const prs = [
+      makePR({ url: 'https://github.com/o/r/pull/1', status: 'healthy', number: 1 }),
+      makePR({ url: 'https://github.com/o/r/pull/2', status: 'dormant', number: 2 }),
+    ];
+
+    const { container } = renderPRList({
+      prs,
+      shelvedUrls: new Set(['https://github.com/o/r/pull/2']),
+    });
+
+    const shelvedHeader = [...container.querySelectorAll('.pr-section-header')].find((el) =>
+      el.textContent?.includes('Shelved'),
+    );
+    expect(shelvedHeader).toBeTruthy();
+    expect(shelvedHeader?.querySelector('.pr-section-count')?.textContent).toBe('1');
+  });
+
+  it('displays PR title, repo#number, and activity age', () => {
+    const prs = [
+      makePR({
+        url: 'https://github.com/o/r/pull/42',
+        repo: 'o/r',
+        number: 42,
+        title: 'Fix critical bug',
+        daysSinceActivity: 3,
+        status: 'healthy',
+      }),
+    ];
+
+    const { container } = renderPRList({ prs });
+
+    expect(container.textContent).toContain('o/r#42');
+    expect(container.textContent).toContain('Fix critical bug');
+    expect(container.textContent).toContain('3d');
+  });
+});

--- a/packages/dashboard/src/components/recent-activity.test.tsx
+++ b/packages/dashboard/src/components/recent-activity.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/preact';
+import { RecentActivity } from './recent-activity';
+import { makeMergedPR, makeClosedPR, makeShelvedRef } from '../test-helpers';
+
+describe('RecentActivity', () => {
+  it('returns null when all arrays are empty', () => {
+    const { container } = render(<RecentActivity mergedPRs={[]} closedPRs={[]} autoUnshelvedPRs={[]} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders merged PR section', () => {
+    const merged = [makeMergedPR({ title: 'Add feature X' })];
+
+    const { container } = render(<RecentActivity mergedPRs={merged} closedPRs={[]} autoUnshelvedPRs={[]} />);
+
+    expect(container.textContent).toContain('Merged (1)');
+    expect(container.textContent).toContain('Add feature X');
+    expect(container.querySelector('.recent-activity-badge--merged')?.textContent).toBe('Merged');
+  });
+
+  it('renders closed PR section', () => {
+    const closed = [makeClosedPR({ title: 'Stale PR', closedBy: 'maintainer' })];
+
+    const { container } = render(<RecentActivity mergedPRs={[]} closedPRs={closed} autoUnshelvedPRs={[]} />);
+
+    expect(container.textContent).toContain('Closed (1)');
+    expect(container.textContent).toContain('Stale PR');
+  });
+
+  it('renders auto-unshelved PR section', () => {
+    const unshelved = [makeShelvedRef({ title: 'Revived PR', number: 42 })];
+
+    const { container } = render(<RecentActivity mergedPRs={[]} closedPRs={[]} autoUnshelvedPRs={unshelved} />);
+
+    expect(container.textContent).toContain('Auto-Unshelved (1)');
+    expect(container.textContent).toContain('Revived PR');
+  });
+
+  it('renders multiple sections together', () => {
+    const merged = [makeMergedPR()];
+    const closed = [makeClosedPR()];
+    const unshelved = [makeShelvedRef()];
+
+    const { container } = render(
+      <RecentActivity mergedPRs={merged} closedPRs={closed} autoUnshelvedPRs={unshelved} />,
+    );
+
+    expect(container.querySelectorAll('.recent-activity-section')).toHaveLength(3);
+  });
+});

--- a/packages/dashboard/src/components/stats-bar.test.tsx
+++ b/packages/dashboard/src/components/stats-bar.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/preact';
+import { StatsBar } from './stats-bar';
+
+describe('StatsBar', () => {
+  const stats = { activePRs: 5, shelvedPRs: 2, mergedPRs: 10, closedPRs: 3, mergeRate: '76.9%' };
+
+  it('renders all stat cards', () => {
+    const { container } = render(<StatsBar stats={stats} />);
+    const cards = container.querySelectorAll('.stat-card');
+    expect(cards).toHaveLength(5);
+  });
+
+  it('displays correct values', () => {
+    const { container } = render(<StatsBar stats={stats} />);
+    const values = [...container.querySelectorAll('.stat-value')].map((el) => el.textContent);
+    expect(values).toEqual(['5', '2', '10', '3', '76.9%']);
+  });
+
+  it('displays correct labels', () => {
+    const { container } = render(<StatsBar stats={stats} />);
+    const labels = [...container.querySelectorAll('.stat-label')].map((el) => el.textContent);
+    expect(labels).toEqual(['Active PRs', 'Shelved PRs', 'Merged PRs', 'Closed PRs', 'Merge Rate']);
+  });
+});

--- a/packages/dashboard/src/hooks/use-dashboard.test.ts
+++ b/packages/dashboard/src/hooks/use-dashboard.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/preact';
+import { useDashboard } from './use-dashboard';
+import { makeDashboardData } from '../test-helpers';
+import type { DashboardData } from '../types';
+
+describe('useDashboard', () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function mockFetchOk(data: DashboardData) {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(data),
+    });
+  }
+
+  function mockFetchError(status: number, body?: { error: string }) {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status,
+      json: () => (body ? Promise.resolve(body) : Promise.reject(new Error('no body'))),
+    });
+  }
+
+  it('fetches data on mount and transitions from loading to loaded', async () => {
+    const data = makeDashboardData();
+    mockFetchOk(data);
+
+    const { result } = renderHook(() => useDashboard());
+
+    // Initially loading
+    expect(result.current.loading).toBe(true);
+    expect(result.current.data).toBe(null);
+
+    // Wait for fetch to complete
+    await vi.waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual(data);
+    expect(result.current.error).toBe(null);
+    expect(mockFetch).toHaveBeenCalledWith('/api/data', undefined);
+  });
+
+  it('sets error state on fetch failure', async () => {
+    mockFetchError(500, { error: 'Internal Server Error' });
+
+    const { result } = renderHook(() => useDashboard());
+
+    await vi.waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.data).toBe(null);
+    expect(result.current.error).toBe('Internal Server Error');
+  });
+
+  it('sets HTTP status as error when no error body', async () => {
+    mockFetchError(502);
+
+    const { result } = renderHook(() => useDashboard());
+
+    await vi.waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('HTTP 502');
+  });
+
+  it('refresh calls POST /api/refresh', async () => {
+    const data = makeDashboardData();
+    mockFetchOk(data);
+
+    const { result } = renderHook(() => useDashboard());
+
+    await vi.waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    const refreshedData = makeDashboardData({ stats: { ...data.stats, activePRs: 3 } });
+    mockFetchOk(refreshedData);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(mockFetch).toHaveBeenLastCalledWith('/api/refresh', { method: 'POST' });
+    expect(result.current.data?.stats.activePRs).toBe(3);
+  });
+
+  it('performAction sends action and updates data', async () => {
+    const data = makeDashboardData();
+    mockFetchOk(data);
+
+    const { result } = renderHook(() => useDashboard());
+
+    await vi.waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    const updatedData = makeDashboardData({ shelvedPRUrls: ['https://github.com/org/repo/pull/1'] });
+    mockFetchOk(updatedData);
+
+    await act(async () => {
+      await result.current.performAction({ action: 'shelve', url: 'https://github.com/org/repo/pull/1' });
+    });
+
+    expect(mockFetch).toHaveBeenLastCalledWith('/api/action', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'shelve', url: 'https://github.com/org/repo/pull/1' }),
+    });
+    expect(result.current.data?.shelvedPRUrls).toEqual(['https://github.com/org/repo/pull/1']);
+  });
+
+  it('performAction re-fetches on failure and re-throws', async () => {
+    const data = makeDashboardData();
+    mockFetchOk(data);
+
+    const { result } = renderHook(() => useDashboard());
+
+    await vi.waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // Action fails
+    mockFetchError(500, { error: 'Server error' });
+    // Re-fetch succeeds
+    const refreshedData = makeDashboardData({ stats: { ...data.stats, activePRs: 4 } });
+    mockFetchOk(refreshedData);
+
+    await expect(
+      act(async () => {
+        await result.current.performAction({ action: 'shelve', url: 'https://github.com/x/y/pull/1' });
+      }),
+    ).rejects.toThrow('Server error');
+
+    // Data should be refreshed despite the error
+    expect(result.current.data?.stats.activePRs).toBe(4);
+  });
+
+  it('clearError resets error to null', async () => {
+    mockFetchError(500, { error: 'Something went wrong' });
+
+    const { result } = renderHook(() => useDashboard());
+
+    await vi.waitFor(() => {
+      expect(result.current.error).toBe('Something went wrong');
+    });
+
+    act(() => {
+      result.current.clearError();
+    });
+
+    expect(result.current.error).toBe(null);
+  });
+});

--- a/packages/dashboard/src/test-helpers.ts
+++ b/packages/dashboard/src/test-helpers.ts
@@ -1,0 +1,98 @@
+import type { FetchedPR, MergedPR, ClosedPR, ShelvedPRRef, CommentedIssueWithResponse, DashboardData } from './types';
+
+export function makePR(overrides: Partial<FetchedPR> = {}): FetchedPR {
+  return {
+    id: 1,
+    url: 'https://github.com/owner/repo/pull/1',
+    repo: 'owner/repo',
+    number: 1,
+    title: 'Test PR',
+    status: 'healthy',
+    displayLabel: '[Healthy]',
+    displayDescription: 'Everything looks good',
+    createdAt: '2025-06-01T00:00:00Z',
+    updatedAt: '2025-06-10T00:00:00Z',
+    daysSinceActivity: 5,
+    ciStatus: 'passing',
+    failingCheckNames: [],
+    classifiedChecks: [],
+    hasMergeConflict: false,
+    reviewDecision: 'approved',
+    hasUnrespondedComment: false,
+    hasIncompleteChecklist: false,
+    maintainerActionHints: [],
+    ...overrides,
+  };
+}
+
+export function makeMergedPR(overrides: Partial<MergedPR> = {}): MergedPR {
+  return {
+    url: 'https://github.com/owner/repo/pull/10',
+    repo: 'owner/repo',
+    number: 10,
+    title: 'Merged PR',
+    mergedAt: '2025-06-09T00:00:00Z',
+    ...overrides,
+  };
+}
+
+export function makeClosedPR(overrides: Partial<ClosedPR> = {}): ClosedPR {
+  return {
+    url: 'https://github.com/owner/repo/pull/11',
+    repo: 'owner/repo',
+    number: 11,
+    title: 'Closed PR',
+    closedAt: '2025-06-08T00:00:00Z',
+    ...overrides,
+  };
+}
+
+export function makeShelvedRef(overrides: Partial<ShelvedPRRef> = {}): ShelvedPRRef {
+  return {
+    number: 20,
+    url: 'https://github.com/owner/repo/pull/20',
+    title: 'Shelved PR',
+    repo: 'owner/repo',
+    daysSinceActivity: 30,
+    status: 'dormant',
+    ...overrides,
+  };
+}
+
+export function makeIssueResponse(overrides: Partial<CommentedIssueWithResponse> = {}): CommentedIssueWithResponse {
+  return {
+    repo: 'owner/repo',
+    number: 100,
+    title: 'Test Issue',
+    url: 'https://github.com/owner/repo/issues/100',
+    userLastCommentedAt: '2025-06-01T00:00:00Z',
+    labels: ['bug'],
+    daysSinceUserComment: 3,
+    status: 'new_response',
+    lastResponseAuthor: 'maintainer',
+    lastResponseBody: 'Thanks for the report!',
+    lastResponseAt: '2025-06-04T00:00:00Z',
+    isFromMaintainer: true,
+    ...overrides,
+  };
+}
+
+export function makeDashboardData(overrides: Partial<DashboardData> = {}): DashboardData {
+  return {
+    stats: { activePRs: 2, shelvedPRs: 0, mergedPRs: 5, closedPRs: 1, mergeRate: '83.3%' },
+    prsByRepo: {},
+    topRepos: [],
+    monthlyMerged: {},
+    monthlyOpened: {},
+    monthlyClosed: {},
+    activePRs: [],
+    shelvedPRUrls: [],
+    dismissedUrls: [],
+    recentlyMergedPRs: [],
+    recentlyClosedPRs: [],
+    autoUnshelvedPRs: [],
+    commentedIssues: [],
+    issueResponses: [],
+    ...overrides,
+  };
+}

--- a/packages/dashboard/src/utils.test.ts
+++ b/packages/dashboard/src/utils.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { truncate, formatDate, statusColor, ciStatusColor } from './utils';
+
+describe('truncate', () => {
+  it('returns the string unchanged if within limit', () => {
+    expect(truncate('short', 10)).toBe('short');
+  });
+
+  it('returns the string unchanged if exactly at limit', () => {
+    expect(truncate('exact', 5)).toBe('exact');
+  });
+
+  it('truncates and adds ellipsis when exceeding limit', () => {
+    expect(truncate('hello world', 5)).toBe('hello...');
+  });
+
+  it('handles empty string', () => {
+    expect(truncate('', 10)).toBe('');
+  });
+});
+
+describe('formatDate', () => {
+  it('formats a valid ISO date', () => {
+    const result = formatDate('2025-06-15T12:00:00Z');
+    expect(result).toContain('Jun');
+    expect(result).toContain('15');
+    expect(result).toContain('2025');
+  });
+
+  it('returns the original string for invalid dates', () => {
+    expect(formatDate('not-a-date')).toBe('not-a-date');
+  });
+
+  it('returns the original string for empty string', () => {
+    expect(formatDate('')).toBe('');
+  });
+});
+
+describe('statusColor', () => {
+  it.each([
+    'needs_response',
+    'needs_changes',
+    'failing_ci',
+    'merge_conflict',
+    'missing_required_files',
+    'needs_rebase',
+    'incomplete_checklist',
+  ] as const)('returns error color for action-required status "%s"', (status) => {
+    expect(statusColor(status)).toBe('var(--accent-error)');
+  });
+
+  it.each([
+    'changes_addressed',
+    'waiting_on_maintainer',
+    'ci_blocked',
+    'ci_not_running',
+    'waiting',
+  ] as const)('returns info color for waiting status "%s"', (status) => {
+    expect(statusColor(status)).toBe('var(--accent-info)');
+  });
+
+  it('returns open color for healthy status', () => {
+    expect(statusColor('healthy')).toBe('var(--accent-open)');
+  });
+
+  it.each(['approaching_dormant', 'dormant'] as const)(
+    'returns warning color for staleness status "%s"',
+    (status) => {
+      expect(statusColor(status)).toBe('var(--accent-warning)');
+    },
+  );
+
+  it('returns muted color for unknown status', () => {
+    expect(statusColor('unknown_status')).toBe('var(--text-muted)');
+  });
+});
+
+describe('ciStatusColor', () => {
+  it('returns green for passing', () => {
+    expect(ciStatusColor('passing')).toBe('var(--accent-open)');
+  });
+
+  it('returns red for failing', () => {
+    expect(ciStatusColor('failing')).toBe('var(--accent-error)');
+  });
+
+  it('returns yellow for pending', () => {
+    expect(ciStatusColor('pending')).toBe('var(--accent-warning)');
+  });
+
+  it('returns muted for unknown', () => {
+    expect(ciStatusColor('unknown')).toBe('var(--text-muted)');
+  });
+});

--- a/packages/dashboard/vitest.config.ts
+++ b/packages/dashboard/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import preact from '@preact/preset-vite';
+
+export default defineConfig({
+  plugins: [preact()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,7 +44,7 @@ importers:
         version: 20.19.35
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.0.18(@types/node@20.19.35)(tsx@4.21.0))
+        version: 4.0.18(vitest@4.0.18(@types/node@20.19.35)(jsdom@28.1.0)(tsx@4.21.0))
       esbuild:
         specifier: ^0.27.3
         version: 0.27.3
@@ -56,7 +56,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.16
-        version: 4.0.18(@types/node@20.19.35)(tsx@4.21.0)
+        version: 4.0.18(@types/node@20.19.35)(jsdom@28.1.0)(tsx@4.21.0)
 
   packages/dashboard:
     dependencies:
@@ -73,12 +73,21 @@ importers:
       '@preact/preset-vite':
         specifier: ^2.9.4
         version: 2.10.3(@babel/core@7.29.0)(preact@10.28.4)(rollup@4.59.0)(vite@6.4.1(@types/node@25.3.3)(tsx@4.21.0))
+      '@testing-library/preact':
+        specifier: ^3.2.4
+        version: 3.2.4(preact@10.28.4)
+      jsdom:
+        specifier: ^28.1.0
+        version: 28.1.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: ^6.3.5
         version: 6.4.1(@types/node@25.3.3)(tsx@4.21.0)
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@25.3.3)(jsdom@28.1.0)(tsx@4.21.0)
 
   packages/mcp-server:
     dependencies:
@@ -106,9 +115,22 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.16
-        version: 4.0.18(@types/node@25.3.3)(tsx@4.21.0)
+        version: 4.0.18(@types/node@25.3.3)(jsdom@28.1.0)(tsx@4.21.0)
 
 packages:
+
+  '@acemir/cssom@0.9.31':
+    resolution: {integrity: sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==}
+
+  '@asamuzakjp/css-color@5.0.1':
+    resolution: {integrity: sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@6.8.1':
+    resolution: {integrity: sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -191,6 +213,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/runtime@7.28.6':
+    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -206,6 +232,41 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.1.1':
+    resolution: {integrity: sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.0.2':
+    resolution: {integrity: sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.29':
+    resolution: {integrity: sha512-jx9GjkkP5YHuTmko2eWAvpPnb0mB4mGRr2U7XwVNwevm8nlpobZEVk+GNmiYMk2VuA75v+plfXWyroWKmICZXg==}
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -558,6 +619,15 @@ packages:
     resolution: {integrity: sha512-bIZEUzOI1jkhviX2cp5vNyXQc6olzb2ohewQubuYlMXZ2Q/XjBO0x0XhGPvc9fjSIiUN0vw+0hq53BJ4eQSJKQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@exodus/bytes@1.14.1':
+    resolution: {integrity: sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
   '@hono/node-server@1.19.9':
     resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
     engines: {node: '>=18.14.1'}
@@ -831,6 +901,19 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@testing-library/dom@8.20.1':
+    resolution: {integrity: sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==}
+    engines: {node: '>=12'}
+
+  '@testing-library/preact@3.2.4':
+    resolution: {integrity: sha512-F+kJ243LP6VmEK1M809unzTE/ijg+bsMNuiRN0JEDIJBELKKDNhdgC/WrUSZ7klwJvtlO3wQZ9ix+jhObG07Fg==}
+    engines: {node: '>= 12'}
+    peerDependencies:
+      preact: '>=10 || ^10.0.0-alpha.0 || ^10.0.0-beta.0'
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -963,6 +1046,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -977,12 +1064,35 @@ packages:
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  aria-query@5.1.3:
+    resolution: {integrity: sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==}
+
+  array-buffer-byte-length@1.0.2:
+    resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
+    engines: {node: '>= 0.4'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
   ast-v8-to-istanbul@0.3.12:
     resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
+
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
 
   babel-plugin-transform-hook-names@1.0.2:
     resolution: {integrity: sha512-5gafyjyyBTTdX/tQQ0hRgu4AhNHG/hqWi0ZZmg2xvs2FgRkJXzDNKBZCyoYqgFkovfDrgM8OoKg8karoUvWeCw==}
@@ -1000,6 +1110,9 @@ packages:
 
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
@@ -1028,6 +1141,10 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
+  call-bind@1.0.8:
+    resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
+    engines: {node: '>= 0.4'}
+
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
@@ -1039,9 +1156,20 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
   chart.js@4.5.1:
     resolution: {integrity: sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==}
     engines: {pnpm: '>=8'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
@@ -1077,9 +1205,21 @@ packages:
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
 
+  css-tree@3.1.0:
+    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   css-what@6.2.2:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
+
+  cssstyle@6.2.0:
+    resolution: {integrity: sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==}
+    engines: {node: '>=20'}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1090,12 +1230,30 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  deep-equal@2.2.3:
+    resolution: {integrity: sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==}
+    engines: {node: '>= 0.4'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -1128,6 +1286,10 @@ packages:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -1135,6 +1297,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-get-iterator@1.1.3:
+    resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -1287,6 +1452,10 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
+
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -1302,6 +1471,9 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  functions-have-names@1.2.3:
+    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -1326,12 +1498,23 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
+  has-bigints@1.1.0:
+    resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
+    engines: {node: '>= 0.4'}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
   hasown@2.0.2:
@@ -1346,12 +1529,24 @@ packages:
     resolution: {integrity: sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==}
     engines: {node: '>=16.9.0'}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -1372,6 +1567,10 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  internal-slot@1.1.0:
+    resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
+    engines: {node: '>= 0.4'}
+
   ip-address@10.0.1:
     resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
     engines: {node: '>= 12'}
@@ -1379,6 +1578,30 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  is-arguments@1.2.0:
+    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
+    engines: {node: '>= 0.4'}
+
+  is-array-buffer@3.0.5:
+    resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
+    engines: {node: '>= 0.4'}
+
+  is-bigint@1.1.0:
+    resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
+    engines: {node: '>= 0.4'}
+
+  is-boolean-object@1.2.2:
+    resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
+    engines: {node: '>= 0.4'}
+
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
+
+  is-date-object@1.1.0:
+    resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
+    engines: {node: '>= 0.4'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1388,8 +1611,50 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-map@2.0.3:
+    resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
+    engines: {node: '>= 0.4'}
+
+  is-number-object@1.1.1:
+    resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
+    engines: {node: '>= 0.4'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
+
+  is-set@2.0.3:
+    resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
+    engines: {node: '>= 0.4'}
+
+  is-shared-array-buffer@1.0.4:
+    resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
+    engines: {node: '>= 0.4'}
+
+  is-string@1.1.1:
+    resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
+    engines: {node: '>= 0.4'}
+
+  is-symbol@1.1.1:
+    resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
+    engines: {node: '>= 0.4'}
+
+  is-weakmap@2.0.2:
+    resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
+    engines: {node: '>= 0.4'}
+
+  is-weakset@2.0.4:
+    resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
+    engines: {node: '>= 0.4'}
+
+  isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1414,6 +1679,15 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsdom@28.1.0:
+    resolution: {integrity: sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -1457,8 +1731,16 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lru-cache@11.2.6:
+    resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1473,6 +1755,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.12.2:
+    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -1526,6 +1811,18 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
+  object-is@1.1.6:
+    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
+    engines: {node: '>= 0.4'}
+
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
+  object.assign@4.1.7:
+    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
+    engines: {node: '>= 0.4'}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
@@ -1547,6 +1844,9 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -1581,6 +1881,10 @@ packages:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
+
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1596,6 +1900,10 @@ packages:
     resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
     engines: {node: '>=14'}
     hasBin: true
+
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -1617,6 +1925,13 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  regexp.prototype.flags@1.5.4:
+    resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
+    engines: {node: '>= 0.4'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -1633,8 +1948,16 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
+  safe-regex-test@1.1.0:
+    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
+    engines: {node: '>= 0.4'}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -1652,6 +1975,14 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
+  set-function-name@2.0.2:
+    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
+    engines: {node: '>= 0.4'}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -1712,9 +2043,16 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  stop-iteration-iterator@1.1.0:
+    resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
+    engines: {node: '>= 0.4'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1731,9 +2069,24 @@ packages:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.24:
+    resolution: {integrity: sha512-pj7yygNMoMRqG7ML2SDQ0xNIOfN3IBDUcPVM2Sg6hP96oFNN2nqnzHreT3z9xLq85IWJyNTvD38O002DdOrPMw==}
+
+  tldts@7.0.24:
+    resolution: {integrity: sha512-1r6vQTTt1rUiJkI5vX7KG8PR342Ru/5Oh13kEQP2SMbRSZpOey9SrBe27IDxkoWulx8ShWu4K6C0BkctP8Z1bQ==}
+    hasBin: true
+
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tough-cookie@6.0.0:
+    resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
@@ -1771,6 +2124,10 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici@7.22.0:
+    resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
+    engines: {node: '>=20.18.1'}
 
   universal-user-agent@7.0.3:
     resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
@@ -1837,46 +2194,6 @@ packages:
       yaml:
         optional: true
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
   vitest@4.0.18:
     resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -1911,6 +2228,34 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  which-boxed-primitive@1.1.1:
+    resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
+    engines: {node: '>= 0.4'}
+
+  which-collection@1.0.2:
+    resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
+    engines: {node: '>= 0.4'}
+
+  which-typed-array@1.1.20:
+    resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
+    engines: {node: '>= 0.4'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1928,6 +2273,13 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -1944,6 +2296,26 @@ packages:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
+
+  '@acemir/cssom@0.9.31': {}
+
+  '@asamuzakjp/css-color@5.0.1':
+    dependencies:
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.2.6
+
+  '@asamuzakjp/dom-selector@6.8.1':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.1.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.6
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -2051,6 +2423,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/runtime@7.28.6': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -2075,6 +2449,32 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.1.0
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.29': {}
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -2265,6 +2665,8 @@ snapshots:
     dependencies:
       '@eslint/core': 1.1.0
       levn: 0.4.1
+
+  '@exodus/bytes@1.14.1': {}
 
   '@hono/node-server@1.19.9(hono@4.12.3)':
     dependencies:
@@ -2520,6 +2922,24 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@testing-library/dom@8.20.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.28.6
+      '@types/aria-query': 5.0.4
+      aria-query: 5.1.3
+      chalk: 4.1.2
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      pretty-format: 27.5.1
+
+  '@testing-library/preact@3.2.4(preact@10.28.4)':
+    dependencies:
+      '@testing-library/dom': 8.20.1
+      preact: 10.28.4
+
+  '@types/aria-query@5.0.4': {}
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -2632,7 +3052,7 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       eslint-visitor-keys: 5.0.1
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@20.19.35)(tsx@4.21.0))':
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@20.19.35)(jsdom@28.1.0)(tsx@4.21.0))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -2644,7 +3064,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@20.19.35)(tsx@4.21.0)
+      vitest: 4.0.18(@types/node@20.19.35)(jsdom@28.1.0)(tsx@4.21.0)
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -2655,21 +3075,21 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@20.19.35)(tsx@4.21.0))':
+  '@vitest/mocker@4.0.18(vite@6.4.1(@types/node@20.19.35)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@20.19.35)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@20.19.35)(tsx@4.21.0)
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.3.3)(tsx@4.21.0))':
+  '@vitest/mocker@4.0.18(vite@6.4.1(@types/node@25.3.3)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.3.3)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.3.3)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -2704,6 +3124,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
@@ -2722,6 +3144,23 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
+
+  aria-query@5.1.3:
+    dependencies:
+      deep-equal: 2.2.3
+
+  array-buffer-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      is-array-buffer: 3.0.5
+
   assertion-error@2.0.1: {}
 
   ast-v8-to-istanbul@0.3.12:
@@ -2729,6 +3168,10 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
       js-tokens: 10.0.0
+
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
 
   babel-plugin-transform-hook-names@1.0.2(@babel/core@7.29.0):
     dependencies:
@@ -2739,6 +3182,10 @@ snapshots:
   baseline-browser-mapping@2.10.0: {}
 
   before-after-hook@4.0.0: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   body-parser@2.2.2:
     dependencies:
@@ -2777,6 +3224,13 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
+  call-bind@1.0.8:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
   call-bound@1.0.4:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -2786,9 +3240,20 @@ snapshots:
 
   chai@6.2.2: {}
 
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   chart.js@4.5.1:
     dependencies:
       '@kurkle/color': 0.3.4
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
 
   commander@14.0.3: {}
 
@@ -2821,15 +3286,71 @@ snapshots:
       domutils: 3.2.2
       nth-check: 2.1.1
 
+  css-tree@3.1.0:
+    dependencies:
+      mdn-data: 2.12.2
+      source-map-js: 1.2.1
+
   css-what@6.2.2: {}
+
+  cssstyle@6.2.0:
+    dependencies:
+      '@asamuzakjp/css-color': 5.0.1
+      '@csstools/css-syntax-patches-for-csstree': 1.0.29
+      css-tree: 3.1.0
+      lru-cache: 11.2.6
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.6.0: {}
+
+  deep-equal@2.2.3:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      call-bind: 1.0.8
+      es-get-iterator: 1.1.3
+      get-intrinsic: 1.3.0
+      is-arguments: 1.2.0
+      is-array-buffer: 3.0.5
+      is-date-object: 1.1.0
+      is-regex: 1.2.1
+      is-shared-array-buffer: 1.0.4
+      isarray: 2.0.5
+      object-is: 1.1.6
+      object-keys: 1.1.1
+      object.assign: 4.1.7
+      regexp.prototype.flags: 1.5.4
+      side-channel: 1.1.0
+      which-boxed-primitive: 1.1.1
+      which-collection: 1.0.2
+      which-typed-array: 1.1.20
+
   deep-is@0.1.4: {}
 
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
+
   depd@2.0.0: {}
+
+  dom-accessibility-api@0.5.16: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -2863,9 +3384,23 @@ snapshots:
 
   entities@4.5.0: {}
 
+  entities@6.0.1: {}
+
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-get-iterator@1.1.3:
+    dependencies:
+      call-bind: 1.0.8
+      get-intrinsic: 1.3.0
+      has-symbols: 1.1.0
+      is-arguments: 1.2.0
+      is-map: 2.0.3
+      is-set: 2.0.3
+      is-string: 1.1.1
+      isarray: 2.0.5
+      stop-iteration-iterator: 1.1.0
 
   es-module-lexer@1.7.0: {}
 
@@ -3100,6 +3635,10 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
+
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
@@ -3108,6 +3647,8 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  functions-have-names@1.2.3: {}
 
   gensync@1.0.0-beta.2: {}
 
@@ -3139,9 +3680,19 @@ snapshots:
 
   gopd@1.2.0: {}
 
+  has-bigints@1.1.0: {}
+
   has-flag@4.0.0: {}
 
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+
   has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
 
   hasown@2.0.2:
     dependencies:
@@ -3150,6 +3701,12 @@ snapshots:
   he@1.2.0: {}
 
   hono@4.12.3: {}
+
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.14.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   html-escaper@2.0.2: {}
 
@@ -3160,6 +3717,20 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   iconv-lite@0.7.2:
     dependencies:
@@ -3173,9 +3744,42 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  internal-slot@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      hasown: 2.0.2
+      side-channel: 1.1.0
+
   ip-address@10.0.1: {}
 
   ipaddr.js@1.9.1: {}
+
+  is-arguments@1.2.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-array-buffer@3.0.5:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
+  is-bigint@1.1.0:
+    dependencies:
+      has-bigints: 1.1.0
+
+  is-boolean-object@1.2.2:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-callable@1.2.7: {}
+
+  is-date-object@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
 
   is-extglob@2.1.1: {}
 
@@ -3183,7 +3787,49 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-map@2.0.3: {}
+
+  is-number-object@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-potential-custom-element-name@1.0.1: {}
+
   is-promise@4.0.0: {}
+
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  is-set@2.0.3: {}
+
+  is-shared-array-buffer@1.0.4:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-string@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-symbol@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-symbols: 1.1.0
+      safe-regex-test: 1.1.0
+
+  is-weakmap@2.0.2: {}
+
+  is-weakset@2.0.4:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
+  isarray@2.0.5: {}
 
   isexe@2.0.0: {}
 
@@ -3205,6 +3851,33 @@ snapshots:
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
+
+  jsdom@28.1.0:
+    dependencies:
+      '@acemir/cssom': 0.9.31
+      '@asamuzakjp/dom-selector': 6.8.1
+      '@bramus/specificity': 2.4.2
+      '@exodus/bytes': 1.14.1
+      cssstyle: 6.2.0
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.0
+      undici: 7.22.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - supports-color
 
   jsesc@3.1.0: {}
 
@@ -3237,9 +3910,13 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lru-cache@11.2.6: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -3256,6 +3933,8 @@ snapshots:
       semver: 7.7.4
 
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.12.2: {}
 
   media-typer@1.1.0: {}
 
@@ -3294,6 +3973,22 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
+  object-is@1.1.6:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+
+  object-keys@1.1.1: {}
+
+  object.assign@4.1.7:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+      has-symbols: 1.1.0
+      object-keys: 1.1.1
+
   obug@2.1.1: {}
 
   on-finished@2.4.1:
@@ -3321,6 +4016,10 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  parse5@8.0.0:
+    dependencies:
+      entities: 6.0.1
+
   parseurl@1.3.3: {}
 
   path-exists@4.0.0: {}
@@ -3339,6 +4038,8 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
+  possible-typed-array-names@1.1.0: {}
+
   postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
@@ -3350,6 +4051,12 @@ snapshots:
   prelude-ls@1.2.1: {}
 
   prettier@3.8.1: {}
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   proxy-addr@2.0.7:
     dependencies:
@@ -3370,6 +4077,17 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       unpipe: 1.0.0
+
+  react-is@17.0.2: {}
+
+  regexp.prototype.flags@1.5.4:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-errors: 1.3.0
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      set-function-name: 2.0.2
 
   require-from-string@2.0.2: {}
 
@@ -3416,7 +4134,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  safe-regex-test@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-regex: 1.2.1
+
   safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   semver@6.3.1: {}
 
@@ -3446,6 +4174,22 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+
+  set-function-name@2.0.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      functions-have-names: 1.2.3
+      has-property-descriptors: 1.0.2
 
   setprototypeof@1.2.0: {}
 
@@ -3503,9 +4247,16 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  stop-iteration-iterator@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      internal-slot: 1.1.0
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  symbol-tree@3.2.4: {}
 
   tinybench@2.9.0: {}
 
@@ -3518,7 +4269,21 @@ snapshots:
 
   tinyrainbow@3.0.3: {}
 
+  tldts-core@7.0.24: {}
+
+  tldts@7.0.24:
+    dependencies:
+      tldts-core: 7.0.24
+
   toidentifier@1.0.1: {}
+
+  tough-cookie@6.0.0:
+    dependencies:
+      tldts: 7.0.24
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
@@ -3558,6 +4323,8 @@ snapshots:
 
   undici-types@7.18.2: {}
 
+  undici@7.22.0: {}
+
   universal-user-agent@7.0.3: {}
 
   unpipe@1.0.0: {}
@@ -3584,6 +4351,19 @@ snapshots:
       stack-trace: 1.0.0-pre2
       vite: 6.4.1(@types/node@25.3.3)(tsx@4.21.0)
 
+  vite@6.4.1(@types/node@20.19.35)(tsx@4.21.0):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 20.19.35
+      fsevents: 2.3.3
+      tsx: 4.21.0
+
   vite@6.4.1(@types/node@25.3.3)(tsx@4.21.0):
     dependencies:
       esbuild: 0.25.12
@@ -3597,36 +4377,10 @@ snapshots:
       fsevents: 2.3.3
       tsx: 4.21.0
 
-  vite@7.3.1(@types/node@20.19.35)(tsx@4.21.0):
-    dependencies:
-      esbuild: 0.27.3
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.59.0
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 20.19.35
-      fsevents: 2.3.3
-      tsx: 4.21.0
-
-  vite@7.3.1(@types/node@25.3.3)(tsx@4.21.0):
-    dependencies:
-      esbuild: 0.27.3
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.59.0
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 25.3.3
-      fsevents: 2.3.3
-      tsx: 4.21.0
-
-  vitest@4.0.18(@types/node@20.19.35)(tsx@4.21.0):
+  vitest@4.0.18(@types/node@20.19.35)(jsdom@28.1.0)(tsx@4.21.0):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@20.19.35)(tsx@4.21.0))
+      '@vitest/mocker': 4.0.18(vite@6.4.1(@types/node@20.19.35)(tsx@4.21.0))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -3643,10 +4397,11 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@20.19.35)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@20.19.35)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.35
+      jsdom: 28.1.0
     transitivePeerDependencies:
       - jiti
       - less
@@ -3660,10 +4415,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.18(@types/node@25.3.3)(tsx@4.21.0):
+  vitest@4.0.18(@types/node@25.3.3)(jsdom@28.1.0)(tsx@4.21.0):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.3)(tsx@4.21.0))
+      '@vitest/mocker': 4.0.18(vite@6.4.1(@types/node@25.3.3)(tsx@4.21.0))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -3680,10 +4435,11 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@25.3.3)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.3.3)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.3.3
+      jsdom: 28.1.0
     transitivePeerDependencies:
       - jiti
       - less
@@ -3696,6 +4452,47 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.14.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  which-boxed-primitive@1.1.1:
+    dependencies:
+      is-bigint: 1.1.0
+      is-boolean-object: 1.2.2
+      is-number-object: 1.1.1
+      is-string: 1.1.1
+      is-symbol: 1.1.1
+
+  which-collection@1.0.2:
+    dependencies:
+      is-map: 2.0.3
+      is-set: 2.0.3
+      is-weakmap: 2.0.2
+      is-weakset: 2.0.4
+
+  which-typed-array@1.1.20:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
 
   which@2.0.2:
     dependencies:
@@ -3709,6 +4506,10 @@ snapshots:
   word-wrap@1.2.5: {}
 
   wrappy@1.0.2: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 


### PR DESCRIPTION
## Summary

- Adds 97 tests across 10 test files for the `packages/dashboard` Preact SPA, achieving comprehensive coverage of all components, hooks, utilities, and app-level integration
- Creates shared test factory helpers (`makePR`, `makeDashboardData`, etc.) in `test-helpers.ts` for consistent, DRY test data
- Configures vitest with jsdom environment and `@preact/preset-vite` for component testing

## Test Coverage Breakdown

| File | Tests | Coverage |
|------|-------|----------|
| `utils.test.ts` | 27 | truncate, formatDate, statusColor, ciStatusColor |
| `use-dashboard.test.ts` | 7 | fetch, error handling, refresh, actions, clearError |
| `stats-bar.test.tsx` | 3 | stat card rendering and values |
| `filter-bar.test.tsx` | 4 | dropdowns, search input, onChange callbacks |
| `pr-list.test.tsx` | 7 | grouping by status, shelving, selection, display |
| `action-bar.test.tsx` | 10 | shelve/unshelve, dismiss, snooze flow, errors |
| `recent-activity.test.tsx` | 5 | merged, closed, auto-unshelved sections |
| `issue-list.test.tsx` | 6 | items, maintainer/community badges, comments |
| `pr-detail.test.tsx` | 18 | fields, checks, comments, conditional sections |
| `app.test.tsx` | 10 | loading, error, filtering, dropdown population |

Closes #492

## Test plan
- [x] All 97 dashboard tests pass (`pnpm test` in packages/dashboard)
- [x] All 1639+ workspace tests pass (`pnpm test` at root)
- [x] TypeScript typechecks clean
- [x] PR review toolkit run (2 passes, converged)