### PR TITLE
fix: resolve prettier formatting violations

### DIFF
--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -264,7 +264,9 @@ export const commands: CLICommandDef[] = [
             if (options.json) {
               outputJson(data);
             } else {
-              console.log('Note: In v2, PR read state is not tracked locally. PRs are fetched fresh on each daily run.');
+              console.log(
+                'Note: In v2, PR read state is not tracked locally. PRs are fetched fresh on each daily run.',
+              );
             }
           } catch (err) {
             handleCommandError(err, options.json);

--- a/packages/core/src/cli.test.ts
+++ b/packages/core/src/cli.test.ts
@@ -90,9 +90,23 @@ const localOnlySet = new Set(LOCAL_ONLY_COMMANDS);
 
 describe('LOCAL_ONLY_COMMANDS (derived from registry)', () => {
   const expectedLocalOnly = [
-    'status', 'config', 'read', 'untrack', 'setup', 'checkSetup',
-    'serve', 'parse-issue-list', 'check-integration', 'local-repos',
-    'startup', 'shelve', 'unshelve', 'dismiss', 'undismiss', 'snooze', 'unsnooze',
+    'status',
+    'config',
+    'read',
+    'untrack',
+    'setup',
+    'checkSetup',
+    'serve',
+    'parse-issue-list',
+    'check-integration',
+    'local-repos',
+    'startup',
+    'shelve',
+    'unshelve',
+    'dismiss',
+    'undismiss',
+    'snooze',
+    'unsnooze',
   ];
 
   const expectedTokenRequired = ['daily', 'search', 'vet', 'track', 'comments', 'post', 'init', 'claim'];

--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -21,17 +21,23 @@ vi.mock('./http-cache.js', () => ({
     setInflight: vi.fn().mockReturnValue(() => {}),
   }),
   // Pass through to the fetcher so octokit mocks are still exercised
-  cachedRequest: vi.fn().mockImplementation(async (_cache: unknown, _url: string, fetcher: (h: Record<string, string>) => Promise<{ data: unknown }>) => {
-    const response = await fetcher({});
-    return response.data;
-  }),
-  cachedTimeBased: vi.fn().mockImplementation(async (cache: any, _key: string, _maxAgeMs: number, fetcher: () => Promise<unknown>) => {
-    const cached = cache.getIfFresh(_key, _maxAgeMs);
-    if (cached) return cached;
-    const result = await fetcher();
-    cache.set(_key, '', result);
-    return result;
-  }),
+  cachedRequest: vi
+    .fn()
+    .mockImplementation(
+      async (_cache: unknown, _url: string, fetcher: (h: Record<string, string>) => Promise<{ data: unknown }>) => {
+        const response = await fetcher({});
+        return response.data;
+      },
+    ),
+  cachedTimeBased: vi
+    .fn()
+    .mockImplementation(async (cache: any, _key: string, _maxAgeMs: number, fetcher: () => Promise<unknown>) => {
+      const cached = cache.getIfFresh(_key, _maxAgeMs);
+      if (cached) return cached;
+      const result = await fetcher();
+      cache.set(_key, '', result);
+      return result;
+    }),
 }));
 
 vi.mock('./state.js', () => ({
@@ -1494,7 +1500,9 @@ describe('Search result caching (#487)', () => {
       issues: { get: vi.fn(), listEventsForTimeline: vi.fn().mockResolvedValue({ data: [] }) },
       search: { issuesAndPullRequests: vi.fn().mockResolvedValue({ data: { total_count: 0, items: [] } }) },
       repos: {
-        get: vi.fn().mockResolvedValue({ data: { open_issues_count: 0, pushed_at: new Date().toISOString(), stargazers_count: 100, forks_count: 10 } }),
+        get: vi.fn().mockResolvedValue({
+          data: { open_issues_count: 0, pushed_at: new Date().toISOString(), stargazers_count: 100, forks_count: 10 },
+        }),
         listCommits: vi.fn().mockResolvedValue({ data: [{ commit: { author: { date: new Date().toISOString() } } }] }),
         getContent: vi.fn().mockRejectedValue(new Error('404 Not Found')),
       },

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -71,15 +71,10 @@ export class IssueDiscovery {
     per_page: number;
   }): Promise<{ total_count: number; items: GitHubSearchItem[] }> {
     const cacheKey = `search:${params.q}:${params.sort}:${params.order}:${params.per_page}`;
-    return cachedTimeBased(
-      getHttpCache(),
-      cacheKey,
-      SEARCH_CACHE_TTL_MS,
-      async () => {
-        const { data } = await this.octokit.search.issuesAndPullRequests(params);
-        return data;
-      },
-    );
+    return cachedTimeBased(getHttpCache(), cacheKey, SEARCH_CACHE_TTL_MS, async () => {
+      const { data } = await this.octokit.search.issuesAndPullRequests(params);
+      return data;
+    });
   }
 
   /**

--- a/packages/core/src/core/issue-vetting.test.ts
+++ b/packages/core/src/core/issue-vetting.test.ts
@@ -19,13 +19,15 @@ vi.mock('./http-cache.js', () => ({
     setInflight: vi.fn().mockReturnValue(() => {}),
   }),
   cachedRequest: vi.fn(),
-  cachedTimeBased: vi.fn().mockImplementation(async (cache: any, _key: string, _maxAgeMs: number, fetcher: () => Promise<unknown>) => {
-    const cached = cache.getIfFresh(_key, _maxAgeMs);
-    if (cached) return cached;
-    const result = await fetcher();
-    cache.set(_key, '', result);
-    return result;
-  }),
+  cachedTimeBased: vi
+    .fn()
+    .mockImplementation(async (cache: any, _key: string, _maxAgeMs: number, fetcher: () => Promise<unknown>) => {
+      const cached = cache.getIfFresh(_key, _maxAgeMs);
+      if (cached) return cached;
+      const result = await fetcher();
+      cache.set(_key, '', result);
+      return result;
+    }),
 }));
 
 vi.mock('./logger.js', () => ({

--- a/packages/core/src/core/pr-monitor.ts
+++ b/packages/core/src/core/pr-monitor.ts
@@ -320,8 +320,7 @@ export class PRMonitor {
     const classifiedChecks = classifyFailingChecks(failingCheckNames, failingCheckConclusions);
 
     // Determine status
-    const hasActionableCIFailure =
-      ciStatus === 'failing' && classifiedChecks.some((c) => c.category === 'actionable');
+    const hasActionableCIFailure = ciStatus === 'failing' && classifiedChecks.some((c) => c.category === 'actionable');
     const status = this.determineStatus({
       ciStatus,
       hasMergeConflict,

--- a/packages/dashboard/src/components/action-bar.test.tsx
+++ b/packages/dashboard/src/components/action-bar.test.tsx
@@ -12,16 +12,9 @@ interface ActionBarOptions {
 }
 
 function renderActionBar(options: ActionBarOptions = {}) {
-  const {
-    pr = makePR(),
-    isShelved = false,
-    isDismissed = false,
-    onAction = vi.fn(),
-  } = options;
+  const { pr = makePR(), isShelved = false, isDismissed = false, onAction = vi.fn() } = options;
 
-  return render(
-    <ActionBar pr={pr} isShelved={isShelved} isDismissed={isDismissed} onAction={onAction} />,
-  );
+  return render(<ActionBar pr={pr} isShelved={isShelved} isDismissed={isDismissed} onAction={onAction} />);
 }
 
 describe('ActionBar', () => {

--- a/packages/dashboard/src/components/filter-bar.test.tsx
+++ b/packages/dashboard/src/components/filter-bar.test.tsx
@@ -13,18 +13,11 @@ interface FilterBarOptions {
 }
 
 function renderFilterBar(options: FilterBarOptions = {}) {
-  const {
-    filters = defaultFilters,
-    onFilterChange = vi.fn(),
-    repos = [],
-    statuses = [],
-  } = options;
+  const { filters = defaultFilters, onFilterChange = vi.fn(), repos = [], statuses = [] } = options;
 
   return {
     onFilterChange,
-    ...render(
-      <FilterBar filters={filters} onFilterChange={onFilterChange} repos={repos} statuses={statuses} />,
-    ),
+    ...render(<FilterBar filters={filters} onFilterChange={onFilterChange} repos={repos} statuses={statuses} />),
   };
 }
 

--- a/packages/dashboard/src/components/pr-detail.test.tsx
+++ b/packages/dashboard/src/components/pr-detail.test.tsx
@@ -13,17 +13,13 @@ interface PRDetailOptions {
 }
 
 function renderPRDetail(options: PRDetailOptions = {}) {
-  const {
-    pr = makePR(),
-    isShelved = false,
-    isDismissed = false,
-    onAction = vi.fn(),
-    onClose = vi.fn(),
-  } = options;
+  const { pr = makePR(), isShelved = false, isDismissed = false, onAction = vi.fn(), onClose = vi.fn() } = options;
 
   return {
     onClose,
-    ...render(<PRDetail pr={pr} isShelved={isShelved} isDismissed={isDismissed} onAction={onAction} onClose={onClose} />),
+    ...render(
+      <PRDetail pr={pr} isShelved={isShelved} isDismissed={isDismissed} onAction={onAction} onClose={onClose} />,
+    ),
   };
 }
 

--- a/packages/dashboard/src/components/recent-activity.test.tsx
+++ b/packages/dashboard/src/components/recent-activity.test.tsx
@@ -42,9 +42,7 @@ describe('RecentActivity', () => {
     const closed = [makeClosedPR()];
     const unshelved = [makeShelvedRef()];
 
-    const { container } = render(
-      <RecentActivity mergedPRs={merged} closedPRs={closed} autoUnshelvedPRs={unshelved} />,
-    );
+    const { container } = render(<RecentActivity mergedPRs={merged} closedPRs={closed} autoUnshelvedPRs={unshelved} />);
 
     expect(container.querySelectorAll('.recent-activity-section')).toHaveLength(3);
   });

--- a/packages/dashboard/src/utils.test.ts
+++ b/packages/dashboard/src/utils.test.ts
@@ -49,26 +49,20 @@ describe('statusColor', () => {
     expect(statusColor(status)).toBe('var(--accent-error)');
   });
 
-  it.each([
-    'changes_addressed',
-    'waiting_on_maintainer',
-    'ci_blocked',
-    'ci_not_running',
-    'waiting',
-  ] as const)('returns info color for waiting status "%s"', (status) => {
-    expect(statusColor(status)).toBe('var(--accent-info)');
-  });
+  it.each(['changes_addressed', 'waiting_on_maintainer', 'ci_blocked', 'ci_not_running', 'waiting'] as const)(
+    'returns info color for waiting status "%s"',
+    (status) => {
+      expect(statusColor(status)).toBe('var(--accent-info)');
+    },
+  );
 
   it('returns open color for healthy status', () => {
     expect(statusColor('healthy')).toBe('var(--accent-open)');
   });
 
-  it.each(['approaching_dormant', 'dormant'] as const)(
-    'returns warning color for staleness status "%s"',
-    (status) => {
-      expect(statusColor(status)).toBe('var(--accent-warning)');
-    },
-  );
+  it.each(['approaching_dormant', 'dormant'] as const)('returns warning color for staleness status "%s"', (status) => {
+    expect(statusColor(status)).toBe('var(--accent-warning)');
+  });
 
   it('returns muted color for unknown status', () => {
     expect(statusColor('unknown_status')).toBe('var(--text-muted)');


### PR DESCRIPTION
## Summary

- Fixes CI format check failures across 11 files in core and dashboard packages
- All failures were Prettier formatting violations introduced in recent PRs
- Unblocks the release-please PR (#506)

## Test plan
- [x] `pnpm run format:check` passes
- [x] All tests pass (1639+)