### PR TITLE
fix: address repo audit findings — security, docs, and input validation

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "oss-autopilot": {
       "command": "npx",
-      "args": ["@oss-autopilot/mcp"]
+      "args": ["@oss-autopilot/mcp@1.0.2"]
     }
   }
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Thanks for your interest in contributing! This project helps developers manage t
 ### Prerequisites
 
 - Node.js 20+
+- [pnpm](https://pnpm.io/) (install: `corepack enable && corepack prepare pnpm@latest --activate`)
 - GitHub CLI (`gh`) authenticated: `gh auth login`
 
 ### Setup
@@ -31,13 +32,14 @@ pnpm test
 ```
 oss-autopilot/
 ├── packages/
-│   ├── core/               # @oss-autopilot/core (TypeScript CLI)
+│   ├── core/               # @oss-autopilot/core (TypeScript CLI + core library)
 │   │   ├── src/
 │   │   │   ├── core/       # Core logic (state, PR monitoring, types)
 │   │   │   ├── commands/   # CLI commands (daily, search, track, etc.)
 │   │   │   └── formatters/ # Output formatters (JSON)
 │   │   └── dist/           # Built CLI bundle (generated)
-│   └── dashboard/          # @oss-autopilot/dashboard (placeholder)
+│   ├── dashboard/          # @oss-autopilot/dashboard (Preact SPA dashboard)
+│   └── mcp-server/         # @oss-autopilot/mcp (MCP server for IDE integrations)
 ├── commands/               # Plugin slash commands (.md files)
 ├── agents/                 # Plugin agent definitions (.md files)
 ├── .claude-plugin/         # Plugin manifest
@@ -65,6 +67,7 @@ git checkout -b fix/your-bug-fix
 - Add tests if applicable
 - Run `pnpm test` to ensure tests pass
 - Run `pnpm run build` to ensure it compiles
+- Run `pnpm lint` and `pnpm format:check` to catch style issues (also enforced by pre-commit hook)
 - **Do NOT manually bump versions or edit CHANGELOG.md** — versioning is automated via [release-please](https://github.com/googleapis/release-please)
 
 ### 4. Commit

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -9,14 +9,6 @@ PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 messages=""
 
-# --- Step 0: Auto-pull marketplace clone for self-updates ---
-# Workaround for https://github.com/anthropics/claude-code/issues/26744
-# Marketplace plugins don't auto-update, so we pull on session start.
-MARKETPLACE_DIR="${HOME}/.claude/plugins/marketplaces/oss-autopilot"
-if [ -d "${MARKETPLACE_DIR}/.git" ]; then
-  (cd "${MARKETPLACE_DIR}" && git pull --ff-only) >/dev/null 2>&1 || true
-fi
-
 # --- Step 1: Rebuild stale CLI bundle (if needed) ---
 if [ -f "${PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" ] && [ "${PLUGIN_ROOT}/packages/core/package.json" -nt "${PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" ]; then
   if (cd "${PLUGIN_ROOT}/packages/core" && npm install --silent 2>/dev/null && npm run bundle --silent 2>/dev/null); then
@@ -76,8 +68,12 @@ fi
 
 # --- Output JSON ---
 if [ -n "$messages" ]; then
-  # Escape for JSON
-  escaped=$(printf '%s' "$messages" | sed 's/\\/\\\\/g; s/"/\\"/g')
+  # Escape for JSON: use jq if available, fall back to sed
+  if command -v jq &>/dev/null; then
+    escaped=$(printf '%s' "$messages" | jq -Rrs '@json | .[1:-1]')
+  else
+    escaped=$(printf '%s' "$messages" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g' | tr '\n' ' ')
+  fi
   cat <<EOF
 {
   "systemMessage": "${escaped}",

--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -126,6 +126,11 @@ export const commands: CLICommandDef[] = [
               }
               maxResults = parsed;
             }
+            const MAX_SEARCH_RESULTS = 100;
+            if (maxResults > MAX_SEARCH_RESULTS) {
+              console.warn(`Capping search to ${MAX_SEARCH_RESULTS} results (requested: ${maxResults})`);
+              maxResults = MAX_SEARCH_RESULTS;
+            }
             if (!options.json) {
               console.log(`\nSearching for issues (max ${maxResults})...\n`);
             }

--- a/packages/core/src/cli.test.ts
+++ b/packages/core/src/cli.test.ts
@@ -397,6 +397,26 @@ describe('Command registration', () => {
   });
 });
 
+// ─── Search maxResults cap ────────────────────────────────────────────────────
+
+describe('Search maxResults cap', () => {
+  it('should enforce MAX_SEARCH_RESULTS = 100 in the search command definition', () => {
+    const searchCmd = commands.find((c) => c.name === 'search');
+    expect(searchCmd).toBeDefined();
+
+    // Verify the cap constant is defined in the source (structural check)
+    const src = readFileSync(join(__dirname, 'cli-registry.ts'), 'utf-8');
+    const match = src.match(/const MAX_SEARCH_RESULTS\s*=\s*(\d+)/);
+    expect(match).not.toBeNull();
+    expect(Number(match![1])).toBe(100);
+  });
+
+  it('should warn to console when capping maxResults', () => {
+    const src = readFileSync(join(__dirname, 'cli-registry.ts'), 'utf-8');
+    expect(src).toContain('Capping search to');
+  });
+});
+
 // ─── Lazy import verification ─────────────────────────────────────────────────
 
 describe('Lazy imports', () => {

--- a/packages/core/src/commands/dashboard-lifecycle.test.ts
+++ b/packages/core/src/commands/dashboard-lifecycle.test.ts
@@ -23,10 +23,17 @@ vi.mock('./dashboard.js', () => ({
 const mockFindRunningDashboardServer = vi.fn();
 const mockIsDashboardServerRunning = vi.fn();
 const mockReadDashboardServerInfo = vi.fn();
+const mockRemoveDashboardServerInfo = vi.fn();
 vi.mock('./dashboard-server.js', () => ({
   findRunningDashboardServer: () => mockFindRunningDashboardServer(),
   isDashboardServerRunning: (port: number) => mockIsDashboardServerRunning(port),
   readDashboardServerInfo: () => mockReadDashboardServerInfo(),
+  removeDashboardServerInfo: () => mockRemoveDashboardServerInfo(),
+}));
+
+const mockGetCLIVersion = vi.fn().mockReturnValue('0.44.6');
+vi.mock('../core/index.js', () => ({
+  getCLIVersion: () => mockGetCLIVersion(),
 }));
 
 // ── Import after mocks ──────────────────────────────────────────────
@@ -61,13 +68,110 @@ describe('launchDashboardServer', () => {
     expect(mockSpawn).not.toHaveBeenCalled();
   });
 
-  it('should return existing server when already running', async () => {
+  it('should return existing server when already running with same version', async () => {
     mockFindRunningDashboardServer.mockResolvedValue({ port: 3000, url: 'http://localhost:3000' });
+    mockReadDashboardServerInfo.mockReturnValue({
+      pid: 12345,
+      port: 3000,
+      startedAt: '2026-01-01T00:00:00Z',
+      version: '0.44.6',
+    });
+    mockGetCLIVersion.mockReturnValue('0.44.6');
 
     const result = await launchDashboardServer();
 
     expect(result).toEqual({ url: 'http://localhost:3000', port: 3000, alreadyRunning: true });
     expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it('should return existing server when PID file has no version (backward compat)', async () => {
+    mockFindRunningDashboardServer.mockResolvedValue({ port: 3000, url: 'http://localhost:3000' });
+    mockReadDashboardServerInfo.mockReturnValue({ pid: 12345, port: 3000, startedAt: '2026-01-01T00:00:00Z' });
+
+    const result = await launchDashboardServer();
+
+    expect(mockReadDashboardServerInfo).toHaveBeenCalled();
+    expect(result).toEqual({ url: 'http://localhost:3000', port: 3000, alreadyRunning: true });
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it('should kill and relaunch server when version mismatches (#548)', async () => {
+    mockFindRunningDashboardServer.mockResolvedValue({ port: 3000, url: 'http://localhost:3000' });
+    // First call: version check reads old server info; second call: polling reads new server info
+    mockReadDashboardServerInfo
+      .mockReturnValueOnce({ pid: 12345, port: 3000, startedAt: '2026-01-01T00:00:00Z', version: '0.44.4' })
+      .mockReturnValueOnce({ pid: 99999, port: 3000, startedAt: '2026-01-01T00:00:01Z', version: '0.44.6' });
+    mockGetCLIVersion.mockReturnValue('0.44.6');
+    mockIsDashboardServerRunning.mockResolvedValueOnce(true);
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = await launchDashboardServer();
+    consoleSpy.mockRestore();
+
+    expect(processKillSpy).toHaveBeenCalledWith(12345, 'SIGTERM');
+    expect(mockRemoveDashboardServerInfo).toHaveBeenCalled();
+    expect(mockSpawn).toHaveBeenCalled();
+    expect(result).toEqual({ url: 'http://localhost:3000', port: 3000, alreadyRunning: false });
+  });
+
+  it('should return existing server when kill fails with EPERM (#548)', async () => {
+    mockFindRunningDashboardServer.mockResolvedValue({ port: 3000, url: 'http://localhost:3000' });
+    mockReadDashboardServerInfo.mockReturnValueOnce({
+      pid: 12345,
+      port: 3000,
+      startedAt: '2026-01-01T00:00:00Z',
+      version: '0.44.4',
+    });
+    mockGetCLIVersion.mockReturnValue('0.44.6');
+    // Simulate EPERM — PID recycled to another user's process
+    const epermErr = Object.assign(new Error('Operation not permitted'), { code: 'EPERM' });
+    processKillSpy.mockImplementation(() => {
+      throw epermErr;
+    });
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = await launchDashboardServer();
+    consoleSpy.mockRestore();
+
+    // Should NOT remove PID file when kill failed with EPERM
+    expect(mockRemoveDashboardServerInfo).not.toHaveBeenCalled();
+    // Should NOT spawn — return existing server rather than a doomed attempt
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(result).toEqual({ url: 'http://localhost:3000', port: 3000, alreadyRunning: true });
+  });
+
+  it('should not kill server when getCLIVersion returns fallback 0.0.0', async () => {
+    mockFindRunningDashboardServer.mockResolvedValue({ port: 3000, url: 'http://localhost:3000' });
+    mockReadDashboardServerInfo.mockReturnValueOnce({
+      pid: 12345,
+      port: 3000,
+      startedAt: '2026-01-01T00:00:00Z',
+      version: '0.44.4',
+    });
+    // getCLIVersion could not read package.json — returns fallback
+    mockGetCLIVersion.mockReturnValue('0.0.0');
+
+    const result = await launchDashboardServer();
+
+    // Should NOT kill — unreliable version read
+    expect(processKillSpy).not.toHaveBeenCalled();
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(result).toEqual({ url: 'http://localhost:3000', port: 3000, alreadyRunning: true });
+  });
+
+  it('should relaunch when PID file disappears between health check and version read', async () => {
+    mockFindRunningDashboardServer.mockResolvedValue({ port: 3000, url: 'http://localhost:3000' });
+    // PID file disappeared (race condition)
+    mockReadDashboardServerInfo
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce({ pid: 99999, port: 3000, startedAt: '2026-01-01T00:00:01Z', version: '0.44.6' });
+    mockIsDashboardServerRunning.mockResolvedValueOnce(true);
+
+    const result = await launchDashboardServer();
+
+    // Should fall through and spawn a new server
+    expect(mockSpawn).toHaveBeenCalled();
+    expect(result).toEqual({ url: 'http://localhost:3000', port: 3000, alreadyRunning: false });
   });
 
   it('should spawn detached child process when no server running', async () => {

--- a/packages/core/src/commands/dashboard-lifecycle.ts
+++ b/packages/core/src/commands/dashboard-lifecycle.ts
@@ -5,8 +5,14 @@
  */
 
 import { spawn } from 'child_process';
-import { findRunningDashboardServer, isDashboardServerRunning, readDashboardServerInfo } from './dashboard-server.js';
+import {
+  findRunningDashboardServer,
+  isDashboardServerRunning,
+  readDashboardServerInfo,
+  removeDashboardServerInfo,
+} from './dashboard-server.js';
 import { resolveAssetsDir } from './dashboard.js';
+import { getCLIVersion } from '../core/index.js';
 
 const DEFAULT_PORT = 3000;
 const POLL_INTERVAL_MS = 200;
@@ -41,7 +47,40 @@ export async function launchDashboardServer(options?: { port?: number }): Promis
   // 2. Check if a server is already running
   const existing = await findRunningDashboardServer();
   if (existing) {
-    return { url: existing.url, port: existing.port, alreadyRunning: true };
+    // If the running server is from a different CLI version, kill it and relaunch
+    // so the dashboard uses the current version's code (#548)
+    const info = readDashboardServerInfo();
+    const currentVersion = getCLIVersion();
+    if (!info) {
+      // PID file disappeared between health check and now (race condition).
+      // Fall through to launch a new server.
+    } else if (info.version && currentVersion !== '0.0.0' && info.version !== currentVersion) {
+      console.error(
+        `[STARTUP] Dashboard server version mismatch (running: ${info.version}, current: ${currentVersion}). Restarting...`,
+      );
+      let killed = false;
+      try {
+        process.kill(info.pid, 'SIGTERM');
+        killed = true;
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === 'ESRCH') {
+          killed = true; // Already exited
+        } else {
+          console.error(`[STARTUP] Could not kill outdated dashboard (PID ${info.pid}): ${(err as Error).message}`);
+        }
+      }
+      if (killed) {
+        removeDashboardServerInfo();
+      } else {
+        // Could not kill old server (e.g. EPERM); return it rather than
+        // attempting a doomed spawn on the same port.
+        return { url: existing.url, port: existing.port, alreadyRunning: true };
+      }
+      // Fall through to launch a new server
+    } else {
+      return { url: existing.url, port: existing.port, alreadyRunning: true };
+    }
   }
 
   // 3. Launch as detached child process

--- a/packages/core/src/commands/dashboard-server.test.ts
+++ b/packages/core/src/commands/dashboard-server.test.ts
@@ -70,6 +70,7 @@ vi.mock('../core/index.js', () => ({
   getStateManager: vi.fn(() => mockStateManager),
   getGitHubToken: vi.fn(() => null),
   getDataDir: vi.fn(() => pidTestDir),
+  getCLIVersion: vi.fn(() => '0.44.6'),
 }));
 
 // Mock fetchDashboardData so we never call GitHub

--- a/packages/core/src/commands/dashboard-server.ts
+++ b/packages/core/src/commands/dashboard-server.ts
@@ -9,7 +9,7 @@
 import * as http from 'http';
 import * as fs from 'fs';
 import * as path from 'path';
-import { getStateManager, getGitHubToken, getDataDir } from '../core/index.js';
+import { getStateManager, getGitHubToken, getDataDir, getCLIVersion } from '../core/index.js';
 import { errorMessage, ValidationError } from '../core/errors.js';
 import { warn } from '../core/logger.js';
 import {
@@ -52,6 +52,7 @@ export interface DashboardServerInfo {
   pid: number;
   port: number;
   startedAt: string;
+  version?: string;
 }
 
 interface DashboardJsonData {
@@ -125,6 +126,8 @@ export function readDashboardServerInfo(): DashboardServerInfo | null {
       typeof parsed !== 'object' ||
       parsed === null ||
       typeof parsed.pid !== 'number' ||
+      !Number.isInteger(parsed.pid) ||
+      parsed.pid <= 0 ||
       typeof parsed.port !== 'number' ||
       typeof parsed.startedAt !== 'string'
     ) {
@@ -594,7 +597,12 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
   }
 
   // Write PID file so other processes can detect this running server
-  writeDashboardServerInfo({ pid: process.pid, port: actualPort, startedAt: new Date().toISOString() });
+  writeDashboardServerInfo({
+    pid: process.pid,
+    port: actualPort,
+    startedAt: new Date().toISOString(),
+    version: getCLIVersion(),
+  });
 
   const serverUrl = `http://localhost:${actualPort}`;
   warn(MODULE, `Dashboard server running at ${serverUrl}`);

--- a/packages/core/src/core/pr-monitor.test.ts
+++ b/packages/core/src/core/pr-monitor.test.ts
@@ -293,6 +293,136 @@ describe('PRMonitor changes_addressed detection', () => {
   });
 });
 
+describe('PRMonitor commit author filtering (#547)', () => {
+  beforeEach(() => {
+    mockOctokitInstance = {};
+  });
+
+  it('should return needs_response when HEAD commit is by a non-contributor', () => {
+    const monitor = new PRMonitor('fake-token');
+    const result = (monitor as any).determineStatus({
+      ciStatus: 'passing',
+      hasMergeConflict: false,
+      hasUnrespondedComment: true,
+      hasIncompleteChecklist: false,
+      reviewDecision: 'changes_requested',
+      daysSinceActivity: 2,
+      dormantThreshold: 30,
+      approachingThreshold: 25,
+      latestCommitDate: '2026-02-08T12:00:00Z',
+      latestCommitAuthor: 'maintainer-user',
+      contributorUsername: 'contributor-user',
+      lastMaintainerCommentDate: '2026-02-07T10:00:00Z',
+    });
+
+    expect(result).toBe('needs_response');
+  });
+
+  it('should return changes_addressed when HEAD commit is by the contributor', () => {
+    const monitor = new PRMonitor('fake-token');
+    const result = (monitor as any).determineStatus({
+      ciStatus: 'passing',
+      hasMergeConflict: false,
+      hasUnrespondedComment: true,
+      hasIncompleteChecklist: false,
+      reviewDecision: 'changes_requested',
+      daysSinceActivity: 2,
+      dormantThreshold: 30,
+      approachingThreshold: 25,
+      latestCommitDate: '2026-02-08T12:00:00Z',
+      latestCommitAuthor: 'contributor-user',
+      contributorUsername: 'contributor-user',
+      lastMaintainerCommentDate: '2026-02-07T10:00:00Z',
+    });
+
+    expect(result).toBe('changes_addressed');
+  });
+
+  it('should return needs_response when commit is within 2 minutes of comment (race condition)', () => {
+    const monitor = new PRMonitor('fake-token');
+    const result = (monitor as any).determineStatus({
+      ciStatus: 'passing',
+      hasMergeConflict: false,
+      hasUnrespondedComment: true,
+      hasIncompleteChecklist: false,
+      reviewDecision: 'changes_requested',
+      daysSinceActivity: 2,
+      dormantThreshold: 30,
+      approachingThreshold: 25,
+      // 44 seconds after comment — not enough time to address feedback
+      latestCommitDate: '2026-02-07T10:00:44Z',
+      latestCommitAuthor: 'contributor-user',
+      contributorUsername: 'contributor-user',
+      lastMaintainerCommentDate: '2026-02-07T10:00:00Z',
+    });
+
+    expect(result).toBe('needs_response');
+  });
+
+  it('should degrade gracefully when commit author is unknown', () => {
+    const monitor = new PRMonitor('fake-token');
+    const result = (monitor as any).determineStatus({
+      ciStatus: 'passing',
+      hasMergeConflict: false,
+      hasUnrespondedComment: true,
+      hasIncompleteChecklist: false,
+      reviewDecision: 'changes_requested',
+      daysSinceActivity: 2,
+      dormantThreshold: 30,
+      approachingThreshold: 25,
+      latestCommitDate: '2026-02-08T12:00:00Z',
+      // No author info — degrade gracefully (treat as contributor)
+      latestCommitAuthor: undefined,
+      contributorUsername: 'contributor-user',
+      lastMaintainerCommentDate: '2026-02-07T10:00:00Z',
+    });
+
+    expect(result).toBe('changes_addressed');
+  });
+
+  it('should handle case-insensitive author comparison', () => {
+    const monitor = new PRMonitor('fake-token');
+    const result = (monitor as any).determineStatus({
+      ciStatus: 'passing',
+      hasMergeConflict: false,
+      hasUnrespondedComment: true,
+      hasIncompleteChecklist: false,
+      reviewDecision: 'changes_requested',
+      daysSinceActivity: 2,
+      dormantThreshold: 30,
+      approachingThreshold: 25,
+      latestCommitDate: '2026-02-08T12:00:00Z',
+      latestCommitAuthor: 'ContributorUser',
+      contributorUsername: 'contributoruser',
+      lastMaintainerCommentDate: '2026-02-07T10:00:00Z',
+    });
+
+    expect(result).toBe('changes_addressed');
+  });
+
+  it('should return needs_changes when non-contributor commit after changes_requested review', () => {
+    const monitor = new PRMonitor('fake-token');
+    const result = (monitor as any).determineStatus({
+      ciStatus: 'passing',
+      hasMergeConflict: false,
+      hasUnrespondedComment: false,
+      hasIncompleteChecklist: false,
+      reviewDecision: 'changes_requested',
+      daysSinceActivity: 2,
+      dormantThreshold: 30,
+      approachingThreshold: 25,
+      latestCommitDate: '2026-02-09T10:00:00Z',
+      latestCommitAuthor: 'maintainer-user',
+      contributorUsername: 'contributor-user',
+      lastMaintainerCommentDate: undefined,
+      latestChangesRequestedDate: '2026-02-08T11:52:22Z',
+    });
+
+    // Non-contributor commit should not count — still needs_changes
+    expect(result).toBe('needs_changes');
+  });
+});
+
 describe('PRMonitor needs_changes detection', () => {
   beforeEach(() => {
     mockOctokitInstance = {};

--- a/packages/core/src/core/pr-monitor.ts
+++ b/packages/core/src/core/pr-monitor.ts
@@ -271,10 +271,14 @@ export class PRMonitor {
     // (to detect needs_changes: review requested changes but no new commits pushed)
     const ciPromise = this.getCIStatus(owner, repo, ghPR.head.sha);
     const needCommitDate = hasUnrespondedComment || reviewDecision === 'changes_requested';
-    const commitDatePromise = needCommitDate
+    const commitInfoPromise = needCommitDate
       ? this.octokit.repos
           .getCommit({ owner, repo, ref: ghPR.head.sha })
-          .then((res) => res.data.commit.author?.date)
+          .then((res) => ({
+            date: res.data.commit.author?.date,
+            // GitHub user login of the commit author (may differ from git author)
+            author: res.data.author?.login,
+          }))
           .catch((err: unknown) => {
             // Rate limit errors must propagate — silently swallowing them produces
             // misleading status (e.g. needs_changes when changes were addressed) (#469).
@@ -298,10 +302,12 @@ export class PRMonitor {
           })
       : Promise.resolve(undefined);
 
-    const [{ status: ciStatus, failingCheckNames, failingCheckConclusions }, latestCommitDate] = await Promise.all([
+    const [{ status: ciStatus, failingCheckNames, failingCheckConclusions }, commitInfo] = await Promise.all([
       ciPromise,
-      commitDatePromise,
+      commitInfoPromise,
     ]);
+    const latestCommitDate = commitInfo?.date;
+    const latestCommitAuthor = commitInfo?.author;
 
     // Analyze PR body for incomplete checklists (delegated to checklist-analysis module)
     const { hasIncompleteChecklist, checklistStats } = analyzeChecklist(ghPR.body || '');
@@ -330,6 +336,8 @@ export class PRMonitor {
       dormantThreshold: config.dormantThresholdDays,
       approachingThreshold: config.approachingDormantDays,
       latestCommitDate,
+      latestCommitAuthor,
+      contributorUsername: config.githubUsername,
       lastMaintainerCommentDate: lastMaintainerComment?.createdAt,
       latestChangesRequestedDate,
       hasActionableCIFailure,
@@ -391,18 +399,32 @@ export class PRMonitor {
       daysSinceActivity,
       dormantThreshold,
       approachingThreshold,
-      latestCommitDate,
+      latestCommitDate: rawCommitDate,
+      latestCommitAuthor,
+      contributorUsername,
       lastMaintainerCommentDate,
       latestChangesRequestedDate,
       hasActionableCIFailure = true,
     } = input;
 
+    // Only count the latest commit if it was authored by the contributor (#547).
+    // Non-contributor commits (maintainer merge commits, GitHub suggestion commits)
+    // should not mask unaddressed feedback.
+    const latestCommitDate =
+      rawCommitDate && this.isContributorCommit(latestCommitAuthor, contributorUsername) ? rawCommitDate : undefined;
+
     // Priority order: needs_response/needs_changes/changes_addressed > failing_ci > merge_conflict > incomplete_checklist > dormant > approaching_dormant > waiting_on_maintainer > waiting/healthy
 
     if (hasUnrespondedComment) {
       // If the contributor pushed a commit after the maintainer's comment,
-      // the changes have been addressed — waiting for maintainer re-review
-      if (latestCommitDate && lastMaintainerCommentDate && latestCommitDate > lastMaintainerCommentDate) {
+      // the changes have been addressed — waiting for maintainer re-review.
+      // Require a minimum 2-minute gap to avoid false positives from race
+      // conditions (pushing while review is being submitted) (#547).
+      if (
+        latestCommitDate &&
+        lastMaintainerCommentDate &&
+        this.isCommitAfterComment(latestCommitDate, lastMaintainerCommentDate)
+      ) {
         // Safety net (#431): if a CHANGES_REQUESTED review was submitted after
         // the commit, the maintainer still expects changes — don't mask it
         if (latestChangesRequestedDate && latestCommitDate < latestChangesRequestedDate) {
@@ -459,6 +481,35 @@ export class PRMonitor {
     }
 
     return 'healthy';
+  }
+
+  /**
+   * Check whether the HEAD commit was authored by the contributor (#547).
+   * Returns true when the author matches or when author info is unavailable
+   * (graceful degradation — don't break existing behavior if the API omits it).
+   */
+  private isContributorCommit(commitAuthor?: string, contributorUsername?: string): boolean {
+    if (!commitAuthor || !contributorUsername) return true; // degrade gracefully
+    return commitAuthor.toLowerCase() === contributorUsername.toLowerCase();
+  }
+
+  /** Minimum gap (ms) between maintainer comment and contributor commit for
+   *  the commit to count as "addressing" the feedback (#547). Prevents false
+   *  positives from race conditions, clock skew, and in-flight pushes. */
+  private static readonly MIN_RESPONSE_GAP_MS = 2 * 60 * 1000; // 2 minutes
+
+  /**
+   * Check whether the contributor's commit is meaningfully after the maintainer's
+   * comment — i.e. the commit timestamp is at least MIN_RESPONSE_GAP_MS later (#547).
+   */
+  private isCommitAfterComment(commitDate: string, commentDate: string): boolean {
+    const commitMs = new Date(commitDate).getTime();
+    const commentMs = new Date(commentDate).getTime();
+    if (Number.isNaN(commitMs) || Number.isNaN(commentMs)) {
+      // Fall back to simple string comparison (pre-#547 behavior)
+      return commitDate > commentDate;
+    }
+    return commitMs - commentMs >= PRMonitor.MIN_RESPONSE_GAP_MS;
   }
 
   /**

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -60,6 +60,10 @@ export interface DetermineStatusInput {
   dormantThreshold: number;
   approachingThreshold: number;
   latestCommitDate?: string;
+  /** GitHub login of the HEAD commit's author (from `repos.getCommit`). */
+  latestCommitAuthor?: string;
+  /** GitHub login of the PR contributor (configured username). */
+  contributorUsername?: string;
   lastMaintainerCommentDate?: string;
   latestChangesRequestedDate?: string;
   /** True if at least one failing CI check is classified as 'actionable'. */

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,0 +1,159 @@
+# @oss-autopilot/mcp
+
+MCP server for [OSS Autopilot](https://github.com/costajohnt/oss-autopilot) — exposes PR tracking, issue discovery, and contribution management as MCP tools for any MCP-compatible client.
+
+[![npm](https://img.shields.io/npm/v/@oss-autopilot/mcp)](https://www.npmjs.com/package/@oss-autopilot/mcp)
+![Node](https://img.shields.io/badge/node-%3E%3D20-brightgreen)
+![License](https://img.shields.io/badge/license-MIT-green)
+
+## What It Provides
+
+| Feature | Count | Description |
+|---------|-------|-------------|
+| **Tools** | 21 | `daily`, `status`, `search`, `vet`, `track`, `untrack`, `read`, `comments`, `post`, `claim`, `config`, `init`, `setup`, `check-setup`, `startup`, `shelve`, `unshelve`, `dismiss`, `undismiss`, `snooze`, `unsnooze` |
+| **Resources** | 5 | `oss://status`, `oss://config`, `oss://prs`, `oss://prs/shelved`, `oss://pr/{owner}/{repo}/{number}` |
+| **Prompts** | 3 | `triage` (PR prioritization), `respond-to-pr` (draft response), `find-issues` (discover issues) |
+
+Supports **stdio** (default) and **Streamable HTTP** transports.
+
+## Prerequisites
+
+- Node.js 20+
+- [GitHub CLI](https://cli.github.com/) authenticated (`gh auth login`)
+
+## Quick Start
+
+```bash
+# 1. Initialize with your GitHub username
+npx @oss-autopilot/mcp@latest --init <your-github-username>
+
+# 2. Add the server to your MCP client (see config examples below)
+
+# 3. Use the tools — e.g. "daily" to check your PRs, "search" to find issues
+```
+
+## Client Configuration
+
+### Claude Desktop
+
+Add to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "oss-autopilot": {
+      "command": "npx",
+      "args": ["@oss-autopilot/mcp@latest"]
+    }
+  }
+}
+```
+
+### Cursor
+
+Add to `.cursor/mcp.json` in your project or global config:
+
+```json
+{
+  "mcpServers": {
+    "oss-autopilot": {
+      "command": "npx",
+      "args": ["@oss-autopilot/mcp@latest"]
+    }
+  }
+}
+```
+
+### Codex CLI
+
+```bash
+codex mcp add oss -- npx @oss-autopilot/mcp@latest
+```
+
+### Windsurf
+
+Add to your Windsurf MCP config:
+
+```json
+{
+  "mcpServers": {
+    "oss-autopilot": {
+      "command": "npx",
+      "args": ["@oss-autopilot/mcp@latest"]
+    }
+  }
+}
+```
+
+### Streamable HTTP (any client)
+
+Run the server in HTTP mode instead of stdio:
+
+```bash
+npx @oss-autopilot/mcp@latest --http --port 3001
+```
+
+The server listens at `http://127.0.0.1:3001/mcp` and accepts POST requests.
+
+## Tools Reference
+
+| Tool | Description | Read-only |
+|------|-------------|-----------|
+| `daily` | Run daily PR monitoring check with prioritized summary | No |
+| `status` | Show current PR tracking status | Yes |
+| `search` | Search GitHub for contributable issues | Yes |
+| `vet` | Analyze an issue for contribution suitability | Yes |
+| `track` | Start tracking a pull request | No |
+| `untrack` | Stop tracking a pull request | No |
+| `read` | Mark PR notifications as read | No |
+| `comments` | Fetch and display PR comments | Yes |
+| `post` | Post a comment on an issue or PR | No |
+| `claim` | Claim an issue by posting a comment | No |
+| `config` | Get or set configuration values | No |
+| `init` | Initialize with a GitHub username | No |
+| `setup` | Configure preferences (languages, interests) | No |
+| `check-setup` | Check if setup is complete | Yes |
+| `startup` | Run startup checks (auth, state, config) | No |
+| `shelve` | Temporarily hide a PR from daily checks | No |
+| `unshelve` | Return a shelved PR to active monitoring | No |
+| `dismiss` | Dismiss an issue or PR from notifications | No |
+| `undismiss` | Re-enable notifications for a dismissed item | No |
+| `snooze` | Snooze a PR for a number of days | No |
+| `unsnooze` | Unsnooze a PR immediately | No |
+
+## Resources Reference
+
+| Resource URI | Description |
+|-------------|-------------|
+| `oss://status` | PR tracking status (cached local state) |
+| `oss://config` | Current configuration |
+| `oss://prs` | Active open PRs from last daily digest |
+| `oss://prs/shelved` | Shelved PRs |
+| `oss://pr/{owner}/{repo}/{number}` | Detail for a specific PR |
+
+## Prompts Reference
+
+| Prompt | Args | Description |
+|--------|------|-------------|
+| `triage` | none | Fetches daily digest and builds a prioritized triage list |
+| `respond-to-pr` | `prUrl` | Fetches PR comments and context for drafting a response |
+| `find-issues` | `maxResults?` | Searches for issues ranked by viability score |
+
+## Programmatic Usage
+
+The server can also be imported and used as a library:
+
+```typescript
+import { createServer } from '@oss-autopilot/mcp';
+
+const server = createServer();
+// Connect to your own transport
+```
+
+## More Information
+
+See the [main repository README](https://github.com/costajohnt/oss-autopilot) for the full documentation, including the Claude Code plugin, CLI usage, dashboard, and contributing guide.
+
+## License
+
+MIT

--- a/packages/mcp-server/src/prompts.ts
+++ b/packages/mcp-server/src/prompts.ts
@@ -83,7 +83,11 @@ export function registerPrompts(server: McpServer): void {
     },
     async ({ maxResults }) => {
       try {
-        const data = await runSearch({ maxResults: maxResults ?? 5 });
+        const MAX_SEARCH_RESULTS = 100;
+        let capped = maxResults ?? 5;
+        if (!Number.isInteger(capped) || capped < 1) capped = 5;
+        if (capped > MAX_SEARCH_RESULTS) capped = MAX_SEARCH_RESULTS;
+        const data = await runSearch({ maxResults: capped });
         const candidateList = data.candidates
           .map(
             (c, i) =>

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -104,7 +104,17 @@ export function registerTools(server: McpServer): void {
       },
       annotations: { readOnlyHint: true },
     },
-    wrapTool((args: { maxResults?: number }) => runSearch({ maxResults: args.maxResults ?? 5 })),
+    wrapTool((args: { maxResults?: number }) => {
+      const MAX_SEARCH_RESULTS = 100;
+      let maxResults = args.maxResults ?? 5;
+      if (!Number.isInteger(maxResults) || maxResults < 1) {
+        throw new Error(`Invalid maxResults: ${maxResults}. Must be a positive integer.`);
+      }
+      if (maxResults > MAX_SEARCH_RESULTS) {
+        maxResults = MAX_SEARCH_RESULTS;
+      }
+      return runSearch({ maxResults });
+    }),
   );
 
   // 4. vet — Vet an issue for contribution suitability


### PR DESCRIPTION
## Summary

Addresses all 7 open issues from the repo audit:

- **#547** — Fix classification bug: filter `latestCommitDate` to contributor-authored commits only, add 2-min minimum gap to prevent race conditions
- **#548** — Kill and relaunch dashboard server on CLI version mismatch; write version to PID file
- **#549** — Add comprehensive mcp-server README (21 tools, 5 resources, 3 prompts, client configs)
- **#550** — Remove silent auto-pull from session-start hook, fix JSON escaping with jq/sed fallback
- **#551** — Pin MCP server version in .mcp.json, remove non-functional release-please extra-files entry
- **#552** — Update CONTRIBUTING.md with mcp-server package, lint/format instructions
- **#553** — Cap search maxResults at 100 in CLI, MCP tools, and MCP prompts; reject invalid values

### Additional hardening from PR review convergence

- PID file validation: reject non-positive-integer PIDs to prevent `process.kill(-1)` broadcasts
- Guard against `getCLIVersion()` `'0.0.0'` fallback causing false version mismatches
- NaN-safe date comparison in commit/comment time gap check
- Newline/tab escaping in session-start.sh sed fallback
- EPERM handling: return existing server rather than doomed spawn on occupied port
- TOCTOU race handling: PID file disappearing between health check and version read

## Test plan

- [x] All 1436 unit tests pass (`pnpm test`)
- [x] Prettier formatting passes
- [x] PR review toolkit converged (4 rounds: code-reviewer, silent-failure-hunter, code-simplifier, test-analyzer, comment-analyzer, type-design-analyzer)
- [x] #547: non-contributor commit filtering, 2-min time gap, NaN dates, case-insensitive author, graceful degradation
- [x] #548: same version reuse, backward compat (no version), kill+relaunch, EPERM fallback, TOCTOU race, '0.0.0' guard
- [x] #553: upper cap (100), lower bound (rejects 0/negative/float), prompt + tool + CLI parity
- [x] session-start.sh: jq path, sed fallback, no auto-pull