### PR TITLE
fix: eliminate ReDoS vulnerability in issue-vetting regex

### DIFF
--- a/packages/core/src/core/issue-vetting.ts
+++ b/packages/core/src/core/issue-vetting.ts
@@ -602,7 +602,7 @@ export class IssueVetter {
     if (!body || body.length < 50) return false;
 
     // Check for clear structure
-    const hasSteps = /\d+\.|[-*]\s/.test(body);
+    const hasSteps = /\d\.|[-*]\s/.test(body);
     const hasCodeBlock = /```/.test(body);
     const hasExpectedBehavior = /expect|should|must|want/i.test(body);
 


### PR DESCRIPTION
## Summary

- Replace `\d+\.` with `\d\.` in `analyzeRequirements()` to prevent polynomial backtracking (ReDoS)
- A single digit before the dot is sufficient to detect numbered list items

Fixes CodeQL alert [js/polynomial-redos](https://github.com/costajohnt/oss-autopilot/security/code-scanning/1) (CWE-1333)

## Test plan

- [x] All 1436 unit tests pass
- [x] One-character change — `\d+\.` → `\d\.` — removes the ambiguous quantifier