### PR TITLE
fix: merge changes_addressed into waiting_on_maintainer status

### DIFF
--- a/.claude-plugin/scripts/health-check.cjs
+++ b/.claude-plugin/scripts/health-check.cjs
@@ -9,7 +9,7 @@
  * - If showHealthCheck is false in config, exits silently
  * - If no state exists, shows a first-run hint to run /oss
  * - If last digest is >7 days old, nudges the user to catch up
- * - Otherwise, outputs a compact one-liner: "OSS: 15 active PRs — 1 need response, 5 awaiting re-review (2h ago)"
+ * - Otherwise, outputs a compact one-liner: "OSS: 15 active PRs — 1 need response, 5 waiting on maintainer (2h ago)"
  *
  * Configuration: Set showHealthCheck to false to disable:
  *   node packages/core/dist/cli.bundle.cjs setup --set showHealthCheck=false
@@ -51,7 +51,6 @@ try {
     const ciFailing = (d.ciFailingPRs || []).length;
     const conflicts = (d.mergeConflictPRs || []).length;
     const needsChanges = (d.needsChangesPRs || []).length;
-    const addressed = (d.changesAddressedPRs || []).length;
     const waitMaintainer = (d.waitingOnMaintainerPRs || []).length;
     // Actionable items first (you need to do something)
     if (needResponse > 0) segments.push(needResponse + ' need response');
@@ -59,7 +58,6 @@ try {
     if (ciFailing > 0) segments.push(ciFailing + ' CI failing');
     if (conflicts > 0) segments.push(conflicts + ' conflicts');
     // Informational items (waiting on others)
-    if (addressed > 0) segments.push(addressed + ' awaiting re-review');
     if (waitMaintainer > 0) segments.push(waitMaintainer + ' waiting on maintainer');
     if (segments.length > 0) {
       console.log('OSS: ' + total + ' active PRs — ' + segments.join(', ') + ' (' + ageLabel + ')');

--- a/packages/core/src/commands/daily-orchestration.test.ts
+++ b/packages/core/src/commands/daily-orchestration.test.ts
@@ -118,7 +118,6 @@ function makeDigest(prs: FetchedPR[] = []): DailyDigest {
     missingRequiredFilesPRs: [],
     incompleteChecklistPRs: [],
     needsChangesPRs: prs.filter((p) => p.status === 'needs_changes'),
-    changesAddressedPRs: [],
     waitingOnMaintainerPRs: [],
     approachingDormant: [],
     dormantPRs: prs.filter((p) => p.status === 'dormant'),

--- a/packages/core/src/commands/daily.test.ts
+++ b/packages/core/src/commands/daily.test.ts
@@ -258,7 +258,7 @@ describe('computeRepoSignals', () => {
   });
 
   it('should mark repo as having active maintainers for review-related statuses', () => {
-    const statuses = ['waiting_on_maintainer', 'changes_addressed', 'needs_response', 'needs_changes'] as const;
+    const statuses = ['waiting_on_maintainer', 'needs_response', 'needs_changes'] as const;
     for (const status of statuses) {
       const prs = [makePR({ repo: `owner/${status}`, status })];
       const result = computeRepoSignals(prs);
@@ -447,7 +447,6 @@ function makeDigest(prs: FetchedPR[]): DailyDigest {
     missingRequiredFilesPRs: [],
     incompleteChecklistPRs: [],
     needsChangesPRs: prs.filter((p) => p.status === 'needs_changes'),
-    changesAddressedPRs: prs.filter((p) => p.status === 'changes_addressed'),
     waitingOnMaintainerPRs: [],
     approachingDormant: [],
     dormantPRs: [],

--- a/packages/core/src/commands/dashboard-data.test.ts
+++ b/packages/core/src/commands/dashboard-data.test.ts
@@ -25,7 +25,6 @@ function makeDigest(overrides: Partial<DailyDigest> = {}): DailyDigest {
     missingRequiredFilesPRs: [],
     incompleteChecklistPRs: [],
     needsChangesPRs: [],
-    changesAddressedPRs: [],
     waitingOnMaintainerPRs: [],
     approachingDormant: [],
     dormantPRs: [],

--- a/packages/core/src/commands/dashboard-server.test.ts
+++ b/packages/core/src/commands/dashboard-server.test.ts
@@ -120,7 +120,6 @@ function makeDigest(overrides: Partial<DailyDigest> = {}): DailyDigest {
     missingRequiredFilesPRs: [],
     incompleteChecklistPRs: [],
     needsChangesPRs: [],
-    changesAddressedPRs: [],
     waitingOnMaintainerPRs: [],
     approachingDormant: [],
     dormantPRs: [],

--- a/packages/core/src/commands/dashboard-templates.ts
+++ b/packages/core/src/commands/dashboard-templates.ts
@@ -47,7 +47,6 @@ export function generateDashboardHtml(
 
   // Waiting on Others: informational, no contributor action needed
   const waitingOnOthers = [
-    ...(digest.changesAddressedPRs || []),
     ...(digest.waitingOnMaintainerPRs || []),
     ...(digest.ciBlockedPRs || []),
     ...(digest.ciNotRunningPRs || []),
@@ -150,7 +149,6 @@ export function generateDashboardHtml(
         <option value="needs-changes">Needs Changes</option>
         <option value="ci-failing">CI Failing</option>
         <option value="conflict">Merge Conflict</option>
-        <option value="changes-addressed">Changes Addressed</option>
         <option value="waiting-maintainer">Waiting on Maintainer</option>
         <option value="ci-blocked">CI Blocked</option>
         <option value="ci-not-running">CI Not Running</option>
@@ -252,14 +250,20 @@ export function generateDashboardHtml(
       </div>
       <div class="health-items">
         ${renderHealthItems(
-          digest.changesAddressedPRs || [],
-          'changes-addressed',
-          SVG_ICONS.checkCircle,
-          'Changes Addressed',
-          (pr) =>
-            `Awaiting re-review${pr.lastMaintainerComment ? ` from @${escapeHtml(pr.lastMaintainerComment.author)}` : ''}`,
+          digest.waitingOnMaintainerPRs || [],
+          'waiting-maintainer',
+          SVG_ICONS.clock,
+          'Waiting on Maintainer',
+          (pr) => {
+            if (pr.hasUnrespondedComment && pr.lastMaintainerComment) {
+              return `Changes addressed — waiting for @${escapeHtml(pr.lastMaintainerComment.author)} to re-review`;
+            }
+            if (pr.reviewDecision === 'changes_requested') {
+              return 'Changes addressed — awaiting re-review';
+            }
+            return titleMeta(pr);
+          },
         )}
-        ${renderHealthItems(digest.waitingOnMaintainerPRs || [], 'waiting-maintainer', SVG_ICONS.clock, 'Waiting on Maintainer', titleMeta)}
         ${renderHealthItems(digest.ciBlockedPRs || [], 'ci-blocked', SVG_ICONS.lock, 'CI Blocked', titleMeta)}
         ${renderHealthItems(digest.ciNotRunningPRs || [], 'ci-not-running', SVG_ICONS.infoCircle, 'CI Not Running', titleMeta)}
       </div>
@@ -471,7 +475,7 @@ export function generateDashboardHtml(
             const hasIssues =
               pr.ciStatus === 'failing' ||
               pr.hasMergeConflict ||
-              (pr.hasUnrespondedComment && pr.status !== 'changes_addressed') ||
+              (pr.hasUnrespondedComment && pr.status !== 'waiting_on_maintainer') ||
               pr.status === 'needs_changes';
             const isStale = pr.daysSinceActivity >= approachingDormantDays;
             const itemClass = hasIssues ? 'has-issues' : isStale ? 'stale' : '';
@@ -481,13 +485,11 @@ export function generateDashboardHtml(
                 ? 'ci-failing'
                 : pr.hasMergeConflict
                   ? 'conflict'
-                  : pr.hasUnrespondedComment && pr.status !== 'changes_addressed' && pr.status !== 'failing_ci'
+                  : pr.hasUnrespondedComment && pr.status !== 'waiting_on_maintainer' && pr.status !== 'failing_ci'
                     ? 'needs-response'
                     : pr.status === 'needs_changes'
                       ? 'needs-changes'
-                      : pr.status === 'changes_addressed'
-                        ? 'changes-addressed'
-                        : 'active';
+                      : 'active';
 
             return `
         <div class="pr-item ${itemClass}" data-status="${prStatus}" data-repo="${escapeHtml(pr.repo)}" data-title="${escapeHtml(pr.title.toLowerCase())}">
@@ -520,9 +522,9 @@ export function generateDashboardHtml(
               ${pr.ciStatus === 'passing' ? '<span class="badge badge-passing">CI Passing</span>' : ''}
               ${pr.ciStatus === 'pending' ? '<span class="badge badge-pending">CI Pending</span>' : ''}
               ${pr.hasMergeConflict ? '<span class="badge badge-conflict">Merge Conflict</span>' : ''}
-              ${pr.hasUnrespondedComment && pr.status === 'changes_addressed' ? '<span class="badge badge-changes-addressed">Changes Addressed</span>' : ''}
-              ${pr.hasUnrespondedComment && pr.status !== 'changes_addressed' && pr.status !== 'failing_ci' ? '<span class="badge badge-needs-response">Needs Response</span>' : ''}
-              ${pr.reviewDecision === 'changes_requested' ? '<span class="badge badge-changes-requested">Changes Requested</span>' : ''}
+              ${pr.status === 'waiting_on_maintainer' && (pr.hasUnrespondedComment || pr.reviewDecision === 'changes_requested') ? '<span class="badge badge-changes-addressed">Changes Addressed</span>' : ''}
+              ${pr.hasUnrespondedComment && pr.status !== 'waiting_on_maintainer' && pr.status !== 'failing_ci' ? '<span class="badge badge-needs-response">Needs Response</span>' : ''}
+              ${pr.reviewDecision === 'changes_requested' && pr.status !== 'waiting_on_maintainer' ? '<span class="badge badge-changes-requested">Changes Requested</span>' : ''}
               ${isStale ? `<span class="badge badge-stale">${pr.daysSinceActivity}d inactive</span>` : ''}
             </div>
           </div>

--- a/packages/core/src/commands/startup.test.ts
+++ b/packages/core/src/commands/startup.test.ts
@@ -294,7 +294,6 @@ describe('runStartup behavior', () => {
         missingRequiredFilesPRs: [],
         incompleteChecklistPRs: [],
         needsChangesPRs: [],
-        changesAddressedPRs: [],
         waitingOnMaintainerPRs: [],
         approachingDormant: [],
         dormantPRs: [],

--- a/packages/core/src/core/daily-logic.test.ts
+++ b/packages/core/src/core/daily-logic.test.ts
@@ -63,10 +63,9 @@ describe('ACTIVE_MAINTAINER_STATUSES', () => {
   it('should contain expected active maintainer statuses', () => {
     expect(ACTIVE_MAINTAINER_STATUSES.has('healthy')).toBe(true);
     expect(ACTIVE_MAINTAINER_STATUSES.has('waiting_on_maintainer')).toBe(true);
-    expect(ACTIVE_MAINTAINER_STATUSES.has('changes_addressed')).toBe(true);
     expect(ACTIVE_MAINTAINER_STATUSES.has('needs_response')).toBe(true);
     expect(ACTIVE_MAINTAINER_STATUSES.has('needs_changes')).toBe(true);
-    expect(ACTIVE_MAINTAINER_STATUSES.size).toBe(5);
+    expect(ACTIVE_MAINTAINER_STATUSES.size).toBe(4);
   });
 });
 

--- a/packages/core/src/core/daily-logic.ts
+++ b/packages/core/src/core/daily-logic.ts
@@ -45,7 +45,6 @@ export const CRITICAL_STATUSES: ReadonlySet<FetchedPRStatus> = new Set([
 export const ACTIVE_MAINTAINER_STATUSES: ReadonlySet<FetchedPRStatus> = new Set([
   'healthy',
   'waiting_on_maintainer',
-  'changes_addressed',
   'needs_response',
   'needs_changes',
 ]);
@@ -384,22 +383,20 @@ export function formatSummary(
     lines.push('');
   }
 
-  // Changes Addressed (waiting for maintainer re-review)
-  if (digest.changesAddressedPRs.length > 0) {
-    lines.push('### \u{1F4E4} Changes Addressed');
-    for (const pr of digest.changesAddressedPRs) {
-      const maintainer = pr.lastMaintainerComment?.author || 'maintainer';
-      lines.push(`- [${pr.repo}#${pr.number}](${pr.url}): ${pr.title}`);
-      lines.push(`  \u2514\u2500 Waiting for @${maintainer} to re-review`);
-    }
-    lines.push('');
-  }
-
-  // Waiting on Maintainer (approved, no action needed from user)
+  // Waiting on Maintainer (approved or changes addressed, no action needed from user)
   if (digest.waitingOnMaintainerPRs.length > 0) {
     lines.push('### \u23F3 Waiting on Maintainer');
     for (const pr of digest.waitingOnMaintainerPRs) {
-      lines.push(`- [${pr.repo}#${pr.number}](${pr.url}): ${pr.title} (approved)`);
+      if (pr.hasUnrespondedComment && pr.lastMaintainerComment) {
+        const maintainer = pr.lastMaintainerComment.author;
+        lines.push(`- [${pr.repo}#${pr.number}](${pr.url}): ${pr.title}`);
+        lines.push(`  \u2514\u2500 Changes addressed — waiting for @${maintainer} to re-review`);
+      } else if (pr.reviewDecision === 'changes_requested') {
+        lines.push(`- [${pr.repo}#${pr.number}](${pr.url}): ${pr.title}`);
+        lines.push(`  \u2514\u2500 Changes addressed — awaiting re-review`);
+      } else {
+        lines.push(`- [${pr.repo}#${pr.number}](${pr.url}): ${pr.title} (approved)`);
+      }
     }
     lines.push('');
   }
@@ -545,20 +542,18 @@ export function printDigest(
     console.log('');
   }
 
-  if (digest.changesAddressedPRs.length > 0) {
-    console.log('\u{1F4E4} Changes Addressed:');
-    for (const pr of digest.changesAddressedPRs) {
-      const maintainer = pr.lastMaintainerComment?.author || 'maintainer';
-      console.log(`  - ${pr.repo}#${pr.number}: ${pr.title}`);
-      console.log(`    Waiting for @${maintainer} to re-review`);
-    }
-    console.log('');
-  }
-
   if (digest.waitingOnMaintainerPRs.length > 0) {
     console.log('\u23F3 Waiting on Maintainer:');
     for (const pr of digest.waitingOnMaintainerPRs) {
-      console.log(`  - ${pr.repo}#${pr.number}: ${pr.title} (approved)`);
+      if (pr.hasUnrespondedComment && pr.lastMaintainerComment) {
+        console.log(`  - ${pr.repo}#${pr.number}: ${pr.title}`);
+        console.log(`    Changes addressed \u2014 waiting for @${pr.lastMaintainerComment.author} to re-review`);
+      } else if (pr.reviewDecision === 'changes_requested') {
+        console.log(`  - ${pr.repo}#${pr.number}: ${pr.title}`);
+        console.log(`    Changes addressed \u2014 awaiting re-review`);
+      } else {
+        console.log(`  - ${pr.repo}#${pr.number}: ${pr.title} (approved)`);
+      }
     }
     console.log('');
   }

--- a/packages/core/src/core/display-utils.test.ts
+++ b/packages/core/src/core/display-utils.test.ts
@@ -69,15 +69,17 @@ describe('computeDisplayLabel', () => {
     expect(result.displayLabel).toBe('[Waiting on Maintainer]');
   });
 
-  it('should return [Changes Addressed] for changes_addressed status', () => {
+  it('should return [Waiting on Maintainer] with re-review context when changes addressed', () => {
     const result = computeDisplayLabel(
       makePR({
-        status: 'changes_addressed',
+        status: 'waiting_on_maintainer',
+        hasUnrespondedComment: true,
         lastMaintainerComment: { author: 'reviewer', body: 'LGTM with changes', createdAt: '2026-02-07T10:00:00Z' },
       }),
     );
-    expect(result.displayLabel).toBe('[Changes Addressed]');
+    expect(result.displayLabel).toBe('[Waiting on Maintainer]');
     expect(result.displayDescription).toContain('@reviewer');
+    expect(result.displayDescription).toContain('Changes addressed');
   });
 
   it('should return [Incomplete Checklist] for incomplete_checklist status', () => {

--- a/packages/core/src/core/display-utils.ts
+++ b/packages/core/src/core/display-utils.ts
@@ -72,20 +72,21 @@ const STATUS_DISPLAY: Record<FetchedPRStatus, { label: string; description: (pr:
         ? `${pr.checklistStats.checked}/${pr.checklistStats.total} items checked`
         : 'PR body has unchecked required checkboxes',
   },
-  changes_addressed: {
-    label: '[Changes Addressed]',
-    description: (pr) =>
-      pr.lastMaintainerComment
-        ? `Waiting for @${pr.lastMaintainerComment.author} to re-review`
-        : 'Waiting for maintainer re-review',
-  },
   waiting: {
     label: '[Waiting]',
     description: () => 'CI pending or awaiting review',
   },
   waiting_on_maintainer: {
     label: '[Waiting on Maintainer]',
-    description: () => 'Approved and CI passes — waiting for merge',
+    description: (pr) => {
+      if (pr.hasUnrespondedComment && pr.lastMaintainerComment) {
+        return `Changes addressed — waiting for @${pr.lastMaintainerComment.author} to re-review`;
+      }
+      if (pr.reviewDecision === 'changes_requested') {
+        return 'Changes addressed — awaiting re-review';
+      }
+      return 'Approved and CI passes — waiting for merge';
+    },
   },
   healthy: {
     label: '[Healthy]',

--- a/packages/core/src/core/pr-monitor.test.ts
+++ b/packages/core/src/core/pr-monitor.test.ts
@@ -214,12 +214,12 @@ describe('PRMonitor CI status deduplication', () => {
   });
 });
 
-describe('PRMonitor changes_addressed detection', () => {
+describe('PRMonitor waiting_on_maintainer detection (changes addressed path)', () => {
   beforeEach(() => {
     mockOctokitInstance = {};
   });
 
-  it('should return changes_addressed when commit is newer than maintainer comment', () => {
+  it('should return waiting_on_maintainer when commit is newer than maintainer comment', () => {
     const monitor = new PRMonitor('fake-token');
     const result = (monitor as any).determineStatus({
       ciStatus: 'passing',
@@ -234,7 +234,7 @@ describe('PRMonitor changes_addressed detection', () => {
       lastMaintainerCommentDate: '2026-02-07T10:00:00Z', // older
     });
 
-    expect(result).toBe('changes_addressed');
+    expect(result).toBe('waiting_on_maintainer');
   });
 
   it('should return needs_response when commit is older than maintainer comment', () => {
@@ -318,7 +318,7 @@ describe('PRMonitor commit author filtering (#547)', () => {
     expect(result).toBe('needs_response');
   });
 
-  it('should return changes_addressed when HEAD commit is by the contributor', () => {
+  it('should return waiting_on_maintainer when HEAD commit is by the contributor', () => {
     const monitor = new PRMonitor('fake-token');
     const result = (monitor as any).determineStatus({
       ciStatus: 'passing',
@@ -335,7 +335,7 @@ describe('PRMonitor commit author filtering (#547)', () => {
       lastMaintainerCommentDate: '2026-02-07T10:00:00Z',
     });
 
-    expect(result).toBe('changes_addressed');
+    expect(result).toBe('waiting_on_maintainer');
   });
 
   it('should return needs_response when commit is within 2 minutes of comment (race condition)', () => {
@@ -377,7 +377,7 @@ describe('PRMonitor commit author filtering (#547)', () => {
       lastMaintainerCommentDate: '2026-02-07T10:00:00Z',
     });
 
-    expect(result).toBe('changes_addressed');
+    expect(result).toBe('waiting_on_maintainer');
   });
 
   it('should handle case-insensitive author comparison', () => {
@@ -397,7 +397,7 @@ describe('PRMonitor commit author filtering (#547)', () => {
       lastMaintainerCommentDate: '2026-02-07T10:00:00Z',
     });
 
-    expect(result).toBe('changes_addressed');
+    expect(result).toBe('waiting_on_maintainer');
   });
 
   it('should return needs_changes when non-contributor commit after changes_requested review', () => {
@@ -447,7 +447,7 @@ describe('PRMonitor needs_changes detection', () => {
     expect(result).toBe('needs_changes');
   });
 
-  it('should return changes_addressed when commits pushed after changes_requested review', () => {
+  it('should return waiting_on_maintainer when commits pushed after changes_requested review', () => {
     const monitor = new PRMonitor('fake-token');
     const result = (monitor as any).determineStatus({
       ciStatus: 'passing',
@@ -463,7 +463,7 @@ describe('PRMonitor needs_changes detection', () => {
       latestChangesRequestedDate: '2026-02-08T11:52:22Z', // before commit
     });
 
-    expect(result).toBe('changes_addressed');
+    expect(result).toBe('waiting_on_maintainer');
   });
 
   it('should return needs_changes when no commit date available', () => {
@@ -620,7 +620,7 @@ describe('PRMonitor determineStatus — remaining paths', () => {
     ).toBe('needs_response');
   });
 
-  it('should return changes_addressed when commit is after both comment and review (#431)', () => {
+  it('should return waiting_on_maintainer when commit is after both comment and review (#431)', () => {
     expect(
       callDetermineStatus({
         hasUnrespondedComment: true,
@@ -628,7 +628,7 @@ describe('PRMonitor determineStatus — remaining paths', () => {
         lastMaintainerCommentDate: '2026-03-01T12:00:00Z',
         latestChangesRequestedDate: '2026-03-01T14:02:00Z', // before commit
       }),
-    ).toBe('changes_addressed');
+    ).toBe('waiting_on_maintainer');
   });
 });
 
@@ -1181,10 +1181,9 @@ describe('PRMonitor generateDigest', () => {
       makeDigestPR({ status: 'dormant', number: 5 }),
       makeDigestPR({ status: 'approaching_dormant', number: 6 }),
       makeDigestPR({ status: 'needs_changes', number: 7 }),
-      makeDigestPR({ status: 'changes_addressed', number: 8 }),
-      makeDigestPR({ status: 'waiting_on_maintainer', number: 9 }),
-      makeDigestPR({ status: 'incomplete_checklist', number: 10 }),
-      makeDigestPR({ status: 'waiting', number: 11 }),
+      makeDigestPR({ status: 'waiting_on_maintainer', number: 8 }),
+      makeDigestPR({ status: 'incomplete_checklist', number: 9 }),
+      makeDigestPR({ status: 'waiting', number: 10 }),
     ];
 
     const monitor = new PRMonitor('fake-token');
@@ -1193,13 +1192,12 @@ describe('PRMonitor generateDigest', () => {
     expect(digest.prsNeedingResponse.map((p) => p.number)).toEqual([1]);
     expect(digest.ciFailingPRs.map((p) => p.number)).toEqual([2]);
     expect(digest.mergeConflictPRs.map((p) => p.number)).toEqual([3]);
-    expect(digest.healthyPRs.map((p) => p.number)).toEqual([4, 11]); // healthy + waiting
+    expect(digest.healthyPRs.map((p) => p.number)).toEqual([4, 10]); // healthy + waiting
     expect(digest.dormantPRs.map((p) => p.number)).toEqual([5]);
     expect(digest.approachingDormant.map((p) => p.number)).toEqual([6]);
     expect(digest.needsChangesPRs.map((p) => p.number)).toEqual([7]);
-    expect(digest.changesAddressedPRs.map((p) => p.number)).toEqual([8]);
-    expect(digest.waitingOnMaintainerPRs.map((p) => p.number)).toEqual([9]);
-    expect(digest.incompleteChecklistPRs.map((p) => p.number)).toEqual([10]);
+    expect(digest.waitingOnMaintainerPRs.map((p) => p.number)).toEqual([8]);
+    expect(digest.incompleteChecklistPRs.map((p) => p.number)).toEqual([9]);
   });
 
   it('should calculate totalNeedingAttention correctly', () => {
@@ -1478,7 +1476,7 @@ describe('PRMonitor fetchRecentlyMergedPRs', () => {
   });
 });
 
-describe('PRMonitor CI failure overrides changes_addressed (Issue #68)', () => {
+describe('PRMonitor CI failure overrides waiting_on_maintainer (Issue #68)', () => {
   beforeEach(() => {
     mockOctokitInstance = {};
   });
@@ -1516,7 +1514,7 @@ describe('PRMonitor CI failure overrides changes_addressed (Issue #68)', () => {
     return (monitor as any).determineStatus({ ...defaults, ...overrides });
   }
 
-  it('should return failing_ci when changes_addressed (comment path) and CI is failing', () => {
+  it('should return failing_ci when waiting_on_maintainer (comment path) and CI is failing', () => {
     expect(
       callDetermineStatus({
         ciStatus: 'failing',
@@ -1527,7 +1525,7 @@ describe('PRMonitor CI failure overrides changes_addressed (Issue #68)', () => {
     ).toBe('failing_ci');
   });
 
-  it('should return failing_ci when changes_addressed (review path) and CI is failing', () => {
+  it('should return failing_ci when waiting_on_maintainer (review path) and CI is failing', () => {
     expect(
       callDetermineStatus({
         ciStatus: 'failing',
@@ -1538,7 +1536,7 @@ describe('PRMonitor CI failure overrides changes_addressed (Issue #68)', () => {
     ).toBe('failing_ci');
   });
 
-  it('should still return changes_addressed when CI is passing (comment path regression)', () => {
+  it('should still return waiting_on_maintainer when CI is passing (comment path regression)', () => {
     expect(
       callDetermineStatus({
         ciStatus: 'passing',
@@ -1546,10 +1544,10 @@ describe('PRMonitor CI failure overrides changes_addressed (Issue #68)', () => {
         latestCommitDate: '2026-02-08T12:00:00Z',
         lastMaintainerCommentDate: '2026-02-07T10:00:00Z',
       }),
-    ).toBe('changes_addressed');
+    ).toBe('waiting_on_maintainer');
   });
 
-  it('should still return changes_addressed when CI is passing (review path regression)', () => {
+  it('should still return waiting_on_maintainer when CI is passing (review path regression)', () => {
     expect(
       callDetermineStatus({
         ciStatus: 'passing',
@@ -1557,7 +1555,7 @@ describe('PRMonitor CI failure overrides changes_addressed (Issue #68)', () => {
         latestCommitDate: '2026-02-09T10:00:00Z',
         latestChangesRequestedDate: '2026-02-08T11:52:22Z',
       }),
-    ).toBe('changes_addressed');
+    ).toBe('waiting_on_maintainer');
   });
 
   it('should still prioritize needs_response over failing_ci', () => {
@@ -1565,7 +1563,7 @@ describe('PRMonitor CI failure overrides changes_addressed (Issue #68)', () => {
       callDetermineStatus({
         ciStatus: 'failing',
         hasUnrespondedComment: true,
-        // No commit after maintainer comment → needs_response, not changes_addressed
+        // No commit after maintainer comment → needs_response, not waiting_on_maintainer
       }),
     ).toBe('needs_response');
   });
@@ -1628,7 +1626,7 @@ describe('PRMonitor non-actionable CI failures return ci_blocked (Issue #502)', 
     expect(callDetermineStatus({ ciStatus: 'failing', hasActionableCIFailure: true })).toBe('failing_ci');
   });
 
-  it('should return changes_addressed (comment path) when CI failing but not actionable', () => {
+  it('should return waiting_on_maintainer (comment path) when CI failing but not actionable', () => {
     expect(
       callDetermineStatus({
         ciStatus: 'failing',
@@ -1637,10 +1635,10 @@ describe('PRMonitor non-actionable CI failures return ci_blocked (Issue #502)', 
         latestCommitDate: '2026-02-08T12:00:00Z',
         lastMaintainerCommentDate: '2026-02-07T10:00:00Z',
       }),
-    ).toBe('changes_addressed');
+    ).toBe('waiting_on_maintainer');
   });
 
-  it('should return changes_addressed (review path) when CI failing but not actionable', () => {
+  it('should return waiting_on_maintainer (review path) when CI failing but not actionable', () => {
     expect(
       callDetermineStatus({
         ciStatus: 'failing',
@@ -1649,7 +1647,7 @@ describe('PRMonitor non-actionable CI failures return ci_blocked (Issue #502)', 
         latestCommitDate: '2026-02-09T10:00:00Z',
         latestChangesRequestedDate: '2026-02-08T11:52:22Z',
       }),
-    ).toBe('changes_addressed');
+    ).toBe('waiting_on_maintainer');
   });
 
   it('should default hasActionableCIFailure to true for backward compatibility', () => {
@@ -2022,24 +2020,35 @@ describe('computeDisplayLabel (#79)', () => {
     expect(displayDescription).toBe('Required files are missing');
   });
 
-  it('should return [Changes Addressed] with author', () => {
+  it('should return [Waiting on Maintainer] with re-review description when changes addressed', () => {
     const { displayLabel, displayDescription } = computeDisplayLabel(
       makePR({
-        status: 'changes_addressed',
+        status: 'waiting_on_maintainer',
+        hasUnrespondedComment: true,
         lastMaintainerComment: { author: 'reviewer', body: 'Changes needed', createdAt: '2026-02-07T10:00:00Z' },
       }),
     );
-    expect(displayLabel).toBe('[Changes Addressed]');
-    expect(displayDescription).toBe('Waiting for @reviewer to re-review');
+    expect(displayLabel).toBe('[Waiting on Maintainer]');
+    expect(displayDescription).toBe('Changes addressed — waiting for @reviewer to re-review');
   });
 
-  it('should return fallback for changes_addressed without comment', () => {
+  it('should return re-review description for waiting_on_maintainer with changes_requested review', () => {
     const { displayDescription } = computeDisplayLabel(
       makePR({
-        status: 'changes_addressed',
+        status: 'waiting_on_maintainer',
+        reviewDecision: 'changes_requested',
       }),
     );
-    expect(displayDescription).toBe('Waiting for maintainer re-review');
+    expect(displayDescription).toBe('Changes addressed — awaiting re-review');
+  });
+
+  it('should return approved description for waiting_on_maintainer without changes context', () => {
+    const { displayDescription } = computeDisplayLabel(
+      makePR({
+        status: 'waiting_on_maintainer',
+      }),
+    );
+    expect(displayDescription).toBe('Approved and CI passes — waiting for merge');
   });
 
   it('should return [Dormant] with days count', () => {
@@ -2086,7 +2095,6 @@ describe('computeDisplayLabel (#79)', () => {
       'missing_required_files',
       'incomplete_checklist',
       'needs_changes',
-      'changes_addressed',
       'waiting',
       'waiting_on_maintainer',
       'healthy',

--- a/packages/core/src/core/pr-monitor.ts
+++ b/packages/core/src/core/pr-monitor.ts
@@ -184,12 +184,11 @@ export class PRMonitor {
         needs_rebase: 6,
         missing_required_files: 7,
         incomplete_checklist: 8,
-        changes_addressed: 9,
-        approaching_dormant: 10,
-        dormant: 11,
-        waiting: 12,
-        waiting_on_maintainer: 13,
-        healthy: 14,
+        approaching_dormant: 9,
+        dormant: 10,
+        waiting: 11,
+        waiting_on_maintainer: 12,
+        healthy: 13,
       };
       return statusPriority[a.status] - statusPriority[b.status];
     });
@@ -267,7 +266,7 @@ export class PRMonitor {
 
     // Fetch CI status and (conditionally) latest commit date in parallel
     // We need the commit date when hasUnrespondedComment is true (to distinguish
-    // "needs_response" from "changes_addressed") OR when reviewDecision is "changes_requested"
+    // "needs_response" from "waiting_on_maintainer") OR when reviewDecision is "changes_requested"
     // (to detect needs_changes: review requested changes but no new commits pushed)
     const ciPromise = this.getCIStatus(owner, repo, ghPR.head.sha);
     const needCommitDate = hasUnrespondedComment || reviewDecision === 'changes_requested';
@@ -413,7 +412,7 @@ export class PRMonitor {
     const latestCommitDate =
       rawCommitDate && this.isContributorCommit(latestCommitAuthor, contributorUsername) ? rawCommitDate : undefined;
 
-    // Priority order: needs_response/needs_changes/changes_addressed > failing_ci > merge_conflict > incomplete_checklist > dormant > approaching_dormant > waiting_on_maintainer > waiting/healthy
+    // Priority order: needs_response/needs_changes > failing_ci > merge_conflict > incomplete_checklist > dormant > approaching_dormant > waiting_on_maintainer > waiting/healthy
 
     if (hasUnrespondedComment) {
       // If the contributor pushed a commit after the maintainer's comment,
@@ -431,9 +430,9 @@ export class PRMonitor {
           return 'needs_response';
         }
         if (ciStatus === 'failing' && hasActionableCIFailure) return 'failing_ci';
-        // Non-actionable CI failures (infrastructure, fork, auth) don't block changes_addressed —
+        // Non-actionable CI failures (infrastructure, fork, auth) don't block waiting_on_maintainer —
         // the contributor can't fix them, so the relevant status is "waiting for re-review" (#502)
-        return 'changes_addressed';
+        return 'waiting_on_maintainer';
       }
       return 'needs_response';
     }
@@ -444,10 +443,10 @@ export class PRMonitor {
       if (!latestCommitDate || latestCommitDate < latestChangesRequestedDate) {
         return 'needs_changes';
       }
-      // Commit is after review — changes have been addressed
+      // Commit is after review — changes have been addressed, waiting for re-review
       if (ciStatus === 'failing' && hasActionableCIFailure) return 'failing_ci';
-      // Non-actionable CI failures don't block changes_addressed (#502)
-      return 'changes_addressed';
+      // Non-actionable CI failures don't block waiting_on_maintainer (#502)
+      return 'waiting_on_maintainer';
     }
 
     if (ciStatus === 'failing') {
@@ -714,7 +713,6 @@ export class PRMonitor {
     const missingRequiredFilesPRs = prs.filter((pr) => pr.status === 'missing_required_files');
     const incompleteChecklistPRs = prs.filter((pr) => pr.status === 'incomplete_checklist');
     const needsChangesPRs = prs.filter((pr) => pr.status === 'needs_changes');
-    const changesAddressedPRs = prs.filter((pr) => pr.status === 'changes_addressed');
     const waitingOnMaintainerPRs = prs.filter((pr) => pr.status === 'waiting_on_maintainer');
 
     return {
@@ -729,7 +727,6 @@ export class PRMonitor {
       missingRequiredFilesPRs,
       incompleteChecklistPRs,
       needsChangesPRs,
-      changesAddressedPRs,
       waitingOnMaintainerPRs,
       approachingDormant,
       dormantPRs,

--- a/packages/core/src/core/test-utils.ts
+++ b/packages/core/src/core/test-utils.ts
@@ -57,7 +57,6 @@ export function makeDailyDigest(overrides: Partial<DailyDigest> = {}): DailyDige
     missingRequiredFilesPRs: [],
     incompleteChecklistPRs: [],
     needsChangesPRs: [],
-    changesAddressedPRs: [],
     waitingOnMaintainerPRs: [],
     approachingDormant: [],
     dormantPRs: [],

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -86,9 +86,9 @@ export interface DetermineStatusInput {
  *
  * **Waiting (no action needed right now):**
  * - `ci_blocked` — All failing CI checks are non-actionable (infrastructure, fork limitation, auth gate)
- * - `changes_addressed` — Contributor pushed commits after reviewer feedback; awaiting re-review
  * - `waiting` — CI is pending or no specific action needed
- * - `waiting_on_maintainer` — PR is approved and CI passes; waiting for maintainer to merge
+ * - `waiting_on_maintainer` — Ball is in the maintainer's court (approved and waiting for merge,
+ *   OR contributor pushed commits after reviewer feedback and awaiting re-review)
  * - `healthy` — Everything looks good; normal review cycle
  *
  * **Staleness warnings:**
@@ -105,7 +105,6 @@ export type FetchedPRStatus =
   | 'missing_required_files'
   | 'incomplete_checklist'
   | 'needs_changes'
-  | 'changes_addressed'
   | 'waiting'
   | 'waiting_on_maintainer'
   | 'healthy'
@@ -409,7 +408,6 @@ export interface DailyDigest {
   missingRequiredFilesPRs: FetchedPR[];
   incompleteChecklistPRs: FetchedPR[];
   needsChangesPRs: FetchedPR[];
-  changesAddressedPRs: FetchedPR[];
   waitingOnMaintainerPRs: FetchedPR[];
   /** PRs with no activity for 25+ days (configurable via `approachingDormantDays`). */
   approachingDormant: FetchedPR[];

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -103,7 +103,6 @@ export interface DailyDigestCompact {
   missingRequiredFilesPRs: string[];
   incompleteChecklistPRs: string[];
   needsChangesPRs: string[];
-  changesAddressedPRs: string[];
   waitingOnMaintainerPRs: string[];
   approachingDormant: string[];
   dormantPRs: string[];
@@ -159,7 +158,6 @@ export function deduplicateDigest(digest: DailyDigest): DailyDigestCompact {
     missingRequiredFilesPRs: toUrls(digest.missingRequiredFilesPRs),
     incompleteChecklistPRs: toUrls(digest.incompleteChecklistPRs),
     needsChangesPRs: toUrls(digest.needsChangesPRs),
-    changesAddressedPRs: toUrls(digest.changesAddressedPRs),
     waitingOnMaintainerPRs: toUrls(digest.waitingOnMaintainerPRs),
     approachingDormant: toUrls(digest.approachingDormant),
     dormantPRs: toUrls(digest.dormantPRs),

--- a/packages/dashboard/src/components/filter-bar.tsx
+++ b/packages/dashboard/src/components/filter-bar.tsx
@@ -24,7 +24,6 @@ const STATUS_LABELS: Record<FetchedPRStatus, string> = {
   missing_required_files: 'Missing Required Files',
   incomplete_checklist: 'Incomplete Checklist',
   needs_changes: 'Needs Changes',
-  changes_addressed: 'Changes Addressed',
   waiting: 'Waiting',
   waiting_on_maintainer: 'Waiting on Maintainer',
   healthy: 'Healthy',

--- a/packages/dashboard/src/components/pr-list.tsx
+++ b/packages/dashboard/src/components/pr-list.tsx
@@ -22,12 +22,7 @@ const ACTION_REQUIRED: Set<FetchedPRStatus> = new Set([
 ]);
 
 /** Statuses that belong in the "Waiting on Others" section. */
-const WAITING: Set<FetchedPRStatus> = new Set([
-  'changes_addressed',
-  'waiting_on_maintainer',
-  'ci_blocked',
-  'ci_not_running',
-]);
+const WAITING: Set<FetchedPRStatus> = new Set(['waiting_on_maintainer', 'ci_blocked', 'ci_not_running']);
 
 /** Statuses that belong in the "Healthy / Stale" section. */
 const HEALTHY: Set<FetchedPRStatus> = new Set(['healthy', 'approaching_dormant', 'dormant', 'waiting']);

--- a/packages/dashboard/src/utils.test.ts
+++ b/packages/dashboard/src/utils.test.ts
@@ -49,7 +49,7 @@ describe('statusColor', () => {
     expect(statusColor(status)).toBe('var(--accent-error)');
   });
 
-  it.each(['changes_addressed', 'waiting_on_maintainer', 'ci_blocked', 'ci_not_running', 'waiting'] as const)(
+  it.each(['waiting_on_maintainer', 'ci_blocked', 'ci_not_running', 'waiting'] as const)(
     'returns info color for waiting status "%s"',
     (status) => {
       expect(statusColor(status)).toBe('var(--accent-info)');

--- a/packages/dashboard/src/utils.ts
+++ b/packages/dashboard/src/utils.ts
@@ -28,7 +28,6 @@ export function statusColor(status: FetchedPRStatus | string): string {
     case 'needs_rebase':
     case 'incomplete_checklist':
       return 'var(--accent-error)';
-    case 'changes_addressed':
     case 'waiting_on_maintainer':
     case 'ci_blocked':
     case 'ci_not_running':

--- a/workflows/work-through-issues.md
+++ b/workflows/work-through-issues.md
@@ -72,7 +72,7 @@ For each issue in `actionableIssues`, include a Task tool call grouped by repo:
 | Merge Conflict | Tier 2 | Identify conflicting files, recommend resolution strategy (see pr-health-checker's "Merge Conflict Resolution Strategies" for direct resolution vs squash-and-reapply vs asking the maintainer). DO NOT push. |
 | Needs Response | Tier 2 | Analyze maintainer feedback, draft a response. DO NOT post — return for approval. |
 | Changes Requested | Tier 2 | Analyze requested changes, investigate what needs to change, recommend approach. |
-| Changes Addressed | Info | Note that changes were pushed after maintainer review — no contributor action needed, awaiting re-review. |
+| Waiting on Maintainer | Info | Note that the ball is in the maintainer's court — either approved and waiting for merge, or changes were pushed after review and awaiting re-review. No contributor action needed. |
 | Missing Required Files | Tier 2 | Identify what's missing (changeset, CLA, etc.), draft the file. DO NOT push. |
 
 **Agent dispatch prompt template for comprehensive PR check:**


### PR DESCRIPTION
## Summary

- **Removes `changes_addressed` as a separate `FetchedPRStatus`** and merges it into `waiting_on_maintainer`. From the contributor's perspective, both states mean "the ball is in the maintainer's court" — having two separate categories added cognitive overhead without actionable distinction.
- **Makes `waiting_on_maintainer` display context-sensitive**: "Changes addressed — waiting for @author to re-review" (unresponded comment), "Changes addressed — awaiting re-review" (changes_requested review), or "Approved and CI passes — waiting for merge" (default).
- **Updates health-check script, dashboard templates, workflow docs, and all tests** to reflect the merged state.

Closes #559
Closes #560
Closes #561

## Changes across 21 files

- `types.ts`: Remove `changes_addressed` from union type, remove `changesAddressedPRs` from `DailyDigest`
- `pr-monitor.ts`: Return `waiting_on_maintainer` where `changes_addressed` was returned
- `display-utils.ts`: Context-sensitive description for `waiting_on_maintainer`
- `daily-logic.ts`: Merge "Changes Addressed" section into "Waiting on Maintainer" in formatSummary/printDigest
- `json.ts`: Remove from `DailyDigestCompact`
- `dashboard-templates.ts`: Remove dead filter option, fix badge logic for both comment and review paths
- `health-check.cjs`: Remove stale `changesAddressedPRs` reference
- `workflows/work-through-issues.md`: Update dispatch table
- Dashboard components (`filter-bar.tsx`, `pr-list.tsx`, `utils.ts`): Remove `changes_addressed` references
- 7 test files updated consistently

## Test plan

- [x] All 1654 tests pass (1455 core + 96 dashboard + 103 MCP server)
- [x] No remaining `changes_addressed`/`changesAddressedPRs` references in source code
- [x] PR review toolkit: 6 agents (code-reviewer, silent-failure-hunter, code-simplifier, pr-test-analyzer, comment-analyzer, type-design-analyzer) — all findings addressed, converged on second pass