### PR TITLE
fix: update stale comments referencing removed changes_addressed status

### DIFF
--- a/packages/core/src/core/daily-logic.ts
+++ b/packages/core/src/core/daily-logic.ts
@@ -116,7 +116,7 @@ export function groupPRsByRepo(prs: FetchedPR[]): RepoGroup[] {
 /**
  * Compute per-repo maintainer signals from observed open PR data.
  * - isResponsive: true if any PR in the repo has a maintainer comment and stalenessTier is active
- * - hasActiveMaintainers: true if any non-dormant PR exists in the repo
+ * - hasActiveMaintainers: true if any non-stale PR exists in the repo (stalenessTier is 'active')
  */
 export function computeRepoSignals(prs: FetchedPR[]): Map<string, ComputedRepoSignals> {
   const repoMap = buildRepoMap(prs, 'COMPUTE_SIGNALS');

--- a/packages/core/src/core/pr-monitor.ts
+++ b/packages/core/src/core/pr-monitor.ts
@@ -253,7 +253,7 @@ export class PRMonitor {
 
     // Fetch CI status and (conditionally) latest commit date in parallel
     // We need the commit date when hasUnrespondedComment is true (to distinguish
-    // "needs_response" from "changes_addressed") OR when reviewDecision is "changes_requested"
+    // "needs_response" from "waiting_on_maintainer") OR when reviewDecision is "changes_requested"
     // (to detect needs_changes: review requested changes but no new commits pushed)
     const ciPromise = this.getCIStatus(owner, repo, ghPR.head.sha);
     const needCommitDate = hasUnrespondedComment || reviewDecision === 'changes_requested';

--- a/workflows/work-through-issues.md
+++ b/workflows/work-through-issues.md
@@ -72,7 +72,7 @@ For each issue in `actionableIssues`, include a Task tool call grouped by repo:
 | Merge Conflict | Tier 2 | Identify conflicting files, recommend resolution strategy (see pr-health-checker's "Merge Conflict Resolution Strategies" for direct resolution vs squash-and-reapply vs asking the maintainer). DO NOT push. |
 | Needs Response | Tier 2 | Analyze maintainer feedback, draft a response. DO NOT post — return for approval. |
 | Changes Requested | Tier 2 | Analyze requested changes, investigate what needs to change, recommend approach. |
-| Changes Addressed | Info | Note that changes were pushed after maintainer review — no contributor action needed, awaiting re-review. |
+| Waiting on Maintainer | Info | Note that the ball is in the maintainer's court — either approved and waiting for merge, or changes were pushed after review and awaiting re-review. No contributor action needed. |
 | Missing Required Files | Tier 2 | Identify what's missing (changeset, CLA, etc.), draft the file. DO NOT push. |
 
 **Agent dispatch prompt template for comprehensive PR check:**


### PR DESCRIPTION
## Summary

- **pr-monitor.ts:256**: Comment referenced `"changes_addressed"` as a peer-level status to `"needs_response"` — updated to `"waiting_on_maintainer"` to match the 2-status taxonomy from PR #564
- **daily-logic.ts:119**: Comment said "non-dormant" but `STALE_STATUSES` excludes both `dormant` and `approaching_dormant` — clarified to "non-stale (stalenessTier is 'active')"
- **work-through-issues.md:75**: Dispatch table had a `Changes Addressed` row from the old 13-status taxonomy — updated to `Waiting on Maintainer` with a description covering both the approved-waiting-for-merge and changes-addressed-awaiting-re-review cases

Found during PR review of #562 (which was closed as superseded by #564).

## Test plan

- [x] All 1637 tests pass (1450 core + 84 dashboard + 103 MCP server)
- [x] Comment-only and doc-only changes — no logic modifications