### PR TITLE
fix: update check fails to parse release tag with component prefix

### DIFF
--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -51,7 +51,7 @@ if [ -n "$CURRENT" ]; then
   if [ "$should_check" = true ]; then
     mkdir -p "${HOME}/.oss-autopilot"
     touch "$LAST_CHECK"
-    LATEST=$(gh api repos/costajohnt/oss-autopilot/releases/latest --jq '.tag_name' 2>/dev/null | sed 's/^v//' || echo "")
+    LATEST=$(gh api repos/costajohnt/oss-autopilot/releases/latest --jq '.tag_name' 2>/dev/null | sed 's/^[^0-9]*//' || echo "")
     # Validate LATEST looks like a version (digits and dots), not an error response
     if [ -n "$LATEST" ] && echo "$LATEST" | grep -qE '^[0-9]+\.' && [ "$LATEST" != "$CURRENT" ]; then
       update_msg="OSS Autopilot v${LATEST} available (you have v${CURRENT}). Run: /plugin update oss-autopilot"


### PR DESCRIPTION
## Summary

The session-start hook's update check silently fails because release-please tags the latest release as `core-v0.44.10` (component prefix), but the hook only strips a `v` prefix with `sed 's/^v//'`. The result `core-v0.44.10` fails the `^[0-9]+\.` validation regex, so the update notification is never shown.

**Fix:** Use `sed 's/^[^0-9]*//'` to strip all leading non-digit characters, handling any tag prefix (`v`, `core-v`, `mcp-v`, etc.).

## Test plan

- [x] `echo "core-v0.44.10" | sed 's/^[^0-9]*//'` → `0.44.10`
- [x] `echo "v0.44.10" | sed 's/^[^0-9]*//'` → `0.44.10`
- [x] `echo "0.44.10" | sed 's/^[^0-9]*//'` → `0.44.10`
- [x] All 1641 tests pass