### PR TITLE
fix: auto-pull marketplace clone when update is available

### DIFF
--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -54,6 +54,13 @@ if [ -n "$CURRENT" ]; then
     LATEST=$(gh api repos/costajohnt/oss-autopilot/releases/latest --jq '.tag_name' 2>/dev/null | sed 's/^[^0-9]*//' || echo "")
     # Validate LATEST looks like a version (digits and dots), not an error response
     if [ -n "$LATEST" ] && echo "$LATEST" | grep -qE '^[0-9]+\.' && [ "$LATEST" != "$CURRENT" ]; then
+      # Pull the marketplace clone so /plugin update sees the new version
+      MARKETPLACE_DIR="${HOME}/.claude/plugins/marketplaces/oss-autopilot"
+      if [ -d "${MARKETPLACE_DIR}/.git" ]; then
+        git -C "${MARKETPLACE_DIR}" fetch origin main --quiet 2>/dev/null \
+          && git -C "${MARKETPLACE_DIR}" reset --hard origin/main --quiet 2>/dev/null \
+          || true
+      fi
       update_msg="OSS Autopilot v${LATEST} available (you have v${CURRENT}). Run: /plugin update oss-autopilot"
       messages="${messages:+${messages}\n}${update_msg}"
     fi


### PR DESCRIPTION
## Summary

The marketplace clone at `~/.claude/plugins/marketplaces/oss-autopilot/` is never updated after the initial `/plugin marketplace add`. This means `/plugin install` and `/plugin update` keep installing the stale version from the original clone — even when the user is told a new version is available.

**Fix:** When the session-start hook detects a newer release, it now pulls the marketplace clone (`git fetch && git reset --hard origin/main`) before prompting the user to run `/plugin update`. This way the marketplace has the latest code and the update command actually installs the new version.

## Changes

- `hooks/session-start.sh`: Added marketplace clone pull inside the update-available check

## Test plan

- [x] All 1641 tests pass
- [x] Verified manually: after pull, `~/.claude/plugins/marketplaces/oss-autopilot/.claude-plugin/plugin.json` shows the latest version
- [x] `|| true` ensures pull failures don't break the session-start hook