### PR TITLE
fix: correct release-please output keys for root path

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,8 +14,8 @@ jobs:
     name: Release Please
     runs-on: ubuntu-latest
     outputs:
-      core-released: ${{ steps.release.outputs['.--release_created'] }}
-      core-tag: ${{ steps.release.outputs['.--tag_name'] }}
+      core-released: ${{ steps.release.outputs.release_created }}
+      core-tag: ${{ steps.release.outputs.tag_name }}
       mcp-released: ${{ steps.release.outputs['packages/mcp-server--release_created'] }}
       mcp-tag: ${{ steps.release.outputs['packages/mcp-server--tag_name'] }}
     steps:


### PR DESCRIPTION
## Summary

- Fix output key mapping: `.--release_created` → `release_created`, `.--tag_name` → `tag_name`
- When package path is `.` (root), release-please-action outputs unprefixed keys, not `.--` prefixed
- This was the actual root cause of npm publish being skipped since v0.44.4

## Context

The previous fix (#579) removed the racing `release.yml`, but that was only half the problem. Even without the race, the publish job was still skipped because the output key didn't match. The `setPathOutput` function in release-please-action does:

```typescript
if (path === '.') {
  core.setOutput(key, value);  // no prefix
} else {
  core.setOutput(`${path}--${key}`, value);  // prefixed
}
```

## Test plan

- [ ] Merge → release-please PR created
- [ ] Merge release PR → `Publish to npm` job runs (not skipped)
- [ ] `npm view @oss-autopilot/core version` shows new version