### PR TITLE
fix: apply minStars filter to dashboard closed PR count

### DIFF
--- a/packages/core/src/commands/daily.ts
+++ b/packages/core/src/commands/daily.ts
@@ -314,7 +314,7 @@ async function updateRepoScores(
     warn(MODULE, `Failed to fetch repo star counts: ${errorMessage(error)}`);
     warn(
       MODULE,
-      'Dashboard minStars filter will use cached star counts (or be skipped for repos without cached data).',
+      'Repos without cached star data will be excluded from stats until star counts are fetched on the next successful run.',
     );
     starCounts = new Map();
   }

--- a/packages/core/src/commands/dashboard-data.test.ts
+++ b/packages/core/src/commands/dashboard-data.test.ts
@@ -89,7 +89,7 @@ describe('buildDashboardStats', () => {
     expect(stats.mergedPRs).toBe(42);
   });
 
-  it('sums closedWithoutMergeCount across all repoScores', () => {
+  it('sums closedWithoutMergeCount across repoScores that meet minStars', () => {
     const state = makeState({
       repoScores: {
         'a/b': {
@@ -97,6 +97,7 @@ describe('buildDashboardStats', () => {
           score: 5,
           mergedPRCount: 1,
           closedWithoutMergeCount: 3,
+          stargazersCount: 100,
           avgResponseDays: null,
           lastEvaluatedAt: '2025-06-01T00:00:00Z',
           signals: { hasActiveMaintainers: true, isResponsive: true, hasHostileComments: false },
@@ -106,6 +107,7 @@ describe('buildDashboardStats', () => {
           score: 7,
           mergedPRCount: 2,
           closedWithoutMergeCount: 1,
+          stargazersCount: 200,
           avgResponseDays: null,
           lastEvaluatedAt: '2025-06-01T00:00:00Z',
           signals: { hasActiveMaintainers: true, isResponsive: true, hasHostileComments: false },
@@ -114,6 +116,36 @@ describe('buildDashboardStats', () => {
     });
     const stats = buildDashboardStats(makeDigest(), state);
     expect(stats.closedPRs).toBe(4); // 3 + 1
+  });
+
+  it('excludes repos below minStars from closedPRs count (#576)', () => {
+    const state = makeState({
+      config: { githubUsername: 'testuser', shelvedPRUrls: [], minStars: 50 },
+      repoScores: {
+        'big/repo': {
+          repo: 'big/repo',
+          score: 8,
+          mergedPRCount: 5,
+          closedWithoutMergeCount: 3,
+          stargazersCount: 500,
+          avgResponseDays: null,
+          lastEvaluatedAt: '2025-06-01T00:00:00Z',
+          signals: { hasActiveMaintainers: true, isResponsive: true, hasHostileComments: false },
+        },
+        'tiny/repo': {
+          repo: 'tiny/repo',
+          score: 2,
+          mergedPRCount: 1,
+          closedWithoutMergeCount: 10,
+          stargazersCount: 5,
+          avgResponseDays: null,
+          lastEvaluatedAt: '2025-06-01T00:00:00Z',
+          signals: { hasActiveMaintainers: true, isResponsive: true, hasHostileComments: false },
+        },
+      },
+    });
+    const stats = buildDashboardStats(makeDigest(), state);
+    expect(stats.closedPRs).toBe(3); // only big/repo; tiny/repo (5 stars) excluded
   });
 
   it('formats mergeRate as a percentage string', () => {
@@ -129,6 +161,34 @@ describe('buildDashboardStats', () => {
     (digest.summary as any).mergeRate = null;
     const stats = buildDashboardStats(digest, makeState());
     expect(stats.mergeRate).toBe('0.0%');
+  });
+
+  it('excludes repos with undefined stargazersCount from closedPRs count', () => {
+    const state = makeState({
+      repoScores: {
+        'known/repo': {
+          repo: 'known/repo',
+          score: 8,
+          mergedPRCount: 2,
+          closedWithoutMergeCount: 4,
+          stargazersCount: 500,
+          avgResponseDays: null,
+          lastEvaluatedAt: '2025-06-01T00:00:00Z',
+          signals: { hasActiveMaintainers: true, isResponsive: true, hasHostileComments: false },
+        },
+        'unknown/repo': {
+          repo: 'unknown/repo',
+          score: 3,
+          mergedPRCount: 1,
+          closedWithoutMergeCount: 7,
+          avgResponseDays: null,
+          lastEvaluatedAt: '2025-06-01T00:00:00Z',
+          signals: { hasActiveMaintainers: true, isResponsive: true, hasHostileComments: false },
+        },
+      },
+    });
+    const stats = buildDashboardStats(makeDigest(), state);
+    expect(stats.closedPRs).toBe(4); // only known/repo; unknown/repo has no stargazersCount
   });
 
   it('handles missing repoScores gracefully', () => {
@@ -191,6 +251,23 @@ describe('computePRsByRepo', () => {
     const result = computePRsByRepo(digest, state);
 
     expect(result['owner/alpha']).toEqual({ active: 1, merged: 3, closed: 1 });
+  });
+
+  it('should exclude repoScores below minStars', () => {
+    const digest = makeDigest();
+    const state = makeState({
+      repoScores: {
+        'owner/popular': { mergedPRCount: 5, closedWithoutMergeCount: 2, stargazersCount: 100 } as any,
+        'owner/tiny': { mergedPRCount: 3, closedWithoutMergeCount: 1, stargazersCount: 10 } as any,
+        'owner/unknown': { mergedPRCount: 2, closedWithoutMergeCount: 1 } as any,
+      },
+    });
+
+    const result = computePRsByRepo(digest, state);
+
+    expect(result['owner/popular']).toEqual({ active: 0, merged: 5, closed: 2 });
+    expect(result['owner/tiny']).toBeUndefined(); // below default minStars (50)
+    expect(result['owner/unknown']).toBeUndefined(); // undefined stars excluded
   });
 
   it('should return empty object when no PRs and no scores', () => {

--- a/packages/core/src/commands/dashboard-data.ts
+++ b/packages/core/src/commands/dashboard-data.ts
@@ -8,9 +8,6 @@ import { getStateManager, PRMonitor, IssueConversationMonitor } from '../core/in
 import { errorMessage, isRateLimitOrAuthError } from '../core/errors.js';
 import { warn } from '../core/logger.js';
 import { emptyPRCountsResult } from '../core/github-stats.js';
-import { toShelvedPRRef, buildStarFilter } from './daily.js';
-
-const MODULE = 'dashboard-data';
 import {
   isBelowMinStars,
   type DailyDigest,
@@ -19,6 +16,9 @@ import {
   type MergedPR,
   type CommentedIssue,
 } from '../core/types.js';
+import { toShelvedPRRef, buildStarFilter } from './daily.js';
+
+const MODULE = 'dashboard-data';
 
 export interface DashboardStats {
   activePRs: number;
@@ -35,11 +35,15 @@ export function buildDashboardStats(digest: DailyDigest, state: Readonly<AgentSt
     mergeRate: 0,
     totalNeedingAttention: 0,
   };
+  const minStars = state.config.minStars ?? 50;
   return {
     activePRs: summary.totalActivePRs,
     shelvedPRs: (digest.shelvedPRs || []).length,
     mergedPRs: summary.totalMergedAllTime,
-    closedPRs: Object.values(state.repoScores || {}).reduce((sum, s) => sum + (s.closedWithoutMergeCount || 0), 0),
+    closedPRs: Object.values(state.repoScores || {}).reduce(
+      (sum, s) => sum + (isBelowMinStars(s.stargazersCount, minStars) ? 0 : s.closedWithoutMergeCount || 0),
+      0,
+    ),
     mergeRate: `${(summary.mergeRate ?? 0).toFixed(1)}%`,
   };
 }

--- a/packages/core/src/commands/dashboard-scripts.ts
+++ b/packages/core/src/commands/dashboard-scripts.ts
@@ -152,9 +152,8 @@ export function generateDashboardScripts(
       if (exRepos.some((r) => r.toLowerCase() === repoLower)) return true;
       if (exOrgs?.some((o) => o.toLowerCase() === repoLower.split('/')[0])) return true;
       const score = (state.repoScores || {})[repo];
-      // Fail-open: repos without cached star data are shown (not excluded).
-      // Unlike issue-discovery (fail-closed), the dashboard shows the user's own
-      // contribution history — hiding repos just because a star fetch failed would be confusing.
+      // Fail-closed: repos without cached star data are excluded from charts.
+      // Star data is populated by the daily check; repos appear once stars are fetched.
       if (isBelowMinStars(score?.stargazersCount, starThreshold)) return true;
       return false;
     };

--- a/packages/core/src/core/github-stats.test.ts
+++ b/packages/core/src/core/github-stats.test.ts
@@ -241,7 +241,7 @@ describe('fetchUserPRCounts star filtering', () => {
     expect(result.monthlyCounts['2025-06']).toBe(1);
   });
 
-  it('should include repos with unknown star counts (not yet fetched)', async () => {
+  it('should exclude repos with unknown star counts (not yet fetched)', async () => {
     const items = [
       makeMergedItem('known-org', 'known-repo', '2025-06-01T00:00:00Z'),
       makeMergedItem('unknown-org', 'new-repo', '2025-06-02T00:00:00Z'),
@@ -257,8 +257,9 @@ describe('fetchUserPRCounts star filtering', () => {
 
     const result = await fetchUserMergedPRCounts(octokit, 'testuser', starFilter);
 
-    // Both should be included — unknown-org/new-repo has no star data, so it passes
-    expect(result.repos.size).toBe(2);
+    // Only known-org/known-repo included — unknown-org/new-repo has no star data, so it's excluded
+    expect(result.repos.size).toBe(1);
+    expect(result.repos.has('known-org/known-repo')).toBe(true);
   });
 
   it('should not filter when no starFilter is provided', async () => {

--- a/packages/core/src/core/github-stats.ts
+++ b/packages/core/src/core/github-stats.ts
@@ -138,8 +138,7 @@ async function fetchUserPRCounts<R>(
       // Those filters control issue discovery/search, not historical statistics.
 
       // Skip repos below the minimum star threshold (#576).
-      // Repos with unknown star counts (not yet fetched) are included — they'll be
-      // filtered on the next run once star data is cached in repoScores.
+      // Repos with unknown star counts (not yet fetched) are also excluded (fail-closed).
       if (starFilter && isBelowMinStars(starFilter.knownStarCounts.get(repo), starFilter.minStars)) {
         continue;
       }

--- a/packages/core/src/core/state.test.ts
+++ b/packages/core/src/core/state.test.ts
@@ -1031,14 +1031,14 @@ describe('StateManager getStats exclusion filtering', () => {
     expect(stats.mergeRate).toBe('50.0%');
   });
 
-  it('should exclude repos with fewer than 50 stars', () => {
+  it('should exclude repos with fewer than 50 stars or unknown star count', () => {
     stateManager.updateRepoScore('owner/big-repo', { mergedPRCount: 5, stargazersCount: 100 });
     stateManager.updateRepoScore('owner/small-repo', { mergedPRCount: 3, stargazersCount: 10 });
-    stateManager.updateRepoScore('owner/no-stars', { mergedPRCount: 2 }); // stargazersCount undefined — included (unknown ≠ low)
+    stateManager.updateRepoScore('owner/no-stars', { mergedPRCount: 2 }); // stargazersCount undefined — excluded
 
     const stats = stateManager.getStats();
-    expect(stats.mergedPRs).toBe(7); // big-repo (5) + no-stars (2); small-repo excluded
-    expect(stats.totalTracked).toBe(2);
+    expect(stats.mergedPRs).toBe(5); // only big-repo; small-repo (10 stars) and no-stars (undefined) excluded
+    expect(stats.totalTracked).toBe(1);
   });
 
   it('should include repos with exactly 50 stars', () => {

--- a/packages/core/src/core/types.test.ts
+++ b/packages/core/src/core/types.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { isBelowMinStars } from './types.js';
+
+describe('isBelowMinStars', () => {
+  it('returns true when stargazersCount is undefined', () => {
+    expect(isBelowMinStars(undefined, 50)).toBe(true);
+  });
+
+  it('returns true when stargazersCount is below threshold', () => {
+    expect(isBelowMinStars(10, 50)).toBe(true);
+  });
+
+  it('returns true when stargazersCount is zero', () => {
+    expect(isBelowMinStars(0, 50)).toBe(true);
+  });
+
+  it('returns false when stargazersCount equals threshold', () => {
+    expect(isBelowMinStars(50, 50)).toBe(false);
+  });
+
+  it('returns false when stargazersCount exceeds threshold', () => {
+    expect(isBelowMinStars(100, 50)).toBe(false);
+  });
+
+  it('returns false when threshold is zero and stars are zero', () => {
+    expect(isBelowMinStars(0, 0)).toBe(false);
+  });
+});

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -497,11 +497,10 @@ export interface StarFilter {
 
 /**
  * Check if a repo should be excluded based on its star count.
- * Returns true if the repo is known to be below the threshold.
- * Repos with unknown star counts pass through (fail-open).
+ * Returns true if the repo is below the threshold or has unknown star count.
  */
 export function isBelowMinStars(stargazersCount: number | undefined, minStars: number): boolean {
-  return stargazersCount !== undefined && stargazersCount < minStars;
+  return stargazersCount === undefined || stargazersCount < minStars;
 }
 
 /** Manual status override for a PR, set via dashboard or CLI. Auto-clears when new activity is detected. */


### PR DESCRIPTION
## Summary

- **Bug 1**: `buildDashboardStats()` didn't filter `closedPRs` by `config.minStars` — dashboard showed 29 instead of 16
- **Bug 2**: `isBelowMinStars()` treated `undefined` star counts as "not below threshold" (fail-open), inflating counts with repos that have no cached star data (e.g. old private org repos)
- Updates stale comments and warning messages to reflect the new fail-closed semantics
- Adds unit tests for `isBelowMinStars` predicate and integration tests for the filtering paths

## Test plan

- [x] All 1477 core tests pass (53 test files)
- [x] New `types.test.ts` covers `isBelowMinStars` edge cases (undefined, below, at, above threshold)
- [x] New tests verify `buildDashboardStats` excludes repos below minStars and with undefined stars
- [x] New test verifies `computePRsByRepo` excludes repos below minStars
- [x] Verified against live state data: closed count now returns 16 (was 29)

Closes #576