### PR TITLE
fix: resolve TypeScript discriminated union error in pr-template

### DIFF
--- a/packages/core/src/core/pr-template.ts
+++ b/packages/core/src/core/pr-template.ts
@@ -50,8 +50,12 @@ export async function fetchPRTemplate(octokit: Octokit, owner: string, repo: str
         debug(MODULE, `${path} is a directory (multiple templates?), skipping`);
         continue;
       }
-      if (data.type !== 'file' || !data.content) {
-        debug(MODULE, `${path} is type "${data.type}" with ${data.content ? 'content' : 'no content'}, skipping`);
+      if (data.type !== 'file') {
+        debug(MODULE, `${path} is type "${data.type}", skipping`);
+        continue;
+      }
+      if (!data.content) {
+        debug(MODULE, `${path} has no content, skipping`);
         continue;
       }
 


### PR DESCRIPTION
## Summary
- Split the type guard in `fetchPRTemplate` into two separate `if` checks so TypeScript can narrow the Octokit `getContent` discriminated union correctly
- `data.content` only exists on the `file` variant, not `symlink` or `submodule` — the combined check `data.type !== 'file' || !data.content` fails `tsc` because TS can't narrow through `||`

## Test plan
- [x] `pnpm --filter @oss-autopilot/core run build` passes (was failing)
- [x] All 1702 tests pass