### PR TITLE
feat: add rate limiting to dashboard server API endpoints

### DIFF
--- a/packages/core/src/commands/dashboard-server.ts
+++ b/packages/core/src/commands/dashboard-server.ts
@@ -23,6 +23,7 @@ import {
 } from './dashboard-data.js';
 import { openInBrowser } from './startup.js';
 import { writeDashboardServerInfo, removeDashboardServerInfo } from './dashboard-process.js';
+import { RateLimiter } from './rate-limiter.js';
 import type {
   DailyDigest,
   AgentState,
@@ -271,6 +272,11 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
     );
   }
 
+  // ── Rate limiters ───────────────────────────────────────────────────────
+  const dataLimiter = new RateLimiter({ maxRequests: 30, windowMs: 60_000 }); // 30/min
+  const actionLimiter = new RateLimiter({ maxRequests: 10, windowMs: 60_000 }); // 10/min
+  const refreshLimiter = new RateLimiter({ maxRequests: 2, windowMs: 60_000 }); // 2/min
+
   // ── Request handler ──────────────────────────────────────────────────────
   const server = http.createServer(async (req, res) => {
     const method = req.method || 'GET';
@@ -279,6 +285,12 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
     try {
       // ── API routes ─────────────────────────────────────────────────────
       if (url === '/api/data' && method === 'GET') {
+        const check = dataLimiter.check();
+        if (!check.allowed) {
+          res.setHeader('Retry-After', String(check.retryAfterSeconds));
+          sendError(res, 429, 'Too many requests');
+          return;
+        }
         sendJson(res, 200, cachedJsonData);
         return;
       }
@@ -288,6 +300,12 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
           sendError(res, 403, 'Invalid origin');
           return;
         }
+        const check = actionLimiter.check();
+        if (!check.allowed) {
+          res.setHeader('Retry-After', String(check.retryAfterSeconds));
+          sendError(res, 429, 'Too many requests');
+          return;
+        }
         await handleAction(req, res);
         return;
       }
@@ -295,6 +313,12 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
       if (url === '/api/refresh' && method === 'POST') {
         if (!isValidOrigin(req, actualPort)) {
           sendError(res, 403, 'Invalid origin');
+          return;
+        }
+        const check = refreshLimiter.check();
+        if (!check.allowed) {
+          res.setHeader('Retry-After', String(check.retryAfterSeconds));
+          sendError(res, 429, 'Too many requests');
           return;
         }
         await handleRefresh(req, res);

--- a/packages/core/src/commands/rate-limiter.test.ts
+++ b/packages/core/src/commands/rate-limiter.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { RateLimiter } from './rate-limiter.js';
+
+describe('RateLimiter', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should allow requests under the limit', () => {
+    const limiter = new RateLimiter({ maxRequests: 3, windowMs: 60_000 });
+
+    expect(limiter.check()).toEqual({ allowed: true });
+    expect(limiter.check()).toEqual({ allowed: true });
+    expect(limiter.check()).toEqual({ allowed: true });
+  });
+
+  it('should reject requests over the limit', () => {
+    const limiter = new RateLimiter({ maxRequests: 2, windowMs: 60_000 });
+
+    expect(limiter.check().allowed).toBe(true);
+    expect(limiter.check().allowed).toBe(true);
+
+    const result = limiter.check();
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) {
+      expect(result.retryAfterSeconds).toBeGreaterThan(0);
+      expect(result.retryAfterSeconds).toBeLessThanOrEqual(60);
+    }
+  });
+
+  it('should allow requests again after the window expires', () => {
+    const limiter = new RateLimiter({ maxRequests: 1, windowMs: 10_000 });
+
+    expect(limiter.check().allowed).toBe(true);
+    expect(limiter.check().allowed).toBe(false);
+
+    // Advance past the window
+    vi.advanceTimersByTime(10_001);
+
+    expect(limiter.check().allowed).toBe(true);
+  });
+
+  it('should return correct retryAfterSeconds', () => {
+    const limiter = new RateLimiter({ maxRequests: 1, windowMs: 30_000 });
+
+    expect(limiter.check().allowed).toBe(true);
+
+    // Advance 10 seconds into the window
+    vi.advanceTimersByTime(10_000);
+
+    const result = limiter.check();
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) {
+      // Should be ~20 seconds remaining
+      expect(result.retryAfterSeconds).toBe(20);
+    }
+  });
+
+  it('should use a sliding window (oldest request expires first)', () => {
+    const limiter = new RateLimiter({ maxRequests: 2, windowMs: 10_000 });
+
+    // Request at t=0
+    expect(limiter.check().allowed).toBe(true);
+
+    // Request at t=5s
+    vi.advanceTimersByTime(5_000);
+    expect(limiter.check().allowed).toBe(true);
+
+    // Request at t=6s — should be rejected (2 in window)
+    vi.advanceTimersByTime(1_000);
+    expect(limiter.check().allowed).toBe(false);
+
+    // Advance to t=10.001s — first request falls out of window
+    vi.advanceTimersByTime(4_001);
+    expect(limiter.check().allowed).toBe(true);
+  });
+});

--- a/packages/core/src/commands/rate-limiter.ts
+++ b/packages/core/src/commands/rate-limiter.ts
@@ -1,0 +1,49 @@
+/**
+ * Simple in-memory sliding-window rate limiter for the dashboard server.
+ *
+ * Each endpoint gets its own limiter with a configurable max number of
+ * requests per time window. Returns 429 with Retry-After when exceeded.
+ */
+
+export interface RateLimiterConfig {
+  /** Maximum requests allowed within the window. */
+  maxRequests: number;
+  /** Window duration in milliseconds. */
+  windowMs: number;
+}
+
+export class RateLimiter {
+  private readonly maxRequests: number;
+  private readonly windowMs: number;
+  /** Timestamps of accepted requests within the current window. */
+  private timestamps: number[] = [];
+
+  constructor(config: RateLimiterConfig) {
+    this.maxRequests = config.maxRequests;
+    this.windowMs = config.windowMs;
+  }
+
+  /**
+   * Check if a request is allowed.
+   *
+   * @returns `{ allowed: true }` if under the limit, or
+   *          `{ allowed: false, retryAfterSeconds }` if rate-limited.
+   */
+  check(): { allowed: true } | { allowed: false; retryAfterSeconds: number } {
+    const now = Date.now();
+    const windowStart = now - this.windowMs;
+
+    // Prune timestamps outside the current window
+    this.timestamps = this.timestamps.filter((t) => t > windowStart);
+
+    if (this.timestamps.length >= this.maxRequests) {
+      // Earliest timestamp in window — client must wait until it expires
+      const oldestInWindow = this.timestamps[0];
+      const retryAfterMs = oldestInWindow + this.windowMs - now;
+      return { allowed: false, retryAfterSeconds: Math.ceil(retryAfterMs / 1000) };
+    }
+
+    this.timestamps.push(now);
+    return { allowed: true };
+  }
+}


### PR DESCRIPTION
## Summary

- Add sliding-window `RateLimiter` class with per-endpoint instances
- `/api/data`: 30 requests/min (read-only cached JSON)
- `/api/action`: 10 requests/min (state writes)
- `/api/refresh`: 2 requests/min (triggers full GitHub API fetch)
- Returns `429 Too Many Requests` with `Retry-After` header when limits are hit

## Why

A runaway browser tab or rapid clicks on the SPA's "Refresh" button can exhaust the user's GitHub API quota (5,000/hour). Each refresh makes N+1 API calls (1 search + 1 per PR), so 300 rapid refreshes would drain the hourly quota.

## Test plan

- [x] Unit tests for `RateLimiter` class (5 tests: allow, reject, window expiry, retryAfter calculation, sliding window)
- [x] All 1508 existing tests pass
- [x] TypeScript compilation clean
- [x] Full monorepo build passes

Closes #603