### PR TITLE
fix: remove unrecognized "icon" key from plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,7 +6,6 @@
     "name": "John Costa",
     "url": "https://github.com/costajohnt"
   },
-  "icon": "assets/icon.svg",
   "repository": "https://github.com/costajohnt/oss-autopilot",
   "homepage": "https://github.com/costajohnt/oss-autopilot#readme",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Remove the `"icon"` field from `.claude-plugin/plugin.json` — Claude Code's plugin validator rejects it as an unrecognized key, preventing the plugin from loading.

## Test plan

- [x] Verified plugin.json is valid JSON after removal