### PR TITLE
feat: add clickable merged PR count with detail view

### DIFF
--- a/packages/core/src/commands/dashboard-data.test.ts
+++ b/packages/core/src/commands/dashboard-data.test.ts
@@ -9,8 +9,9 @@ import {
   computeTopRepos,
   getMonthlyData,
   mergeMonthlyCounts,
+  storedToMergedPRs,
 } from './dashboard-data.js';
-import type { DailyDigest, AgentState, ShelvedPRRef } from '../core/types.js';
+import type { DailyDigest, AgentState, ShelvedPRRef, StoredMergedPR } from '../core/types.js';
 
 function makeDigest(overrides: Partial<DailyDigest> = {}): DailyDigest {
   return {
@@ -388,5 +389,99 @@ describe('mergeMonthlyCounts', () => {
     mergeMonthlyCounts(existing, fresh);
     expect(existing).toEqual({ '2026-01': 5 });
     expect(fresh).toEqual({ '2026-02': 10 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// storedToMergedPRs
+// ---------------------------------------------------------------------------
+
+describe('storedToMergedPRs', () => {
+  it('converts stored PRs to MergedPR format with parsed repo and number', () => {
+    const stored: StoredMergedPR[] = [
+      { url: 'https://github.com/owner/repo/pull/42', title: 'Fix bug', mergedAt: '2025-06-10T00:00:00Z' },
+    ];
+
+    const result = storedToMergedPRs(stored);
+
+    expect(result).toEqual([
+      {
+        url: 'https://github.com/owner/repo/pull/42',
+        repo: 'owner/repo',
+        number: 42,
+        title: 'Fix bug',
+        mergedAt: '2025-06-10T00:00:00Z',
+      },
+    ]);
+  });
+
+  it('skips entries with unparseable URLs', () => {
+    const stored: StoredMergedPR[] = [
+      { url: 'https://example.com/not-a-pr', title: 'Bad URL', mergedAt: '2025-06-10T00:00:00Z' },
+      { url: 'https://github.com/owner/repo/pull/1', title: 'Good', mergedAt: '2025-06-10T00:00:00Z' },
+    ];
+
+    const result = storedToMergedPRs(stored);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].repo).toBe('owner/repo');
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(storedToMergedPRs([])).toEqual([]);
+  });
+
+  it('handles multiple PRs from different repos', () => {
+    const stored: StoredMergedPR[] = [
+      { url: 'https://github.com/a/b/pull/1', title: 'PR1', mergedAt: '2025-06-10T00:00:00Z' },
+      { url: 'https://github.com/c/d/pull/99', title: 'PR2', mergedAt: '2025-06-09T00:00:00Z' },
+    ];
+
+    const result = storedToMergedPRs(stored);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].repo).toBe('a/b');
+    expect(result[0].number).toBe(1);
+    expect(result[1].repo).toBe('c/d');
+    expect(result[1].number).toBe(99);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildDashboardStats with storedMergedCount
+// ---------------------------------------------------------------------------
+
+describe('buildDashboardStats with storedMergedCount', () => {
+  it('uses storedMergedCount when higher than totalMergedAllTime', () => {
+    const digest = makeDigest({
+      summary: { totalActivePRs: 0, totalNeedingAttention: 0, totalMergedAllTime: 50, mergeRate: 80 },
+    });
+    const stats = buildDashboardStats(digest, makeState(), 120);
+    expect(stats.mergedPRs).toBe(120);
+  });
+
+  it('uses totalMergedAllTime when higher than storedMergedCount', () => {
+    const digest = makeDigest({
+      summary: { totalActivePRs: 0, totalNeedingAttention: 0, totalMergedAllTime: 500, mergeRate: 80 },
+    });
+    const stats = buildDashboardStats(digest, makeState(), 200);
+    expect(stats.mergedPRs).toBe(500);
+  });
+
+  it('falls back to totalMergedAllTime when storedMergedCount is undefined', () => {
+    const digest = makeDigest({
+      summary: { totalActivePRs: 0, totalNeedingAttention: 0, totalMergedAllTime: 42, mergeRate: 80 },
+    });
+    const stats = buildDashboardStats(digest, makeState());
+    expect(stats.mergedPRs).toBe(42);
+  });
+
+  it('uses storedMergedCount of 0 correctly (does not fall back)', () => {
+    const digest = makeDigest({
+      summary: { totalActivePRs: 0, totalNeedingAttention: 0, totalMergedAllTime: 10, mergeRate: 80 },
+    });
+    // storedMergedCount=0 is explicitly provided, so Math.max(0, 10) = 10
+    const stats = buildDashboardStats(digest, makeState(), 0);
+    expect(stats.mergedPRs).toBe(10);
   });
 });

--- a/packages/core/src/commands/dashboard-data.ts
+++ b/packages/core/src/commands/dashboard-data.ts
@@ -4,16 +4,18 @@
  * Consumed by the dashboard HTTP server (dashboard-server.ts) for the SPA API.
  */
 
-import { getStateManager, PRMonitor, IssueConversationMonitor } from '../core/index.js';
+import { getStateManager, PRMonitor, IssueConversationMonitor, getOctokit } from '../core/index.js';
 import { errorMessage, isRateLimitOrAuthError } from '../core/errors.js';
 import { warn } from '../core/logger.js';
-import { emptyPRCountsResult } from '../core/github-stats.js';
+import { emptyPRCountsResult, fetchMergedPRsSince } from '../core/github-stats.js';
+import { parseGitHubUrl } from '../core/utils.js';
 import {
   isBelowMinStars,
   type DailyDigest,
   type AgentState,
   type ClosedPR,
   type MergedPR,
+  type StoredMergedPR,
   type CommentedIssue,
 } from '../core/types.js';
 import { toShelvedPRRef, buildStarFilter } from './daily.js';
@@ -28,7 +30,11 @@ export interface DashboardStats {
   mergeRate: string;
 }
 
-export function buildDashboardStats(digest: DailyDigest, state: Readonly<AgentState>): DashboardStats {
+export function buildDashboardStats(
+  digest: DailyDigest,
+  state: Readonly<AgentState>,
+  storedMergedCount?: number,
+): DashboardStats {
   const summary = digest.summary || {
     totalActivePRs: 0,
     totalMergedAllTime: 0,
@@ -36,10 +42,16 @@ export function buildDashboardStats(digest: DailyDigest, state: Readonly<AgentSt
     totalNeedingAttention: 0,
   };
   const minStars = state.config.minStars ?? 50;
+  // Use the higher of stored merged PR count and repoScores-derived count to avoid regressions
+  // when stored list hasn't caught up yet (first fetch caps at 300)
+  const mergedPRs =
+    storedMergedCount !== undefined
+      ? Math.max(storedMergedCount, summary.totalMergedAllTime)
+      : summary.totalMergedAllTime;
   return {
     activePRs: summary.totalActivePRs,
     shelvedPRs: (digest.shelvedPRs || []).length,
-    mergedPRs: summary.totalMergedAllTime,
+    mergedPRs,
     closedPRs: Object.values(state.repoScores || {}).reduce(
       (sum, s) => sum + (isBelowMinStars(s.stargazersCount, minStars) ? 0 : s.closedWithoutMergeCount || 0),
       0,
@@ -117,6 +129,7 @@ export function updateMonthlyAnalytics(
 export interface DashboardFetchResult {
   digest: DailyDigest;
   commentedIssues: CommentedIssue[];
+  allMergedPRs: MergedPR[];
 }
 
 /**
@@ -128,47 +141,64 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
   const stateManager = getStateManager();
   const prMonitor = new PRMonitor(token);
   const issueMonitor = new IssueConversationMonitor(token);
+  const octokit = getOctokit(token);
+  const config = stateManager.getState().config;
 
   // Build star filter from cached repoScores (#576)
   const starFilter = buildStarFilter(stateManager.getState());
 
-  const [{ prs, failures }, recentlyClosedPRs, recentlyMergedPRs, mergedResult, closedResult, fetchedIssues] =
-    await Promise.all([
-      prMonitor.fetchUserOpenPRs(),
-      prMonitor.fetchRecentlyClosedPRs().catch((err): ClosedPR[] => {
-        if (isRateLimitOrAuthError(err)) throw err;
-        warn(MODULE, `Failed to fetch recently closed PRs: ${errorMessage(err)}`);
-        return [];
-      }),
-      prMonitor.fetchRecentlyMergedPRs().catch((err): MergedPR[] => {
-        if (isRateLimitOrAuthError(err)) throw err;
-        warn(MODULE, `Failed to fetch recently merged PRs: ${errorMessage(err)}`);
-        return [];
-      }),
-      prMonitor.fetchUserMergedPRCounts(starFilter).catch((err) => {
-        if (isRateLimitOrAuthError(err)) throw err;
-        warn(MODULE, `Failed to fetch merged PR counts: ${errorMessage(err)}`);
-        return emptyPRCountsResult<{ count: number; lastMergedAt: string }>();
-      }),
-      prMonitor.fetchUserClosedPRCounts(starFilter).catch((err) => {
-        if (isRateLimitOrAuthError(err)) throw err;
-        warn(MODULE, `Failed to fetch closed PR counts: ${errorMessage(err)}`);
-        return emptyPRCountsResult<number>();
-      }),
-      issueMonitor.fetchCommentedIssues().catch((error) => {
-        if (isRateLimitOrAuthError(error)) throw error;
-        const msg = errorMessage(error);
-        if (msg.includes('No GitHub username configured')) {
-          warn(MODULE, `Issue conversation tracking requires setup: ${msg}`);
-        } else {
-          warn(MODULE, `Issue conversation fetch failed: ${msg}`);
-        }
-        return {
-          issues: [] as CommentedIssue[],
-          failures: [{ issueUrl: 'N/A', error: `Issue conversation fetch failed: ${msg}` }],
-        };
-      }),
-    ]);
+  // Get watermark for incremental merged PR fetch
+  const watermark = stateManager.getMergedPRWatermark();
+
+  const [
+    { prs, failures },
+    recentlyClosedPRs,
+    recentlyMergedPRs,
+    mergedResult,
+    closedResult,
+    fetchedIssues,
+    newMergedPRs,
+  ] = await Promise.all([
+    prMonitor.fetchUserOpenPRs(),
+    prMonitor.fetchRecentlyClosedPRs().catch((err): ClosedPR[] => {
+      if (isRateLimitOrAuthError(err)) throw err;
+      warn(MODULE, `Failed to fetch recently closed PRs: ${errorMessage(err)}`);
+      return [];
+    }),
+    prMonitor.fetchRecentlyMergedPRs().catch((err): MergedPR[] => {
+      if (isRateLimitOrAuthError(err)) throw err;
+      warn(MODULE, `Failed to fetch recently merged PRs: ${errorMessage(err)}`);
+      return [];
+    }),
+    prMonitor.fetchUserMergedPRCounts(starFilter).catch((err) => {
+      if (isRateLimitOrAuthError(err)) throw err;
+      warn(MODULE, `Failed to fetch merged PR counts: ${errorMessage(err)}`);
+      return emptyPRCountsResult<{ count: number; lastMergedAt: string }>();
+    }),
+    prMonitor.fetchUserClosedPRCounts(starFilter).catch((err) => {
+      if (isRateLimitOrAuthError(err)) throw err;
+      warn(MODULE, `Failed to fetch closed PR counts: ${errorMessage(err)}`);
+      return emptyPRCountsResult<number>();
+    }),
+    issueMonitor.fetchCommentedIssues().catch((error) => {
+      if (isRateLimitOrAuthError(error)) throw error;
+      const msg = errorMessage(error);
+      if (msg.includes('No GitHub username configured')) {
+        warn(MODULE, `Issue conversation tracking requires setup: ${msg}`);
+      } else {
+        warn(MODULE, `Issue conversation fetch failed: ${msg}`);
+      }
+      return {
+        issues: [] as CommentedIssue[],
+        failures: [{ issueUrl: 'N/A', error: `Issue conversation fetch failed: ${msg}` }],
+      };
+    }),
+    fetchMergedPRsSince(octokit, config, watermark).catch((err): StoredMergedPR[] => {
+      if (isRateLimitOrAuthError(err)) throw err;
+      warn(MODULE, `Failed to fetch merged PRs for storage: ${errorMessage(err)}`);
+      return [];
+    }),
+  ]);
 
   const commentedIssues = fetchedIssues.issues;
   if (fetchedIssues.failures.length > 0) {
@@ -178,6 +208,16 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
   if (failures.length > 0) {
     warn(MODULE, `${failures.length} PR fetch(es) failed`);
   }
+
+  // Store new merged PRs incrementally (dedupes by URL)
+  try {
+    stateManager.addMergedPRs(newMergedPRs);
+  } catch (error) {
+    warn(MODULE, `Failed to store merged PRs: ${errorMessage(error)}`);
+  }
+
+  // Convert stored merged PRs to full MergedPR type (derive repo/number from URL)
+  const allMergedPRs = storedToMergedPRs(stateManager.getMergedPRs());
 
   // Store monthly chart data (opened/merged/closed) so charts have data
   const { monthlyCounts, monthlyOpenedCounts: openedFromMerged } = mergedResult;
@@ -204,7 +244,34 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
   }
   warn(MODULE, `Refreshed: ${prs.length} PRs fetched`);
 
-  return { digest, commentedIssues };
+  return { digest, commentedIssues, allMergedPRs };
+}
+
+/**
+ * Convert StoredMergedPR[] to MergedPR[] by deriving repo and number from URL.
+ * Skips entries with unparseable URLs.
+ */
+export function storedToMergedPRs(stored: StoredMergedPR[]): MergedPR[] {
+  const results: MergedPR[] = [];
+  let skipped = 0;
+  for (const pr of stored) {
+    const parsed = parseGitHubUrl(pr.url);
+    if (!parsed) {
+      skipped++;
+      continue;
+    }
+    results.push({
+      url: pr.url,
+      repo: `${parsed.owner}/${parsed.repo}`,
+      number: parsed.number,
+      title: pr.title,
+      mergedAt: pr.mergedAt,
+    });
+  }
+  if (skipped > 0) {
+    warn(MODULE, `Skipped ${skipped} stored merged PR(s) with unparseable URLs`);
+  }
+  return results;
 }
 
 /**

--- a/packages/core/src/commands/dashboard-server.test.ts
+++ b/packages/core/src/commands/dashboard-server.test.ts
@@ -59,6 +59,7 @@ const mockStateManager = {
   unshelvePR: vi.fn().mockReturnValue(true),
   setStatusOverride: vi.fn(),
   getStatusOverride: vi.fn().mockReturnValue(undefined),
+  getMergedPRs: vi.fn().mockReturnValue([]),
 };
 
 // Create a temp dir for PID file tests (needs to exist before mock is evaluated)
@@ -90,6 +91,7 @@ vi.mock('./dashboard-data.js', () => ({
     closedPRs: 1,
     mergeRate: '83.3%',
   })),
+  storedToMergedPRs: vi.fn(() => []),
 }));
 
 import {
@@ -354,9 +356,11 @@ describe('dashboard-server', () => {
       expect(data).toHaveProperty('recentlyMergedPRs');
       expect(data).toHaveProperty('recentlyClosedPRs');
       expect(data).toHaveProperty('autoUnshelvedPRs');
+      expect(data).toHaveProperty('allMergedPRs');
       expect(Array.isArray(data.recentlyMergedPRs)).toBe(true);
       expect(Array.isArray(data.recentlyClosedPRs)).toBe(true);
       expect(Array.isArray(data.autoUnshelvedPRs)).toBe(true);
+      expect(Array.isArray(data.allMergedPRs)).toBe(true);
     });
 
     it('should return stats with correct values', async () => {

--- a/packages/core/src/commands/dashboard-server.ts
+++ b/packages/core/src/commands/dashboard-server.ts
@@ -19,6 +19,7 @@ import {
   computeTopRepos,
   getMonthlyData,
   buildDashboardStats,
+  storedToMergedPRs,
   type DashboardStats,
 } from './dashboard-data.js';
 import { openInBrowser } from './startup.js';
@@ -69,6 +70,7 @@ interface DashboardJsonData {
   autoUnshelvedPRs: ShelvedPRRef[];
   commentedIssues: CommentedIssue[];
   issueResponses: CommentedIssueWithResponse[];
+  allMergedPRs: MergedPR[];
   offline?: boolean;
   lastUpdated?: string;
 }
@@ -143,11 +145,14 @@ function buildDashboardJson(
   digest: DailyDigest,
   state: Readonly<AgentState>,
   commentedIssues: CommentedIssue[],
+  allMergedPRs?: MergedPR[],
 ): DashboardJsonData {
   const prsByRepo = computePRsByRepo(digest, state);
   const topRepos = computeTopRepos(prsByRepo);
   const { monthlyMerged, monthlyOpened, monthlyClosed } = getMonthlyData(state);
-  const stats = buildDashboardStats(digest, state);
+  // Derive allMergedPRs from state if not provided (e.g. initial load from cached state)
+  const mergedPRs = allMergedPRs ?? storedToMergedPRs(getStateManager().getMergedPRs());
+  const stats = buildDashboardStats(digest, state, mergedPRs.length);
   const issueResponses = commentedIssues.filter((i): i is CommentedIssueWithResponse => i.status === 'new_response');
 
   return {
@@ -164,6 +169,7 @@ function buildDashboardJson(
     autoUnshelvedPRs: digest.autoUnshelvedPRs || [],
     commentedIssues,
     issueResponses,
+    allMergedPRs: mergedPRs,
   };
 }
 
@@ -215,7 +221,7 @@ function setSecurityHeaders(res: http.ServerResponse): void {
 function isValidOrigin(req: http.IncomingMessage, port: number): boolean {
   const origin = req.headers['origin'];
   if (!origin) return true; // No Origin header = same-origin request (non-browser or same-page)
-  const allowed = [`http://localhost:${port}`, `http://127.0.0.1:${port}`];
+  const allowed = [`http://localhost:${port}`, `http://127.0.0.1:${port}`, `http://oss.localhost:${port}`];
   return allowed.includes(origin);
 }
 
@@ -434,7 +440,12 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
       const result = await fetchDashboardData(currentToken);
       cachedDigest = result.digest;
       cachedCommentedIssues = result.commentedIssues;
-      cachedJsonData = buildDashboardJson(cachedDigest, stateManager.getState(), cachedCommentedIssues);
+      cachedJsonData = buildDashboardJson(
+        cachedDigest,
+        stateManager.getState(),
+        cachedCommentedIssues,
+        result.allMergedPRs,
+      );
       sendJson(res, 200, cachedJsonData);
     } catch (error) {
       warn(MODULE, `Dashboard refresh failed: ${errorMessage(error)}`);
@@ -542,7 +553,7 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
   });
 
   const serverUrl = `http://localhost:${actualPort}`;
-  warn(MODULE, `Dashboard server running at ${serverUrl}`);
+  warn(MODULE, `Dashboard server running at ${serverUrl} (also: http://oss.localhost:${actualPort})`);
 
   // ── Background refresh ─────────────────────────────────────────────────
   // Port is bound and PID file written — now fetch fresh data from GitHub
@@ -552,7 +563,12 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
       .then((result) => {
         cachedDigest = result.digest;
         cachedCommentedIssues = result.commentedIssues;
-        cachedJsonData = buildDashboardJson(cachedDigest, stateManager.getState(), cachedCommentedIssues);
+        cachedJsonData = buildDashboardJson(
+          cachedDigest,
+          stateManager.getState(),
+          cachedCommentedIssues,
+          result.allMergedPRs,
+        );
         warn(MODULE, 'Background data refresh complete');
       })
       .catch((error) => {

--- a/packages/core/src/core/github-stats.ts
+++ b/packages/core/src/core/github-stats.ts
@@ -5,7 +5,7 @@
 
 import { Octokit } from '@octokit/rest';
 import { extractOwnerRepo, parseGitHubUrl, isOwnRepo } from './utils.js';
-import { ClosedPR, MergedPR, isBelowMinStars, type StarFilter } from './types.js';
+import { ClosedPR, MergedPR, StoredMergedPR, isBelowMinStars, type StarFilter } from './types.js';
 import { debug, warn } from './logger.js';
 import { getHttpCache } from './http-cache.js';
 
@@ -367,4 +367,70 @@ export async function fetchRecentlyMergedPRs(
       };
     },
   );
+}
+
+/**
+ * Fetch merged PRs since a watermark date for incremental storage.
+ * If no watermark is provided (first-ever fetch), fetches all merged PRs (up to pagination cap).
+ * Returns StoredMergedPR[] (minimal: url, title, mergedAt) for state persistence.
+ */
+export async function fetchMergedPRsSince(
+  octokit: Octokit,
+  config: { githubUsername: string },
+  since?: string,
+): Promise<StoredMergedPR[]> {
+  if (!config.githubUsername) {
+    warn(MODULE, 'Skipping merged PRs fetch: no githubUsername configured.');
+    return [];
+  }
+
+  const dateFilter = since ? ` merged:>${since}` : '';
+  const q = `is:pr is:merged author:${config.githubUsername} -user:${config.githubUsername}${dateFilter}`;
+
+  debug(MODULE, `Fetching merged PRs${since ? ` since ${since}` : ' (all time)'}...`);
+
+  const results: StoredMergedPR[] = [];
+  let page = 1;
+  let fetched = 0;
+
+  while (true) {
+    const { data } = await octokit.search.issuesAndPullRequests({
+      q,
+      sort: 'updated',
+      order: 'desc',
+      per_page: 100,
+      page,
+    });
+
+    for (const item of data.items) {
+      const parsed = parseGitHubUrl(item.html_url);
+      if (!parsed) {
+        warn(MODULE, `Skipping merged PR with unparseable URL: ${item.html_url}`);
+        continue;
+      }
+      if (isOwnRepo(parsed.owner, config.githubUsername)) continue;
+
+      const mergedAt = item.pull_request?.merged_at || item.closed_at || '';
+      if (!mergedAt) {
+        warn(MODULE, `Skipping merged PR with no merge date: ${item.html_url}`);
+        continue;
+      }
+      results.push({
+        url: item.html_url,
+        title: item.title,
+        mergedAt,
+      });
+    }
+
+    fetched += data.items.length;
+
+    if (fetched >= data.total_count || fetched >= 1000 || data.items.length === 0 || page >= MAX_PAGINATION_PAGES) {
+      break;
+    }
+
+    page++;
+  }
+
+  debug(MODULE, `Fetched ${results.length} merged PRs${since ? ' (incremental)' : ' (initial)'}`);
+  return results;
 }

--- a/packages/core/src/core/state.test.ts
+++ b/packages/core/src/core/state.test.ts
@@ -1944,3 +1944,109 @@ describe('StateManager initializeWithDefaults', () => {
     saveSpy.mockRestore();
   });
 });
+
+describe('StateManager merged PRs', () => {
+  let stateManager: StateManager;
+
+  beforeEach(() => {
+    stateManager = new StateManager(true);
+  });
+
+  describe('getMergedPRs', () => {
+    it('returns empty array when no merged PRs stored', () => {
+      expect(stateManager.getMergedPRs()).toEqual([]);
+    });
+
+    it('returns stored merged PRs', () => {
+      const prs = [{ url: 'https://github.com/a/b/pull/1', title: 'PR 1', mergedAt: '2025-06-10T00:00:00Z' }];
+      stateManager.addMergedPRs(prs);
+      expect(stateManager.getMergedPRs()).toEqual(prs);
+    });
+  });
+
+  describe('addMergedPRs', () => {
+    it('deduplicates by URL', () => {
+      const pr1 = { url: 'https://github.com/a/b/pull/1', title: 'PR 1', mergedAt: '2025-06-10T00:00:00Z' };
+      const pr1Dup = { url: 'https://github.com/a/b/pull/1', title: 'PR 1 updated', mergedAt: '2025-06-11T00:00:00Z' };
+      const pr2 = { url: 'https://github.com/a/b/pull/2', title: 'PR 2', mergedAt: '2025-06-09T00:00:00Z' };
+
+      stateManager.addMergedPRs([pr1]);
+      stateManager.addMergedPRs([pr1Dup, pr2]);
+
+      const result = stateManager.getMergedPRs();
+      expect(result).toHaveLength(2);
+      expect(result.map((p) => p.url)).toEqual(['https://github.com/a/b/pull/1', 'https://github.com/a/b/pull/2']);
+      // Original title preserved (not overwritten by duplicate)
+      expect(result.find((p) => p.url === pr1.url)?.title).toBe('PR 1');
+    });
+
+    it('sorts by mergedAt descending (newest first)', () => {
+      const prs = [
+        { url: 'https://github.com/a/b/pull/1', title: 'Old', mergedAt: '2025-01-01T00:00:00Z' },
+        { url: 'https://github.com/a/b/pull/2', title: 'New', mergedAt: '2025-06-15T00:00:00Z' },
+        { url: 'https://github.com/a/b/pull/3', title: 'Mid', mergedAt: '2025-03-10T00:00:00Z' },
+      ];
+
+      stateManager.addMergedPRs(prs);
+
+      const result = stateManager.getMergedPRs();
+      expect(result.map((p) => p.title)).toEqual(['New', 'Mid', 'Old']);
+    });
+
+    it('does nothing when passed empty array', () => {
+      const pr = { url: 'https://github.com/a/b/pull/1', title: 'PR 1', mergedAt: '2025-06-10T00:00:00Z' };
+      stateManager.addMergedPRs([pr]);
+      const before = stateManager.getMergedPRs();
+
+      stateManager.addMergedPRs([]);
+
+      expect(stateManager.getMergedPRs()).toEqual(before);
+    });
+
+    it('does nothing when all PRs are duplicates', () => {
+      const pr = { url: 'https://github.com/a/b/pull/1', title: 'PR 1', mergedAt: '2025-06-10T00:00:00Z' };
+      stateManager.addMergedPRs([pr]);
+
+      const saveSpy = vi.spyOn(stateManager, 'save');
+      stateManager.addMergedPRs([pr]);
+      // save is not called because no new PRs were added (early return)
+      expect(saveSpy).not.toHaveBeenCalled();
+      saveSpy.mockRestore();
+    });
+
+    it('initializes mergedPRs array when undefined', () => {
+      // Force undefined state
+      (stateManager as any).state.mergedPRs = undefined;
+      const pr = { url: 'https://github.com/a/b/pull/1', title: 'PR 1', mergedAt: '2025-06-10T00:00:00Z' };
+
+      stateManager.addMergedPRs([pr]);
+
+      expect(stateManager.getMergedPRs()).toHaveLength(1);
+    });
+  });
+
+  describe('getMergedPRWatermark', () => {
+    it('returns undefined when no merged PRs stored', () => {
+      expect(stateManager.getMergedPRWatermark()).toBeUndefined();
+    });
+
+    it('returns most recent mergedAt (first element after sort)', () => {
+      stateManager.addMergedPRs([
+        { url: 'https://github.com/a/b/pull/1', title: 'Old', mergedAt: '2025-01-01T00:00:00Z' },
+        { url: 'https://github.com/a/b/pull/2', title: 'New', mergedAt: '2025-06-15T00:00:00Z' },
+      ]);
+
+      expect(stateManager.getMergedPRWatermark()).toBe('2025-06-15T00:00:00Z');
+    });
+
+    it('returns undefined when mergedPRs is undefined', () => {
+      (stateManager as any).state.mergedPRs = undefined;
+      expect(stateManager.getMergedPRWatermark()).toBeUndefined();
+    });
+
+    it('returns undefined when most recent mergedAt is empty string', () => {
+      (stateManager as any).state.mergedPRs = [{ url: 'https://github.com/a/b/pull/1', title: 'Bad', mergedAt: '' }];
+      expect(stateManager.getMergedPRWatermark()).toBeUndefined();
+    });
+  });
+});

--- a/packages/core/src/core/state.ts
+++ b/packages/core/src/core/state.ts
@@ -18,6 +18,7 @@ import {
   SnoozeInfo,
   StatusOverride,
   FetchedPRStatus,
+  StoredMergedPR,
   isBelowMinStars,
 } from './types.js';
 import { getStatePath, getBackupDir, getDataDir } from './utils.js';
@@ -485,6 +486,11 @@ export class StateManager {
       s.events = [];
     }
 
+    // Migrate older states that don't have mergedPRs
+    if (s.mergedPRs === undefined) {
+      s.mergedPRs = [];
+    }
+
     // Base requirements for all versions
     const hasBaseFields =
       typeof s.version === 'number' &&
@@ -618,6 +624,47 @@ export class StateManager {
 
   setDailyActivityCounts(counts: Record<string, number>): void {
     this.state.dailyActivityCounts = counts;
+  }
+
+  // === Merged PR Storage ===
+
+  /**
+   * Get all stored merged PRs.
+   * @returns Array of stored merged PRs, sorted by mergedAt desc.
+   */
+  getMergedPRs(): StoredMergedPR[] {
+    return this.state.mergedPRs ?? [];
+  }
+
+  /**
+   * Add new merged PRs to the stored list. Deduplicates by URL and sorts by mergedAt desc.
+   * @param prs - New merged PRs to add.
+   */
+  addMergedPRs(prs: StoredMergedPR[]): void {
+    if (prs.length === 0) return;
+    if (!this.state.mergedPRs) {
+      this.state.mergedPRs = [];
+    }
+    const existingUrls = new Set(this.state.mergedPRs.map((pr) => pr.url));
+    const newPRs = prs.filter((pr) => !existingUrls.has(pr.url));
+    if (newPRs.length === 0) return;
+    this.state.mergedPRs.push(...newPRs);
+    this.state.mergedPRs.sort((a, b) => b.mergedAt.localeCompare(a.mergedAt));
+    debug(MODULE, `Added ${newPRs.length} merged PRs (total: ${this.state.mergedPRs.length})`);
+  }
+
+  /**
+   * Get the most recent mergedAt timestamp from stored merged PRs.
+   * Used as the watermark for incremental fetching.
+   * @returns ISO date string of the most recent merge, or undefined if no stored PRs.
+   */
+  getMergedPRWatermark(): string | undefined {
+    const prs = this.state.mergedPRs;
+    if (!prs || prs.length === 0) return undefined;
+    // List is sorted desc by mergedAt, so first element is most recent
+    const watermark = prs[0].mergedAt;
+    if (!watermark) return undefined;
+    return watermark;
   }
 
   /**

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -374,6 +374,13 @@ export interface ClosedPR {
   closedBy?: string;
 }
 
+/** Minimal merged PR data persisted in state.json. Repo/number derived from URL at display time. */
+export interface StoredMergedPR {
+  url: string;
+  title: string;
+  mergedAt: string; // ISO date — used for sorting + watermark
+}
+
 /** Minimal record of a PR that was merged, used in the daily digest. */
 export interface MergedPR {
   url: string;
@@ -468,6 +475,9 @@ export interface AgentState {
 
   /** Cached local repo scan results (#84). Avoids re-scanning the filesystem every session. */
   localRepoCache?: LocalRepoCache;
+
+  /** All merged PRs stored incrementally. Source of truth for the merged PR detail view. */
+  mergedPRs?: StoredMergedPR[];
 
   activeIssues: TrackedIssue[];
 }

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "@oss-autopilot/core": "workspace:*",
     "chart.js": "^4.4.8",
-    "preact": "^10.25.4"
+    "preact": "^10.25.4",
+    "preact-iso": "^2.11.1"
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.9.4",

--- a/packages/dashboard/src/app.tsx
+++ b/packages/dashboard/src/app.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from 'preact/hooks';
+import { LocationProvider, useLocation } from 'preact-iso';
 import { useDashboard } from './hooks/use-dashboard';
 import { StatsBar } from './components/stats-bar';
 import { FilterBar, type Filters } from './components/filter-bar';
@@ -7,11 +8,34 @@ import { PRDetail } from './components/pr-detail';
 import { ChartPanel } from './components/chart-panel';
 import { IssueList } from './components/issue-list';
 import { RecentActivity } from './components/recent-activity';
+import { MergedPRList } from './components/merged-pr-list';
+import type { DashboardStats } from './types';
 
-export function App() {
+interface DashboardHeaderProps {
+  stats: DashboardStats;
+  loading: boolean;
+  onRefresh: () => void;
+}
+
+function DashboardHeader({ stats, loading, onRefresh }: DashboardHeaderProps) {
+  return (
+    <header class="dashboard-header">
+      <h1>OSS Autopilot</h1>
+      <span class="dashboard-subtitle">
+        {stats.activePRs} active PRs &middot; {stats.mergedPRs} merged &middot; {stats.mergeRate} merge rate
+      </span>
+      <button class="refresh-btn" onClick={onRefresh} disabled={loading}>
+        {loading ? 'Refreshing...' : 'Refresh'}
+      </button>
+    </header>
+  );
+}
+
+function AppContent() {
   const { data, loading, error, clearError, refresh, performAction } = useDashboard();
   const [filters, setFilters] = useState<Filters>({ status: 'all', repo: 'all', search: '' });
   const [selectedUrl, setSelectedUrl] = useState<string | null>(null);
+  const { path, route } = useLocation();
 
   const shelvedUrls = useMemo(() => new Set(data?.shelvedPRUrls ?? []), [data?.shelvedPRUrls]);
 
@@ -37,6 +61,18 @@ export function App() {
 
   if (!data) return null;
 
+  // Route: /merged — show all merged PRs
+  if (path === '/merged') {
+    const mergedPRs = data.allMergedPRs ?? [];
+    return (
+      <div class="dashboard">
+        <DashboardHeader stats={data.stats} loading={loading} onRefresh={refresh} />
+        <MergedPRList mergedPRs={mergedPRs} onBack={() => route('/')} />
+      </div>
+    );
+  }
+
+  // Default route: dashboard home
   const repos = [...new Set(data.activePRs.map((pr) => pr.repo))].sort();
   const statuses = [...new Set(data.activePRs.map((pr) => pr.status))].sort();
 
@@ -54,16 +90,7 @@ export function App() {
 
   return (
     <div class="dashboard">
-      <header class="dashboard-header">
-        <h1>OSS Autopilot</h1>
-        <span class="dashboard-subtitle">
-          {data.stats.activePRs} active PRs &middot; {data.stats.mergedPRs} merged &middot; {data.stats.mergeRate} merge
-          rate
-        </span>
-        <button class="refresh-btn" onClick={refresh} disabled={loading}>
-          {loading ? 'Refreshing...' : 'Refresh'}
-        </button>
-      </header>
+      <DashboardHeader stats={data.stats} loading={loading} onRefresh={refresh} />
 
       {error && (
         <div class="error-banner">
@@ -75,7 +102,7 @@ export function App() {
       )}
 
       <main class="dashboard-main">
-        <StatsBar stats={data.stats} />
+        <StatsBar stats={data.stats} onMergedClick={() => route('/merged')} />
         <FilterBar filters={filters} onFilterChange={setFilters} repos={repos} statuses={statuses} />
 
         <div class="dashboard-content">
@@ -106,5 +133,13 @@ export function App() {
         <IssueList issues={data.issueResponses} />
       </main>
     </div>
+  );
+}
+
+export function App() {
+  return (
+    <LocationProvider>
+      <AppContent />
+    </LocationProvider>
   );
 }

--- a/packages/dashboard/src/components/merged-pr-list.test.tsx
+++ b/packages/dashboard/src/components/merged-pr-list.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/preact';
+import { MergedPRList } from './merged-pr-list';
+import { makeMergedPR } from '../test-helpers';
+
+describe('MergedPRList', () => {
+  const prs = [
+    makeMergedPR({
+      url: 'https://github.com/a/b/pull/1',
+      repo: 'a/b',
+      number: 1,
+      title: 'First PR',
+      mergedAt: '2025-06-10T00:00:00Z',
+    }),
+    makeMergedPR({
+      url: 'https://github.com/c/d/pull/2',
+      repo: 'c/d',
+      number: 2,
+      title: 'Second PR',
+      mergedAt: '2025-06-09T00:00:00Z',
+    }),
+  ];
+
+  it('renders back button that calls onBack', () => {
+    const onBack = vi.fn();
+    const { container } = render(<MergedPRList mergedPRs={prs} onBack={onBack} />);
+    const backBtn = container.querySelector('.merged-view-back') as HTMLButtonElement;
+    expect(backBtn).toBeTruthy();
+    fireEvent.click(backBtn);
+    expect(onBack).toHaveBeenCalledOnce();
+  });
+
+  it('renders all PRs with titles and GitHub links', () => {
+    const { container } = render(<MergedPRList mergedPRs={prs} onBack={() => {}} />);
+    const links = container.querySelectorAll('.recent-activity-link');
+    expect(links).toHaveLength(2);
+    expect((links[0] as HTMLAnchorElement).href).toBe('https://github.com/a/b/pull/1');
+    expect((links[0] as HTMLAnchorElement).target).toBe('_blank');
+    expect((links[0] as HTMLAnchorElement).rel).toBe('noopener noreferrer');
+    expect(links[0].textContent).toBe('a/b#1');
+    expect(links[1].textContent).toBe('c/d#2');
+  });
+
+  it('shows formatted merge dates', () => {
+    const { container } = render(<MergedPRList mergedPRs={prs} onBack={() => {}} />);
+    const dates = container.querySelectorAll('.recent-activity-date');
+    expect(dates).toHaveLength(2);
+    // Just check they render (formatting depends on locale)
+    expect(dates[0].textContent).toBeTruthy();
+  });
+
+  it('shows count in subtitle', () => {
+    const { container } = render(<MergedPRList mergedPRs={prs} onBack={() => {}} />);
+    const subtitle = container.querySelector('.merged-view-subtitle');
+    expect(subtitle?.textContent).toBe('2 total');
+  });
+
+  it('shows empty state when no PRs', () => {
+    const { container } = render(<MergedPRList mergedPRs={[]} onBack={() => {}} />);
+    const empty = container.querySelector('.merged-view-empty');
+    expect(empty).toBeTruthy();
+    expect(empty?.textContent).toContain('No merged PRs found');
+  });
+});

--- a/packages/dashboard/src/components/merged-pr-list.tsx
+++ b/packages/dashboard/src/components/merged-pr-list.tsx
@@ -1,0 +1,40 @@
+import type { MergedPR } from '../types';
+import { truncate, formatDate } from '../utils';
+
+interface MergedPRListProps {
+  mergedPRs: MergedPR[];
+  onBack: () => void;
+}
+
+export function MergedPRList({ mergedPRs, onBack }: MergedPRListProps) {
+  return (
+    <div class="merged-view">
+      <div class="merged-view-header">
+        <button class="merged-view-back" onClick={onBack} type="button">
+          &larr; Back
+        </button>
+        <div>
+          <h2 class="merged-view-title">Merged PRs</h2>
+          <span class="merged-view-subtitle">{mergedPRs.length} total</span>
+        </div>
+      </div>
+
+      {mergedPRs.length === 0 ? (
+        <div class="merged-view-empty">No merged PRs found. Run a dashboard refresh to populate.</div>
+      ) : (
+        <div class="merged-view-list">
+          {mergedPRs.map((pr) => (
+            <div key={pr.url} class="recent-activity-item">
+              <span class="recent-activity-badge recent-activity-badge--merged">Merged</span>
+              <a class="recent-activity-link" href={pr.url} target="_blank" rel="noopener noreferrer">
+                {pr.repo}#{pr.number}
+              </a>
+              <span class="recent-activity-item-title">{truncate(pr.title, 60)}</span>
+              <span class="recent-activity-date">{formatDate(pr.mergedAt)}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/stats-bar.test.tsx
+++ b/packages/dashboard/src/components/stats-bar.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { render } from '@testing-library/preact';
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/preact';
 import { StatsBar } from './stats-bar';
 
 describe('StatsBar', () => {
@@ -21,5 +21,30 @@ describe('StatsBar', () => {
     const { container } = render(<StatsBar stats={stats} />);
     const labels = [...container.querySelectorAll('.stat-label')].map((el) => el.textContent);
     expect(labels).toEqual(['Active PRs', 'Shelved PRs', 'Merged PRs', 'Closed PRs', 'Merge Rate']);
+  });
+
+  it('renders merged card as clickable button when onMergedClick provided', () => {
+    const onClick = vi.fn();
+    const { container } = render(<StatsBar stats={stats} onMergedClick={onClick} />);
+    const clickable = container.querySelectorAll('.stat-card--clickable');
+    expect(clickable).toHaveLength(1);
+    expect(clickable[0].tagName).toBe('BUTTON');
+    expect(clickable[0].querySelector('.stat-label')?.textContent).toBe('Merged PRs');
+  });
+
+  it('calls onMergedClick when merged card is clicked', () => {
+    const onClick = vi.fn();
+    const { container } = render(<StatsBar stats={stats} onMergedClick={onClick} />);
+    const clickable = container.querySelector('.stat-card--clickable') as HTMLButtonElement;
+    fireEvent.click(clickable);
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('renders all cards as divs when onMergedClick not provided', () => {
+    const { container } = render(<StatsBar stats={stats} />);
+    const clickable = container.querySelectorAll('.stat-card--clickable');
+    expect(clickable).toHaveLength(0);
+    const buttons = container.querySelectorAll('button');
+    expect(buttons).toHaveLength(0);
   });
 });

--- a/packages/dashboard/src/components/stats-bar.tsx
+++ b/packages/dashboard/src/components/stats-bar.tsx
@@ -2,6 +2,7 @@ import type { DashboardStats } from '../types';
 
 interface StatsBarProps {
   stats: DashboardStats;
+  onMergedClick?: () => void;
 }
 
 interface StatCardDef {
@@ -9,9 +10,10 @@ interface StatCardDef {
   value: string | number;
   accentVar: string;
   accentDimVar: string;
+  onClick?: () => void;
 }
 
-export function StatsBar({ stats }: StatsBarProps) {
+export function StatsBar({ stats, onMergedClick }: StatsBarProps) {
   const cards: StatCardDef[] = [
     {
       label: 'Active PRs',
@@ -30,6 +32,7 @@ export function StatsBar({ stats }: StatsBarProps) {
       value: stats.mergedPRs,
       accentVar: 'var(--accent-merged)',
       accentDimVar: 'var(--accent-merged-dim)',
+      onClick: onMergedClick,
     },
     {
       label: 'Closed PRs',
@@ -47,16 +50,21 @@ export function StatsBar({ stats }: StatsBarProps) {
 
   return (
     <div class="stats-bar">
-      {cards.map((card) => (
-        <div
-          key={card.label}
-          class="stat-card"
-          style={{ borderLeftColor: card.accentVar, background: card.accentDimVar }}
-        >
-          <span class="stat-value">{card.value}</span>
-          <span class="stat-label">{card.label}</span>
-        </div>
-      ))}
+      {cards.map((card) => {
+        const Tag = card.onClick ? 'button' : 'div';
+        return (
+          <Tag
+            key={card.label}
+            class={`stat-card${card.onClick ? ' stat-card--clickable' : ''}`}
+            style={{ borderLeftColor: card.accentVar, background: card.accentDimVar }}
+            onClick={card.onClick}
+            {...(card.onClick ? { type: 'button' as const } : {})}
+          >
+            <span class="stat-value">{card.value}</span>
+            <span class="stat-label">{card.label}</span>
+          </Tag>
+        );
+      })}
     </div>
   );
 }

--- a/packages/dashboard/src/styles.css
+++ b/packages/dashboard/src/styles.css
@@ -879,6 +879,87 @@ a:hover {
   flex-shrink: 0;
 }
 
+/* === Clickable Stat Card === */
+
+.stat-card--clickable {
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    filter 0.15s;
+}
+
+.stat-card--clickable:hover {
+  filter: brightness(1.3);
+  border-color: var(--accent-merged);
+}
+
+.stat-card--clickable:focus-visible {
+  outline: 2px solid var(--accent-merged);
+  outline-offset: 2px;
+}
+
+/* === Merged PR Detail View === */
+
+.merged-view {
+  max-width: 900px;
+  padding: 0;
+}
+
+.merged-view-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.merged-view-back {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  padding: 6px 14px;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
+}
+
+.merged-view-back:hover {
+  background: var(--bg-surface);
+  border-color: var(--accent-info);
+}
+
+.merged-view-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.merged-view-subtitle {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
+
+.merged-view-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.merged-view-empty {
+  text-align: center;
+  padding: 48px 24px;
+  color: var(--text-muted);
+  font-size: 0.875rem;
+  border: 1px dashed var(--border-muted);
+  border-radius: 8px;
+}
+
 /* === Scrollbar === */
 
 ::-webkit-scrollbar {

--- a/packages/dashboard/src/test-helpers.ts
+++ b/packages/dashboard/src/test-helpers.ts
@@ -94,6 +94,7 @@ export function makeDashboardData(overrides: Partial<DashboardData> = {}): Dashb
     autoUnshelvedPRs: [],
     commentedIssues: [],
     issueResponses: [],
+    allMergedPRs: [],
     ...overrides,
   };
 }

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -51,6 +51,7 @@ export interface DashboardData {
   autoUnshelvedPRs: ShelvedPRRef[];
   commentedIssues: CommentedIssue[];
   issueResponses: CommentedIssueWithResponse[];
+  allMergedPRs: MergedPR[];
 }
 
 /** Actions a user can take from the dashboard. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       preact:
         specifier: ^10.25.4
         version: 10.28.4
+      preact-iso:
+        specifier: ^2.11.1
+        version: 2.11.1(preact-render-to-string@6.6.6(preact@10.28.4))(preact@10.28.4)
     devDependencies:
       '@preact/preset-vite':
         specifier: ^2.9.4
@@ -1978,6 +1981,17 @@ packages:
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  preact-iso@2.11.1:
+    resolution: {integrity: sha512-rLy0RmzP/hrDjnFdnEblxFgKtzUj4njkHrpGJBGS7S4QuYw1zv0lA38qsWpeAAB10JAz/hF2CsHrLen9ufCtbw==}
+    peerDependencies:
+      preact: '>=10 || >= 11.0.0-0'
+      preact-render-to-string: '>=6.4.0'
+
+  preact-render-to-string@6.6.6:
+    resolution: {integrity: sha512-EfqZJytnjJldV+YaaqhthU2oXsEf5e+6rDv957p+zxAvNfFLQOPfvBOTncscQ+akzu6Wrl7s3Pa0LjUQmWJsGQ==}
+    peerDependencies:
+      preact: '>=10 || >= 11.0.0-0'
 
   preact@10.28.4:
     resolution: {integrity: sha512-uKFfOHWuSNpRFVTnljsCluEFq57OKT+0QdOiQo8XWnQ/pSvg7OpX5eNOejELXJMWy+BwM2nobz0FkvzmnpCNsQ==}
@@ -4247,6 +4261,15 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  preact-iso@2.11.1(preact-render-to-string@6.6.6(preact@10.28.4))(preact@10.28.4):
+    dependencies:
+      preact: 10.28.4
+      preact-render-to-string: 6.6.6(preact@10.28.4)
+
+  preact-render-to-string@6.6.6(preact@10.28.4):
+    dependencies:
+      preact: 10.28.4
 
   preact@10.28.4: {}
 


### PR DESCRIPTION
## Summary

- **Persist merged PRs** in `state.json` with incremental watermark-based fetching — first load fetches all (up to 300), subsequent loads fetch only new PRs (typically 0-1 API calls)
- **Clickable "Merged PRs" stat card** navigates to a `/merged` detail view listing all historical merged PRs with GitHub links, using preact-iso for client-side routing
- **`oss.localhost` custom domain** added to allowed CORS origins (modern browsers resolve `*.localhost` to `127.0.0.1` automatically)
- **Robust error handling** — guards against empty `mergedAt` strings corrupting the watermark, warns on unparseable URLs, try-catch around state mutations, `Math.max` prevents count regressions during initial population

Closes #633

## Changes

### Core package
- `StoredMergedPR` type + `mergedPRs` field on `AgentState` with migration
- `StateManager` methods: `getMergedPRs()`, `addMergedPRs()`, `getMergedPRWatermark()`
- `fetchMergedPRsSince()` — watermark-based incremental GitHub Search API fetch
- `storedToMergedPRs()` — converts stored PRs to display format (derives `repo`/`number` from URL)
- `allMergedPRs` added to dashboard API response
- `oss.localhost` added to valid CORS origins

### Dashboard package
- `preact-iso` installed for client-side routing
- `MergedPRList` component — detail view with back button, PR list with GitHub links, empty state
- Stats bar merged card renders as clickable `<button>` with hover/focus styles
- `LocationProvider` + `useLocation()` routing in `App`

## Test plan
- [x] 1712 tests pass (1520 core + 89 dashboard + 103 mcp-server)
- [x] Bundle builds clean (314.7KB core, 1.6MB mcp-server)
- [x] TypeScript type checking passes for core and dashboard
- [x] Prettier formatting passes
- [ ] Manual: stat card clickable with hover effect
- [ ] Manual: `/merged` route shows all merged PRs sorted newest-first
- [ ] Manual: back button returns to dashboard home
- [ ] Manual: direct nav to `/merged` works (page refresh)
- [ ] Manual: `oss.localhost:<port>` resolves correctly