### PR TITLE
fix: auto-refresh marketplace cache on session start

### DIFF
--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -9,6 +9,15 @@ PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 messages=""
 
+# --- Step 0: Auto-refresh marketplace cache (non-blocking) ---
+# Claude Code caches third-party marketplace repos as git clones but never
+# auto-refreshes them, so plugin updates aren't discoverable. A background
+# pull on every session keeps the cache current without blocking startup.
+MARKETPLACE_DIR="$HOME/.claude/plugins/marketplaces/oss-autopilot"
+if [ -d "$MARKETPLACE_DIR/.git" ]; then
+  (cd "$MARKETPLACE_DIR" && git pull --quiet origin main 2>/dev/null) &
+fi
+
 # --- Step 1: Rebuild stale CLI bundle (if needed) ---
 if [ -f "${PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" ] && [ "${PLUGIN_ROOT}/packages/core/package.json" -nt "${PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" ]; then
   if (cd "${PLUGIN_ROOT}/packages/core" && npm install --silent 2>/dev/null && npm run bundle --silent 2>/dev/null); then


### PR DESCRIPTION
## Summary
- Adds a non-blocking background `git pull` to the session-start hook (Step 0) that keeps the marketplace git cache current
- Fixes an issue where the plugin system caches third-party marketplace repos as git clones but never auto-refreshes them, making new versions invisible in the update UI
- Complements the existing version-check logic in Step 2 which only refreshes when a mismatch is already detected via the GitHub API

## Context
After release-please bumps the version on `main`, users can't see the update in `/plugin` because `~/.claude/plugins/marketplaces/oss-autopilot/` is a stale git clone frozen at install time. The background pull runs every session and silently fails if the directory doesn't exist.

## Test plan
- [x] Hook runs without errors: `bash hooks/session-start.sh` produces valid JSON
- [x] All tests pass: `pnpm test`
- [ ] After merge: start a new session → verify `~/.claude/plugins/marketplaces/oss-autopilot/.claude-plugin/plugin.json` shows latest version