### PR TITLE
fix: CLI respects dashboard PR status overrides

### DIFF
--- a/packages/core/src/commands/daily-orchestration.test.ts
+++ b/packages/core/src/commands/daily-orchestration.test.ts
@@ -43,6 +43,7 @@ const mockGetStats = vi.fn();
 const mockIsSnoozed = vi.fn();
 const mockGetIssueDismissedAt = vi.fn();
 const mockUndismissIssue = vi.fn();
+const mockGetStatusOverride = vi.fn();
 
 // daily.ts imports everything from '../core/index.js', so we mock the whole barrel export.
 // PRMonitor and IssueConversationMonitor are used as classes (new PRMonitor(...)),
@@ -83,6 +84,7 @@ vi.mock('../core/index.js', async (importOriginal) => {
       isSnoozed: mockIsSnoozed,
       getIssueDismissedAt: mockGetIssueDismissedAt,
       undismissIssue: mockUndismissIssue,
+      getStatusOverride: mockGetStatusOverride,
     })),
     requireGitHubToken: vi.fn(() => 'test-token'),
     formatRelativeTime: vi.fn(() => '2 days ago'),
@@ -90,6 +92,16 @@ vi.mock('../core/index.js', async (importOriginal) => {
     IssueConversationMonitor: MockIssueConversationMonitor,
   };
 });
+
+// applyStatusOverrides (in daily-logic.ts) imports getStateManager from './state.js' directly,
+// not via the barrel. Mock it so the real function resolves to the same mock state manager.
+vi.mock('../core/state.js', () => ({
+  getStateManager: vi.fn(() => ({
+    getState: mockGetState,
+    getStatusOverride: mockGetStatusOverride,
+    save: mockSave,
+  })),
+}));
 
 // Import AFTER all mocks are declared
 import { executeDailyCheck, runDaily, runDailyForDisplay } from './daily.js';
@@ -200,6 +212,7 @@ beforeEach(() => {
   mockUnshelvePR.mockReturnValue(true);
   mockIsSnoozed.mockReturnValue(false);
   mockGetIssueDismissedAt.mockReturnValue(undefined);
+  mockGetStatusOverride.mockReturnValue(undefined);
   mockUpdateRepoScore.mockImplementation(() => {});
   mockAddTrustedProject.mockImplementation(() => {});
   mockSave.mockImplementation(() => {});
@@ -972,5 +985,81 @@ describe('runDailyForDisplay()', () => {
     if (result.repoGroups.length > 0) {
       expect(result.repoGroups[0]).toHaveProperty('prs');
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// executeDailyCheck() — status override integration (#644)
+// ---------------------------------------------------------------------------
+
+describe('executeDailyCheck() — status overrides (#644)', () => {
+  /** Build state with a statusOverrides entry, merging into the default config. */
+  function stateWithOverrides(overrides: Record<string, { status: string; setAt: string; lastActivityAt: string }>) {
+    const base = makeDefaultState();
+    return { ...base, config: { ...base.config, statusOverrides: overrides } };
+  }
+
+  /** Wire up mocks so getStatusOverride returns the given override for a specific URL. */
+  function setupOverrideMock(prUrl: string, override: { status: string; setAt: string; lastActivityAt: string }) {
+    mockGetStatusOverride.mockImplementation((url: string) => (url === prUrl ? override : undefined));
+  }
+
+  it('PR overridden to waiting_on_maintainer does not appear in actionable issues', async () => {
+    const overriddenPR = makePR({
+      repo: 'owner/repo',
+      number: 1,
+      status: 'needs_addressing',
+      actionReason: 'needs_response',
+    });
+    const normalPR = makePR({
+      repo: 'owner/repo',
+      number: 2,
+      status: 'needs_addressing',
+      actionReason: 'failing_ci',
+    });
+    mockFetchUserOpenPRs.mockResolvedValue({ prs: [overriddenPR, normalPR], failures: [] });
+    mockIsPRShelved.mockReturnValue(false);
+
+    const override = {
+      status: 'waiting_on_maintainer',
+      setAt: '2026-01-20T00:00:00Z',
+      lastActivityAt: overriddenPR.updatedAt,
+    };
+    mockGetState.mockReturnValue(stateWithOverrides({ [overriddenPR.url]: override }));
+    setupOverrideMock(overriddenPR.url, override);
+    mockGenerateDigest.mockImplementation((prs: FetchedPR[]) => makeDigest(prs));
+
+    const result = await executeDailyCheck('test-token');
+
+    const actionableUrls = result.actionableIssues.map((i) => i.prUrl);
+    expect(actionableUrls).not.toContain(overriddenPR.url);
+    expect(actionableUrls).toContain(normalPR.url);
+    expect(result.capacity.criticalIssueCount).toBe(1); // only normalPR
+  });
+
+  it('PR overridden to needs_addressing appears in actionable issues', async () => {
+    const overriddenPR = makePR({
+      repo: 'owner/repo',
+      number: 1,
+      status: 'waiting_on_maintainer',
+      waitReason: 'pending_review',
+    });
+    mockFetchUserOpenPRs.mockResolvedValue({ prs: [overriddenPR], failures: [] });
+    mockIsPRShelved.mockReturnValue(false);
+
+    const override = {
+      status: 'needs_addressing',
+      setAt: '2026-01-20T00:00:00Z',
+      lastActivityAt: overriddenPR.updatedAt,
+    };
+    mockGetState.mockReturnValue(stateWithOverrides({ [overriddenPR.url]: override }));
+    setupOverrideMock(overriddenPR.url, override);
+    mockGenerateDigest.mockImplementation((prs: FetchedPR[]) => makeDigest(prs));
+
+    const result = await executeDailyCheck('test-token');
+
+    const actionableUrls = result.actionableIssues.map((i) => i.prUrl);
+    expect(actionableUrls).toContain(overriddenPR.url);
+    expect(result.capacity.criticalIssueCount).toBe(1);
   });
 });

--- a/packages/core/src/commands/daily.ts
+++ b/packages/core/src/commands/daily.ts
@@ -13,6 +13,7 @@ import {
   IssueConversationMonitor,
   requireGitHubToken,
   CRITICAL_STATUSES,
+  applyStatusOverrides,
   computeRepoSignals,
   groupPRsByRepo,
   assessCapacity,
@@ -52,6 +53,7 @@ const MODULE = 'daily';
 // Re-export domain functions so existing consumers (tests, dashboard, startup)
 // can continue importing from './daily.js' without changes.
 export {
+  applyStatusOverrides,
   computeRepoSignals,
   groupPRsByRepo,
   assessCapacity,
@@ -375,12 +377,17 @@ function partitionPRs(
     warn(MODULE, `Failed to expire/persist snoozes: ${errorMessage(error)}`);
   }
 
+  // Apply dashboard/CLI status overrides before partitioning.
+  // This ensures PRs reclassified in the dashboard (e.g., "Action Required" → "Waiting")
+  // are respected by the CLI pipeline.
+  const overriddenPRs = applyStatusOverrides(prs, stateManager.getState());
+
   // Partition PRs into active vs shelved, auto-unshelving when maintainers engage
   const shelvedPRs: ShelvedPRRef[] = [];
   const autoUnshelvedPRs: ShelvedPRRef[] = [];
   const activePRs: FetchedPR[] = [];
 
-  for (const pr of prs) {
+  for (const pr of overriddenPRs) {
     if (stateManager.isPRShelved(pr.url)) {
       if (CRITICAL_STATUSES.has(pr.status)) {
         stateManager.unshelvePR(pr.url);
@@ -398,10 +405,10 @@ function partitionPRs(
     }
   }
 
-  // Generate digest from fresh data.
+  // Generate digest from override-applied PRs so status categories are correct.
   // Note: digest.openPRs contains ALL fetched PRs (including shelved).
   // We override summary fields below to reflect active-only counts.
-  const digest = prMonitor.generateDigest(prs, recentlyClosedPRs, recentlyMergedPRs);
+  const digest = prMonitor.generateDigest(overriddenPRs, recentlyClosedPRs, recentlyMergedPRs);
 
   // Attach shelve info to digest
   digest.shelvedPRs = shelvedPRs;

--- a/packages/core/src/commands/dashboard-server.test.ts
+++ b/packages/core/src/commands/dashboard-server.test.ts
@@ -71,6 +71,7 @@ vi.mock('../core/index.js', () => ({
   getGitHubToken: vi.fn(() => null),
   getDataDir: vi.fn(() => pidTestDir),
   getCLIVersion: vi.fn(() => '0.44.6'),
+  applyStatusOverrides: vi.fn((prs: unknown[]) => prs),
 }));
 
 // Mock fetchDashboardData so we never call GitHub

--- a/packages/core/src/commands/dashboard-server.ts
+++ b/packages/core/src/commands/dashboard-server.ts
@@ -9,7 +9,7 @@
 import * as http from 'http';
 import * as fs from 'fs';
 import * as path from 'path';
-import { getStateManager, getGitHubToken, getCLIVersion } from '../core/index.js';
+import { getStateManager, getGitHubToken, getCLIVersion, applyStatusOverrides } from '../core/index.js';
 import { errorMessage, ValidationError } from '../core/errors.js';
 import { warn } from '../core/logger.js';
 import { validateUrl, validateGitHubUrl, PR_URL_PATTERN } from './validation.js';
@@ -104,40 +104,6 @@ const MIME_TYPES: Record<string, string> = {
   '.png': 'image/png',
   '.ico': 'image/x-icon',
 };
-
-/**
- * Apply status overrides from state to the PR list.
- * Overrides are auto-cleared if the PR has new activity since the override was set.
- */
-function applyStatusOverrides(prs: FetchedPR[], state: Readonly<AgentState>): FetchedPR[] {
-  const overrides = state.config.statusOverrides;
-  if (!overrides || Object.keys(overrides).length === 0) return prs;
-
-  const stateManager = getStateManager();
-  // Snapshot keys before iteration — clearStatusOverride mutates the same object
-  const overrideUrls = new Set(Object.keys(overrides));
-  let didAutoClear = false;
-  const result = prs.map((pr) => {
-    const override = stateManager.getStatusOverride(pr.url, pr.updatedAt);
-    if (!override) {
-      if (overrideUrls.has(pr.url)) didAutoClear = true;
-      return pr;
-    }
-    if (override.status === pr.status) return pr;
-    return { ...pr, status: override.status };
-  });
-
-  // Persist any auto-cleared overrides so they don't resurrect on restart
-  if (didAutoClear) {
-    try {
-      stateManager.save();
-    } catch (err) {
-      warn(MODULE, `Failed to persist auto-cleared overrides — they may reappear on restart: ${errorMessage(err)}`);
-    }
-  }
-
-  return result;
-}
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 

--- a/packages/core/src/core/daily-logic.test.ts
+++ b/packages/core/src/core/daily-logic.test.ts
@@ -6,7 +6,7 @@
  * import via the re-exports in daily.ts).
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   assessCapacity,
   collectActionableIssues,
@@ -17,10 +17,11 @@ import {
   computeRepoSignals,
   groupPRsByRepo,
   computeActionMenu,
+  applyStatusOverrides,
   CRITICAL_STATUSES,
   STALE_STATUSES,
 } from './daily-logic.js';
-import type { FetchedPR, MaintainerActionHint } from './types.js';
+import type { FetchedPR, MaintainerActionHint, AgentState } from './types.js';
 import { makeFetchedPR, makeDailyDigest, makeCapacityAssessment as makeCapacity } from './test-utils.js';
 
 // ---------------------------------------------------------------------------
@@ -521,5 +522,170 @@ describe('computeActionMenu (core)', () => {
   it('should always include search', () => {
     const menu = computeActionMenu([], makeCapacity());
     expect(menu.items.find((i) => i.key === 'search')).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyStatusOverrides
+// ---------------------------------------------------------------------------
+
+// Mock getStateManager for applyStatusOverrides tests
+const mockGetStatusOverride = vi.fn();
+const mockSave = vi.fn();
+vi.mock('./state.js', () => ({
+  getStateManager: vi.fn(() => ({
+    getStatusOverride: mockGetStatusOverride,
+    save: mockSave,
+  })),
+}));
+
+describe('applyStatusOverrides', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetStatusOverride.mockReturnValue(undefined);
+  });
+
+  function makeState(
+    statusOverrides: Record<string, { status: string; setAt: string; lastActivityAt: string }> = {},
+  ): Readonly<AgentState> {
+    return { config: { statusOverrides } } as unknown as AgentState;
+  }
+
+  it('should return PRs unchanged when no overrides exist', () => {
+    const prs = [makePR({ repo: 'owner/repo', status: 'needs_addressing' })];
+    const state = makeState();
+    const result = applyStatusOverrides(prs, state);
+    expect(result).toBe(prs); // Same reference — early return
+  });
+
+  it('should return PRs unchanged when statusOverrides is empty', () => {
+    const prs = [makePR({ repo: 'owner/repo' })];
+    const state = makeState({});
+    const result = applyStatusOverrides(prs, state);
+    expect(result).toBe(prs);
+  });
+
+  it('should override needs_addressing → waiting_on_maintainer with correct reason fields', () => {
+    const prUrl = 'https://github.com/owner/repo/pull/1';
+    const prs = [
+      makePR({
+        repo: 'owner/repo',
+        number: 1,
+        status: 'needs_addressing',
+        actionReason: 'needs_response',
+        waitReason: undefined,
+      }),
+    ];
+    const state = makeState({
+      [prUrl]: {
+        status: 'waiting_on_maintainer',
+        setAt: '2026-01-01T00:00:00Z',
+        lastActivityAt: '2025-06-15T00:00:00Z',
+      },
+    });
+    mockGetStatusOverride.mockReturnValue({
+      status: 'waiting_on_maintainer',
+      setAt: '2026-01-01T00:00:00Z',
+      lastActivityAt: '2025-06-15T00:00:00Z',
+    });
+
+    const result = applyStatusOverrides(prs, state);
+
+    expect(result[0].status).toBe('waiting_on_maintainer');
+    expect(result[0].actionReason).toBeUndefined();
+    expect(result[0].waitReason).toBe('pending_review');
+  });
+
+  it('should override waiting_on_maintainer → needs_addressing with correct reason fields', () => {
+    const prUrl = 'https://github.com/owner/repo/pull/1';
+    const prs = [
+      makePR({
+        repo: 'owner/repo',
+        number: 1,
+        status: 'waiting_on_maintainer',
+        waitReason: 'pending_review',
+        actionReason: undefined,
+      }),
+    ];
+    const state = makeState({
+      [prUrl]: { status: 'needs_addressing', setAt: '2026-01-01T00:00:00Z', lastActivityAt: '2025-06-15T00:00:00Z' },
+    });
+    mockGetStatusOverride.mockReturnValue({
+      status: 'needs_addressing',
+      setAt: '2026-01-01T00:00:00Z',
+      lastActivityAt: '2025-06-15T00:00:00Z',
+    });
+
+    const result = applyStatusOverrides(prs, state);
+
+    expect(result[0].status).toBe('needs_addressing');
+    expect(result[0].waitReason).toBeUndefined();
+    expect(result[0].actionReason).toBe('needs_response');
+  });
+
+  it('should auto-clear override when PR has new activity and persist', () => {
+    const prUrl = 'https://github.com/owner/repo/pull/1';
+    const prs = [
+      makePR({ repo: 'owner/repo', number: 1, status: 'needs_addressing', updatedAt: '2026-02-01T00:00:00Z' }),
+    ];
+    const state = makeState({
+      [prUrl]: {
+        status: 'waiting_on_maintainer',
+        setAt: '2026-01-01T00:00:00Z',
+        lastActivityAt: '2026-01-01T00:00:00Z',
+      },
+    });
+    // getStatusOverride returns undefined when auto-cleared (updatedAt > lastActivityAt)
+    mockGetStatusOverride.mockReturnValue(undefined);
+
+    const result = applyStatusOverrides(prs, state);
+
+    // PR should keep its original status since override was auto-cleared
+    expect(result[0].status).toBe('needs_addressing');
+    // Should persist the auto-clear
+    expect(mockSave).toHaveBeenCalledOnce();
+  });
+
+  it('should not change PR when override matches current status', () => {
+    const prUrl = 'https://github.com/owner/repo/pull/1';
+    const prs = [makePR({ repo: 'owner/repo', number: 1, status: 'waiting_on_maintainer' })];
+    const state = makeState({
+      [prUrl]: {
+        status: 'waiting_on_maintainer',
+        setAt: '2026-01-01T00:00:00Z',
+        lastActivityAt: '2025-06-15T00:00:00Z',
+      },
+    });
+    mockGetStatusOverride.mockReturnValue({
+      status: 'waiting_on_maintainer',
+      setAt: '2026-01-01T00:00:00Z',
+      lastActivityAt: '2025-06-15T00:00:00Z',
+    });
+
+    const result = applyStatusOverrides(prs, state);
+
+    expect(result[0].status).toBe('waiting_on_maintainer');
+    expect(result[0]).toBe(prs[0]); // Same reference — no mutation
+  });
+
+  it('should not persist when no auto-clears happened', () => {
+    const prUrl = 'https://github.com/owner/repo/pull/1';
+    const prs = [makePR({ repo: 'owner/repo', number: 1, status: 'needs_addressing' })];
+    const state = makeState({
+      [prUrl]: {
+        status: 'waiting_on_maintainer',
+        setAt: '2026-01-01T00:00:00Z',
+        lastActivityAt: '2025-06-15T00:00:00Z',
+      },
+    });
+    mockGetStatusOverride.mockReturnValue({
+      status: 'waiting_on_maintainer',
+      setAt: '2026-01-01T00:00:00Z',
+      lastActivityAt: '2025-06-15T00:00:00Z',
+    });
+
+    applyStatusOverrides(prs, state);
+
+    expect(mockSave).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/core/daily-logic.ts
+++ b/packages/core/src/core/daily-logic.ts
@@ -13,12 +13,15 @@
 
 import { formatRelativeTime } from './utils.js';
 import { warn } from './logger.js';
+import { errorMessage } from './errors.js';
+import { getStateManager } from './state.js';
 import type {
   FetchedPR,
   FetchedPRStatus,
   StalenessTier,
   ActionReason,
   DailyDigest,
+  AgentState,
   ShelvedPRRef,
   MaintainerActionHint,
   ComputedRepoSignals,
@@ -58,6 +61,68 @@ export const CRITICAL_ACTION_REASONS: ReadonlySet<ActionReason> = new Set([
 
 /** Staleness tiers indicating staleness — maintainer comments during these tiers don't count as responsive. */
 export const STALE_STATUSES: ReadonlySet<StalenessTier> = new Set(['dormant', 'approaching_dormant']);
+
+// ---------------------------------------------------------------------------
+// Status overrides
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply status overrides from state to the PR list.
+ * Overrides are auto-cleared if the PR has new activity since the override was set.
+ *
+ * When an override changes the status, the contradictory reason field is cleared
+ * and an appropriate default is set so downstream logic (assessCapacity, collectActionableIssues)
+ * works correctly.
+ */
+const VALID_OVERRIDE_STATUSES: ReadonlySet<FetchedPRStatus> = new Set(['needs_addressing', 'waiting_on_maintainer']);
+
+export function applyStatusOverrides(prs: FetchedPR[], state: Readonly<AgentState>): FetchedPR[] {
+  const overrides = state.config.statusOverrides;
+  if (!overrides || Object.keys(overrides).length === 0) return prs;
+
+  const stateManager = getStateManager();
+  // Snapshot keys before iteration — clearStatusOverride mutates the same object
+  const overrideUrls = new Set(Object.keys(overrides));
+  let didAutoClear = false;
+
+  const result = prs.map((pr) => {
+    try {
+      const override = stateManager.getStatusOverride(pr.url, pr.updatedAt);
+      if (!override) {
+        if (overrideUrls.has(pr.url)) didAutoClear = true;
+        return pr;
+      }
+      if (!VALID_OVERRIDE_STATUSES.has(override.status)) {
+        warn('daily-logic', `Invalid override status "${override.status}" for ${pr.url} — ignoring`);
+        return pr;
+      }
+      if (override.status === pr.status) return pr;
+
+      // Clear the contradictory reason field and set an appropriate default
+      if (override.status === 'waiting_on_maintainer') {
+        return { ...pr, status: override.status, actionReason: undefined, waitReason: 'pending_review' as const };
+      }
+      return { ...pr, status: override.status, waitReason: undefined, actionReason: 'needs_response' as const };
+    } catch (err) {
+      warn('daily-logic', `Failed to apply status override for ${pr.url}: ${errorMessage(err)}`);
+      return pr;
+    }
+  });
+
+  // Persist any auto-cleared overrides so they don't resurrect on restart
+  if (didAutoClear) {
+    try {
+      stateManager.save();
+    } catch (err) {
+      warn(
+        'daily-logic',
+        `Failed to persist auto-cleared overrides — they may reappear on restart: ${errorMessage(err)}`,
+      );
+    }
+  }
+
+  return result;
+}
 
 // ---------------------------------------------------------------------------
 // Internal helpers

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -55,6 +55,7 @@ export { enableDebug, isDebugEnabled, debug, info, warn, timed } from './logger.
 export { HttpCache, getHttpCache, cachedRequest, type CacheEntry } from './http-cache.js';
 export {
   CRITICAL_STATUSES,
+  applyStatusOverrides,
   computeRepoSignals,
   groupPRsByRepo,
   assessCapacity,


### PR DESCRIPTION
## Summary

Closes #644.

- **Extract** `applyStatusOverrides()` from `dashboard-server.ts` to `daily-logic.ts` as a shared utility
- **Integrate** into the daily CLI pipeline (`partitionPRs()` in `daily.ts`), so PRs reclassified in the dashboard are respected on the next `/oss` run
- **Enhance** status override to clear contradictory reason fields (`actionReason`/`waitReason`) and set appropriate defaults, fixing downstream logic in `assessCapacity` and `collectActionableIssues`
- **Harden** with per-PR try-catch (one corrupted override doesn't crash the pipeline) and runtime validation of override status values

## Test plan

- [x] 6 new unit tests in `daily-logic.test.ts` (no overrides, empty overrides, override both directions, auto-clear + persist, no-op when status matches, no persist when no auto-clears)
- [x] 2 new integration tests in `daily-orchestration.test.ts` (override to `waiting_on_maintainer` removes from actionable issues; override to `needs_addressing` adds to actionable issues)
- [x] All 1761 existing tests pass
- [x] Bundle builds cleanly