### PR TITLE
fix: align dashboard terminology from "Action Required" to "Need Attention"

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,10 @@ The dashboard auto-opens at `http://localhost:3000` when you run `/oss`. It's a 
 - Filter and search across all PRs
 
 **Manage your PRs:**
-- PRs are grouped into **Action Required**, **Waiting on Others**, and **Shelved** sections
+- PRs are grouped into **Need Attention**, **Waiting on Others**, and **Shelved** sections
 - Click any PR for a detail panel showing CI status, failing check classification, review decision, maintainer comments, and checklist progress
 - **Shelve/Unshelve** — temporarily hide PRs you're not actively working on
-- **Move to Waiting / Move to Action Required** — override the auto-detected status when you know better
+- **Move to Waiting / Move to Need Attention** — override the auto-detected status when you know better
 
 All actions persist to `~/.oss-autopilot/state.json`.
 

--- a/packages/core/src/commands/daily.ts
+++ b/packages/core/src/commands/daily.ts
@@ -378,7 +378,7 @@ function partitionPRs(
   }
 
   // Apply dashboard/CLI status overrides before partitioning.
-  // This ensures PRs reclassified in the dashboard (e.g., "Action Required" → "Waiting")
+  // This ensures PRs reclassified in the dashboard (e.g., "Need Attention" → "Waiting")
   // are respected by the CLI pipeline.
   const overriddenPRs = applyStatusOverrides(prs, stateManager.getState());
 

--- a/packages/dashboard/src/components/action-bar.test.tsx
+++ b/packages/dashboard/src/components/action-bar.test.tsx
@@ -35,10 +35,10 @@ describe('ActionBar', () => {
     expect(btn?.textContent).toBe('Move to Waiting');
   });
 
-  it('renders override button with "Move to Action Required" for waiting_on_maintainer PR', () => {
+  it('renders override button with "Move to Need Attention" for waiting_on_maintainer PR', () => {
     const { container } = renderActionBar({ pr: makePR({ status: 'waiting_on_maintainer' }) });
     const btn = container.querySelector('.action-btn--override');
-    expect(btn?.textContent).toBe('Move to Action Required');
+    expect(btn?.textContent).toBe('Move to Need Attention');
   });
 
   it('calls onAction with shelve action on button click', async () => {

--- a/packages/dashboard/src/components/action-bar.tsx
+++ b/packages/dashboard/src/components/action-bar.tsx
@@ -24,7 +24,7 @@ export function ActionBar({ pr, isShelved, onAction }: ActionBarProps) {
   }
 
   const oppositeStatus = pr.status === 'needs_addressing' ? 'waiting_on_maintainer' : 'needs_addressing';
-  const overrideLabel = pr.status === 'needs_addressing' ? 'Move to Waiting' : 'Move to Action Required';
+  const overrideLabel = pr.status === 'needs_addressing' ? 'Move to Waiting' : 'Move to Need Attention';
 
   return (
     <div class="action-bar">

--- a/packages/dashboard/src/components/pr-list.test.tsx
+++ b/packages/dashboard/src/components/pr-list.test.tsx
@@ -38,7 +38,7 @@ describe('PRList', () => {
 
     const sections = container.querySelectorAll('.pr-section-header');
     const sectionTitles = [...sections].map((el) => el.textContent?.replace(/\d+$/, '').trim());
-    expect(sectionTitles).toContain('Action Required');
+    expect(sectionTitles).toContain('Need Attention');
     expect(sectionTitles).toContain('Waiting on Others');
   });
 

--- a/packages/dashboard/src/components/pr-list.tsx
+++ b/packages/dashboard/src/components/pr-list.tsx
@@ -9,8 +9,8 @@ interface PRListProps {
   shelvedUrls: Set<string>;
 }
 
-/** Statuses that belong in the "Action Required" section. */
-const ACTION_REQUIRED: Set<FetchedPRStatus> = new Set(['needs_addressing']);
+/** Statuses that belong in the "Need Attention" section. */
+const NEED_ATTENTION: Set<FetchedPRStatus> = new Set(['needs_addressing']);
 
 /** Statuses that belong in the "Waiting on Others" section. */
 const WAITING: Set<FetchedPRStatus> = new Set(['waiting_on_maintainer']);
@@ -67,9 +67,9 @@ export function PRList({ prs, selectedUrl, onSelect, shelvedUrls }: PRListProps)
   const sections: SectionDef[] = [
     {
       id: 'action',
-      title: 'Action Required',
+      title: 'Need Attention',
       accent: 'var(--accent-error)',
-      prs: activePRs.filter((pr) => ACTION_REQUIRED.has(pr.status)),
+      prs: activePRs.filter((pr) => NEED_ATTENTION.has(pr.status)),
     },
     {
       id: 'waiting',


### PR DESCRIPTION
## Summary

- Renamed dashboard section title from "Action Required" to "Need Attention" to match CLI terminology
- Updated override button label from "Move to Action Required" to "Move to Need Attention"
- Updated internal variable name `ACTION_REQUIRED` → `NEED_ATTENTION` for consistency
- Updated README dashboard documentation to reflect new labels

Closes #645

## Test plan

- [x] All existing dashboard tests pass with updated assertions
- [x] All core and MCP server tests pass (no regressions)
- [ ] Verify dashboard UI shows "Need Attention" section header
- [ ] Verify override button reads "Move to Need Attention" for waiting PRs