### PR TITLE
chore: add scheduled CI job to check NPM token validity

### DIFF
--- a/.github/workflows/check-npm-token.yml
+++ b/.github/workflows/check-npm-token.yml
@@ -1,0 +1,26 @@
+name: Check NPM Token
+
+on:
+  schedule:
+    # Every Monday at 09:00 UTC
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check-npm-token:
+    name: Verify NPM token
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check token validity
+        run: |
+          RESULT=$(npm whoami --registry https://registry.npmjs.org/ 2>&1) || {
+            echo "::error::NPM_TOKEN is expired or invalid. Rotate it at https://www.npmjs.com/settings/tokens and update the GitHub secret."
+            echo "npm whoami output: $RESULT"
+            exit 1
+          }
+          echo "NPM token is valid (authenticated as: $RESULT)"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds a new `check-npm-token.yml` workflow that runs `npm whoami` weekly (Monday 09:00 UTC) to verify the `NPM_TOKEN` secret is still valid
- Fails with an actionable error message pointing to the npm token settings page if the token is expired or invalid
- Supports `workflow_dispatch` for manual verification after token rotation

Closes #629

## Test plan

- [ ] Trigger workflow manually via Actions tab → "Check NPM Token" → "Run workflow"
- [ ] Verify it passes with current valid token
- [ ] Confirm weekly cron schedule appears in Actions tab