### PR TITLE
feat(ci): add bundle size tracking and regression detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
   ci:
     name: Node ${{ matrix.node-version }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    # pull-requests: write is needed for the "Check bundle sizes" step to post PR
+    # comments. GitHub Actions does not support per-matrix-entry permissions, so all
+    # matrix jobs receive this grant even though only Node 22/ubuntu uses it.
     permissions:
       contents: read
       pull-requests: write
@@ -132,6 +135,11 @@ jobs:
             if [ -n "$BASELINE_JSON" ]; then
               BASELINE_CORE=$(echo "$BASELINE_JSON" | node -p "try{JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).core}catch{''}" 2>/dev/null || echo "")
               BASELINE_MCP=$(echo "$BASELINE_JSON" | node -p "try{JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).mcp}catch{''}" 2>/dev/null || echo "")
+              if [ -z "$BASELINE_CORE" ] || [ -z "$BASELINE_MCP" ]; then
+                echo "::warning::bundle-sizes.json on badges branch could not be parsed. Delta reporting disabled."
+              fi
+            else
+              echo "::notice::No bundle-sizes.json on badges branch yet. Delta reporting will be available after the next main merge."
             fi
           fi
 
@@ -166,7 +174,7 @@ jobs:
             echo -e "$TABLE"
           } >> "$GITHUB_STEP_SUMMARY"
 
-          # Check thresholds first (must run before any fallible optional steps)
+          # Determine threshold pass/fail before optional steps (PR comment posting may fail)
           FAILED=0
           if [ "$CORE_SIZE" -gt "$BUNDLE_MAX_CORE" ]; then
             echo "::error::Core CLI bundle (${core_kb} KB) exceeds threshold (${core_max_kb} KB)"


### PR DESCRIPTION
## Summary

- Add bundle size threshold enforcement to CI (`BUNDLE_MAX_CORE: 400KB`, `BUNDLE_MAX_MCP: ~1953KB`) as workflow-level env vars
- New "Check bundle sizes" step (Node 22 + ubuntu only) that measures sizes, writes step summary, posts/updates PR comment with delta vs main, and fails CI if thresholds exceeded
- Extend `update-badge` job to record bundle size baselines (`bundle-sizes.json`) on the `badges` branch for delta reporting
- Refactor badge push step to handle multiple badge files generically

## Design Decisions

- **Thresholds as env vars** — visible at top of `ci.yml`, require a deliberate PR to change
- **Baseline on `badges` branch** — consistent with existing test badge pattern
- **PR comments via `gh pr comment --edit-last`** — no external action deps, prevents comment spam
- **Threshold check runs before comment posting** — ensures a GitHub API hiccup can't skip enforcement
- **Baselines validated as numeric, treated atomically** — corrupted baseline gracefully degrades to no-delta mode

## Test Plan

- [ ] CI step summary shows bundle size table
- [ ] PR gets a bundle size comment
- [ ] Temporarily lower `BUNDLE_MAX_CORE` to `100000` → CI fails with clear error
- [ ] Merge to main → `bundle-sizes.json` appears on `badges` branch
- [ ] Follow-up PR shows delta column with "vs main" comparisons

Closes #618