### PR TITLE
test(mcp-server): increase test coverage to 94% statements, 80% branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ node_modules/
 # Build output
 packages/*/dist/
 
+# Test coverage
+coverage/
+
 # Plugin state (user-specific, created at runtime)
 .claude/oss-autopilot/
 data/

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -20,6 +20,7 @@
     "bundle": "esbuild src/index.ts --bundle --platform=node --target=node20 --format=cjs --outfile=dist/mcp-server.bundle.cjs",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "pnpm run build && pnpm run bundle"
   },
@@ -33,6 +34,7 @@
     "esbuild": "^0.27.3",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
+    "@vitest/coverage-v8": "^4.0.16",
     "vitest": "^4.0.16"
   },
   "engines": {

--- a/packages/mcp-server/src/index-main.test.ts
+++ b/packages/mcp-server/src/index-main.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
+
+// Mock core dependencies (required by server.ts -> tools.ts/resources.ts/prompts.ts)
+vi.mock('@oss-autopilot/core/commands', () => ({
+  runDaily: vi.fn(),
+  runStatus: vi.fn(),
+  runSearch: vi.fn(),
+  runVet: vi.fn(),
+  runTrack: vi.fn(),
+  runUntrack: vi.fn(),
+  runRead: vi.fn(),
+  runComments: vi.fn(),
+  runPost: vi.fn(),
+  runClaim: vi.fn(),
+  runConfig: vi.fn(),
+  runInit: vi.fn(),
+  runSetup: vi.fn(),
+  runCheckSetup: vi.fn(),
+  runStartup: vi.fn(),
+  runDismiss: vi.fn(),
+  runUndismiss: vi.fn(),
+  runMove: vi.fn(),
+}));
+
+vi.mock('@oss-autopilot/core', () => ({
+  errorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
+  getStateManager: vi.fn().mockReturnValue({
+    getState: vi.fn().mockReturnValue({
+      lastDigest: { openPRs: [], shelvedPRs: [] },
+    }),
+  }),
+}));
+
+// Mock StdioServerTransport — must use function() not arrow to support `new`
+// Needs start/close methods since McpServer.connect() calls transport.start()
+vi.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
+  StdioServerTransport: vi.fn().mockImplementation(function () {
+    return { start: vi.fn().mockResolvedValue(undefined), close: vi.fn().mockResolvedValue(undefined) };
+  }),
+}));
+
+// Mock HTTP server
+const mockListen = vi.fn((_port: number, _host: string, cb: () => void) => cb());
+const mockClose = vi.fn();
+const mockHttpServer = { listen: mockListen, close: mockClose };
+
+vi.mock('node:http', async (importOriginal) => {
+  const original = await importOriginal<typeof import('node:http')>();
+  return {
+    ...original,
+    createServer: vi.fn((_handler: unknown) => mockHttpServer),
+  };
+});
+
+// Mock StreamableHTTPServerTransport
+const mockHandleRequest = vi.fn().mockResolvedValue(undefined);
+vi.mock('@modelcontextprotocol/sdk/server/streamableHttp.js', () => ({
+  StreamableHTTPServerTransport: vi.fn().mockImplementation(function () {
+    return {
+      handleRequest: mockHandleRequest,
+      start: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+  }),
+}));
+
+import { main, ENTRY_SUFFIXES } from './index.js';
+
+// Sentinel error for mocked process.exit
+class ExitError extends Error {
+  constructor(public code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+describe('main() in-process', () => {
+  const originalArgv = process.argv;
+  let mockExit: ReturnType<typeof vi.spyOn>;
+
+  beforeAll(() => {
+    process.setMaxListeners(20); // Avoid MaxListenersExceededWarning
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Mock process.exit to throw so execution stops
+    mockExit = vi.spyOn(process, 'exit').mockImplementation(((code: number) => {
+      throw new ExitError(code ?? 0);
+    }) as never);
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    mockExit.mockRestore();
+    // Clean up SIGINT/SIGTERM listeners added by main()
+    process.removeAllListeners('SIGINT');
+    process.removeAllListeners('SIGTERM');
+  });
+
+  afterAll(() => {
+    process.setMaxListeners(10);
+  });
+
+  describe('stdio mode', () => {
+    it('starts stdio transport when no --http flag', async () => {
+      process.argv = ['node', 'test'];
+
+      await main();
+
+      const { StdioServerTransport } = await import('@modelcontextprotocol/sdk/server/stdio.js');
+      expect(StdioServerTransport).toHaveBeenCalled();
+    });
+  });
+
+  describe('HTTP mode - port parsing', () => {
+    it('uses default port 3001 when --http and no --port', async () => {
+      process.argv = ['node', 'test', '--http'];
+
+      await main();
+
+      expect(mockListen).toHaveBeenCalledWith(3001, '127.0.0.1', expect.any(Function));
+    });
+
+    it('parses --port=N form', async () => {
+      process.argv = ['node', 'test', '--http', '--port=8080'];
+
+      await main();
+
+      expect(mockListen).toHaveBeenCalledWith(8080, '127.0.0.1', expect.any(Function));
+    });
+
+    it('parses --port N (space form)', async () => {
+      process.argv = ['node', 'test', '--http', '--port', '9090'];
+
+      await main();
+
+      expect(mockListen).toHaveBeenCalledWith(9090, '127.0.0.1', expect.any(Function));
+    });
+  });
+
+  describe('HTTP mode - port validation', () => {
+    it('exits with error for port 0', async () => {
+      process.argv = ['node', 'test', '--http', '--port=0'];
+
+      await expect(main()).rejects.toThrow(ExitError);
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it('exits with error for port > 65535', async () => {
+      process.argv = ['node', 'test', '--http', '--port=70000'];
+
+      await expect(main()).rejects.toThrow(ExitError);
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it('exits with error for NaN port', async () => {
+      process.argv = ['node', 'test', '--http', '--port=abc'];
+
+      await expect(main()).rejects.toThrow(ExitError);
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('HTTP mode - request handling', () => {
+    async function setupHttpHandler(): Promise<
+      (req: { url?: string; method?: string }, res: Record<string, unknown>) => Promise<void>
+    > {
+      process.argv = ['node', 'test', '--http', '--port=3001'];
+
+      const { createServer: mockCreateServer } = await import('node:http');
+      let requestHandler!: (req: { url?: string; method?: string }, res: Record<string, unknown>) => Promise<void>;
+      vi.mocked(mockCreateServer).mockImplementationOnce((handler: unknown) => {
+        requestHandler = handler as typeof requestHandler;
+        return mockHttpServer as ReturnType<typeof mockCreateServer>;
+      });
+
+      await main();
+      return requestHandler;
+    }
+
+    it('returns 404 for non-/mcp paths', async () => {
+      const handler = await setupHttpHandler();
+
+      const res = { writeHead: vi.fn(), end: vi.fn(), headersSent: false };
+      await handler({ url: '/wrong-path', method: 'POST' }, res);
+
+      expect(res.writeHead).toHaveBeenCalledWith(404);
+      expect(res.end).toHaveBeenCalledWith('Not Found');
+    });
+
+    it('returns 405 for non-POST to /mcp', async () => {
+      const handler = await setupHttpHandler();
+
+      const res = { writeHead: vi.fn(), end: vi.fn(), headersSent: false };
+      await handler({ url: '/mcp', method: 'GET' }, res);
+
+      expect(res.writeHead).toHaveBeenCalledWith(405);
+      expect(res.end).toHaveBeenCalledWith('Method Not Allowed');
+    });
+
+    it('processes valid POST /mcp through transport', async () => {
+      const handler = await setupHttpHandler();
+
+      const req = { url: '/mcp', method: 'POST' };
+      const res = { writeHead: vi.fn(), end: vi.fn(), headersSent: false };
+      await handler(req, res);
+
+      const { StreamableHTTPServerTransport } = await import('@modelcontextprotocol/sdk/server/streamableHttp.js');
+      expect(StreamableHTTPServerTransport).toHaveBeenCalled();
+      expect(mockHandleRequest).toHaveBeenCalledWith(req, res);
+    });
+
+    it('returns 500 on transport error', async () => {
+      const handler = await setupHttpHandler();
+
+      mockHandleRequest.mockRejectedValueOnce(new Error('Transport error'));
+
+      const res = { writeHead: vi.fn(), end: vi.fn(), headersSent: false };
+      await handler({ url: '/mcp', method: 'POST' }, res);
+
+      expect(res.writeHead).toHaveBeenCalledWith(500);
+      expect(res.end).toHaveBeenCalledWith('Internal Server Error');
+    });
+
+    it('skips writeHead when headers already sent on error', async () => {
+      const handler = await setupHttpHandler();
+
+      mockHandleRequest.mockRejectedValueOnce(new Error('Transport error'));
+
+      const res = { writeHead: vi.fn(), end: vi.fn(), headersSent: true };
+      await handler({ url: '/mcp', method: 'POST' }, res);
+
+      expect(res.writeHead).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('ENTRY_SUFFIXES', () => {
+  it('contains expected paths for isMain detection', () => {
+    expect(ENTRY_SUFFIXES).toContain('/mcp-server/src/index.ts');
+    expect(ENTRY_SUFFIXES).toContain('/mcp-server/dist/index.js');
+    expect(ENTRY_SUFFIXES).toContain('/mcp-server.bundle.cjs');
+    expect(ENTRY_SUFFIXES).toContain('/oss-autopilot-mcp');
+    expect(ENTRY_SUFFIXES).toHaveLength(4);
+  });
+});

--- a/packages/mcp-server/src/index.test.ts
+++ b/packages/mcp-server/src/index.test.ts
@@ -1,17 +1,114 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { request } from 'node:http';
+
+const MCP_SERVER_CWD = new URL('..', import.meta.url).pathname;
+
+const INITIALIZE_BODY = JSON.stringify({
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'initialize',
+  params: {
+    protocolVersion: '2025-03-26',
+    capabilities: {},
+    clientInfo: { name: 'test-client', version: '1.0.0' },
+  },
+});
 
 /** Create a stdio client connected to a fresh MCP server process. */
 async function createStdioClient(): Promise<Client> {
   const transport = new StdioClientTransport({
     command: 'npx',
     args: ['tsx', 'src/index.ts'],
-    cwd: new URL('..', import.meta.url).pathname,
+    cwd: MCP_SERVER_CWD,
   });
   const client = new Client({ name: 'test-client', version: '1.0.0' });
   await client.connect(transport);
   return client;
+}
+
+/** Get a random high port to avoid conflicts in parallel test runs. */
+function randomPort(): number {
+  return 10000 + Math.floor(Math.random() * 50000);
+}
+
+/** Spawn an HTTP MCP server and wait for it to be listening. */
+function spawnHttpServer(args: string[]): Promise<{ port: number; proc: ChildProcess; close: () => void }> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('npx', ['tsx', 'src/index.ts', ...args], {
+      cwd: MCP_SERVER_CWD,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    const timeout = setTimeout(() => {
+      proc.kill('SIGTERM');
+      reject(new Error('HTTP server did not start within 10s'));
+    }, 10_000);
+
+    let stderrData = '';
+    proc.stderr!.on('data', (chunk: Buffer) => {
+      stderrData += chunk.toString();
+      // Server prints "listening on http://127.0.0.1:<port>/mcp" when ready
+      const match = stderrData.match(/listening on http:\/\/127\.0\.0\.1:(\d+)\/mcp/);
+      if (match) {
+        clearTimeout(timeout);
+        const port = parseInt(match[1], 10);
+        resolve({
+          port,
+          proc,
+          close: () => proc.kill('SIGTERM'),
+        });
+      }
+    });
+
+    proc.on('error', (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+
+    proc.on('exit', (code) => {
+      clearTimeout(timeout);
+      if (code !== null && code !== 0) {
+        reject(new Error(`Server exited with code ${code}: ${stderrData}`));
+      }
+    });
+  });
+}
+
+/** Make an HTTP request and return the response status + body. */
+function httpRequest(
+  port: number,
+  method: string,
+  path: string,
+  body?: string,
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path,
+        method,
+        headers: body
+          ? {
+              'Content-Type': 'application/json',
+              Accept: 'application/json, text/event-stream',
+              'Content-Length': Buffer.byteLength(body),
+            }
+          : {},
+      },
+      (res) => {
+        let data = '';
+        res.on('data', (chunk: Buffer) => (data += chunk.toString()));
+        res.on('end', () => resolve({ status: res.statusCode!, body: data }));
+      },
+    );
+    req.on('error', reject);
+    if (body) req.write(body);
+    req.end();
+  });
 }
 
 describe('MCP server stdio transport', { timeout: 30_000 }, () => {
@@ -40,6 +137,81 @@ describe('MCP server stdio transport', { timeout: 30_000 }, () => {
     client = await createStdioClient();
     const { prompts } = await client.listPrompts();
     expect(prompts.length).toBe(3);
+  });
+});
+
+describe('MCP server HTTP transport', { timeout: 30_000 }, () => {
+  let serverHandle: { port: number; proc: ChildProcess; close: () => void } | undefined;
+
+  afterEach(() => {
+    if (serverHandle) {
+      serverHandle.close();
+      serverHandle = undefined;
+    }
+  });
+
+  it('POST /mcp with JSON-RPC initialize returns valid response', async () => {
+    const port = randomPort();
+    serverHandle = await spawnHttpServer(['--http', `--port=${port}`]);
+
+    const res = await httpRequest(serverHandle.port, 'POST', '/mcp', INITIALIZE_BODY);
+
+    expect(res.status).toBe(200);
+    // Streamable HTTP transport returns SSE — extract JSON from "data:" lines
+    const dataLines = res.body
+      .split('\n')
+      .filter((line) => line.startsWith('data: '))
+      .map((line) => line.slice(6));
+    expect(dataLines.length).toBeGreaterThan(0);
+    const parsed = JSON.parse(dataLines[0]);
+    expect(parsed.jsonrpc).toBe('2.0');
+    expect(parsed.id).toBe(1);
+    expect(parsed.result).toBeDefined();
+    expect(parsed.result.serverInfo.name).toBe('oss-autopilot');
+  });
+
+  it('GET / returns 404', async () => {
+    const port = randomPort();
+    serverHandle = await spawnHttpServer(['--http', `--port=${port}`]);
+
+    const res = await httpRequest(serverHandle.port, 'GET', '/');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toBe('Not Found');
+  });
+
+  it('GET /mcp returns 405', async () => {
+    const port = randomPort();
+    serverHandle = await spawnHttpServer(['--http', `--port=${port}`]);
+
+    const res = await httpRequest(serverHandle.port, 'GET', '/mcp');
+
+    expect(res.status).toBe(405);
+    expect(res.body).toBe('Method Not Allowed');
+  });
+
+  it('--port N (space form) works', async () => {
+    const port = randomPort();
+    serverHandle = await spawnHttpServer(['--http', '--port', String(port)]);
+
+    const res = await httpRequest(serverHandle.port, 'POST', '/mcp', INITIALIZE_BODY);
+
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('MCP server invalid port', { timeout: 10_000 }, () => {
+  it('exits with error for invalid port', async () => {
+    const proc = spawn('npx', ['tsx', 'src/index.ts', '--http', '--port=0'], {
+      cwd: MCP_SERVER_CWD,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    const exitCode = await new Promise<number | null>((resolve) => {
+      proc.on('exit', (code) => resolve(code));
+    });
+
+    expect(exitCode).not.toBe(0);
   });
 });
 

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -10,7 +10,7 @@ export { registerTools } from './tools.js';
 export { registerResources } from './resources.js';
 export { registerPrompts } from './prompts.js';
 
-async function main() {
+export async function main() {
   const args = process.argv.slice(2);
   const httpMode = args.includes('--http');
 
@@ -84,7 +84,7 @@ async function main() {
 }
 
 // Only run main() when this is the entry point, not when imported as a module
-const ENTRY_SUFFIXES = [
+export const ENTRY_SUFFIXES = [
   '/mcp-server/src/index.ts',
   '/mcp-server/dist/index.js',
   '/mcp-server.bundle.cjs',

--- a/packages/mcp-server/src/prompts.test.ts
+++ b/packages/mcp-server/src/prompts.test.ts
@@ -60,6 +60,7 @@ vi.mock('@oss-autopilot/core/commands', () => ({
 }));
 
 vi.mock('@oss-autopilot/core', () => ({
+  errorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
   getStateManager: vi.fn().mockReturnValue({
     getState: vi.fn().mockReturnValue({
       lastDigest: { openPRs: [], shelvedPRs: [] },
@@ -68,6 +69,7 @@ vi.mock('@oss-autopilot/core', () => ({
 }));
 
 import { createServer } from './server.js';
+import { runDaily, runComments, runSearch } from '@oss-autopilot/core/commands';
 
 describe('MCP prompt registrations', () => {
   let client: Client;
@@ -172,6 +174,50 @@ describe('MCP prompt registrations', () => {
       expect(text).toContain('Add dark mode');
       expect(text).toContain('APPROVE');
       expect(text).toContain('85/100');
+    });
+  });
+
+  describe('prompt error handling', () => {
+    it('triage returns error message when runDaily rejects', async () => {
+      vi.mocked(runDaily).mockRejectedValueOnce(new Error('GitHub API rate limit'));
+
+      const result = await client.getPrompt({ name: 'triage' });
+
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].role).toBe('user');
+      const text = (result.messages[0].content as { type: 'text'; text: string }).text;
+      expect(text).toContain('Failed to fetch triage data');
+      expect(text).toContain('GitHub API rate limit');
+    });
+
+    it('respond-to-pr returns error message when runComments rejects', async () => {
+      vi.mocked(runComments).mockRejectedValueOnce(new Error('PR not found'));
+
+      const result = await client.getPrompt({
+        name: 'respond-to-pr',
+        arguments: { prUrl: 'https://github.com/octocat/hello-world/pull/999' },
+      });
+
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].role).toBe('user');
+      const text = (result.messages[0].content as { type: 'text'; text: string }).text;
+      expect(text).toContain('Failed to fetch PR comments');
+      expect(text).toContain('PR not found');
+    });
+
+    it('find-issues returns error message when runSearch rejects', async () => {
+      vi.mocked(runSearch).mockRejectedValueOnce(new Error('Search quota exceeded'));
+
+      const result = await client.getPrompt({
+        name: 'find-issues',
+        arguments: { maxResults: '5' },
+      });
+
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].role).toBe('user');
+      const text = (result.messages[0].content as { type: 'text'; text: string }).text;
+      expect(text).toContain('Failed to search for issues');
+      expect(text).toContain('Search quota exceeded');
     });
   });
 });

--- a/packages/mcp-server/src/resources.test.ts
+++ b/packages/mcp-server/src/resources.test.ts
@@ -34,6 +34,7 @@ vi.mock('@oss-autopilot/core/commands', () => ({
 }));
 
 vi.mock('@oss-autopilot/core', () => ({
+  errorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
   splitRepo: (fullName: string) => {
     const [owner, repo] = fullName.split('/');
     return { owner, repo };
@@ -90,6 +91,8 @@ vi.mock('@oss-autopilot/core', () => ({
 }));
 
 import { createServer } from './server.js';
+import { runStatus } from '@oss-autopilot/core/commands';
+import { getStateManager } from '@oss-autopilot/core';
 
 describe('MCP resource registrations', () => {
   let client: Client;
@@ -218,6 +221,54 @@ describe('MCP resource registrations', () => {
       const uris = prResources.map((r) => r.uri);
       expect(uris).toContain('oss://pr/octocat/hello-world/42');
       expect(uris).toContain('oss://pr/octocat/spoon-knife/7');
+    });
+
+    it('returns error for invalid PR number (NaN)', async () => {
+      const result = await client.readResource({
+        uri: 'oss://pr/octocat/hello-world/abc',
+      });
+      expect(result.contents).toHaveLength(1);
+      const data = JSON.parse(result.contents[0].text as string);
+      expect(data.error).toContain('Invalid PR number');
+    });
+  });
+
+  describe('resource error handling', () => {
+    it('wrapResource returns error JSON when runStatus rejects', async () => {
+      vi.mocked(runStatus).mockRejectedValueOnce(new Error('State file not found'));
+
+      const result = await client.readResource({ uri: 'oss://status' });
+
+      expect(result.contents).toHaveLength(1);
+      const data = JSON.parse(result.contents[0].text as string);
+      expect(data.error).toContain('State file not found');
+    });
+
+    it('template list returns empty resources on error', async () => {
+      vi.mocked(getStateManager).mockImplementationOnce(() => {
+        throw new Error('State corrupted');
+      });
+
+      const result = await client.listResources();
+
+      // Should not throw — the template list catch returns { resources: [] }
+      // Static resources should still be listed
+      const staticUris = result.resources.filter((r) => !r.uri.startsWith('oss://pr/')).map((r) => r.uri);
+      expect(staticUris).toContain('oss://status');
+    });
+
+    it('pr-detail read handler catches thrown errors', async () => {
+      vi.mocked(getStateManager).mockImplementationOnce(() => {
+        throw new Error('Unexpected state error');
+      });
+
+      const result = await client.readResource({
+        uri: 'oss://pr/octocat/hello-world/42',
+      });
+
+      expect(result.contents).toHaveLength(1);
+      const data = JSON.parse(result.contents[0].text as string);
+      expect(data.error).toContain('Unexpected state error');
     });
   });
 });

--- a/packages/mcp-server/src/tools-execution.test.ts
+++ b/packages/mcp-server/src/tools-execution.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+// Use vi.hoisted() so mock references are available inside the hoisted vi.mock() factory
+const { mockRunDaily, mockRunSearch, mockRunMove } = vi.hoisted(() => ({
+  mockRunDaily: vi.fn(),
+  mockRunSearch: vi.fn(),
+  mockRunMove: vi.fn(),
+}));
+
+vi.mock('@oss-autopilot/core/commands', () => ({
+  runDaily: mockRunDaily,
+  runStatus: vi.fn(),
+  runSearch: mockRunSearch,
+  runVet: vi.fn(),
+  runTrack: vi.fn(),
+  runUntrack: vi.fn(),
+  runRead: vi.fn(),
+  runComments: vi.fn(),
+  runPost: vi.fn(),
+  runClaim: vi.fn(),
+  runConfig: vi.fn(),
+  runInit: vi.fn(),
+  runSetup: vi.fn(),
+  runCheckSetup: vi.fn(),
+  runStartup: vi.fn(),
+  runDismiss: vi.fn(),
+  runUndismiss: vi.fn(),
+  runMove: mockRunMove,
+}));
+
+vi.mock('@oss-autopilot/core', () => ({
+  errorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
+  getStateManager: vi.fn().mockReturnValue({
+    getState: vi.fn().mockReturnValue({
+      lastDigest: { openPRs: [], shelvedPRs: [] },
+    }),
+  }),
+}));
+
+import { createServer } from './server.js';
+
+describe('tool execution', () => {
+  let client: Client;
+
+  beforeAll(async () => {
+    const server = createServer();
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    client = new Client({ name: 'test-client', version: '0.0.0' });
+    await client.connect(clientTransport);
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  describe('wrapTool ok/err paths', () => {
+    it('daily success returns JSON data via ok()', async () => {
+      const mockData = { summary: 'All clear', openPRs: 0 };
+      mockRunDaily.mockResolvedValueOnce(mockData);
+
+      const result = await client.callTool({ name: 'daily', arguments: {} });
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content).toHaveLength(1);
+      const content = result.content[0] as { type: string; text: string };
+      expect(content.type).toBe('text');
+      const parsed = JSON.parse(content.text);
+      expect(parsed.summary).toBe('All clear');
+    });
+
+    it('daily error returns isError via err()', async () => {
+      mockRunDaily.mockRejectedValueOnce(new Error('GitHub API rate limit'));
+
+      const result = await client.callTool({ name: 'daily', arguments: {} });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toHaveLength(1);
+      const content = result.content[0] as { type: string; text: string };
+      expect(content.text).toContain('GitHub API rate limit');
+    });
+  });
+
+  describe('search validation', () => {
+    it('uses default maxResults of 5 when not provided', async () => {
+      mockRunSearch.mockResolvedValueOnce({ candidates: [] });
+
+      await client.callTool({ name: 'search', arguments: {} });
+
+      expect(mockRunSearch).toHaveBeenCalledWith({ maxResults: 5 });
+    });
+
+    it('caps maxResults at 100 when exceeded', async () => {
+      mockRunSearch.mockResolvedValueOnce({ candidates: [] });
+
+      await client.callTool({ name: 'search', arguments: { maxResults: 500 } });
+
+      expect(mockRunSearch).toHaveBeenCalledWith({ maxResults: 100 });
+    });
+
+    it('returns error for invalid maxResults (-1)', async () => {
+      const result = await client.callTool({
+        name: 'search',
+        arguments: { maxResults: -1 },
+      });
+
+      expect(result.isError).toBe(true);
+      const content = result.content[0] as { type: string; text: string };
+      expect(content.text).toContain('Invalid maxResults');
+    });
+
+    it('returns error for non-integer maxResults (1.5)', async () => {
+      const result = await client.callTool({
+        name: 'search',
+        arguments: { maxResults: 1.5 },
+      });
+
+      expect(result.isError).toBe(true);
+      const content = result.content[0] as { type: string; text: string };
+      expect(content.text).toContain('Invalid maxResults');
+    });
+  });
+
+  describe('shelve/unshelve delegation', () => {
+    it('shelve delegates to runMove with target=shelved', async () => {
+      mockRunMove.mockResolvedValueOnce({ success: true });
+
+      await client.callTool({
+        name: 'shelve',
+        arguments: { prUrl: 'https://github.com/octocat/hello-world/pull/42' },
+      });
+
+      expect(mockRunMove).toHaveBeenCalledWith({
+        prUrl: 'https://github.com/octocat/hello-world/pull/42',
+        target: 'shelved',
+      });
+    });
+
+    it('unshelve delegates to runMove with target=auto', async () => {
+      mockRunMove.mockResolvedValueOnce({ success: true });
+
+      await client.callTool({
+        name: 'unshelve',
+        arguments: { prUrl: 'https://github.com/octocat/hello-world/pull/42' },
+      });
+
+      expect(mockRunMove).toHaveBeenCalledWith({
+        prUrl: 'https://github.com/octocat/hello-world/pull/42',
+        target: 'auto',
+      });
+    });
+  });
+});

--- a/packages/mcp-server/vitest.config.ts
+++ b/packages/mcp-server/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.test.ts'],
+      thresholds: {
+        statements: 75,
+        branches: 65,
+        functions: 75,
+        lines: 75,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       '@types/node':
         specifier: ^25.3.3
         version: 25.3.3
+      '@vitest/coverage-v8':
+        specifier: ^4.0.16
+        version: 4.0.18(vitest@4.0.18(@edge-runtime/vm@3.2.0)(@types/node@25.3.3)(jsdom@28.1.0)(tsx@4.21.0))
       esbuild:
         specifier: ^0.27.3
         version: 0.27.3


### PR DESCRIPTION
## Summary

Closes #615

- Added comprehensive test coverage for the MCP server package, going from **51% to 94% statements** and **36% to 80% branches**
- Created `vitest.config.ts` with enforced coverage thresholds (75/65/75/75) to prevent regression
- All 133 tests pass across 6 test files

## Changes

### New test files
- **`tools-execution.test.ts`** (8 tests): Tool execution via `client.callTool()` — `ok()`/`err()` paths, `wrapTool()` catch, search validation (default maxResults, capping at 100, invalid values), shelve/unshelve delegation to `runMove`
- **`index-main.test.ts`** (13 tests): In-process `main()` function tests — stdio mode, HTTP port parsing (`--port=N`, `--port N`, default), port validation (0, >65535, NaN), HTTP request routing (404, 405, POST /mcp), error handling (500, headersSent guard)

### Enhanced existing tests
- **`prompts.test.ts`** (+3 tests): Error paths for all 3 prompt catch blocks (triage, respond-to-pr, find-issues)
- **`resources.test.ts`** (+4 tests): `wrapResource` error handling, invalid PR number (NaN), template list error recovery, pr-detail read handler catch
- **`index.test.ts`** (+5 tests): HTTP transport integration tests (POST /mcp with SSE parsing, GET / → 404, GET /mcp → 405, --port space form, invalid port exit)

### Infrastructure
- Created `vitest.config.ts` with v8 coverage provider and thresholds
- Added `@vitest/coverage-v8` devDependency and `test:coverage` script
- Exported `main()` and `ENTRY_SUFFIXES` from `index.ts` for testability
- Added `coverage/` to `.gitignore`

## Coverage Results

| File | Stmts | Branch | Funcs | Lines |
|------|-------|--------|-------|-------|
| **All files** | **94.47%** | **80.32%** | **94.28%** | **95.56%** |
| index.ts | 90.56% | 95.23% | 71.42% | 90.19% |
| prompts.ts | 92.85% | 64.28% | 100% | 100% |
| resources.ts | 100% | 71.42% | 100% | 100% |
| server.ts | 83.33% | 50% | 100% | 83.33% |
| tools.ts | 100% | 90% | 100% | 100% |

## Test plan

- [x] `pnpm test` passes across all workspace packages
- [x] `pnpm run lint` passes
- [x] `pnpm run test:coverage` in mcp-server meets all thresholds
- [x] HTTP integration tests verified with real process spawning
- [x] In-process main() tests verified with mocked transports