### PR TITLE
fix(ci): build core types before recording bundle sizes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,9 @@ jobs:
           fi
           rm -f packages/core/test-results.json
 
+      - name: Build core types
+        run: pnpm --filter @oss-autopilot/core run build
+
       - name: Record bundle sizes
         run: |
           pnpm run bundle


### PR DESCRIPTION
## Summary

- Adds missing "Build core types" step to the `update-badge` job before the "Record bundle sizes" step
- The mcp-server esbuild bundle resolves `@oss-autopilot/core/commands` through the package exports map to `./dist/commands/index.js`, which requires core to be built with `tsc` first
- The main `ci` job already had this step (line 68-69), but the `update-badge` job was missing it, causing every main push to fail at the badge update stage

## Test plan

- [ ] CI passes on this PR (the fix is in the `update-badge` job which only runs on main, but the workflow syntax is validated)
- [ ] After merge, the next push to main should produce both bundle-sizes.json entries successfully

Fixes the "Update badges" job failure introduced in #669.