### PR TITLE
fix: correct health-check counts and expand dashboard search scope

### DIFF
--- a/.claude-plugin/scripts/health-check.cjs
+++ b/.claude-plugin/scripts/health-check.cjs
@@ -46,9 +46,11 @@ try {
     const total = d.summary.totalActivePRs || 0;
     if (total === 0) process.exit(0);
     // Build status segments for a compact one-liner
+    // Filter out shelved PRs so breakdown counts match totalActivePRs (#674)
+    const shelvedUrls = new Set((d.shelvedPRs || []).map(function(p) { return p.url; }));
     const segments = [];
-    const needsAddressing = (d.needsAddressingPRs || []).length;
-    const waitMaintainer = (d.waitingOnMaintainerPRs || []).length;
+    const needsAddressing = (d.needsAddressingPRs || []).filter(function(p) { return !shelvedUrls.has(p.url); }).length;
+    const waitMaintainer = (d.waitingOnMaintainerPRs || []).filter(function(p) { return !shelvedUrls.has(p.url); }).length;
     // Actionable items first (you need to do something)
     if (needsAddressing > 0) segments.push(needsAddressing + ' need addressing');
     // Informational items (waiting on others)

--- a/packages/dashboard/src/app.test.tsx
+++ b/packages/dashboard/src/app.test.tsx
@@ -155,6 +155,36 @@ describe('App', () => {
       expect(rows[0].textContent).toContain('Fix auth bug');
     });
 
+    it('filters by search text matching repo name', async () => {
+      const { container } = render(<App />);
+
+      await waitFor(() => {
+        expect(container.querySelector('.dashboard')).toBeTruthy();
+      });
+
+      const searchInput = container.querySelector('.filter-input') as HTMLInputElement;
+      fireEvent.input(searchInput, { target: { value: 'c/d' } });
+
+      const rows = container.querySelectorAll('.pr-row');
+      expect(rows).toHaveLength(1);
+      expect(rows[0].textContent).toContain('Update docs');
+    });
+
+    it('filters by search text matching PR number', async () => {
+      const { container } = render(<App />);
+
+      await waitFor(() => {
+        expect(container.querySelector('.dashboard')).toBeTruthy();
+      });
+
+      const searchInput = container.querySelector('.filter-input') as HTMLInputElement;
+      fireEvent.input(searchInput, { target: { value: '2' } });
+
+      const rows = container.querySelectorAll('.pr-row');
+      expect(rows).toHaveLength(1);
+      expect(rows[0].textContent).toContain('Add feature');
+    });
+
     it('combines multiple filters', async () => {
       const { container } = render(<App />);
 

--- a/packages/dashboard/src/app.tsx
+++ b/packages/dashboard/src/app.tsx
@@ -94,7 +94,8 @@ function AppContent() {
     if (filters.repo !== 'all' && pr.repo !== filters.repo) return false;
     if (filters.search) {
       const term = filters.search.toLowerCase();
-      if (!pr.title.toLowerCase().includes(term)) return false;
+      const searchable = `${pr.title} ${pr.repo} ${pr.number}`.toLowerCase();
+      if (!searchable.includes(term)) return false;
     }
     return true;
   });


### PR DESCRIPTION
## Summary

- **Health-check count mismatch (#674 Bug 1)**: Shelved PRs were included in `needsAddressingPRs` and `waitingOnMaintainerPRs` breakdown arrays but excluded from `totalActivePRs`, so the startup message numbers didn't add up (e.g., "19 active — 5 need addressing, 26 waiting" where 5+26=31). Now filters shelved PR URLs from both arrays before counting.
- **Dashboard search scope (#676)**: Search only matched PR titles. Now matches against repo name (`owner/repo`) and PR number too, so searching "ruby" finds `rubyforgood/*` PRs.

## Test plan

- [x] All 1,883 tests pass (1633 core, 117 dashboard, 133 mcp-server)
- [x] Lint clean, Prettier clean
- [x] 2 new dashboard tests for repo-name and PR-number search matching
- [x] Code review, silent-failure-hunter, and code-simplifier agents found zero issues

Closes #674, closes #676