### PR TITLE
feat: expand issue discovery with scope tiers and fix OR-join bug

### DIFF
--- a/packages/core/src/commands/config.test.ts
+++ b/packages/core/src/commands/config.test.ts
@@ -154,4 +154,86 @@ describe('runConfig', () => {
 
     expect(mockUpdateConfig).not.toHaveBeenCalled();
   });
+
+  it('should remove a label', async () => {
+    await runConfig({ key: 'remove-label', value: 'good first issue' });
+
+    expect(mockUpdateConfig).toHaveBeenCalledWith({
+      labels: ['help wanted'],
+    });
+    expect(mockSave).toHaveBeenCalled();
+  });
+
+  it('should throw when removing a label that does not exist', async () => {
+    await expect(runConfig({ key: 'remove-label', value: 'nonexistent' })).rejects.toThrow('not currently configured');
+  });
+
+  it('should add a scope', async () => {
+    await runConfig({ key: 'add-scope', value: 'beginner' });
+
+    expect(mockUpdateConfig).toHaveBeenCalledWith({ scope: ['beginner'] });
+    expect(mockSave).toHaveBeenCalled();
+  });
+
+  it('should append a scope to existing scopes', async () => {
+    mockGetStateManager.mockReturnValue({
+      getState: vi.fn().mockReturnValue({ config: { ...DEFAULT_CONFIG, scope: ['beginner'] } }),
+      updateConfig: mockUpdateConfig,
+      cleanupExcludedData: mockCleanupExcludedData,
+      save: mockSave,
+    } as any);
+
+    await runConfig({ key: 'add-scope', value: 'intermediate' });
+
+    expect(mockUpdateConfig).toHaveBeenCalledWith({ scope: ['beginner', 'intermediate'] });
+  });
+
+  it('should not add duplicate scope', async () => {
+    mockGetStateManager.mockReturnValue({
+      getState: vi.fn().mockReturnValue({ config: { ...DEFAULT_CONFIG, scope: ['beginner'] } }),
+      updateConfig: mockUpdateConfig,
+      cleanupExcludedData: mockCleanupExcludedData,
+      save: mockSave,
+    } as any);
+
+    await runConfig({ key: 'add-scope', value: 'beginner' });
+
+    expect(mockUpdateConfig).not.toHaveBeenCalled();
+  });
+
+  it('should throw for invalid scope value', async () => {
+    await expect(runConfig({ key: 'add-scope', value: 'expert' })).rejects.toThrow('Invalid scope');
+  });
+
+  it('should remove a scope', async () => {
+    mockGetStateManager.mockReturnValue({
+      getState: vi.fn().mockReturnValue({ config: { ...DEFAULT_CONFIG, scope: ['beginner', 'intermediate'] } }),
+      updateConfig: mockUpdateConfig,
+      cleanupExcludedData: mockCleanupExcludedData,
+      save: mockSave,
+    } as any);
+
+    await runConfig({ key: 'remove-scope', value: 'beginner' });
+
+    expect(mockUpdateConfig).toHaveBeenCalledWith({ scope: ['intermediate'] });
+  });
+
+  it('should throw when removing the last scope', async () => {
+    mockGetStateManager.mockReturnValue({
+      getState: vi.fn().mockReturnValue({ config: { ...DEFAULT_CONFIG, scope: ['beginner'] } }),
+      updateConfig: mockUpdateConfig,
+      cleanupExcludedData: mockCleanupExcludedData,
+      save: mockSave,
+    } as any);
+
+    await expect(runConfig({ key: 'remove-scope', value: 'beginner' })).rejects.toThrow('Cannot remove the last scope');
+  });
+
+  it('should throw when removing a scope that is not set', async () => {
+    await expect(runConfig({ key: 'remove-scope', value: 'advanced' })).rejects.toThrow('not currently set');
+  });
+
+  it('should throw for invalid scope value in remove-scope', async () => {
+    await expect(runConfig({ key: 'remove-scope', value: 'expert' })).rejects.toThrow('Invalid scope');
+  });
 });

--- a/packages/core/src/commands/config.ts
+++ b/packages/core/src/commands/config.ts
@@ -4,6 +4,7 @@
  */
 
 import { getStateManager } from '../core/index.js';
+import { ISSUE_SCOPES, type IssueScope } from '../core/types.js';
 import type { ConfigOutput } from '../formatters/json.js';
 import { validateGitHubUsername } from './validation.js';
 
@@ -19,6 +20,13 @@ export interface ConfigSetOutput {
 }
 
 export type ConfigCommandOutput = ConfigOutput | ConfigSetOutput;
+
+function validateScope(value: string): IssueScope {
+  if (!(ISSUE_SCOPES as readonly string[]).includes(value)) {
+    throw new Error(`Invalid scope "${value}". Valid scopes: ${ISSUE_SCOPES.join(', ')}`);
+  }
+  return value as IssueScope;
+}
 
 export async function runConfig(options: ConfigOptions): Promise<ConfigCommandOutput> {
   const stateManager = getStateManager();
@@ -49,6 +57,35 @@ export async function runConfig(options: ConfigOptions): Promise<ConfigCommandOu
         stateManager.updateConfig({ labels: [...currentConfig.labels, value] });
       }
       break;
+    case 'remove-label':
+      if (!currentConfig.labels.includes(value)) {
+        throw new Error(
+          `Label "${value}" is not currently configured. Current labels: ${currentConfig.labels.join(', ')}`,
+        );
+      }
+      stateManager.updateConfig({ labels: currentConfig.labels.filter((l) => l !== value) });
+      break;
+    case 'add-scope': {
+      const scope = validateScope(value);
+      const currentScopes = currentConfig.scope ?? [];
+      if (!currentScopes.includes(scope)) {
+        stateManager.updateConfig({ scope: [...currentScopes, scope] });
+      }
+      break;
+    }
+    case 'remove-scope': {
+      const scope = validateScope(value);
+      const existingScopes = currentConfig.scope ?? [];
+      if (!existingScopes.includes(scope)) {
+        throw new Error(`Scope "${value}" is not currently set`);
+      }
+      const filtered = existingScopes.filter((s) => s !== scope);
+      if (filtered.length === 0) {
+        throw new Error('Cannot remove the last scope. Use setup to clear scopes entirely.');
+      }
+      stateManager.updateConfig({ scope: filtered });
+      break;
+    }
     case 'exclude-repo': {
       const parts = value.split('/');
       if (parts.length !== 2 || !parts[0] || !parts[1]) {

--- a/packages/core/src/commands/setup.test.ts
+++ b/packages/core/src/commands/setup.test.ts
@@ -311,9 +311,45 @@ describe('runSetup', () => {
         config: expect.objectContaining({
           projectCategories: ['devtools'],
           preferredOrgs: ['vercel'],
+          scope: [],
         }),
       }),
     );
+  });
+
+  it('should handle valid scope setting', async () => {
+    const result = (await runSetup({ set: ['scope=beginner,intermediate'] })) as SetupSetOutput;
+    expect(mockUpdateConfig).toHaveBeenCalledWith({ scope: ['beginner', 'intermediate'] });
+    expect(result.settings.scope).toBe('beginner, intermediate');
+  });
+
+  it('should warn for invalid scope values', async () => {
+    const result = (await runSetup({ set: ['scope=beginner,expert'] })) as SetupSetOutput;
+    expect(mockUpdateConfig).toHaveBeenCalledWith({ scope: ['beginner'] });
+    expect(result.warnings).toEqual(expect.arrayContaining([expect.stringContaining('Unknown issue scopes')]));
+  });
+
+  it('should clear scope when empty value provided', async () => {
+    const result = (await runSetup({ set: ['scope='] })) as SetupSetOutput;
+    expect(mockUpdateConfig).toHaveBeenCalledWith({ scope: undefined });
+    expect(result.settings.scope).toBe('(empty — using labels only)');
+  });
+
+  it('should deduplicate scope values', async () => {
+    await runSetup({ set: ['scope=beginner,beginner,intermediate'] });
+    expect(mockUpdateConfig).toHaveBeenCalledWith({ scope: ['beginner', 'intermediate'] });
+  });
+
+  it('should include scope in setup prompts', async () => {
+    mockGetStateManager.mockReturnValue({
+      getState: vi.fn().mockReturnValue({ config: { ...DEFAULT_CONFIG, setupComplete: false } }),
+      updateConfig: mockUpdateConfig,
+      save: mockSave,
+    } as any);
+
+    const result = (await runSetup({})) as SetupRequiredOutput;
+    const settings = result.prompts.map((p) => p.setting);
+    expect(settings).toContain('scope');
   });
 });
 

--- a/packages/core/src/commands/setup.ts
+++ b/packages/core/src/commands/setup.ts
@@ -6,7 +6,7 @@
 import { getStateManager, DEFAULT_CONFIG } from '../core/index.js';
 import { ValidationError } from '../core/errors.js';
 import { validateGitHubUsername } from './validation.js';
-import { PROJECT_CATEGORIES, type ProjectCategory } from '../core/types.js';
+import { PROJECT_CATEGORIES, type ProjectCategory, ISSUE_SCOPES, type IssueScope } from '../core/types.js';
 
 /** Parse and validate a positive integer setting value. */
 function parsePositiveInt(value: string, settingName: string): number {
@@ -39,6 +39,7 @@ export interface SetupCompleteOutput {
     labels: string[];
     projectCategories: ProjectCategory[];
     preferredOrgs: string[];
+    scope: IssueScope[];
   };
 }
 
@@ -208,6 +209,28 @@ export async function runSetup(options: SetupOptions): Promise<SetupOutput> {
           results[key] = dedupedOrgs.length > 0 ? dedupedOrgs.join(', ') : '(empty)';
           break;
         }
+        case 'scope': {
+          const scopeValues = value
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean);
+          const validScopes: IssueScope[] = [];
+          const invalidScopes: string[] = [];
+          for (const s of scopeValues) {
+            if ((ISSUE_SCOPES as readonly string[]).includes(s)) {
+              validScopes.push(s as IssueScope);
+            } else {
+              invalidScopes.push(s);
+            }
+          }
+          if (invalidScopes.length > 0) {
+            warnings.push(`Unknown issue scopes: ${invalidScopes.join(', ')}. Valid: ${ISSUE_SCOPES.join(', ')}`);
+          }
+          const dedupedScopes = [...new Set(validScopes)];
+          stateManager.updateConfig({ scope: dedupedScopes.length > 0 ? dedupedScopes : undefined });
+          results[key] = dedupedScopes.length > 0 ? dedupedScopes.join(', ') : '(empty — using labels only)';
+          break;
+        }
         case 'complete':
           if (value === 'true') {
             stateManager.markSetupComplete();
@@ -237,6 +260,7 @@ export async function runSetup(options: SetupOptions): Promise<SetupOutput> {
         labels: config.labels,
         projectCategories: config.projectCategories ?? [],
         preferredOrgs: config.preferredOrgs ?? [],
+        scope: config.scope ?? [],
       },
     };
   }
@@ -285,6 +309,14 @@ export async function runSetup(options: SetupOptions): Promise<SetupOutput> {
         prompt: 'What issue labels should we search for?',
         current: config.labels,
         default: ['good first issue', 'help wanted'],
+        type: 'list',
+      },
+      {
+        setting: 'scope',
+        prompt:
+          'What scope of issues do you want to discover? (beginner, intermediate, advanced — leave empty for default labels only)',
+        current: config.scope ?? [],
+        default: [],
         type: 'list',
       },
       {

--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -78,6 +78,9 @@ const {
   applyPerRepoCap,
   DOC_ONLY_LABELS,
   BEGINNER_LABELS: _BEGINNER_LABELS,
+  buildEffectiveLabels,
+  interleaveArrays,
+  SCOPE_LABELS,
 } = await import('./issue-discovery.js');
 
 const { getStateManager } = await import('./state.js');
@@ -1741,5 +1744,72 @@ describe('formatCandidate', () => {
 
     expect(output).toContain('Has 3 linked PRs');
     expect(output).toContain('Recently discussed');
+  });
+});
+
+describe('buildEffectiveLabels', () => {
+  it('should return scope labels for a single scope', () => {
+    const result = buildEffectiveLabels(['beginner'], []);
+    expect(result).toEqual(SCOPE_LABELS.beginner);
+  });
+
+  it('should merge labels from multiple scopes', () => {
+    const result = buildEffectiveLabels(['beginner', 'intermediate'], []);
+    for (const label of SCOPE_LABELS.beginner) {
+      expect(result).toContain(label);
+    }
+    for (const label of SCOPE_LABELS.intermediate) {
+      expect(result).toContain(label);
+    }
+  });
+
+  it('should merge custom labels with scope labels', () => {
+    const result = buildEffectiveLabels(['beginner'], ['custom-label']);
+    expect(result).toContain('good first issue');
+    expect(result).toContain('custom-label');
+  });
+
+  it('should deduplicate when custom labels overlap with scope labels', () => {
+    const result = buildEffectiveLabels(['beginner'], ['good first issue', 'custom']);
+    const gfiCount = result.filter((l) => l === 'good first issue').length;
+    expect(gfiCount).toBe(1);
+    expect(result).toContain('custom');
+  });
+
+  it('should return only custom labels when scopes is empty', () => {
+    const result = buildEffectiveLabels([], ['my-label']);
+    expect(result).toEqual(['my-label']);
+  });
+});
+
+describe('interleaveArrays', () => {
+  it('should interleave two equal-length arrays', () => {
+    const result = interleaveArrays([
+      ['a1', 'a2', 'a3'],
+      ['b1', 'b2', 'b3'],
+    ]);
+    expect(result).toEqual(['a1', 'b1', 'a2', 'b2', 'a3', 'b3']);
+  });
+
+  it('should handle arrays of different lengths', () => {
+    const result = interleaveArrays([
+      ['a1', 'a2'],
+      ['b1', 'b2', 'b3'],
+    ]);
+    expect(result).toEqual(['a1', 'b1', 'a2', 'b2', 'b3']);
+  });
+
+  it('should handle three arrays', () => {
+    const result = interleaveArrays([['a1'], ['b1'], ['c1']]);
+    expect(result).toEqual(['a1', 'b1', 'c1']);
+  });
+
+  it('should handle empty arrays', () => {
+    expect(interleaveArrays([])).toEqual([]);
+    expect(interleaveArrays([[], []])).toEqual([]);
+  });
+
+  it('should handle single array', () => {
+    expect(interleaveArrays([['a', 'b']])).toEqual(['a', 'b']);
   });
 });

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -13,7 +13,7 @@ import { Octokit } from '@octokit/rest';
 import { getOctokit, checkRateLimit } from './github.js';
 import { getStateManager } from './state.js';
 import { daysBetween, getDataDir } from './utils.js';
-import { DEFAULT_CONFIG, type SearchPriority, type IssueCandidate } from './types.js';
+import { DEFAULT_CONFIG, type SearchPriority, type IssueCandidate, type IssueScope, SCOPE_LABELS } from './types.js';
 import { ValidationError, errorMessage, getHttpStatusCode, isRateLimitError } from './errors.js';
 import { debug, info, warn } from './logger.js';
 import { getHttpCache, cachedTimeBased } from './http-cache.js';
@@ -37,9 +37,39 @@ export {
 export { calculateRepoQualityBonus, calculateViabilityScore, type ViabilityScoreParams } from './issue-scoring.js';
 export { type CheckResult } from './issue-vetting.js';
 // Re-export types that were previously defined here
-export type { SearchPriority, IssueCandidate } from './types.js';
+export type { SearchPriority, IssueCandidate, IssueScope } from './types.js';
+export { SCOPE_LABELS, ISSUE_SCOPES } from './types.js';
 
 const MODULE = 'issue-discovery';
+
+/** Build a GitHub Search API label filter from a list of labels. */
+function buildLabelQuery(labels: string[]): string {
+  if (labels.length === 0) return '';
+  if (labels.length === 1) return `label:"${labels[0]}"`;
+  return `(${labels.map((l) => `label:"${l}"`).join(' OR ')})`;
+}
+
+/** Resolve scope tiers into a flat label list, merged with custom labels. */
+export function buildEffectiveLabels(scopes: IssueScope[], customLabels: string[]): string[] {
+  const labels = new Set<string>();
+  for (const scope of scopes) {
+    for (const label of SCOPE_LABELS[scope] ?? []) labels.add(label);
+  }
+  for (const label of customLabels) labels.add(label);
+  return [...labels];
+}
+
+/** Round-robin interleave multiple arrays. */
+export function interleaveArrays<T>(arrays: T[][]): T[] {
+  const result: T[] = [];
+  const maxLen = Math.max(...arrays.map((a) => a.length), 0);
+  for (let i = 0; i < maxLen; i++) {
+    for (const arr of arrays) {
+      if (i < arr.length) result.push(arr[i]);
+    }
+  }
+  return result;
+}
 
 /** TTL for cached search API results (15 minutes). */
 const SEARCH_CACHE_TTL_MS = 15 * 60 * 1000;
@@ -225,7 +255,8 @@ export class IssueDiscovery {
   ): Promise<IssueCandidate[]> {
     const config = this.stateManager.getState().config;
     const languages = options.languages || config.languages;
-    const labels = options.labels || config.labels;
+    const scopes = config.scope; // undefined = legacy mode
+    const labels = options.labels || (scopes ? buildEffectiveLabels(scopes, config.labels) : config.labels);
     const maxResults = options.maxResults || 10;
     const minStars = config.minStars ?? 50;
 
@@ -273,7 +304,7 @@ export class IssueDiscovery {
     const now = new Date();
 
     // Build query parts
-    const labelQuery = labels.map((l) => `label:"${l}"`).join(' ');
+    const labelQuery = buildLabelQuery(labels);
     // When languages includes 'any', omit the language filter entirely
     const isAnyLanguage = languages.some((l) => l.toLowerCase() === 'any');
     const langQuery = isAnyLanguage ? '' : languages.map((l) => `language:${l}`).join(' ');
@@ -449,50 +480,95 @@ export class IssueDiscovery {
     }
 
     // Phase 2: General search (if still need more)
+    // When multiple scope tiers are active, fire one query per tier and interleave
+    // results to prevent high-volume tiers (e.g., "enhancement") from drowning out
+    // beginner results.
     let phase2Error: string | null = null;
     if (allCandidates.length < maxResults) {
       info(MODULE, 'Phase 2: General issue search...');
       const remainingNeeded = maxResults - allCandidates.length;
-      try {
-        const data = await this.cachedSearch({
-          q: baseQuery,
-          sort: 'created',
-          order: 'desc',
-          per_page: remainingNeeded * 3, // Fetch extra since some will be filtered
-        });
+      const seenRepos = new Set(allCandidates.map((c) => c.issue.repo));
 
-        info(MODULE, `Found ${data.total_count} issues in general search, processing top ${data.items.length}...`);
-
-        const seenRepos = new Set(allCandidates.map((c) => c.issue.repo));
-        const {
-          candidates: starFiltered,
-          allVetFailed,
-          rateLimitHit: vetRateLimitHit,
-        } = await this.filterVetAndScore(
-          data.items,
-          filterIssues,
-          [phase0RepoSet, starredRepoSet, seenRepos],
-          remainingNeeded,
-          minStars,
-          'Phase 2',
-        );
-
-        allCandidates.push(...starFiltered);
-        if (allVetFailed) {
-          phase2Error = (phase2Error ? phase2Error + '; ' : '') + 'all vetting failed';
+      // Build per-tier label groups. Multi-tier when 2+ scopes; single-tier otherwise.
+      // Both paths use the same loop — interleaving a single-element array is a no-op.
+      const tierLabelGroups: { tier: string; tierLabels: string[] }[] = [];
+      if (scopes && scopes.length > 1) {
+        for (const scope of scopes) {
+          const scopeLabels = SCOPE_LABELS[scope] ?? [];
+          if (scopeLabels.length === 0) {
+            warn(MODULE, `Scope "${scope}" has no labels, skipping tier`);
+            continue;
+          }
+          tierLabelGroups.push({ tier: scope, tierLabels: scopeLabels });
         }
-        if (vetRateLimitHit) {
-          rateLimitHitDuringSearch = true;
+        // Custom labels not in any tier get their own pseudo-tier
+        const allScopeLabels = new Set(scopes.flatMap((s) => SCOPE_LABELS[s] ?? []));
+        const customOnly = config.labels.filter((l) => !allScopeLabels.has(l));
+        if (customOnly.length > 0) {
+          tierLabelGroups.push({ tier: 'custom', tierLabels: customOnly });
         }
-        info(MODULE, `Found ${starFiltered.length} candidates from general search`);
-      } catch (error) {
-        const errMsg = errorMessage(error);
-        phase2Error = errMsg;
-        if (isRateLimitError(error)) {
-          rateLimitHitDuringSearch = true;
-        }
-        warn(MODULE, `Error in general issue search: ${errMsg}`);
+      } else {
+        tierLabelGroups.push({ tier: 'general', tierLabels: labels });
       }
+
+      const budgetPerTier = Math.ceil(remainingNeeded / tierLabelGroups.length);
+      const tierResults: IssueCandidate[][] = [];
+
+      for (const { tier, tierLabels } of tierLabelGroups) {
+        const tierQuery = `is:issue is:open ${buildLabelQuery(tierLabels)} ${langQuery} no:assignee`
+          .replace(/  +/g, ' ')
+          .trim();
+
+        try {
+          const data = await this.cachedSearch({
+            q: tierQuery,
+            sort: 'created',
+            order: 'desc',
+            per_page: budgetPerTier * 3,
+          });
+
+          info(MODULE, `Phase 2 [${tier}]: ${data.total_count} total, processing top ${data.items.length}...`);
+
+          const {
+            candidates: tierCandidates,
+            allVetFailed,
+            rateLimitHit: vetRateLimitHit,
+          } = await this.filterVetAndScore(
+            data.items,
+            filterIssues,
+            [phase0RepoSet, starredRepoSet, seenRepos],
+            budgetPerTier,
+            minStars,
+            `Phase 2 [${tier}]`,
+          );
+
+          tierResults.push(tierCandidates);
+          // Update seenRepos so later tiers don't return duplicate repos
+          for (const c of tierCandidates) seenRepos.add(c.issue.repo);
+          if (allVetFailed) {
+            phase2Error = (phase2Error ? phase2Error + '; ' : '') + `${tier}: all vetting failed`;
+          }
+          if (vetRateLimitHit) {
+            rateLimitHitDuringSearch = true;
+          }
+          info(MODULE, `Found ${tierCandidates.length} candidates from ${tier} tier`);
+        } catch (error) {
+          if (getHttpStatusCode(error) === 401) throw error;
+          const errMsg = errorMessage(error);
+          phase2Error = (phase2Error ? phase2Error + '; ' : '') + `${tier}: ${errMsg}`;
+          if (isRateLimitError(error)) {
+            rateLimitHitDuringSearch = true;
+          }
+          warn(MODULE, `Error in ${tier} tier search: ${errMsg}`);
+          tierResults.push([]);
+        }
+      }
+
+      const interleaved = interleaveArrays(tierResults);
+      if (interleaved.length === 0 && phase2Error) {
+        warn(MODULE, `All ${tierLabelGroups.length} scope tiers failed in Phase 2: ${phase2Error}`);
+      }
+      allCandidates.push(...interleaved.slice(0, remainingNeeded));
     }
 
     // Phase 3: Actively maintained repos (#349)

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -566,6 +566,8 @@ export interface AgentConfig {
   languages: string[];
   /** GitHub labels to filter issues by (e.g., `["good first issue", "help wanted"]`). */
   labels: string[];
+  /** Issue scope tiers to search (e.g., `["beginner", "intermediate"]`). When set, scope tier labels are merged with custom `labels`. When absent, only `labels` is used (legacy behavior). */
+  scope?: IssueScope[];
   /** Repos to exclude from issue discovery/search, in `"owner/repo"` format. */
   excludeRepos: string[];
   /** Organizations to exclude from issue discovery/search (case-insensitive match on owner segment). */
@@ -704,6 +706,17 @@ export const PROJECT_CATEGORIES = [
 ] as const;
 
 export type ProjectCategory = (typeof PROJECT_CATEGORIES)[number];
+
+// -- Issue scope types --
+
+export const ISSUE_SCOPES = ['beginner', 'intermediate', 'advanced'] as const;
+export type IssueScope = (typeof ISSUE_SCOPES)[number];
+
+export const SCOPE_LABELS: Record<IssueScope, string[]> = {
+  beginner: ['good first issue', 'help wanted', 'easy', 'up-for-grabs', 'first-timers-only', 'beginner'],
+  intermediate: ['enhancement', 'feature', 'feature-request', 'contributions welcome'],
+  advanced: ['proposal', 'RFC', 'accepted', 'design'],
+};
 
 // -- Issue discovery types (shared across issue-discovery, issue-vetting, issue-scoring) --
 


### PR DESCRIPTION
## Summary

- **Fix AND→OR label query bug**: Multi-label search queries used space-separated `label:` qualifiers, which GitHub Search API treats as AND. Changed to explicit `(label:"x" OR label:"y")` syntax, dramatically expanding result coverage (~80K → ~856K matching issues).
- **Add issue scope tiers**: New `IssueScope` type with three tiers — `beginner` (good first issue, help wanted, etc.), `intermediate` (enhancement, feature-request, etc.), `advanced` (proposal, RFC, etc.). Users opt in via `config add-scope` or `setup --set scope=beginner,intermediate`.
- **Multi-tier Phase 2 interleaving**: When multiple scopes are active, Phase 2 fires one query per tier with split budgets and round-robin interleaves results, preventing high-volume tiers from drowning out beginner results.
- **Config commands**: Added `add-scope`, `remove-scope`, `remove-label` to the config command.
- **Setup integration**: Added `scope` to `--set` handler and interactive setup prompts.

## Backward Compatibility

- `scope` is optional, defaults to `undefined`
- When `scope` is not set: behavior is identical to today (except the OR-join fix, which is a bug fix for all users)
- No state migration needed — new field is simply absent in old state files

## Test Plan

- [x] All 1908 tests pass (1658 core + 117 dashboard + 133 mcp-server)
- [x] Lint clean
- [x] New tests for `buildEffectiveLabels`, `interleaveArrays`, `buildLabelQuery`
- [x] New tests for config `add-scope`, `remove-scope`, `remove-label` (including validation)
- [x] New tests for setup `scope` setting (valid, invalid, empty, dedup)
- [ ] Manual: `pnpm start -- search --json` with default config → verify OR-joined query
- [ ] Manual: set `scope=beginner,intermediate` → verify mixed results

Closes #683