### PR TITLE
fix: issue-scout agent ignores excludeRepos and excludeOrgs

### DIFF
--- a/commands/oss-search.md
+++ b/commands/oss-search.md
@@ -46,6 +46,7 @@ Task(issue-scout, "Find recently-opened issues (last 30 days) in repos where the
   Get merged-PR repos: read ~/.oss-autopilot/state.json, extract repo names from repoScores entries where mergedPRCount > 0 (sorted by mergedPRCount descending).
   Get open-PR repos: run `gh search prs --author @me --state open --json repository --jq '.[].repository.nameWithOwner' | sort -u`.
   Combine both lists (merged-PR repos first), deduplicate.
+  Read config.excludeRepos and config.excludeOrgs from ~/.oss-autopilot/state.json. Remove any repo that appears in excludeRepos or whose owner matches an entry in excludeOrgs (case-insensitive) from the combined list before searching.
   For each repo: `gh search issues --repo OWNER/REPO --state open --sort created --limit 5`.
   Exclude issues authored by the user (get username from `gh api user -q .login`).
   Return at most 15 total results (prioritize repos with higher mergedPRCount).
@@ -68,10 +69,10 @@ Task(issue-scout, "Search for good-first-issue candidates in trending/popular re
   [If searchedRepos is non-empty, insert: "Exclude results from these repos (already searched in prior rounds): {searchedRepos as comma-separated list}."]
   Exclude issues authored by the user (get username from `gh api user -q .login`).
   Read the user's language preferences from CLI: `config --json`.
-  Read minStars from ~/.oss-autopilot/state.json at path config.minStars (default 50 if missing or null).
+  Read minStars, config.excludeRepos, and config.excludeOrgs from ~/.oss-autopilot/state.json (default minStars to 50 if missing or null).
   Then: gh search issues --label 'good first issue' --language {lang} --state open --sort reactions-+1 --limit 20
   For each candidate, check the repo's star count via `gh api repos/{owner}/{repo} -q .stargazers_count`.
-  Filter out repos with fewer stars than minStars.
+  Filter out repos with fewer stars than minStars. Also filter out any repo in excludeRepos or whose owner matches an entry in excludeOrgs (case-insensitive).
   Focus on repos with high star counts and recent activity.
   Return at most 10 results that pass the filter.
   For each: repo, number, title, URL, labels, star count, source: 'trending-repo', and brief assessment.")


### PR DESCRIPTION
## Summary

- Strategy A (established repos): filters the combined repo list against `config.excludeRepos` and `config.excludeOrgs` **before** iterating, avoiding wasted API calls
- Strategy C (trending repos): filters search results against the same exclusion config **after** the broad GitHub search, alongside the existing star-count filter
- Strategy B already filters via the CLI's `IssueDiscovery.searchIssues()` — no change needed

Closes #709

## Test plan

- [x] `pnpm test` — all tests pass (no TypeScript changes)
- [x] `pnpm run lint` — clean
- [ ] Manual: add a repo to `excludeRepos` in `~/.oss-autopilot/state.json`, run `/oss-search`, confirm Strategy A and C results omit it