### PR TITLE
test: raise issue-discovery.ts and search-phases.ts coverage to 80%+ (#723)

### DIFF
--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -76,6 +76,115 @@ const { analyzeRequirements } = await import('./issue-eligibility.js');
 
 const { getStateManager } = await import('./state.js');
 
+/** Create a search item with enough body content to pass analyzeRequirements */
+function makeSearchItem(repo: string, num: number) {
+  return {
+    html_url: `https://github.com/${repo}/issues/${num}`,
+    repository_url: `https://api.github.com/repos/${repo}`,
+    updated_at: new Date().toISOString(),
+    title: `Test issue ${num}`,
+    labels: [{ name: 'good first issue' }],
+    id: num,
+    comments: 0,
+    body: `1. Step one\n2. Step two\nThis should work correctly.\n${'x'.repeat(200)}`,
+    created_at: new Date().toISOString(),
+    number: num,
+  };
+}
+
+/**
+ * Build state mock for search-related tests.
+ * Sets up getStateManager to return a mock with the supplied config overrides,
+ * repo lists, and activeIssues.
+ */
+function mockStateForSearch(
+  overrides: {
+    mergedPRRepos?: string[];
+    openPRRepos?: string[];
+    starredRepos?: string[];
+    lowScoringRepos?: string[];
+    config?: Record<string, unknown>;
+    activeIssues?: any[];
+    isStarredReposStale?: boolean;
+  } = {},
+): void {
+  const config: Record<string, unknown> = {
+    githubUsername: 'testuser',
+    trustedProjects: [],
+    starredRepos: [],
+    excludeRepos: [],
+    languages: ['typescript'],
+    labels: ['good first issue'],
+    maxIssueAgeDays: 90,
+    includeDocIssues: true,
+    minStars: 0,
+    ...overrides.config,
+  };
+  (getStateManager as any).mockReturnValue({
+    getState: () => ({ config, repoScores: {}, activeIssues: overrides.activeIssues ?? [] }),
+    getStarredRepos: () => overrides.starredRepos ?? [],
+    setStarredRepos: vi.fn(),
+    isStarredReposStale: () => overrides.isStarredReposStale ?? false,
+    getReposWithMergedPRs: () => overrides.mergedPRRepos ?? [],
+    getReposWithOpenPRs: () => overrides.openPRRepos ?? [],
+    getLowScoringRepos: () => overrides.lowScoringRepos ?? [],
+    getRepoScore: () => undefined,
+    getHighScoringRepos: () => [],
+  });
+}
+
+/**
+ * Build a full octokit mock satisfying both search and vetting pipelines.
+ * Accepts a custom searchImpl to route queries by content.
+ */
+function fullOctokitMock(
+  searchImpl?: (params: { q?: string }) => Promise<{ data: { total_count: number; items: any[] } }>,
+): any {
+  const recentDate = new Date().toISOString();
+  const defaultSearch = () => Promise.resolve({ data: { total_count: 0, items: [] } });
+
+  return {
+    search: {
+      issuesAndPullRequests: vi.fn().mockImplementation(searchImpl ?? defaultSearch),
+    },
+    issues: {
+      get: vi.fn().mockImplementation(({ owner, repo, issue_number }: any) =>
+        Promise.resolve({
+          data: {
+            id: issue_number,
+            html_url: `https://github.com/${owner}/${repo}/issues/${issue_number}`,
+            title: `Test issue ${issue_number}`,
+            labels: [{ name: 'good first issue' }],
+            created_at: recentDate,
+            updated_at: recentDate,
+            comments: 0,
+            body: `1. Step one\n2. Step two\nThis should work correctly.\n${'x'.repeat(200)}`,
+          },
+        }),
+      ),
+      listEventsForTimeline: vi.fn().mockResolvedValue({ data: [] }),
+    },
+    repos: {
+      get: vi.fn().mockResolvedValue({
+        data: { open_issues_count: 5, pushed_at: recentDate, stargazers_count: 200, forks_count: 30 },
+      }),
+      listCommits: vi.fn().mockResolvedValue({
+        data: [{ commit: { author: { date: recentDate } } }],
+      }),
+      getContent: vi.fn().mockRejectedValue(new Error('404 Not Found')),
+    },
+    actions: {
+      listRepoWorkflows: vi.fn().mockResolvedValue({ data: { total_count: 1 } }),
+    },
+    paginate: {
+      iterator: vi.fn(),
+    },
+    activity: {
+      listReposStarredByAuthenticatedUser: vi.fn(),
+    },
+  };
+}
+
 describe('calculateViabilityScore', () => {
   const baseParams = {
     repoScore: null as number | null,
@@ -998,47 +1107,8 @@ describe('applyPerRepoCap (#105)', () => {
 describe('aiPolicyBlocklist filtering in searchIssues (#108)', () => {
   let discovery: InstanceType<typeof IssueDiscovery>;
 
-  const makeSearchItem = (repo: string, num: number) => ({
-    html_url: `https://github.com/${repo}/issues/${num}`,
-    repository_url: `https://api.github.com/repos/${repo}`,
-    updated_at: new Date().toISOString(),
-    title: `Test issue ${num}`,
-    labels: [{ name: 'good first issue' }],
-    id: num,
-    comments: 0,
-    body: `1. Step one\n2. Step two\nThis should work correctly.\n${'x'.repeat(200)}`,
-    created_at: new Date().toISOString(),
-    number: num,
-  });
-
-  function mockStateWithBlocklist(aiPolicyBlocklist?: string[]): void {
-    const config: Record<string, unknown> = {
-      githubUsername: 'testuser',
-      trustedProjects: [],
-      starredRepos: [],
-      excludeRepos: [],
-      languages: ['typescript'],
-      labels: ['good first issue'],
-      maxIssueAgeDays: 90,
-      includeDocIssues: true,
-      minStars: 0,
-    };
-    if (aiPolicyBlocklist !== undefined) {
-      config.aiPolicyBlocklist = aiPolicyBlocklist;
-    }
-    (getStateManager as any).mockReturnValue({
-      getState: () => ({ config, repoScores: {}, activeIssues: [] }),
-      getStarredRepos: () => [],
-      isStarredReposStale: () => false,
-      getReposWithMergedPRs: () => [],
-      getReposWithOpenPRs: () => [],
-      getLowScoringRepos: () => [],
-      getRepoScore: () => undefined,
-    });
-  }
-
   beforeEach(() => {
-    mockStateWithBlocklist(['blocked/repo']);
+    mockStateForSearch({ config: { aiPolicyBlocklist: ['blocked/repo'] } });
 
     mockOctokitInstance = {
       search: {
@@ -1091,7 +1161,7 @@ describe('aiPolicyBlocklist filtering in searchIssues (#108)', () => {
   });
 
   it('should pass through all issues when blocklist is empty', async () => {
-    mockStateWithBlocklist([]);
+    mockStateForSearch({ config: { aiPolicyBlocklist: [] } });
     discovery = new IssueDiscovery('fake-token');
 
     const candidates = await discovery.searchIssues({ maxResults: 10 });
@@ -1101,7 +1171,7 @@ describe('aiPolicyBlocklist filtering in searchIssues (#108)', () => {
   });
 
   it('should handle undefined blocklist gracefully', async () => {
-    mockStateWithBlocklist(undefined);
+    mockStateForSearch();
     discovery = new IssueDiscovery('fake-token');
 
     const candidates = await discovery.searchIssues({ maxResults: 10 });
@@ -1112,7 +1182,7 @@ describe('aiPolicyBlocklist filtering in searchIssues (#108)', () => {
   });
 
   it('should fall back to DEFAULT_CONFIG blocklist when config value is undefined', async () => {
-    mockStateWithBlocklist(undefined);
+    mockStateForSearch();
     // Include matplotlib/matplotlib (which IS in DEFAULT_CONFIG.aiPolicyBlocklist) in search results
     mockOctokitInstance.search.issuesAndPullRequests.mockResolvedValue({
       data: {
@@ -1242,79 +1312,11 @@ describe('IssueDiscovery.formatCandidate', () => {
 describe('Phase 3: actively maintained repos (#349)', () => {
   let discovery: InstanceType<typeof IssueDiscovery>;
 
-  const makeSearchItem = (repo: string, num: number) => ({
-    html_url: `https://github.com/${repo}/issues/${num}`,
-    repository_url: `https://api.github.com/repos/${repo}`,
-    updated_at: new Date().toISOString(),
-    title: `Test issue ${num}`,
-    labels: [{ name: 'good first issue' }],
-    id: num,
-    comments: 0,
-    body: `1. Step one\n2. Step two\nThis should work correctly.\n${'x'.repeat(200)}`,
-    created_at: new Date().toISOString(),
-    number: num,
-  });
-
   beforeEach(() => {
-    (getStateManager as any).mockReturnValue({
-      getState: () => ({
-        config: {
-          githubUsername: 'testuser',
-          trustedProjects: [],
-          starredRepos: [],
-          excludeRepos: [],
-          languages: ['typescript'],
-          labels: ['good first issue'],
-          maxIssueAgeDays: 90,
-          includeDocIssues: true,
-          minStars: 50,
-        },
-        repoScores: {},
-        activeIssues: [],
-      }),
-      getStarredRepos: () => [],
-      isStarredReposStale: () => false,
-      getReposWithMergedPRs: () => [],
-      getReposWithOpenPRs: () => [],
-      getLowScoringRepos: () => [],
-      getRepoScore: () => undefined,
-    });
-
-    mockOctokitInstance = {
-      search: {
-        issuesAndPullRequests: vi.fn(),
-      },
-      issues: {
-        get: vi.fn().mockImplementation(({ owner, repo, issue_number }: any) =>
-          Promise.resolve({
-            data: {
-              id: issue_number,
-              html_url: `https://github.com/${owner}/${repo}/issues/${issue_number}`,
-              title: `Test issue ${issue_number}`,
-              labels: [{ name: 'good first issue' }],
-              created_at: new Date().toISOString(),
-              updated_at: new Date().toISOString(),
-              comments: 0,
-              body: `1. Step one\n2. Step two\nThis should work correctly.\n${'x'.repeat(200)}`,
-            },
-          }),
-        ),
-        listEventsForTimeline: vi.fn().mockResolvedValue({ data: [] }),
-      },
-      repos: {
-        get: vi.fn().mockResolvedValue({
-          data: { open_issues_count: 5, pushed_at: new Date().toISOString(), stargazers_count: 100, forks_count: 20 },
-        }),
-        listCommits: vi.fn().mockResolvedValue({
-          data: [{ commit: { author: { date: new Date().toISOString() } } }],
-        }),
-        getContent: vi.fn().mockRejectedValue(new Error('404 Not Found')),
-      },
-      actions: {
-        listRepoWorkflows: vi.fn().mockResolvedValue({ data: { total_count: 1 } }),
-      },
-    };
-
+    mockStateForSearch({ config: { minStars: 50 } });
+    mockOctokitInstance = fullOctokitMock();
+    // Phase 3 tests use .mockResolvedValueOnce chains, so reset the default impl
+    mockOctokitInstance.search.issuesAndPullRequests.mockReset();
     discovery = new IssueDiscovery('fake-token');
   });
 
@@ -1447,20 +1449,7 @@ describe('Search result caching (#487)', () => {
     mockCache.getIfFresh.mockReturnValue(null);
     mockCache.set.mockClear();
 
-    mockOctokitInstance = {
-      issues: { get: vi.fn(), listEventsForTimeline: vi.fn().mockResolvedValue({ data: [] }) },
-      search: { issuesAndPullRequests: vi.fn().mockResolvedValue({ data: { total_count: 0, items: [] } }) },
-      repos: {
-        get: vi.fn().mockResolvedValue({
-          data: { open_issues_count: 0, pushed_at: new Date().toISOString(), stargazers_count: 100, forks_count: 10 },
-        }),
-        listCommits: vi.fn().mockResolvedValue({ data: [{ commit: { author: { date: new Date().toISOString() } } }] }),
-        getContent: vi.fn().mockRejectedValue(new Error('404 Not Found')),
-      },
-      actions: { listRepoWorkflows: vi.fn().mockResolvedValue({ data: { total_count: 0 } }) },
-      paginate: { iterator: vi.fn() },
-      activity: { listReposStarredByAuthenticatedUser: vi.fn() },
-    };
+    mockOctokitInstance = fullOctokitMock();
     discovery = new IssueDiscovery('fake-token');
   });
 
@@ -1709,5 +1698,825 @@ describe('formatCandidate', () => {
 
     expect(output).toContain('Has 3 linked PRs');
     expect(output).toContain('Recently discussed');
+  });
+});
+
+// ── Orchestration tests: fetchStarredRepos, getStarredReposWithRefresh, searchIssues ──
+
+const { checkRateLimit } = await import('./github.js');
+
+describe('fetchStarredRepos', () => {
+  let discovery: InstanceType<typeof IssueDiscovery>;
+
+  /** Set the paginate mock to yield the given pages */
+  function mockPaginator(pages: Array<{ data: any[] }>): void {
+    mockOctokitInstance.paginate.iterator = vi.fn().mockReturnValue(
+      (async function* () {
+        for (const page of pages) yield page;
+      })(),
+    );
+  }
+
+  beforeEach(() => {
+    mockStateForSearch();
+    mockOctokitInstance = fullOctokitMock();
+    discovery = new IssueDiscovery('fake-token');
+  });
+
+  it('should paginate through starred repos', async () => {
+    mockPaginator([
+      { data: [{ full_name: 'org/repo1' }, { full_name: 'org/repo2' }] },
+      { data: [{ full_name: 'org/repo3' }] },
+    ]);
+
+    const repos = await discovery.fetchStarredRepos();
+    expect(repos).toEqual(['org/repo1', 'org/repo2', 'org/repo3']);
+  });
+
+  it('should handle Repository response type with full_name directly on object', async () => {
+    mockPaginator([{ data: [{ full_name: 'direct/repo' }] }]);
+
+    const repos = await discovery.fetchStarredRepos();
+    expect(repos).toContain('direct/repo');
+  });
+
+  it('should handle StarredRepository response type with nested repo.full_name', async () => {
+    mockPaginator([{ data: [{ repo: { full_name: 'nested/repo' } }] }]);
+
+    const repos = await discovery.fetchStarredRepos();
+    expect(repos).toContain('nested/repo');
+  });
+
+  it('should limit to 5 pages', async () => {
+    let pagesYielded = 0;
+    mockOctokitInstance.paginate.iterator = vi.fn().mockReturnValue(
+      (async function* () {
+        for (let page = 0; page < 10; page++) {
+          pagesYielded++;
+          yield { data: [{ full_name: `org/repo${page}` }] };
+        }
+      })(),
+    );
+
+    const repos = await discovery.fetchStarredRepos();
+    expect(repos).toHaveLength(5);
+    expect(pagesYielded).toBe(5);
+  });
+
+  it('should fall back to cached repos on API error', async () => {
+    mockStateForSearch({ starredRepos: ['cached/repo1', 'cached/repo2'] });
+    mockOctokitInstance.paginate.iterator = vi.fn().mockReturnValue({
+      [Symbol.asyncIterator]() {
+        return { next: () => Promise.reject(new Error('API error')) };
+      },
+    });
+    discovery = new IssueDiscovery('fake-token');
+
+    const repos = await discovery.fetchStarredRepos();
+    expect(repos).toEqual(['cached/repo1', 'cached/repo2']);
+  });
+
+  it('should warn when no cached repos available on error', async () => {
+    mockStateForSearch({ starredRepos: [] });
+    mockOctokitInstance.paginate.iterator = vi.fn().mockReturnValue({
+      [Symbol.asyncIterator]() {
+        return { next: () => Promise.reject(new Error('Network timeout')) };
+      },
+    });
+    discovery = new IssueDiscovery('fake-token');
+
+    const repos = await discovery.fetchStarredRepos();
+    expect(repos).toEqual([]);
+  });
+});
+
+describe('getStarredReposWithRefresh', () => {
+  it('should fetch from API when cache is stale', async () => {
+    mockStateForSearch({ starredRepos: ['old/repo'], isStarredReposStale: true });
+    mockOctokitInstance = fullOctokitMock();
+    mockOctokitInstance.paginate = {
+      iterator: vi.fn().mockReturnValue(
+        (async function* () {
+          yield { data: [{ full_name: 'fresh/repo' }] };
+        })(),
+      ),
+    };
+    const discovery = new IssueDiscovery('fake-token');
+
+    const repos = await discovery.getStarredReposWithRefresh();
+    expect(repos).toContain('fresh/repo');
+  });
+
+  it('should return cached repos when cache is fresh', async () => {
+    mockStateForSearch({ starredRepos: ['cached/repo'], isStarredReposStale: false });
+    mockOctokitInstance = fullOctokitMock();
+    const discovery = new IssueDiscovery('fake-token');
+
+    const repos = await discovery.getStarredReposWithRefresh();
+    expect(repos).toEqual(['cached/repo']);
+  });
+});
+
+describe('searchIssues orchestration', () => {
+  beforeEach(async () => {
+    // Restore http-cache mocks (clearAllMocks would wipe their implementations)
+    const httpCache = await import('./http-cache.js');
+    const mockCache = {
+      getIfFresh: vi.fn().mockReturnValue(null),
+      get: vi.fn().mockReturnValue(null),
+      set: vi.fn(),
+      hasInflight: vi.fn().mockReturnValue(false),
+      getInflight: vi.fn().mockReturnValue(undefined),
+      setInflight: vi.fn().mockReturnValue(() => {}),
+    };
+    vi.mocked(httpCache.getHttpCache).mockReturnValue(mockCache as any);
+    vi.mocked(httpCache.cachedTimeBased).mockImplementation(
+      async (cache: any, _key: string, _maxAgeMs: number, fetcher: () => Promise<unknown>) => {
+        const cached = cache.getIfFresh(_key, _maxAgeMs);
+        if (cached) return cached;
+        const result = await fetcher();
+        cache.set(_key, '', result);
+        return result;
+      },
+    );
+    vi.mocked(httpCache.cachedRequest).mockImplementation(
+      async (_cache: unknown, _url: string, fetcher: (h: Record<string, string>) => Promise<{ data: unknown }>) => {
+        const response = await fetcher({});
+        return response.data;
+      },
+    );
+    // Restore default rate limit mock
+    vi.mocked(checkRateLimit).mockResolvedValue({
+      remaining: 30,
+      limit: 30,
+      resetAt: new Date().toISOString(),
+    });
+  });
+
+  describe('Phase 0: merged-PR and open-PR repos', () => {
+    it('should search merged-PR repos with established query (no label filter)', async () => {
+      mockStateForSearch({ mergedPRRepos: ['merged/repo1'] });
+      mockOctokitInstance = fullOctokitMock((params) => {
+        if (params.q?.includes('repo:merged/repo1')) {
+          return Promise.resolve({
+            data: { total_count: 1, items: [makeSearchItem('merged/repo1', 1)] },
+          });
+        }
+        return Promise.resolve({ data: { total_count: 0, items: [] } });
+      });
+      const discovery = new IssueDiscovery('fake-token');
+
+      const candidates = await discovery.searchIssues({ maxResults: 5 });
+      expect(candidates.length).toBeGreaterThanOrEqual(1);
+      expect(candidates[0].issue.repo).toBe('merged/repo1');
+    });
+
+    it('should search open-PR repos after merged-PR repos', async () => {
+      mockStateForSearch({
+        mergedPRRepos: ['merged/repo'],
+        openPRRepos: ['open/repo'],
+      });
+      mockOctokitInstance = fullOctokitMock((params) => {
+        if (params.q?.includes('repo:open/repo')) {
+          return Promise.resolve({
+            data: { total_count: 1, items: [makeSearchItem('open/repo', 1)] },
+          });
+        }
+        if (params.q?.includes('repo:merged/repo')) {
+          return Promise.resolve({
+            data: { total_count: 1, items: [makeSearchItem('merged/repo', 2)] },
+          });
+        }
+        return Promise.resolve({ data: { total_count: 0, items: [] } });
+      });
+      const discovery = new IssueDiscovery('fake-token');
+
+      const candidates = await discovery.searchIssues({ maxResults: 10 });
+      const repos = candidates.map((c) => c.issue.repo);
+      expect(repos).toContain('merged/repo');
+      expect(repos).toContain('open/repo');
+    });
+
+    it('should skip Phase 0 when no merged/open PR repos', async () => {
+      mockStateForSearch({ mergedPRRepos: [], openPRRepos: [] });
+      mockOctokitInstance = fullOctokitMock((params) => {
+        if (params.q?.includes('good first issue')) {
+          return Promise.resolve({
+            data: { total_count: 1, items: [makeSearchItem('phase2/repo', 1)] },
+          });
+        }
+        return Promise.resolve({ data: { total_count: 0, items: [] } });
+      });
+      const discovery = new IssueDiscovery('fake-token');
+
+      const candidates = await discovery.searchIssues({ maxResults: 5 });
+      // Should still find results from later phases
+      expect(candidates.length).toBeGreaterThanOrEqual(1);
+
+      // Verify no batched repo: queries were made (Phase 0 uses `searchInRepos` which builds
+      // queries with "(repo:a OR repo:b)" syntax — distinct from vetting's single repo: queries)
+      const calls = mockOctokitInstance.search.issuesAndPullRequests.mock.calls;
+      const batchedRepoCalls = calls.filter((c: any[]) => {
+        const q = c[0]?.q ?? '';
+        return q.includes('(repo:') && q.includes(' OR ');
+      });
+      expect(batchedRepoCalls).toHaveLength(0);
+    });
+
+    it('should cap Phase 0 repos at 10', async () => {
+      const manyRepos = Array.from({ length: 15 }, (_, i) => `org/repo${i}`);
+      mockStateForSearch({ mergedPRRepos: manyRepos });
+      mockOctokitInstance = fullOctokitMock(() => Promise.resolve({ data: { total_count: 0, items: [] } }));
+      const discovery = new IssueDiscovery('fake-token');
+
+      await expect(discovery.searchIssues({ maxResults: 5 })).rejects.toThrow(/No issue candidates found/);
+
+      // Check that repo: queries don't include repos beyond the cap
+      const calls = mockOctokitInstance.search.issuesAndPullRequests.mock.calls;
+      const allQueries = calls.map((c: any[]) => c[0]?.q ?? '').join(' ');
+      // repo10 through repo14 should not appear (slice(0,10) keeps repo0-repo9)
+      expect(allQueries).not.toContain('repo:org/repo10');
+      expect(allQueries).not.toContain('repo:org/repo14');
+    });
+
+    it('should search open-PR repos independently when merged repos fill Phase 0a', async () => {
+      // Open-PR repos that are NOT in mergedPRRepos — covers the openPhase0Repos branch
+      mockStateForSearch({
+        mergedPRRepos: ['merged/repo'],
+        openPRRepos: ['open/repo'],
+      });
+      mockOctokitInstance = fullOctokitMock((params) => {
+        if (params.q?.includes('repo:merged/repo') && !params.q?.includes('repo:open/repo')) {
+          return Promise.resolve({
+            data: { total_count: 1, items: [makeSearchItem('merged/repo', 1)] },
+          });
+        }
+        if (params.q?.includes('repo:open/repo')) {
+          return Promise.resolve({
+            data: { total_count: 1, items: [makeSearchItem('open/repo', 2)] },
+          });
+        }
+        return Promise.resolve({ data: { total_count: 0, items: [] } });
+      });
+      const discovery = new IssueDiscovery('fake-token');
+
+      const candidates = await discovery.searchIssues({ maxResults: 10 });
+      const repos = candidates.map((c) => c.issue.repo);
+      expect(repos).toContain('open/repo');
+    });
+
+    it('should omit language filter when languages includes "any"', async () => {
+      mockStateForSearch({
+        config: { languages: ['any'] },
+      });
+      mockOctokitInstance = fullOctokitMock((params) => {
+        if (params.q?.includes('good first issue')) {
+          return Promise.resolve({
+            data: { total_count: 1, items: [makeSearchItem('any/repo', 1)] },
+          });
+        }
+        return Promise.resolve({ data: { total_count: 0, items: [] } });
+      });
+      const discovery = new IssueDiscovery('fake-token');
+
+      const candidates = await discovery.searchIssues({ maxResults: 5 });
+      expect(candidates.length).toBeGreaterThanOrEqual(1);
+
+      // Verify no language: filter in the query
+      const calls = mockOctokitInstance.search.issuesAndPullRequests.mock.calls;
+      const hasLanguageFilter = calls.some((c: any[]) => c[0]?.q?.includes('language:'));
+      expect(hasLanguageFilter).toBe(false);
+    });
+
+    it('should track phase0Error when all batches fail', async () => {
+      mockStateForSearch({ mergedPRRepos: ['merged/repo1'] });
+      const error = new Error('Server error');
+      mockOctokitInstance = fullOctokitMock((params) => {
+        if (params.q?.includes('repo:')) {
+          return Promise.reject(error);
+        }
+        return Promise.resolve({ data: { total_count: 0, items: [] } });
+      });
+      const discovery = new IssueDiscovery('fake-token');
+
+      // Should still throw since no results were found anywhere
+      await expect(discovery.searchIssues({ maxResults: 5 })).rejects.toThrow(/Phase 0/);
+    });
+
+    it('should track rateLimitHit from Phase 0', async () => {
+      mockStateForSearch({ mergedPRRepos: ['merged/repo1'] });
+      const rateLimitError = Object.assign(new Error('rate limit exceeded'), { status: 403 });
+      mockOctokitInstance = fullOctokitMock((params) => {
+        if (params.q?.includes('repo:')) {
+          return Promise.reject(rateLimitError);
+        }
+        return Promise.resolve({ data: { total_count: 0, items: [] } });
+      });
+      const discovery = new IssueDiscovery('fake-token');
+
+      // With rate limit and no results, should return [] with rateLimitWarning
+      const candidates = await discovery.searchIssues({ maxResults: 5 });
+      expect(candidates).toEqual([]);
+      expect(discovery.rateLimitWarning).toBeTruthy();
+    });
+  });
+
+  describe('Phase 0.5: preferred orgs', () => {
+    it('should search preferred orgs with org: filter', async () => {
+      mockStateForSearch({ config: { preferredOrgs: ['myorg'] } });
+      mockOctokitInstance = fullOctokitMock((params) => {
+        if (params.q?.includes('org:myorg')) {
+          return Promise.resolve({
+            data: { total_count: 1, items: [makeSearchItem('myorg/repo', 1)] },
+          });
+        }
+        return Promise.resolve({ data: { total_count: 0, items: [] } });
+      });
+      const discovery = new IssueDiscovery('fake-token');
+
+      const candidates = await discovery.searchIssues({ maxResults: 5 });
+      expect(candidates.length).toBeGreaterThanOrEqual(1);
+      expect(candidates.some((c) => c.issue.repo === 'myorg/repo')).toBe(true);
+    });
+
+    it('should skip orgs already covered by Phase 0 repos', async () => {
+      mockStateForSearch({
+        mergedPRRepos: ['myorg/repo1'],
+        config: { preferredOrgs: ['myorg'] },
+      });
+      mockOctokitInstance = fullOctokitMock((params) => {
+        if (params.q?.includes('repo:myorg/repo1')) {
+          return Promise.resolve({
+            data: { total_count: 1, items: [makeSearchItem('myorg/repo1', 1)] },
+          });
+        }
+        return Promise.resolve({ data: { total_count: 0, items: [] } });
+      });
+      const discovery = new IssueDiscovery('fake-token');
+
+      await discovery.searchIssues({ maxResults: 10 });
+
+      // No org: query should have been made since myorg is covered by Phase 0
+      const calls = mockOctokitInstance.search.issuesAndPullRequests.mock.calls;
+      const orgCalls = calls.filter((c: any[]) => c[0]?.q?.includes('org:myorg'));
+      expect(orgCalls).toHaveLength(0);
+    });
+
+    it('should handle API error in preferred org search', async () => {
+      mockStateForSearch({ config: { preferredOrgs: ['failorg'] } });
+      mockOctokitInstance = fullOctokitMock((params) => {
+        if (params.q?.includes('org:failorg')) {
+          return Promise.reject(new Error('API error'));
+        }
+        return Promise.resolve({ data: { total_count: 0, items: [] } });
+      });
+      const discovery = new IssueDiscovery('fake-token');
+
+      // Should include error details for the org phase
+      await expect(discovery.searchIssues({ maxResults: 5 })).rejects.toThrow(/Phase 0\.5/);
+    });
+
+    it('should track rateLimitHit from preferred org search', async () => {
+      mockStateForSearch({ config: { preferredOrgs: ['limitorg'] } });
+      const rateLimitError = Object.assign(new Error('rate limit exceeded'), { status: 403 });
+      mockOctokitInstance = fullOctokitMock((params) => {
+        if (params.q?.includes('org:limitorg')) {
+          return Promise.reject(rateLimitError);
+        }
+        return Promise.resolve({ data: { total_count: 0, items: [] } });
+      });
+      const discovery = new IssueDiscovery('fake-token');
+
+      const candidates = await discovery.searchIssues({ maxResults: 5 });
+      expect(candidates).toEqual([]);
+      expect(discovery.rateLimitWarning).toBeTruthy();
+    });
+  });
+
+  describe('Phase 1: starred repos', () => {
+    it('should search starred repos excluding Phase 0 repos', async () => {
+      mockStateForSearch({
+        mergedPRRepos: ['merged/repo'],
+        starredRepos: ['merged/repo', 'starred/repo'],
+      });
+      mockOctokitInstance = fullOctokitMock((params) => {
+        if (params.q?.includes('repo:starred/repo')) {
+          return Promise.resolve({
+            data: { total_count: 1, items: [makeSearchItem('starred/repo', 1)] },
+          });
+        }
+        if (params.q?.includes('repo:merged/repo')) {
+          return Promise.resolve({ data: { total_count: 0, items: [] } });
+        }
+        return Promise.resolve({ data: { total_count: 0, items: [] } });
+      });
+      const discovery = new IssueDiscovery('fake-token');
+
+      const candidates = await discovery.searchIssues({ maxResults: 10 });
+      const repos = candidates.map((c) => c.issue.repo);
+      expect(repos).toContain('starred/repo');
+    });
+
+    it('should skip Phase 1 when maxResults already met', async () => {
+      mockStateForSearch({
+        mergedPRRepos: ['merged/repo'],
+        starredRepos: ['starred/repo'],
+      });
+      mockOctokitInstance = fullOctokitMock((params) => {
+        if (params.q?.includes('repo:merged/repo')) {
+          return Promise.resolve({
+            data: { total_count: 1, items: [makeSearchItem('merged/repo', 1)] },
+          });
+        }
+        return Promise.resolve({ data: { total_count: 0, items: [] } });
+      });
+      const discovery = new IssueDiscovery('fake-token');
+
+      const candidates = await discovery.searchIssues({ maxResults: 1 });
+      expect(candidates).toHaveLength(1);
+
+      // Verify starred/repo was NOT searched
+      const calls = mockOctokitInstance.search.issuesAndPullRequests.mock.calls;
+      const starredCalls = calls.filter((c: any[]) => c[0]?.q?.includes('repo:starred/repo'));
+      expect(starredCalls).toHaveLength(0);
+    });
+  });
+
+  describe('Phase 2: multi-tier interleaving', () => {
+    it('should fire one query per scope tier when multiple scopes', async () => {
+      mockStateForSearch({
+        config: {
+          scope: ['beginner', 'intermediate'],
+          labels: [],
+        },
+      });
+      mockOctokitInstance = fullOctokitMock((params) => {
+        if (params.q?.includes('good first issue')) {
+          return Promise.resolve({
+            data: { total_count: 1, items: [makeSearchItem('beginner/repo', 1)] },
+          });
+        }
+        if (params.q?.includes('help wanted')) {
+          return Promise.resolve({
+            data: { total_count: 1, items: [makeSearchItem('intermediate/repo', 2)] },
+          });
+        }
+        return Promise.resolve({ data: { total_count: 0, items: [] } });
+      });
+      const discovery = new IssueDiscovery('fake-token');
+
+      const candidates = await discovery.searchIssues({ maxResults: 10 });
+      // Should have results from both tiers
+      expect(candidates.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should use single tier when only one scope', async () => {
+      mockStateForSearch({
+        config: { scope: ['beginner'], labels: [] },
+      });
+      mockOctokitInstance = fullOctokitMock((params) => {
+        if (params.q?.includes('good first issue')) {
+          return Promise.resolve({
+            data: { total_count: 1, items: [makeSearchItem('only/repo', 1)] },
+          });
+        }
+        return Promise.resolve({ data: { total_count: 0, items: [] } });
+      });
+      const discovery = new IssueDiscovery('fake-token');
+
+      const candidates = await discovery.searchIssues({ maxResults: 10 });
+      expect(candidates.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should re-throw 401 errors', async () => {
+      mockStateForSearch();
+      const authError = Object.assign(new Error('Bad credentials'), { status: 401 });
+      mockOctokitInstance = fullOctokitMock(() => Promise.reject(authError));
+      const discovery = new IssueDiscovery('fake-token');
+
+      await expect(discovery.searchIssues({ maxResults: 5 })).rejects.toThrow('Bad credentials');
+    });
+
+    it('should handle scope with no labels gracefully', async () => {
+      // Use an invalid scope that has no SCOPE_LABELS entry
+      mockStateForSearch({
+        config: {
+          scope: ['beginner', 'nonexistent_scope' as any],
+          labels: [],
+        },
+      });
+      mockOctokitInstance = fullOctokitMock((params) => {
+        if (params.q?.includes('good first issue')) {
+          return Promise.resolve({
+            data: { total_count: 1, items: [makeSearchItem('beginner/repo', 1)] },
+          });
+        }
+        return Promise.resolve({ data: { total_count: 0, items: [] } });
+      });
+      const discovery = new IssueDiscovery('fake-token');
+
+      // Should still find results from valid scope, invalid scope is skipped
+      const candidates = await discovery.searchIssues({ maxResults: 5 });
+      expect(candidates.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should create custom pseudo-tier for labels not in any scope', async () => {
+      mockStateForSearch({
+        config: {
+          scope: ['beginner', 'intermediate'],
+          labels: ['custom-label'],
+        },
+      });
+      mockOctokitInstance = fullOctokitMock((params) => {
+        if (params.q?.includes('custom-label')) {
+          return Promise.resolve({
+            data: { total_count: 1, items: [makeSearchItem('custom/repo', 1)] },
+          });
+        }
+        if (params.q?.includes('good first issue')) {
+          return Promise.resolve({
+            data: { total_count: 1, items: [makeSearchItem('beginner/repo', 2)] },
+          });
+        }
+        return Promise.resolve({ data: { total_count: 0, items: [] } });
+      });
+      const discovery = new IssueDiscovery('fake-token');
+
+      const candidates = await discovery.searchIssues({ maxResults: 10 });
+      expect(candidates.length).toBeGreaterThanOrEqual(1);
+
+      // Verify the custom label was queried
+      const calls = mockOctokitInstance.search.issuesAndPullRequests.mock.calls;
+      const customCalls = calls.filter((c: any[]) => c[0]?.q?.includes('custom-label'));
+      expect(customCalls.length).toBeGreaterThan(0);
+    });
+
+    it('should interleave results from multiple tiers', async () => {
+      mockStateForSearch({
+        config: {
+          scope: ['beginner', 'intermediate'],
+          labels: [],
+        },
+      });
+      mockOctokitInstance = fullOctokitMock((params) => {
+        if (params.q?.includes('good first issue') && !params.q?.includes('help wanted')) {
+          return Promise.resolve({
+            data: {
+              total_count: 2,
+              items: [makeSearchItem('beginner/repo1', 1), makeSearchItem('beginner/repo2', 2)],
+            },
+          });
+        }
+        if (params.q?.includes('help wanted')) {
+          return Promise.resolve({
+            data: {
+              total_count: 1,
+              items: [makeSearchItem('intermediate/repo1', 3)],
+            },
+          });
+        }
+        return Promise.resolve({ data: { total_count: 0, items: [] } });
+      });
+      const discovery = new IssueDiscovery('fake-token');
+
+      const candidates = await discovery.searchIssues({ maxResults: 10 });
+      // Should have results from both tiers
+      const repos = candidates.map((c) => c.issue.repo);
+      const hasBeginner = repos.some((r) => r.startsWith('beginner/'));
+      const hasIntermediate = repos.some((r) => r.startsWith('intermediate/'));
+      expect(hasBeginner || hasIntermediate).toBe(true);
+    });
+  });
+
+  describe('result aggregation and sorting', () => {
+    it('should sort by priority > recommendation > score', async () => {
+      mockStateForSearch({
+        mergedPRRepos: ['merged/repo'],
+        starredRepos: ['starred/repo'],
+      });
+      mockOctokitInstance = fullOctokitMock((params) => {
+        if (params.q?.includes('repo:merged/repo')) {
+          return Promise.resolve({
+            data: { total_count: 1, items: [makeSearchItem('merged/repo', 1)] },
+          });
+        }
+        if (params.q?.includes('repo:starred/repo')) {
+          return Promise.resolve({
+            data: { total_count: 1, items: [makeSearchItem('starred/repo', 2)] },
+          });
+        }
+        if (params.q?.includes('good first issue')) {
+          return Promise.resolve({
+            data: { total_count: 1, items: [makeSearchItem('general/repo', 3)] },
+          });
+        }
+        return Promise.resolve({ data: { total_count: 0, items: [] } });
+      });
+      const discovery = new IssueDiscovery('fake-token');
+
+      const candidates = await discovery.searchIssues({ maxResults: 10 });
+      expect(candidates.length).toBeGreaterThanOrEqual(2);
+      // merged_pr priority should come before starred/normal
+      const mergedIdx = candidates.findIndex((c) => c.searchPriority === 'merged_pr');
+      const normalIdx = candidates.findIndex((c) => c.searchPriority === 'normal');
+      expect(mergedIdx).toBeGreaterThanOrEqual(0);
+      expect(normalIdx).toBeGreaterThanOrEqual(0);
+      expect(mergedIdx).toBeLessThan(normalIdx);
+    });
+
+    it('should apply per-repo cap of 2', async () => {
+      mockStateForSearch();
+      mockOctokitInstance = fullOctokitMock((params) => {
+        if (params.q?.includes('good first issue')) {
+          return Promise.resolve({
+            data: {
+              total_count: 4,
+              items: [
+                makeSearchItem('same/repo', 1),
+                makeSearchItem('same/repo', 2),
+                makeSearchItem('same/repo', 3),
+                makeSearchItem('other/repo', 4),
+              ],
+            },
+          });
+        }
+        return Promise.resolve({ data: { total_count: 0, items: [] } });
+      });
+      const discovery = new IssueDiscovery('fake-token');
+
+      const candidates = await discovery.searchIssues({ maxResults: 10 });
+      const sameRepoCount = candidates.filter((c) => c.issue.repo === 'same/repo').length;
+      expect(sameRepoCount).toBeLessThanOrEqual(2);
+    });
+
+    it('should respect maxResults limit', async () => {
+      mockStateForSearch();
+      mockOctokitInstance = fullOctokitMock((params) => {
+        if (params.q?.includes('good first issue')) {
+          return Promise.resolve({
+            data: {
+              total_count: 5,
+              items: [
+                makeSearchItem('repo/a', 1),
+                makeSearchItem('repo/b', 2),
+                makeSearchItem('repo/c', 3),
+                makeSearchItem('repo/d', 4),
+                makeSearchItem('repo/e', 5),
+              ],
+            },
+          });
+        }
+        return Promise.resolve({ data: { total_count: 0, items: [] } });
+      });
+      const discovery = new IssueDiscovery('fake-token');
+
+      const candidates = await discovery.searchIssues({ maxResults: 3 });
+      expect(candidates.length).toBeLessThanOrEqual(3);
+    });
+  });
+
+  describe('Phase 2/3 vetting failures', () => {
+    it('should track allVetFailed in Phase 2 when all vetting fails', async () => {
+      mockStateForSearch();
+      mockOctokitInstance = fullOctokitMock((params) => {
+        if (params.q?.includes('good first issue')) {
+          return Promise.resolve({
+            data: { total_count: 1, items: [makeSearchItem('vet-fail/repo', 1)] },
+          });
+        }
+        return Promise.resolve({ data: { total_count: 0, items: [] } });
+      });
+      // Make issues.get throw to cause vetting failure
+      mockOctokitInstance.issues.get.mockRejectedValue(new Error('Not Found'));
+      const discovery = new IssueDiscovery('fake-token');
+
+      // When vetting fails but no rate limit, we get a ValidationError
+      await expect(discovery.searchIssues({ maxResults: 5 })).rejects.toThrow(/No issue candidates found/);
+    });
+
+    it('should track rateLimitHit from Phase 2 vetting', async () => {
+      mockStateForSearch();
+      mockOctokitInstance = fullOctokitMock((params) => {
+        if (params.q?.includes('good first issue')) {
+          return Promise.resolve({
+            data: { total_count: 1, items: [makeSearchItem('ratelimit/repo', 1)] },
+          });
+        }
+        return Promise.resolve({ data: { total_count: 0, items: [] } });
+      });
+      // Make repos.get throw with rate limit to trigger rateLimitHit from vetter
+      const rateLimitError = Object.assign(new Error('rate limit exceeded'), { status: 403 });
+      mockOctokitInstance.issues.get.mockRejectedValue(rateLimitError);
+      const discovery = new IssueDiscovery('fake-token');
+
+      const candidates = await discovery.searchIssues({ maxResults: 5 });
+      expect(candidates).toEqual([]);
+      expect(discovery.rateLimitWarning).toBeTruthy();
+    });
+
+    it('should track Phase 3 vetting failure', async () => {
+      mockStateForSearch();
+      mockOctokitInstance = fullOctokitMock((params) => {
+        // Phase 2 returns empty, Phase 3 finds an issue
+        if (params.q?.includes('archived:false')) {
+          return Promise.resolve({
+            data: { total_count: 1, items: [makeSearchItem('maintained/repo', 1)] },
+          });
+        }
+        return Promise.resolve({ data: { total_count: 0, items: [] } });
+      });
+      // Make all vetting fail
+      mockOctokitInstance.issues.get.mockRejectedValue(new Error('Not Found'));
+      const discovery = new IssueDiscovery('fake-token');
+
+      await expect(discovery.searchIssues({ maxResults: 5 })).rejects.toThrow(/No issue candidates found/);
+    });
+
+    it('should track Phase 3 rateLimitHit from vetting', async () => {
+      mockStateForSearch();
+      mockOctokitInstance = fullOctokitMock((params) => {
+        // Phase 2 returns empty, Phase 3 finds an issue
+        if (params.q?.includes('archived:false')) {
+          return Promise.resolve({
+            data: { total_count: 1, items: [makeSearchItem('maintained/repo', 1)] },
+          });
+        }
+        return Promise.resolve({ data: { total_count: 0, items: [] } });
+      });
+      // Make vetting hit rate limit
+      const rateLimitError = Object.assign(new Error('rate limit exceeded'), { status: 403 });
+      mockOctokitInstance.issues.get.mockRejectedValue(rateLimitError);
+      const discovery = new IssueDiscovery('fake-token');
+
+      const candidates = await discovery.searchIssues({ maxResults: 5 });
+      expect(candidates).toEqual([]);
+      expect(discovery.rateLimitWarning).toBeTruthy();
+    });
+  });
+
+  describe('rate limit handling', () => {
+    it('should set rateLimitWarning on low pre-flight quota', async () => {
+      mockStateForSearch();
+      vi.mocked(checkRateLimit).mockResolvedValueOnce({
+        remaining: 2,
+        limit: 30,
+        resetAt: new Date().toISOString(),
+      });
+      mockOctokitInstance = fullOctokitMock((params) => {
+        if (params.q?.includes('good first issue')) {
+          return Promise.resolve({
+            data: { total_count: 1, items: [makeSearchItem('any/repo', 1)] },
+          });
+        }
+        return Promise.resolve({ data: { total_count: 0, items: [] } });
+      });
+      const discovery = new IssueDiscovery('fake-token');
+
+      await discovery.searchIssues({ maxResults: 5 });
+      expect(discovery.rateLimitWarning).toContain('quota low');
+    });
+
+    it('should return [] when all phases fail due to rate limits', async () => {
+      mockStateForSearch();
+      const rateLimitError = Object.assign(new Error('rate limit exceeded'), { status: 403 });
+      mockOctokitInstance = fullOctokitMock(() => Promise.reject(rateLimitError));
+      const discovery = new IssueDiscovery('fake-token');
+
+      const candidates = await discovery.searchIssues({ maxResults: 5 });
+      expect(candidates).toEqual([]);
+      expect(discovery.rateLimitWarning).toBeTruthy();
+    });
+
+    it('should throw ValidationError when no results and no rate limits', async () => {
+      mockStateForSearch();
+      mockOctokitInstance = fullOctokitMock(() => Promise.resolve({ data: { total_count: 0, items: [] } }));
+      const discovery = new IssueDiscovery('fake-token');
+
+      await expect(discovery.searchIssues({ maxResults: 5 })).rejects.toThrow(/No issue candidates found/);
+    });
+
+    it('should set partial warning on rate-limited search with some results', async () => {
+      mockStateForSearch();
+      let callCount = 0;
+      const rateLimitError = Object.assign(new Error('rate limit exceeded'), { status: 403 });
+      mockOctokitInstance = fullOctokitMock((params) => {
+        callCount++;
+        // First call (Phase 2) returns results, Phase 3 hits rate limit
+        if (callCount === 1 && params.q?.includes('good first issue')) {
+          return Promise.resolve({
+            data: { total_count: 1, items: [makeSearchItem('partial/repo', 1)] },
+          });
+        }
+        if (params.q?.includes('archived:false')) {
+          return Promise.reject(rateLimitError);
+        }
+        return Promise.resolve({ data: { total_count: 0, items: [] } });
+      });
+      const discovery = new IssueDiscovery('fake-token');
+
+      const candidates = await discovery.searchIssues({ maxResults: 10 });
+      expect(candidates.length).toBeGreaterThan(0);
+      expect(discovery.rateLimitWarning).toContain('incomplete');
+    });
   });
 });

--- a/packages/core/src/core/search-phases.test.ts
+++ b/packages/core/src/core/search-phases.test.ts
@@ -1,6 +1,40 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { buildLabelQuery, buildEffectiveLabels, interleaveArrays, batchRepos } from './search-phases.js';
 import { SCOPE_LABELS } from './types.js';
+import type { GitHubSearchItem } from './issue-filtering.js';
+import { makeGitHubSearchItem, makeIssueCandidate } from './test-utils.js';
+
+// ── Mocks for infrastructure function tests ──
+
+/** Build a fresh http-cache mock with all cache misses (null returns) */
+function makeCacheMock() {
+  return {
+    getIfFresh: vi.fn().mockReturnValue(null),
+    get: vi.fn().mockReturnValue(null),
+    set: vi.fn(),
+    hasInflight: vi.fn().mockReturnValue(false),
+    getInflight: vi.fn().mockReturnValue(undefined),
+    setInflight: vi.fn().mockReturnValue(() => {}),
+  };
+}
+
+vi.mock('./http-cache.js', () => ({
+  getHttpCache: vi.fn().mockReturnValue(makeCacheMock()),
+  cachedTimeBased: vi
+    .fn()
+    .mockImplementation(async (cache: any, _key: string, _maxAgeMs: number, fetcher: () => Promise<unknown>) => {
+      const cached = cache.getIfFresh(_key, _maxAgeMs);
+      if (cached) return cached;
+      const result = await fetcher();
+      cache.set(_key, '', result);
+      return result;
+    }),
+}));
+
+const { cachedSearchIssues, filterVetAndScore, searchInRepos } = await import('./search-phases.js');
+const { getHttpCache, cachedTimeBased } = await import('./http-cache.js');
+
+// ── Pure function tests (existing) ──
 
 describe('buildLabelQuery', () => {
   it('returns empty string for no labels', () => {
@@ -115,5 +149,329 @@ describe('batchRepos', () => {
       ['a', 'b'],
       ['c', 'd'],
     ]);
+  });
+});
+
+// ── Infrastructure function tests ──
+
+describe('cachedSearchIssues', () => {
+  let mockOctokit: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockOctokit = {
+      search: {
+        issuesAndPullRequests: vi.fn().mockResolvedValue({
+          data: { total_count: 1, items: [makeGitHubSearchItem('owner/repo', 1)] },
+        }),
+      },
+    };
+    vi.mocked(getHttpCache).mockReturnValue(makeCacheMock() as any);
+  });
+
+  it('should call octokit.search with provided params', async () => {
+    const params = { q: 'is:issue is:open', sort: 'created' as const, order: 'desc' as const, per_page: 10 };
+    await cachedSearchIssues(mockOctokit, params);
+    expect(mockOctokit.search.issuesAndPullRequests).toHaveBeenCalledWith(params);
+  });
+
+  it('should return data from octokit response', async () => {
+    const result = await cachedSearchIssues(mockOctokit, {
+      q: 'is:issue',
+      sort: 'created',
+      order: 'desc',
+      per_page: 10,
+    });
+    expect(result).toHaveProperty('total_count', 1);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].html_url).toContain('owner/repo');
+  });
+
+  it('should build cache key from query, sort, order, per_page', async () => {
+    const params = { q: 'is:issue label:"bug"', sort: 'updated' as const, order: 'asc' as const, per_page: 25 };
+    await cachedSearchIssues(mockOctokit, params);
+    const calledKey = vi.mocked(cachedTimeBased).mock.calls[0][1];
+    expect(calledKey).toBe('search:is:issue label:"bug":updated:asc:25');
+  });
+
+  it('should return cached result when cache has fresh data', async () => {
+    const cachedData = { total_count: 5, items: [makeGitHubSearchItem('cached/repo', 99)] };
+    const cache = makeCacheMock();
+    cache.getIfFresh.mockReturnValue(cachedData);
+    vi.mocked(getHttpCache).mockReturnValue(cache as any);
+
+    const result = await cachedSearchIssues(mockOctokit, {
+      q: 'is:issue',
+      sort: 'created',
+      order: 'desc',
+      per_page: 10,
+    });
+    expect(result).toEqual(cachedData);
+    expect(mockOctokit.search.issuesAndPullRequests).not.toHaveBeenCalled();
+  });
+});
+
+describe('filterVetAndScore', () => {
+  let mockVetter: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockVetter = {
+      vetIssuesParallel: vi.fn().mockResolvedValue({
+        candidates: [makeIssueCandidate()],
+        allFailed: false,
+        rateLimitHit: false,
+      }),
+    };
+  });
+
+  it('should remove spam repos detected by label farming', async () => {
+    // Create items from a spammy repo (5+ beginner labels triggers farming detection)
+    const spamItem = makeGitHubSearchItem('spam/repo', 1, {
+      labels: [
+        { name: 'good first issue' },
+        { name: 'hacktoberfest' },
+        { name: 'easy' },
+        { name: 'beginner' },
+        { name: 'starter' },
+      ],
+    });
+    const legitItem = makeGitHubSearchItem('legit/repo', 2);
+
+    await filterVetAndScore(mockVetter, [spamItem, legitItem], (items) => items, [], 10, 0, 'test');
+
+    // Vetter should only receive the legit item's URL
+    const vettedUrls = mockVetter.vetIssuesParallel.mock.calls[0][0];
+    expect(vettedUrls).toEqual([legitItem.html_url]);
+  });
+
+  it('should apply caller-provided filterFn', async () => {
+    const items = [
+      makeGitHubSearchItem('owner/repo', 1),
+      makeGitHubSearchItem('owner/repo', 2),
+      makeGitHubSearchItem('owner/repo', 3),
+    ];
+
+    // Filter keeps only issue #2
+    const filterFn = (items: GitHubSearchItem[]) => items.filter((i) => i.html_url.includes('/2'));
+
+    await filterVetAndScore(mockVetter, items, filterFn, [], 10, 0, 'test');
+
+    const vettedUrls = mockVetter.vetIssuesParallel.mock.calls[0][0];
+    expect(vettedUrls).toHaveLength(1);
+    expect(vettedUrls[0]).toContain('/issues/2');
+  });
+
+  it('should exclude items matching any excludedRepoSet', async () => {
+    const items = [
+      makeGitHubSearchItem('excluded/repo', 1),
+      makeGitHubSearchItem('also-excluded/repo', 2),
+      makeGitHubSearchItem('allowed/repo', 3),
+    ];
+
+    const excluded1 = new Set(['excluded/repo']);
+    const excluded2 = new Set(['also-excluded/repo']);
+
+    await filterVetAndScore(mockVetter, items, (i) => i, [excluded1, excluded2], 10, 0, 'test');
+
+    const vettedUrls = mockVetter.vetIssuesParallel.mock.calls[0][0];
+    expect(vettedUrls).toEqual(['https://github.com/allowed/repo/issues/3']);
+  });
+
+  it('should pass filtered URLs to vetter.vetIssuesParallel', async () => {
+    const items = [makeGitHubSearchItem('owner/repo', 1), makeGitHubSearchItem('owner/repo', 2)];
+
+    await filterVetAndScore(mockVetter, items, (i) => i, [], 5, 0, 'test');
+
+    expect(mockVetter.vetIssuesParallel).toHaveBeenCalledWith(
+      ['https://github.com/owner/repo/issues/1', 'https://github.com/owner/repo/issues/2'],
+      5,
+      'normal',
+    );
+  });
+
+  it('should filter candidates below minStars', async () => {
+    mockVetter.vetIssuesParallel.mockResolvedValue({
+      candidates: [
+        makeIssueCandidate({ projectHealth: { stargazersCount: 10, checkFailed: false } as any }),
+        makeIssueCandidate({ projectHealth: { stargazersCount: 200, checkFailed: false } as any }),
+      ],
+      allFailed: false,
+      rateLimitHit: false,
+    });
+
+    const items = [makeGitHubSearchItem('low/stars', 1), makeGitHubSearchItem('high/stars', 2)];
+    const result = await filterVetAndScore(mockVetter, items, (i) => i, [], 10, 50, 'test');
+
+    expect(result.candidates).toHaveLength(1);
+    expect(result.candidates[0].projectHealth.stargazersCount).toBe(200);
+  });
+
+  it('should keep candidates when checkFailed is true regardless of stars', async () => {
+    mockVetter.vetIssuesParallel.mockResolvedValue({
+      candidates: [makeIssueCandidate({ projectHealth: { stargazersCount: 5, checkFailed: true } as any })],
+      allFailed: false,
+      rateLimitHit: false,
+    });
+
+    const items = [makeGitHubSearchItem('unknown/stars', 1)];
+    const result = await filterVetAndScore(mockVetter, items, (i) => i, [], 10, 100, 'test');
+
+    expect(result.candidates).toHaveLength(1);
+  });
+
+  it('should return empty when all items filtered before vetting', async () => {
+    const items = [makeGitHubSearchItem('excluded/repo', 1)];
+    const excluded = new Set(['excluded/repo']);
+
+    const result = await filterVetAndScore(mockVetter, items, (i) => i, [excluded], 10, 0, 'test');
+
+    expect(result.candidates).toEqual([]);
+    expect(result.allVetFailed).toBe(false);
+    expect(result.rateLimitHit).toBe(false);
+    expect(mockVetter.vetIssuesParallel).not.toHaveBeenCalled();
+  });
+
+  it('should propagate allFailed and rateLimitHit from vetter', async () => {
+    mockVetter.vetIssuesParallel.mockResolvedValue({
+      candidates: [],
+      allFailed: true,
+      rateLimitHit: true,
+    });
+
+    const items = [makeGitHubSearchItem('owner/repo', 1)];
+    const result = await filterVetAndScore(mockVetter, items, (i) => i, [], 10, 0, 'test');
+
+    expect(result.allVetFailed).toBe(true);
+    expect(result.rateLimitHit).toBe(true);
+  });
+
+  it('should cap items sent to vetter at remainingNeeded*2', async () => {
+    // Create 10 items
+    const items = Array.from({ length: 10 }, (_, i) => makeGitHubSearchItem('owner/repo', i + 1));
+
+    await filterVetAndScore(mockVetter, items, (i) => i, [], 3, 0, 'test');
+
+    // remainingNeeded=3, so max items to vet = 3*2 = 6
+    const vettedUrls = mockVetter.vetIssuesParallel.mock.calls[0][0];
+    expect(vettedUrls).toHaveLength(6);
+  });
+});
+
+describe('searchInRepos', () => {
+  let mockOctokit: any;
+  let mockVetter: any;
+  const passthrough = (items: GitHubSearchItem[]) => items;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockOctokit = {
+      search: {
+        issuesAndPullRequests: vi.fn().mockResolvedValue({
+          data: { total_count: 1, items: [makeGitHubSearchItem('owner/repo', 1)] },
+        }),
+      },
+    };
+    mockVetter = {
+      vetIssuesParallel: vi.fn().mockResolvedValue({
+        candidates: [makeIssueCandidate()],
+        allFailed: false,
+        rateLimitHit: false,
+      }),
+    };
+    vi.mocked(getHttpCache).mockReturnValue(makeCacheMock() as any);
+  });
+
+  it('should batch repos and search each batch', async () => {
+    // 7 repos with batch size 5 = 2 batches
+    const repos = ['a/1', 'a/2', 'a/3', 'a/4', 'a/5', 'a/6', 'a/7'];
+    await searchInRepos(mockOctokit, mockVetter, repos, 'is:issue', 20, 'normal', passthrough);
+
+    // Should have made 2 search calls (batches of 5)
+    expect(mockOctokit.search.issuesAndPullRequests).toHaveBeenCalledTimes(2);
+
+    // First batch query should contain repos 1-5
+    const firstQuery = mockOctokit.search.issuesAndPullRequests.mock.calls[0][0].q;
+    expect(firstQuery).toContain('repo:a/1');
+    expect(firstQuery).toContain('repo:a/5');
+
+    // Second batch query should contain repos 6-7
+    const secondQuery = mockOctokit.search.issuesAndPullRequests.mock.calls[1][0].q;
+    expect(secondQuery).toContain('repo:a/6');
+    expect(secondQuery).toContain('repo:a/7');
+  });
+
+  it('should stop searching when maxResults reached', async () => {
+    // Return 3 candidates from first batch
+    mockVetter.vetIssuesParallel.mockResolvedValue({
+      candidates: [makeIssueCandidate(), makeIssueCandidate(), makeIssueCandidate()],
+      allFailed: false,
+      rateLimitHit: false,
+    });
+
+    const repos = Array.from({ length: 15 }, (_, i) => `org/repo${i}`);
+    const result = await searchInRepos(mockOctokit, mockVetter, repos, 'is:issue', 3, 'normal', passthrough);
+
+    // Should have stopped after first batch since we got 3 candidates (= maxResults)
+    expect(result.candidates.length).toBeGreaterThanOrEqual(3);
+    expect(mockOctokit.search.issuesAndPullRequests.mock.calls.length).toBeLessThan(3);
+  });
+
+  it('should handle per-batch errors and continue', async () => {
+    // First batch fails, second succeeds
+    mockOctokit.search.issuesAndPullRequests.mockRejectedValueOnce(new Error('Server error')).mockResolvedValueOnce({
+      data: { total_count: 1, items: [makeGitHubSearchItem('org/repo6', 1)] },
+    });
+
+    const repos = Array.from({ length: 10 }, (_, i) => `org/repo${i}`);
+    const result = await searchInRepos(mockOctokit, mockVetter, repos, 'is:issue', 10, 'normal', passthrough);
+
+    expect(result.candidates.length).toBeGreaterThan(0);
+    expect(result.allBatchesFailed).toBe(false);
+  });
+
+  it('should set allBatchesFailed when all batches fail', async () => {
+    mockOctokit.search.issuesAndPullRequests.mockRejectedValue(new Error('Server error'));
+
+    const repos = ['org/repo1', 'org/repo2'];
+    const result = await searchInRepos(mockOctokit, mockVetter, repos, 'is:issue', 10, 'normal', passthrough);
+
+    expect(result.allBatchesFailed).toBe(true);
+    expect(result.candidates).toEqual([]);
+  });
+
+  it('should track rateLimitHit on rate limit error', async () => {
+    const rateLimitError = new Error('API rate limit exceeded');
+    (rateLimitError as any).status = 403;
+    mockOctokit.search.issuesAndPullRequests.mockRejectedValue(rateLimitError);
+
+    const repos = ['org/repo1'];
+    const result = await searchInRepos(mockOctokit, mockVetter, repos, 'is:issue', 10, 'normal', passthrough);
+
+    expect(result.rateLimitHit).toBe(true);
+    expect(result.allBatchesFailed).toBe(true);
+    expect(result.candidates).toEqual([]);
+  });
+
+  it('should track rateLimitHit with 429 status code', async () => {
+    const rateLimitError = new Error('Too Many Requests');
+    (rateLimitError as any).status = 429;
+    mockOctokit.search.issuesAndPullRequests.mockRejectedValue(rateLimitError);
+
+    const repos = ['org/repo1'];
+    const result = await searchInRepos(mockOctokit, mockVetter, repos, 'is:issue', 10, 'normal', passthrough);
+
+    expect(result.rateLimitHit).toBe(true);
+    expect(result.allBatchesFailed).toBe(true);
+    expect(result.candidates).toEqual([]);
+  });
+
+  it('should return empty candidates for empty repos list', async () => {
+    const result = await searchInRepos(mockOctokit, mockVetter, [], 'is:issue', 10, 'normal', passthrough);
+
+    expect(result.candidates).toEqual([]);
+    expect(result.allBatchesFailed).toBe(false);
+    expect(result.rateLimitHit).toBe(false);
+    expect(mockOctokit.search.issuesAndPullRequests).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/core/test-utils.ts
+++ b/packages/core/src/core/test-utils.ts
@@ -19,6 +19,7 @@ import type {
 import { DEFAULT_CONFIG, INITIAL_STATE } from './types.js';
 import type { CapacityAssessment } from '../formatters/json.js';
 import type { StateManager, Stats } from './state.js';
+import type { GitHubSearchItem } from './issue-filtering.js';
 
 // ---------------------------------------------------------------------------
 // FetchedPR
@@ -204,6 +205,30 @@ export function makeStateManagerMock(
     getHighScoringRepos: () => [],
     getLowScoringRepos: () => [],
   } as unknown as StateManager;
+}
+
+// ---------------------------------------------------------------------------
+// GitHubSearchItem (octokit.search.issuesAndPullRequests result item)
+// ---------------------------------------------------------------------------
+
+export function makeGitHubSearchItem(
+  repo: string,
+  number: number,
+  overrides?: Partial<GitHubSearchItem>,
+): GitHubSearchItem {
+  return {
+    id: number,
+    html_url: `https://github.com/${repo}/issues/${number}`,
+    repository_url: `https://api.github.com/repos/${repo}`,
+    updated_at: new Date().toISOString(),
+    title: `Test issue #${number}`,
+    labels: [{ name: 'good first issue' }],
+    comments: 0,
+    body: 'Test issue body with enough content to be meaningful.',
+    created_at: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+    number,
+    ...overrides,
+  };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds ~50 new test cases covering multi-phase search orchestration (`searchIssues`), starred repo fetching (`fetchStarredRepos`, `getStarredReposWithRefresh`), and infrastructure functions (`cachedSearchIssues`, `filterVetAndScore`, `searchInRepos`)
- Adds `makeGitHubSearchItem` factory to `test-utils.ts` centralizing mock construction
- No source code changes — purely additive test coverage

### Coverage results

| File | Before (stmt/branch) | After (stmt/branch) |
|------|---------------------|---------------------|
| `search-phases.ts` | 59% / 59% | 100% / 100% |
| `issue-discovery.ts` | 54% / 43% | 94% / 81% |

Closes #723

## Test plan

- [x] `pnpm test` — all 2167 tests pass (1868 core + 166 dashboard + 133 mcp-server)
- [x] `pnpm run lint` — clean
- [x] Coverage verified via `npx vitest run --coverage`