### PR TITLE
test: raise dashboard-data.ts and dashboard-server.ts coverage to 80%+

### DIFF
--- a/packages/core/src/commands/dashboard-data.test.ts
+++ b/packages/core/src/commands/dashboard-data.test.ts
@@ -921,7 +921,6 @@ describe('fetchDashboardData', () => {
 
   it('degrades gracefully when fetchRecentlyClosedPRs fails', async () => {
     mockFetchRecentlyClosedPRs.mockRejectedValue(new Error('timeout'));
-    mockIsRateLimitOrAuthError.mockReturnValue(false);
 
     const result = await fetchDashboardData('test-token');
 
@@ -942,7 +941,6 @@ describe('fetchDashboardData', () => {
 
   it('degrades gracefully when fetchRecentlyMergedPRs fails', async () => {
     mockFetchRecentlyMergedPRs.mockRejectedValue(new Error('network error'));
-    mockIsRateLimitOrAuthError.mockReturnValue(false);
 
     const result = await fetchDashboardData('test-token');
 
@@ -955,7 +953,6 @@ describe('fetchDashboardData', () => {
 
   it('degrades gracefully when fetchUserMergedPRCounts fails', async () => {
     mockFetchUserMergedPRCounts.mockRejectedValue(new Error('search API error'));
-    mockIsRateLimitOrAuthError.mockReturnValue(false);
 
     const result = await fetchDashboardData('test-token');
 
@@ -966,9 +963,29 @@ describe('fetchDashboardData', () => {
     );
   });
 
+  it('degrades gracefully when fetchUserClosedPRCounts fails', async () => {
+    mockFetchUserClosedPRCounts.mockRejectedValue(new Error('search API error'));
+
+    const result = await fetchDashboardData('test-token');
+
+    expect(result.digest).toBeDefined();
+    expect(mockWarn).toHaveBeenCalledWith(
+      'dashboard-data',
+      expect.stringContaining('Failed to fetch closed PR counts'),
+    );
+  });
+
+  it('warns on general issue conversation fetch failure', async () => {
+    mockFetchCommentedIssues.mockRejectedValue(new Error('socket timeout'));
+
+    const result = await fetchDashboardData('test-token');
+
+    expect(result.commentedIssues).toEqual([]);
+    expect(mockWarn).toHaveBeenCalledWith('dashboard-data', expect.stringContaining('Issue conversation fetch failed'));
+  });
+
   it("handles 'No GitHub username configured' from issue monitor", async () => {
     mockFetchCommentedIssues.mockRejectedValue(new Error('No GitHub username configured'));
-    mockIsRateLimitOrAuthError.mockReturnValue(false);
 
     const result = await fetchDashboardData('test-token');
 
@@ -984,7 +1001,8 @@ describe('fetchDashboardData', () => {
     mockBatch.mockImplementation(() => {
       throw new Error('disk write failed');
     });
-    // Ensure lastDigest is set despite batch failure (it was set before)
+    // Pre-populate lastDigest on state to simulate a previous successful fetch,
+    // so the function can still return data despite the batch failure
     const state = makeDefaultState();
     const digest = makeMockDigest();
     state.lastDigest = digest;
@@ -1075,6 +1093,22 @@ describe('fetchDashboardData', () => {
     expect(mockAddMergedPRs).toHaveBeenCalled();
     expect(mockAddClosedPRs).toHaveBeenCalled();
     expect(mockWarn).toHaveBeenCalledWith('dashboard-data', expect.stringContaining('Failed to store merged PRs'));
+    expect(result.digest).toBeDefined();
+  });
+
+  it('isolates addClosedPRs failure from addMergedPRs', async () => {
+    mockAddClosedPRs.mockImplementation(() => {
+      throw new Error('closed storage failed');
+    });
+    mockFetchClosedPRsSince.mockResolvedValue([
+      { url: 'https://github.com/a/b/pull/2', title: 'New closed', closedAt: '2026-01-02T00:00:00Z' },
+    ]);
+
+    const result = await fetchDashboardData('test-token');
+
+    expect(mockAddMergedPRs).toHaveBeenCalled();
+    expect(mockAddClosedPRs).toHaveBeenCalled();
+    expect(mockWarn).toHaveBeenCalledWith('dashboard-data', expect.stringContaining('Failed to store closed PRs'));
     expect(result.digest).toBeDefined();
   });
 });

--- a/packages/core/src/commands/dashboard-server.test.ts
+++ b/packages/core/src/commands/dashboard-server.test.ts
@@ -2,7 +2,9 @@
  * Tests for dashboard server (dashboard-server.ts)
  *
  * Covers: static file serving, API data endpoint, action endpoint,
- * method validation, SPA fallback routing, content types.
+ * refresh endpoint, method validation, SPA fallback routing, content types,
+ * security headers, origin validation, rate limiting, path traversal
+ * protection, body size limits, action validation edge cases.
  *
  * Strategy: Mock the http module to capture the request handler passed
  * to createServer, then test it directly without spinning up a real
@@ -187,7 +189,6 @@ interface MockResponseResult {
 }
 
 function createMockRes(): { res: ServerResponse; result: Promise<MockResponseResult> } {
-  // EventEmitter imported at top of file
   const resEmitter = new EventEmitter();
   let statusCode = 200;
   const headers: Record<string, string | number> = {};
@@ -302,7 +303,7 @@ describe('dashboard-server', () => {
     return result;
   }
 
-  // Helper to send a request with custom headers (e.g. Origin for CORS tests)
+  // Helper to send a request with custom headers (e.g. Origin for origin validation / CSRF protection tests)
   async function sendRequestWithHeaders(
     method: string,
     url: string,
@@ -686,6 +687,22 @@ describe('dashboard-server', () => {
       expect(data).toHaveProperty('monthlyMerged');
     });
 
+    it('should return 500 when runMove throws', async () => {
+      mockRunMove.mockRejectedValueOnce(new Error('move failed'));
+      const result = await sendRequest(
+        'POST',
+        '/api/action',
+        JSON.stringify({
+          action: 'move',
+          url: 'https://github.com/owner/repo/pull/1',
+          target: 'shelved',
+        }),
+      );
+      expect(result.statusCode).toBe(500);
+      const data = JSON.parse(result.body);
+      expect(data.error).toBe('Action failed');
+    });
+
     it('should accept a valid dismiss_issue_response action', async () => {
       const result = await sendRequest(
         'POST',
@@ -877,6 +894,10 @@ describe('dashboard-server', () => {
   // ── POST /api/refresh ─────────────────────────────────────────
 
   describe('POST /api/refresh', () => {
+    afterEach(() => {
+      vi.mocked(getGitHubToken).mockReturnValue(null as any);
+    });
+
     it('should return 401 when no GitHub token is available', async () => {
       const result = await sendRequest('POST', '/api/refresh');
       expect(result.statusCode).toBe(401);
@@ -900,9 +921,6 @@ describe('dashboard-server', () => {
       expect(data).toHaveProperty('stats');
       expect(data).toHaveProperty('activePRs');
       expect(vi.mocked(fetchDashboardData)).toHaveBeenCalledWith('test-token');
-
-      // Restore default mock
-      vi.mocked(getGitHubToken).mockReturnValue(null as any);
     });
 
     it('should return 500 when fetchDashboardData throws', async () => {
@@ -913,9 +931,6 @@ describe('dashboard-server', () => {
       expect(result.statusCode).toBe(500);
       const data = JSON.parse(result.body);
       expect(data.error).toContain('Refresh failed');
-
-      // Restore default mock
-      vi.mocked(getGitHubToken).mockReturnValue(null as any);
     });
 
     it('should reject refresh with invalid origin', async () => {


### PR DESCRIPTION
## Summary

- Add 25 tests for `dashboard-data.ts` covering `updateMonthlyAnalytics()` and `fetchDashboardData()` — error isolation, graceful degradation, rate limit re-throws, shelve partitioning, stored PR conversion
- Add 24 tests for `dashboard-server.ts` covering security headers, origin validation, rate limiting, refresh endpoint, path traversal protection, body size limits, action validation edge cases, and `runMove` failure handling
- Coverage: `dashboard-data.ts` 47% → **87.5%**, `dashboard-server.ts` 61% → **80.2%**

## Test plan

- [x] `pnpm test` — all 1986 tests pass (65 files), 0 failures
- [x] `pnpm run lint` — clean
- [x] Coverage verified via `npx vitest run --coverage`
- [x] pr-review-toolkit converged (2 rounds): code-reviewer, silent-failure-hunter, code-simplifier, pr-test-analyzer, comment-analyzer — zero Critical/Recommended findings

Closes #730