### PR TITLE
chore: define stability policy and prepare for 1.0.0 release

### DIFF
--- a/packages/core/STABILITY.md
+++ b/packages/core/STABILITY.md
@@ -1,0 +1,39 @@
+# Stability Policy
+
+This document defines what is covered by semantic versioning in `@oss-autopilot/core`.
+
+## Stable (covered by semver)
+
+Breaking changes to these surfaces will only occur in major version bumps.
+
+### CLI (`oss-autopilot` binary)
+
+- Command names and their `--json` output shape (`{ success, data, error, timestamp }`)
+- Exit codes: 0 for success, 1 for errors
+- `--json` flag availability on all commands
+
+### Library exports (`@oss-autopilot/core`)
+
+- `@oss-autopilot/core` — `StateManager`, `PRMonitor`, `IssueDiscovery`, `getOctokit`, utility functions
+- `@oss-autopilot/core/types` — all exported type definitions
+- `@oss-autopilot/core/commands` — `runDaily`, `runSearch`, `runStatus`, `runVet`, and all other `run*` command functions
+
+### State file (`~/.oss-autopilot/state.json`)
+
+- Forward-compatible: new fields may be added without a major bump
+- Existing field semantics will not change without a migration and major bump
+
+## Experimental (may change in minor versions)
+
+- Dashboard HTTP server API (`/api/data`, `/api/action`, `/api/refresh` response shapes)
+- `DashboardJsonData` internal type
+- `computePRsByRepo`, `computeTopRepos`, `getMonthlyData` helper functions
+- Text-mode display formatting (`formatSummary`, `printDigest`, `formatBriefSummary`)
+- CI analysis internals (`classifyCICheck`, `classifyFailingChecks`)
+
+## Internal (no stability guarantees)
+
+- Anything not exported from the three public entry points
+- Test utilities (`test-utils.ts`)
+- Build artifacts and bundle structure
+- Plugin markdown files (commands, agents, skills, workflows)

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,6 @@
     ".": {
       "release-type": "simple",
       "component": "core",
-      "bump-minor-pre-major": true,
       "draft": false,
       "prerelease": false,
       "changelog-path": "packages/core/CHANGELOG.md",
@@ -25,7 +24,6 @@
     "packages/mcp-server": {
       "release-type": "node",
       "component": "mcp",
-      "bump-minor-pre-major": true,
       "draft": false,
       "prerelease": false
     }


### PR DESCRIPTION
## Summary

- Add `packages/core/STABILITY.md` defining stable, experimental, and internal API surfaces
- Remove `bump-minor-pre-major` from release-please config (no-op at 1.0+)
- Commit includes `Release-As: 1.0.0` footer — once merged, release-please will update PR #734 to cut 1.0.0 instead of 0.60.0

## Stability policy overview

| Surface | Stability |
|---------|-----------|
| CLI commands + `--json` output shape | **Stable** |
| Library exports (core, types, commands) | **Stable** |
| State file schema | **Forward-compatible** |
| Dashboard HTTP API, display formatting, CI analysis internals | Experimental |
| Unexported code, test utils, plugin markdown | Internal |

## Test plan

- [x] No code changes — only docs and config
- [x] `pnpm run lint` — clean
- [x] Verified release-please-config.json is valid JSON

Closes #667