### PR TITLE
feat: add clickable GitHub links to repo/PR/issue references

### DIFF
--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -406,7 +406,7 @@ A repo with a dormant PR should almost never be recommended unless the issue is 
 
 ### From Your Starred/Trusted Repos ⭐
 
-#### 1. [repo/repo#123] - Issue Title (Score: 12)
+#### 1. [acme/widgets#123](https://github.com/acme/widgets/issues/123) - Issue Title (Score: 12)
 **Your history:** You merged 2 PRs here - great relationship!
 **Why it's good:**
 - Clear requirements: [yes/somewhat/no]
@@ -421,7 +421,7 @@ A repo with a dormant PR should almost never be recommended unless the issue is 
 
 ### New Repos to Explore 🔍
 
-#### 2. [new-repo#456] - Issue Title (Score: 7)
+#### 2. [cool-org/toolkit#456](https://github.com/cool-org/toolkit/issues/456) - Issue Title (Score: 7)
 **Your history:** No prior relationship
 **Why it's good:**
 - [reasons]
@@ -432,8 +432,8 @@ A repo with a dormant PR should almost never be recommended unless the issue is 
 
 ### Skipped (Relationship Issues) ⚠️
 
-- **oven-sh/bun** - You have a dormant PR (#25791, 30+ days). Skipping until resolved.
-- **other/repo** - Your last PR was closed without merge.
+- [**oven-sh/bun**](https://github.com/oven-sh/bun) - You have a dormant PR ([#25791](https://github.com/oven-sh/bun/pull/25791), 30+ days). Skipping until resolved.
+- [**other/repo**](https://github.com/other/repo) - Your last PR was closed without merge.
 
 Want me to include these anyway? Some may still have good issues.
 ```

--- a/commands/oss-search.md
+++ b/commands/oss-search.md
@@ -133,7 +133,7 @@ Use AskUserQuestion:
 
 1. Add each candidate to the curated list under `## Pending Vet`:
    ```markdown
-   ### {owner}/{repo} ({stars}★) — {repo description}
+   ### [{owner}/{repo}](https://github.com/{owner}/{repo}) ({stars}★) — {repo description}
    - [#{number}]({url}) — {issue title}
      - **Pending vet** — Found in search round {currentRound}, not yet vetted.
    ```

--- a/commands/oss.md
+++ b/commands/oss.md
@@ -229,8 +229,8 @@ const waitingPRs = data.daily.digest.waitingOnMaintainerPRs.map(url =>
 ```
 Waiting on Others (no action needed):
 
-- owner/repo#123 - Title here (approved, CI passing)
-- owner/repo#456 - Title here (waiting for review)
+- [owner/repo#123](https://github.com/owner/repo/pull/123) - Title here (approved, CI passing)
+- [owner/repo#456](https://github.com/owner/repo/pull/456) - Title here (waiting for review)
 ...
 
 These PRs are progressing normally. Focus on the {count} issues that need attention.

--- a/workflows/action-menu.md
+++ b/workflows/action-menu.md
@@ -39,11 +39,11 @@ Then show the enriched format using the resolved PR's fields:
 ```
 {count} PRs Need Attention (in priority order):
 
-1. {issue.label} {pr.repo}#{pr.number} — {pr.title} ({pr.daysSinceActivity}d)
+1. {issue.label} [{pr.repo}#{pr.number}]({pr.url}) — {pr.title} ({pr.daysSinceActivity}d)
    └─ @{pr.lastMaintainerComment.author}: {formatted maintainerActionHints}
    └─ Effort: {effort} — {action summary}
 
-2. {issue.label} {pr.repo}#{pr.number} — {pr.title} ({pr.daysSinceActivity}d)
+2. {issue.label} [{pr.repo}#{pr.number}]({pr.url}) — {pr.title} ({pr.daysSinceActivity}d)
    └─ @{pr.lastMaintainerComment.author}: {formatted maintainerActionHints}
    └─ Effort: {effort} — {action summary}
 
@@ -74,7 +74,7 @@ If `data.daily.digest.recentlyClosedPRs` has entries, display them **after** the
 
 ```
 Recently closed (informational):
-- {repo}#{number} — {title} (closed without merge on {closedAt date})
+- [{repo}#{number}]({url}) — {title} (closed without merge on {closedAt date})
 ```
 
 These do not require any action. They exist so the user knows what was closed. The Auto-Exclude prompt (in the work-through-issues workflow) may offer to exclude these repos from future searches.

--- a/workflows/review-issue-replies.md
+++ b/workflows/review-issue-replies.md
@@ -16,11 +16,11 @@ When there are issues to review, display each one:
 
 Maintainers responded to your comments on these issues:
 
-1. **owner/repo#123** — Issue title
+1. [**owner/repo#123**](https://github.com/owner/repo/issues/123) — Issue title
    └─ @maintainer: "Go for it! Feel free to submit a PR..."
    └─ Your comment: 5 days ago
 
-2. **owner/repo#456** — Another issue title
+2. [**owner/repo#456**](https://github.com/owner/repo/issues/456) — Another issue title
    └─ @maintainer: "Thanks for the interest. Here's what..."
    └─ Your comment: 2 days ago
 ```

--- a/workflows/work-through-issues.md
+++ b/workflows/work-through-issues.md
@@ -157,18 +157,18 @@ Only show this section if there are Tier 2 items remaining after Phase A:
 
 | # | PR | Issue Type | Maintainer Ask | Effort | Recommended Action |
 |---|-----|-----------|---------------|--------|-------------------|
-| 1 | repo#123 | needs_response | Requested shortcut change + tooltip | Small | Code change + respond |
-| 2 | repo#456 | needs_changes | Fix trailing newline, sync docs | Medium | Code changes + push |
-| 3 | repo#789 | incomplete_checklist | Missing changelog entry | Small | Add changeset file |
+| 1 | [repo#123]({url}) | needs_response | Requested shortcut change + tooltip | Small | Code change + respond |
+| 2 | [repo#456]({url}) | needs_changes | Fix trailing newline, sync docs | Medium | Code changes + push |
+| 3 | [repo#789]({url}) | incomplete_checklist | Missing changelog entry | Small | Add changeset file |
 
 **Key findings:**
-- **repo#123**: Maintainer wants X. 2-line fix in `file.ts`.
-- **repo#456**: 3 changes requested. Tests need updating.
-- **repo#789**: Missing changelog entry required by changeset-bot.
+- [**repo#123**]({url}): Maintainer wants X. 2-line fix in `file.ts`.
+- [**repo#456**]({url}): 3 changes requested. Tests need updating.
+- [**repo#789**]({url}): Missing changelog entry required by changeset-bot.
 ```
 
 Populate the table using data from the Phase A agent results:
-- **PR**: `{repo}#{number}` — short form
+- **PR**: `[{repo}#{number}]({url})` — clickable link to PR
 - **Issue Type**: From `issue.type` (needs_response, needs_changes, ci_failing, merge_conflict, incomplete_checklist)
 - **Maintainer Ask**: 1-line summary of what the maintainer requested (from agent investigation findings)
 - **Effort**: Use the same heuristic as the Action Menu display (Small/Medium/Large)
@@ -204,8 +204,8 @@ The user selects a PR, and you:
 3. After completing the action, if code was changed, route to Pre-Commit Review in the core router — it will read the appropriate workflow file based on `isNewContribution`. After the review completes, return here to Phase C's loop.
 
 **Action failure handling:** After executing the action for a PR:
-- **If successful**: Show "Completed: repo#123 — response posted + code pushed."
-- **If failed**: Show "Failed: repo#123 — {specific error message}. This PR was not addressed."
+- **If successful**: Show "Completed: [repo#123]({url}) — response posted + code pushed."
+- **If failed**: Show "Failed: [repo#123]({url}) — {specific error message}. This PR was not addressed."
   - If the error appears transient (network timeout, rate limit, auth token expired): Offer "Retry" / "Skip and move to next" / "Done for now"
   - If the error appears persistent (merge conflict during apply, file not found, branch deleted): Offer "Investigate the error" / "Skip and move to next" / "Done for now" — do NOT offer "Retry" for errors that will deterministically fail again
 - Track completed, failed, and remaining counts separately in the progress display


### PR DESCRIPTION
## Summary

- Converts bare text repo names, PR numbers, and issue numbers into clickable markdown links across all user-facing plugin display templates
- The CLI already provides `url` fields on all PR/issue objects — this surfaces them in the presentation layer
- AskUserQuestion option labels intentionally left as plain text (they render as picker buttons, not markdown)

Closes #753

## Changes

| File | What changed |
|------|-------------|
| `commands/oss-search.md` | Repo heading in curated issue list |
| `agents/issue-scout.md` | Search result examples + skipped repos section |
| `commands/oss.md` | "Waiting on Others" PR list |
| `workflows/review-issue-replies.md` | Issue reply display |
| `workflows/action-menu.md` | Actionable PRs + recently closed PRs |
| `workflows/work-through-issues.md` | Phase B table, key findings, PR column instruction, Phase C messages |

## Test plan

- [x] `pnpm test` — all 133 tests pass (no TS changes, belt and suspenders)
- [x] `pnpm run lint` — clean
- [x] Grep audit confirms remaining bare `{repo}#{number}` references are only in AskUserQuestion labels or CLI examples
- [ ] Manual: run `/oss` with open PRs → verify action menu has clickable PR links
- [ ] Manual: run `/oss-search` → verify search results have clickable repo headings