### PR TITLE
Fix npm token check to write .npmrc before auth

### DIFF
--- a/.github/workflows/check-npm-token.yml
+++ b/.github/workflows/check-npm-token.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Check token validity
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+          trap 'rm -f ~/.npmrc' EXIT
           RESULT=$(npm whoami --registry https://registry.npmjs.org/ 2>&1) || {
             echo "::error::NPM_TOKEN is expired or invalid. Rotate it at https://www.npmjs.com/settings/tokens and update the GitHub secret."
             echo "npm whoami output: $RESULT"


### PR DESCRIPTION
## Summary
- Fix the Check NPM Token workflow which has never passed
- The `NODE_AUTH_TOKEN` env var isn't read by npm directly without an `.npmrc` file
- Write the token to `~/.npmrc` before running `npm whoami`

## Context
The workflow was mapping `NPM_TOKEN` to `NODE_AUTH_TOKEN` but without a `setup-node` step or manual `.npmrc` creation, npm had no way to find the token. This caused every run to fail with `ENEEDAUTH`.

## Test plan
- [ ] Trigger workflow manually to verify it passes