### PR TITLE
perf: add --compact flag to reduce startup JSON payload size

### DIFF
--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -52,12 +52,18 @@ export const commands: CLICommandDef[] = [
         .command('daily')
         .description('Run daily check on all tracked PRs')
         .option('--json', 'Output as JSON')
+        .option('--compact', 'Reduce JSON payload by omitting summary, repoGroups, and full failure details')
         .action(async (options) => {
           try {
             if (options.json) {
               const { runDaily } = await import('./commands/daily.js');
               const data = await runDaily();
-              outputJson(data);
+              if (options.compact) {
+                const { toCompactDailyOutput } = await import('./formatters/json.js');
+                outputJson(toCompactDailyOutput(data));
+              } else {
+                outputJson(data);
+              }
             } else {
               const { runDailyForDisplay, printDigest } = await import('./commands/daily.js');
               const result = await runDailyForDisplay();
@@ -711,12 +717,18 @@ export const commands: CLICommandDef[] = [
         .command('startup')
         .description('Run all pre-flight checks and daily fetch in one call')
         .option('--json', 'Output as JSON')
+        .option('--compact', 'Reduce JSON payload by omitting summary, repoGroups, and full failure details')
         .action(async (options) => {
           try {
             const { runStartup } = await import('./commands/startup.js');
             const data = await runStartup();
             if (options.json) {
-              outputJson(data);
+              if (options.compact) {
+                const { toCompactStartupOutput } = await import('./formatters/json.js');
+                outputJson(toCompactStartupOutput(data));
+              } else {
+                outputJson(data);
+              }
             } else {
               if (!data.setupComplete) {
                 console.log('Setup incomplete. Run /setup-oss first.');

--- a/packages/core/src/formatters/json.test.ts
+++ b/packages/core/src/formatters/json.test.ts
@@ -4,7 +4,16 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { jsonSuccess, jsonError, outputJson, outputJsonError } from './json.js';
+import {
+  jsonSuccess,
+  jsonError,
+  outputJson,
+  outputJsonError,
+  toCompactDailyOutput,
+  toCompactStartupOutput,
+  type DailyOutput,
+  type StartupOutput,
+} from './json.js';
 
 const ISO_8601_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 
@@ -112,5 +121,182 @@ describe('outputJsonError', () => {
     // The contract: success lives at the envelope level, not inside data
     expect(output.data).toEqual({ foo: 'bar' });
     expect(output.data).not.toHaveProperty('success');
+  });
+});
+
+// --- Compact output tests (#763) ---
+
+function makeMockDailyOutput(): DailyOutput {
+  return {
+    digest: {
+      generatedAt: '2026-03-17T00:00:00.000Z',
+      openPRs: [],
+      needsAddressingPRs: [],
+      waitingOnMaintainerPRs: [],
+      recentlyClosedPRs: [],
+      recentlyMergedPRs: [],
+      shelvedPRs: [],
+      autoUnshelvedPRs: [],
+      summary: { totalActivePRs: 5, totalMergedAllTime: 10, mergeRate: 80, totalNeedingAttention: 2 },
+    },
+    capacity: {
+      hasCapacity: true,
+      activePRCount: 5,
+      maxActivePRs: 20,
+      shelvedPRCount: 0,
+      criticalIssueCount: 0,
+      reason: 'You have capacity',
+    },
+    summary: 'This is a long markdown summary that takes up ~8KB...',
+    briefSummary: '5 Active PRs | 2 need attention',
+    actionableIssues: [
+      {
+        type: 'ci_failing',
+        prUrl: 'https://github.com/org/repo/pull/1',
+        label: '[CI Failing]',
+        isNewContribution: false,
+      },
+    ],
+    actionMenu: {
+      items: [{ key: 'done', label: 'Done for now', description: 'End session' }],
+      context: {
+        hasActionableIssues: true,
+        actionableCount: 1,
+        hasCapacity: true,
+        hasIssueResponses: false,
+        issueResponseCount: 0,
+      },
+    },
+    commentedIssues: [
+      {
+        repo: 'org/repo',
+        number: 1,
+        title: 'Issue',
+        url: 'https://github.com/org/repo/issues/1',
+        userLastCommentedAt: '2026-03-17T00:00:00Z',
+        labels: [],
+        daysSinceUserComment: 1,
+        status: 'waiting',
+      },
+    ],
+    repoGroups: [{ repo: 'org/repo', prUrls: ['https://github.com/org/repo/pull/1'] }],
+    failures: [{ prUrl: 'https://github.com/org/repo/pull/2', error: 'timeout' }],
+  };
+}
+
+describe('toCompactDailyOutput (#763)', () => {
+  it('should retain essential fields', () => {
+    const full = makeMockDailyOutput();
+    const compact = toCompactDailyOutput(full);
+
+    expect(compact.digest).toBe(full.digest);
+    expect(compact.capacity).toBe(full.capacity);
+    expect(compact.briefSummary).toBe(full.briefSummary);
+    expect(compact.actionableIssues).toBe(full.actionableIssues);
+    expect(compact.actionMenu).toBe(full.actionMenu);
+    expect(compact.commentedIssues).toBe(full.commentedIssues);
+  });
+
+  it('should omit summary, repoGroups, failures', () => {
+    const full = makeMockDailyOutput();
+    const compact = toCompactDailyOutput(full);
+
+    expect(compact).not.toHaveProperty('summary');
+    expect(compact).not.toHaveProperty('repoGroups');
+    expect(compact).not.toHaveProperty('failures');
+  });
+
+  it('should retain commentedIssues (used by review-issue-replies workflow)', () => {
+    const full = makeMockDailyOutput();
+    const compact = toCompactDailyOutput(full);
+
+    expect(compact.commentedIssues).toEqual(full.commentedIssues);
+    expect(compact.commentedIssues).toHaveLength(1);
+  });
+
+  it('should include failureCount from failures array length', () => {
+    const full = makeMockDailyOutput();
+    const compact = toCompactDailyOutput(full);
+
+    expect(compact.failureCount).toBe(1); // mock has 1 failure entry
+    expect(compact).not.toHaveProperty('failures');
+  });
+
+  it('should report failureCount 0 when no failures', () => {
+    const full = makeMockDailyOutput();
+    full.failures = [];
+    const compact = toCompactDailyOutput(full);
+
+    expect(compact.failureCount).toBe(0);
+  });
+
+  it('should produce smaller JSON output than the full version', () => {
+    const full = makeMockDailyOutput();
+    const compact = toCompactDailyOutput(full);
+
+    const fullSize = JSON.stringify(full).length;
+    const compactSize = JSON.stringify(compact).length;
+
+    expect(compactSize).toBeLessThan(fullSize);
+  });
+});
+
+describe('toCompactStartupOutput (#763)', () => {
+  it('should retain all non-daily fields', () => {
+    const full: StartupOutput = {
+      version: '1.0.0',
+      setupComplete: true,
+      autoDetected: true,
+      daily: makeMockDailyOutput(),
+      dashboardUrl: 'http://localhost:3000',
+      issueList: { path: 'issues.md', source: 'configured', availableCount: 5, completedCount: 3 },
+    };
+    const compact = toCompactStartupOutput(full);
+
+    expect(compact.version).toBe('1.0.0');
+    expect(compact.setupComplete).toBe(true);
+    expect(compact.autoDetected).toBe(true);
+    expect(compact.dashboardUrl).toBe('http://localhost:3000');
+    expect(compact.issueList).toBe(full.issueList);
+  });
+
+  it('should compact the daily field', () => {
+    const full: StartupOutput = {
+      version: '1.0.0',
+      setupComplete: true,
+      daily: makeMockDailyOutput(),
+    };
+    const compact = toCompactStartupOutput(full);
+
+    // Daily should be compact (no summary, repoGroups, failures)
+    expect(compact.daily).toBeDefined();
+    expect(compact.daily).not.toHaveProperty('summary');
+    expect(compact.daily).not.toHaveProperty('repoGroups');
+    expect(compact.daily).not.toHaveProperty('failures');
+    expect(compact.daily!.briefSummary).toBe(full.daily!.briefSummary);
+    // commentedIssues should be retained
+    expect(compact.daily!.commentedIssues).toBe(full.daily!.commentedIssues);
+  });
+
+  it('should handle missing daily field', () => {
+    const full: StartupOutput = {
+      version: '1.0.0',
+      setupComplete: false,
+    };
+    const compact = toCompactStartupOutput(full);
+
+    expect(compact.daily).toBeUndefined();
+  });
+
+  it('should handle auth error shape', () => {
+    const full: StartupOutput = {
+      version: '1.0.0',
+      setupComplete: true,
+      authError: 'No token',
+    };
+    const compact = toCompactStartupOutput(full);
+
+    expect(compact.authError).toBe('No token');
+    expect(compact.daily).toBeUndefined();
   });
 });

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -134,6 +134,43 @@ export interface DailyOutput {
 }
 
 /**
+ * Compact version of DailyOutput for reduced JSON payload size (#763).
+ * Omits `summary` (pre-rendered markdown ~8KB that duplicates structured fields),
+ * `repoGroups` (derivable from digest.openPRs), and full `failures` array.
+ * Retains `commentedIssues` because downstream workflows (review-issue-replies.md,
+ * action-menu.md) consume it directly.
+ * Includes `failureCount` so consumers can detect partial fetch failures without
+ * carrying the full error payload.
+ */
+export interface CompactDailyOutput {
+  digest: DailyDigestCompact;
+  capacity: CapacityAssessment;
+  briefSummary: string;
+  actionableIssues: CompactActionableIssue[];
+  actionMenu: ActionMenu;
+  commentedIssues: CommentedIssue[];
+  /** Number of PRs that failed to fetch. Non-zero indicates partial results. */
+  failureCount: number;
+}
+
+/**
+ * Strip a full DailyOutput down to the compact subset (#763).
+ * Omits summary, repoGroups, and full failures array. Retains a failureCount
+ * so consumers can detect partial fetch failures.
+ */
+export function toCompactDailyOutput(output: DailyOutput): CompactDailyOutput {
+  return {
+    digest: output.digest,
+    capacity: output.capacity,
+    briefSummary: output.briefSummary,
+    actionableIssues: output.actionableIssues,
+    actionMenu: output.actionMenu,
+    commentedIssues: output.commentedIssues,
+    failureCount: output.failures.length,
+  };
+}
+
+/**
  * Convert a full DailyDigest to the compact format for JSON output (#287).
  * Category arrays become PR URL arrays; full objects stay only in openPRs.
  * Uses URLs (globally unique) instead of numbers to avoid cross-repo collisions.
@@ -262,6 +299,29 @@ export interface StartupOutput {
   /** URL of the interactive SPA dashboard server, when running (e.g., "http://localhost:3000") */
   dashboardUrl?: string;
   issueList?: IssueListInfo;
+}
+
+/**
+ * Compact version of StartupOutput for reduced JSON payload (#763).
+ * Derived from StartupOutput with CompactDailyOutput substituted for DailyOutput.
+ * Using Omit ensures new fields added to StartupOutput are automatically included.
+ */
+export type CompactStartupOutput = Omit<StartupOutput, 'daily'> & {
+  daily?: CompactDailyOutput;
+};
+
+/**
+ * Convert a full StartupOutput to the compact format (#763).
+ * Uses destructuring to auto-forward any new fields added to StartupOutput.
+ */
+export function toCompactStartupOutput(output: StartupOutput): CompactStartupOutput {
+  const { daily, ...rest } = output;
+  return {
+    ...rest,
+    daily: daily ? toCompactDailyOutput(daily) : undefined,
+    dashboardUrl: output.dashboardUrl,
+    issueList: output.issueList,
+  };
 }
 
 /** A single parsed issue from a markdown list (#82) */

--- a/workflows/startup-and-build.md
+++ b/workflows/startup-and-build.md
@@ -54,7 +54,7 @@ if [ -f "${DASHBOARD_PKG}" ] && { [ ! -f "${DASHBOARD_INDEX}" ] || [ -n "$(find 
 fi
 GITHUB_TOKEN=$(gh auth token 2>/dev/null || echo "$GITHUB_TOKEN")
 export GITHUB_TOKEN
-node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" startup --json 2>/tmp/oss-startup-stderr.log
+node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" startup --json --compact 2>/tmp/oss-startup-stderr.log
 ```
 
 ## Parse Output


### PR DESCRIPTION
## Summary
- Adds `--compact` flag to `startup` and `daily` CLI commands that strips non-essential fields from JSON output
- Omits `summary` (~8KB pre-rendered markdown), `repoGroups`, and `failures` from compact mode
- Retains `commentedIssues` (consumed by downstream review-issue-replies workflow — omitting would cause silent regression)
- Plugin's `startup-and-build.md` workflow now uses `--compact` by default
- Default behavior without `--compact` is unchanged (backward compatible)

## Test plan
- [x] Added unit tests for `toCompactDailyOutput()` and `toCompactStartupOutput()` in `json.test.ts`
- [x] Tests verify essential fields retained, non-essential fields omitted
- [x] Tests verify compact output is smaller than full output
- [x] Tests verify auth error and setup incomplete shapes work correctly
- [x] All 2035 core tests pass, plus 166 dashboard and 133 MCP server tests
- [x] Lint passes cleanly

Closes #763