### PR TITLE
feat: add vet-list command for re-vetting curated issue lists

### DIFF
--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -205,6 +205,56 @@ export const commands: CLICommandDef[] = [
     },
   },
 
+  // ── Vet List ──────────────────────────────────────────────────────────
+  {
+    name: 'vet-list',
+    register(program) {
+      program
+        .command('vet-list')
+        .description('Re-vet all available issues in your curated issue list (#764)')
+        .option('--path <file>', 'Path to issue list file (auto-detected if not specified)')
+        .option('--concurrency <n>', 'Max parallel vet operations (default: 5)')
+        .option('--json', 'Output as JSON')
+        .action(async (options) => {
+          try {
+            const { runVetList } = await import('./commands/vet-list.js');
+            const concurrency = options.concurrency ? parseInt(options.concurrency, 10) : undefined;
+            if (concurrency !== undefined && (!Number.isFinite(concurrency) || concurrency < 1)) {
+              throw new Error(`Invalid concurrency "${options.concurrency}". Must be a positive integer.`);
+            }
+            const data = await runVetList({ issueListPath: options.path, concurrency });
+            if (options.json) {
+              outputJson(data);
+            } else {
+              console.log(`\nRe-vetted ${data.summary.total} issues:\n`);
+              console.log(`  Still available: ${data.summary.stillAvailable}`);
+              console.log(`  Claimed:         ${data.summary.claimed}`);
+              console.log(`  Closed:          ${data.summary.closed}`);
+              console.log(`  Has PR:          ${data.summary.hasPR}`);
+              console.log(`  Errors:          ${data.summary.errors}`);
+              console.log('');
+              for (const result of data.results) {
+                const status =
+                  result.listStatus === 'still_available'
+                    ? '\u2705'
+                    : result.listStatus === 'error'
+                      ? '\u274c'
+                      : '\u26a0\ufe0f';
+                console.log(
+                  `${status} [${result.listStatus}] ${result.issue.repo}#${result.issue.number}: ${result.issue.title}`,
+                );
+                if (result.errorMessage) {
+                  console.log(`   Error: ${result.errorMessage}`);
+                }
+              }
+            }
+          } catch (err) {
+            handleCommandError(err, options.json);
+          }
+        });
+    },
+  },
+
   // ── Track ──────────────────────────────────────────────────────────────
   {
     name: 'track',

--- a/packages/core/src/cli.test.ts
+++ b/packages/core/src/cli.test.ts
@@ -112,7 +112,18 @@ describe('LOCAL_ONLY_COMMANDS (derived from registry)', () => {
     'stats',
   ];
 
-  const expectedTokenRequired = ['daily', 'search', 'vet', 'track', 'comments', 'post', 'init', 'claim', 'pr-template'];
+  const expectedTokenRequired = [
+    'daily',
+    'search',
+    'vet',
+    'vet-list',
+    'track',
+    'comments',
+    'post',
+    'init',
+    'claim',
+    'pr-template',
+  ];
 
   it.each(expectedLocalOnly)('should contain local-only command "%s"', (cmd) => {
     expect(LOCAL_ONLY_COMMANDS).toContain(cmd);
@@ -333,6 +344,7 @@ describe('Command registration', () => {
       'status',
       'search',
       'vet',
+      'vet-list',
       'track',
       'untrack',
       'read',

--- a/packages/core/src/commands/vet-list.test.ts
+++ b/packages/core/src/commands/vet-list.test.ts
@@ -1,0 +1,391 @@
+/**
+ * Tests for vet-list command (#764)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { VetOutput } from '../formatters/json.js';
+
+const mockVetIssue = vi.fn();
+
+vi.mock('../core/index.js', () => {
+  const MockIssueDiscovery = vi.fn(function (this: any) {
+    this.vetIssue = mockVetIssue;
+  });
+  return {
+    IssueDiscovery: MockIssueDiscovery,
+    requireGitHubToken: vi.fn().mockReturnValue('ghp_test123'),
+  };
+});
+
+vi.mock('./startup.js', () => ({
+  detectIssueList: vi.fn(),
+}));
+
+vi.mock('./parse-list.js', () => ({
+  runParseList: vi.fn(),
+}));
+
+import { detectIssueList } from './startup.js';
+import { runParseList } from './parse-list.js';
+import { runVetList, classifyListStatus } from './vet-list.js';
+
+const mockDetectIssueList = vi.mocked(detectIssueList);
+const mockRunParseList = vi.mocked(runParseList);
+
+function makeVetOutput(overrides: Partial<VetOutput> = {}): VetOutput {
+  return {
+    issue: {
+      repo: 'owner/repo',
+      number: 1,
+      title: 'Test issue',
+      url: 'https://github.com/owner/repo/issues/1',
+      labels: ['bug'],
+    },
+    recommendation: 'approve',
+    reasonsToApprove: ['Active project'],
+    reasonsToSkip: [],
+    projectHealth: { stars: 500 },
+    vettingResult: { isViable: true },
+    ...overrides,
+  };
+}
+
+describe('classifyListStatus', () => {
+  it('should return still_available for approved issues', () => {
+    const result = classifyListStatus(makeVetOutput({ recommendation: 'approve', reasonsToSkip: [] }));
+    expect(result).toBe('still_available');
+  });
+
+  it('should return still_available for needs_review issues', () => {
+    const result = classifyListStatus(makeVetOutput({ recommendation: 'needs_review', reasonsToSkip: [] }));
+    expect(result).toBe('still_available');
+  });
+
+  it('should return closed when skip reasons mention closed', () => {
+    const result = classifyListStatus(
+      makeVetOutput({
+        recommendation: 'skip',
+        reasonsToSkip: ['Issue is closed'],
+      }),
+    );
+    expect(result).toBe('closed');
+  });
+
+  it('should return claimed when skip reasons mention claimed', () => {
+    const result = classifyListStatus(
+      makeVetOutput({
+        recommendation: 'skip',
+        reasonsToSkip: ['Issue is already claimed by another user'],
+      }),
+    );
+    expect(result).toBe('claimed');
+  });
+
+  it('should return claimed when skip reasons mention assigned', () => {
+    const result = classifyListStatus(
+      makeVetOutput({
+        recommendation: 'skip',
+        reasonsToSkip: ['Issue is assigned to someone'],
+      }),
+    );
+    expect(result).toBe('claimed');
+  });
+
+  it('should return has_pr when skip reasons mention existing PR', () => {
+    const result = classifyListStatus(
+      makeVetOutput({
+        recommendation: 'skip',
+        reasonsToSkip: ['Has existing PR addressing this'],
+      }),
+    );
+    expect(result).toBe('has_pr');
+  });
+
+  it('should return has_pr when skip reasons mention linked PR', () => {
+    const result = classifyListStatus(
+      makeVetOutput({
+        recommendation: 'skip',
+        reasonsToSkip: ['Has linked PR #42'],
+      }),
+    );
+    expect(result).toBe('has_pr');
+  });
+
+  it('should return has_pr when skip reasons mention pull request', () => {
+    const result = classifyListStatus(
+      makeVetOutput({
+        recommendation: 'skip',
+        reasonsToSkip: ['Open pull request found'],
+      }),
+    );
+    expect(result).toBe('has_pr');
+  });
+
+  it('should return still_available for skipped issues with other reasons', () => {
+    const result = classifyListStatus(
+      makeVetOutput({
+        recommendation: 'skip',
+        reasonsToSkip: ['Project is inactive'],
+      }),
+    );
+    expect(result).toBe('still_available');
+  });
+
+  it('should prioritize closed over claimed', () => {
+    const result = classifyListStatus(
+      makeVetOutput({
+        recommendation: 'skip',
+        reasonsToSkip: ['Issue is closed', 'Issue was claimed'],
+      }),
+    );
+    expect(result).toBe('closed');
+  });
+});
+
+describe('runVetList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should throw when no issue list is found and no path provided', async () => {
+    mockDetectIssueList.mockReturnValue(undefined);
+
+    await expect(runVetList()).rejects.toThrow('No issue list found');
+  });
+
+  it('should return empty results for an empty list', async () => {
+    mockDetectIssueList.mockReturnValue({
+      path: '/tmp/issues.md',
+      source: 'configured',
+      availableCount: 0,
+      completedCount: 0,
+    });
+    mockRunParseList.mockResolvedValue({ available: [], completed: [], availableCount: 0, completedCount: 0 });
+
+    const result = await runVetList();
+
+    expect(result.results).toEqual([]);
+    expect(result.summary).toEqual({ total: 0, stillAvailable: 0, claimed: 0, closed: 0, hasPR: 0, errors: 0 });
+  });
+
+  it('should vet available issues and return results', async () => {
+    mockDetectIssueList.mockReturnValue({
+      path: '/tmp/issues.md',
+      source: 'configured',
+      availableCount: 2,
+      completedCount: 0,
+    });
+    mockRunParseList.mockResolvedValue({
+      available: [
+        {
+          repo: 'owner/repo',
+          number: 1,
+          title: 'Fix bug',
+          tier: 'Pursue',
+          url: 'https://github.com/owner/repo/issues/1',
+        },
+        {
+          repo: 'other/lib',
+          number: 2,
+          title: 'Add feature',
+          tier: 'Maybe',
+          url: 'https://github.com/other/lib/issues/2',
+        },
+      ],
+      completed: [],
+      availableCount: 2,
+      completedCount: 0,
+    });
+
+    const candidate1 = {
+      issue: {
+        repo: 'owner/repo',
+        number: 1,
+        title: 'Fix bug',
+        url: 'https://github.com/owner/repo/issues/1',
+        labels: ['bug'],
+      },
+      recommendation: 'approve' as const,
+      reasonsToApprove: ['Good first issue'],
+      reasonsToSkip: [],
+      projectHealth: { stars: 100 },
+      vettingResult: { isViable: true },
+    };
+    const candidate2 = {
+      issue: {
+        repo: 'other/lib',
+        number: 2,
+        title: 'Add feature',
+        url: 'https://github.com/other/lib/issues/2',
+        labels: ['enhancement'],
+      },
+      recommendation: 'skip' as const,
+      reasonsToApprove: [],
+      reasonsToSkip: ['Issue is closed'],
+      projectHealth: { stars: 50 },
+      vettingResult: { isViable: false },
+    };
+    mockVetIssue.mockResolvedValueOnce(candidate1).mockResolvedValueOnce(candidate2);
+
+    const result = await runVetList();
+
+    expect(result.results).toHaveLength(2);
+    expect(result.results[0].listStatus).toBe('still_available');
+    expect(result.results[0].issue.repo).toBe('owner/repo');
+    expect(result.results[1].listStatus).toBe('closed');
+    expect(result.results[1].issue.repo).toBe('other/lib');
+    expect(result.summary.total).toBe(2);
+    expect(result.summary.stillAvailable).toBe(1);
+    expect(result.summary.closed).toBe(1);
+  });
+
+  it('should handle per-issue errors without failing the batch', async () => {
+    mockDetectIssueList.mockReturnValue({
+      path: '/tmp/issues.md',
+      source: 'configured',
+      availableCount: 2,
+      completedCount: 0,
+    });
+    mockRunParseList.mockResolvedValue({
+      available: [
+        {
+          repo: 'owner/repo',
+          number: 1,
+          title: 'Fix bug',
+          tier: 'Pursue',
+          url: 'https://github.com/owner/repo/issues/1',
+        },
+        {
+          repo: 'other/lib',
+          number: 2,
+          title: 'Add feature',
+          tier: 'Maybe',
+          url: 'https://github.com/other/lib/issues/2',
+        },
+      ],
+      completed: [],
+      availableCount: 2,
+      completedCount: 0,
+    });
+
+    const candidate1 = {
+      issue: {
+        repo: 'owner/repo',
+        number: 1,
+        title: 'Fix bug',
+        url: 'https://github.com/owner/repo/issues/1',
+        labels: ['bug'],
+      },
+      recommendation: 'approve' as const,
+      reasonsToApprove: ['Active project'],
+      reasonsToSkip: [],
+      projectHealth: {},
+      vettingResult: {},
+    };
+    mockVetIssue.mockResolvedValueOnce(candidate1).mockRejectedValueOnce(new Error('Rate limit exceeded'));
+
+    const result = await runVetList({ concurrency: 1 });
+
+    expect(result.results).toHaveLength(2);
+    expect(result.results[0].listStatus).toBe('still_available');
+    expect(result.results[1].listStatus).toBe('error');
+    expect(result.results[1].errorMessage).toBe('Rate limit exceeded');
+    expect(result.results[1].recommendation).toBe('skip');
+    expect(result.summary.errors).toBe(1);
+    expect(result.summary.stillAvailable).toBe(1);
+  });
+
+  it('should use provided path instead of auto-detecting', async () => {
+    mockRunParseList.mockResolvedValue({ available: [], completed: [], availableCount: 0, completedCount: 0 });
+
+    await runVetList({ issueListPath: '/custom/path.md' });
+
+    expect(mockDetectIssueList).not.toHaveBeenCalled();
+    expect(mockRunParseList).toHaveBeenCalledWith({ filePath: '/custom/path.md' });
+  });
+
+  it('should use detectIssueList when no path is provided', async () => {
+    mockDetectIssueList.mockReturnValue({
+      path: '/detected/issues.md',
+      source: 'auto-detected',
+      availableCount: 0,
+      completedCount: 0,
+    });
+    mockRunParseList.mockResolvedValue({ available: [], completed: [], availableCount: 0, completedCount: 0 });
+
+    await runVetList();
+
+    expect(mockDetectIssueList).toHaveBeenCalled();
+    expect(mockRunParseList).toHaveBeenCalledWith({ filePath: '/detected/issues.md' });
+  });
+
+  it('should respect concurrency option', async () => {
+    mockDetectIssueList.mockReturnValue({
+      path: '/tmp/issues.md',
+      source: 'configured',
+      availableCount: 3,
+      completedCount: 0,
+    });
+    mockRunParseList.mockResolvedValue({
+      available: [
+        { repo: 'a/b', number: 1, title: 'One', tier: 'T1', url: 'https://github.com/a/b/issues/1' },
+        { repo: 'c/d', number: 2, title: 'Two', tier: 'T1', url: 'https://github.com/c/d/issues/2' },
+        { repo: 'e/f', number: 3, title: 'Three', tier: 'T1', url: 'https://github.com/e/f/issues/3' },
+      ],
+      completed: [],
+      availableCount: 3,
+      completedCount: 0,
+    });
+
+    const makeCandidate = (repo: string, num: number, title: string, url: string) => ({
+      issue: { repo, number: num, title, url, labels: [] },
+      recommendation: 'approve' as const,
+      reasonsToApprove: ['OK'],
+      reasonsToSkip: [],
+      projectHealth: {},
+      vettingResult: {},
+    });
+
+    mockVetIssue
+      .mockResolvedValueOnce(makeCandidate('a/b', 1, 'One', 'https://github.com/a/b/issues/1'))
+      .mockResolvedValueOnce(makeCandidate('c/d', 2, 'Two', 'https://github.com/c/d/issues/2'))
+      .mockResolvedValueOnce(makeCandidate('e/f', 3, 'Three', 'https://github.com/e/f/issues/3'));
+
+    const result = await runVetList({ concurrency: 2 });
+
+    expect(result.results).toHaveLength(3);
+    expect(result.summary.total).toBe(3);
+    expect(result.summary.stillAvailable).toBe(3);
+  });
+
+  it('should handle non-Error thrown values in per-issue errors', async () => {
+    mockDetectIssueList.mockReturnValue({
+      path: '/tmp/issues.md',
+      source: 'configured',
+      availableCount: 1,
+      completedCount: 0,
+    });
+    mockRunParseList.mockResolvedValue({
+      available: [
+        {
+          repo: 'owner/repo',
+          number: 1,
+          title: 'Fix bug',
+          tier: 'Pursue',
+          url: 'https://github.com/owner/repo/issues/1',
+        },
+      ],
+      completed: [],
+      availableCount: 1,
+      completedCount: 0,
+    });
+
+    mockVetIssue.mockRejectedValueOnce('string error');
+
+    const result = await runVetList();
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].listStatus).toBe('error');
+    expect(result.results[0].errorMessage).toBe('string error');
+  });
+});

--- a/packages/core/src/commands/vet-list.ts
+++ b/packages/core/src/commands/vet-list.ts
@@ -1,0 +1,131 @@
+/**
+ * Vet-list command (#764)
+ * Re-vets all available issues in a curated issue list file.
+ */
+
+import { IssueDiscovery, requireGitHubToken } from '../core/index.js';
+import { type VetListOutput, type VetOutput, type VetListItemStatus } from '../formatters/json.js';
+import { detectIssueList } from './startup.js';
+
+interface VetListOptions {
+  issueListPath?: string;
+  concurrency?: number;
+}
+
+/**
+ * Determine the list status from vetting results.
+ * Maps vetting recommendation + reasons to a list-level status.
+ */
+export function classifyListStatus(vetResult: VetOutput): VetListItemStatus {
+  const skipReasons = vetResult.reasonsToSkip.map((r) => r.toLowerCase());
+
+  if (skipReasons.some((r) => r.includes('closed'))) return 'closed';
+  if (skipReasons.some((r) => r.includes('claimed') || r.includes('assigned'))) return 'claimed';
+  if (skipReasons.some((r) => r.includes('existing pr') || r.includes('linked pr') || r.includes('pull request')))
+    return 'has_pr';
+
+  if (vetResult.recommendation === 'approve' || vetResult.recommendation === 'needs_review') {
+    return 'still_available';
+  }
+
+  // Default: if skipped for other reasons, still mark as available
+  // (the vetting result will show why it's not recommended)
+  return 'still_available';
+}
+
+/**
+ * Re-vet all available issues in a curated issue list.
+ * Reads the list file, extracts available (non-done) issues,
+ * and vets each in parallel with concurrency control.
+ *
+ * @param options - Vet-list options
+ * @returns Consolidated vetting results with list status for each issue
+ */
+export async function runVetList(options: VetListOptions = {}): Promise<VetListOutput> {
+  const token = requireGitHubToken();
+  const concurrency = options.concurrency ?? 5;
+
+  // 1. Find and parse the issue list
+  let issueListPath = options.issueListPath;
+  if (!issueListPath) {
+    const detected = detectIssueList();
+    if (!detected) {
+      throw new Error('No issue list found. Provide a path with --path or configure issueListPath in settings.');
+    }
+    issueListPath = detected.path;
+  }
+
+  const { runParseList } = await import('./parse-list.js');
+  const parsed = await runParseList({ filePath: issueListPath });
+
+  if (parsed.available.length === 0) {
+    return {
+      results: [],
+      summary: { total: 0, stillAvailable: 0, claimed: 0, closed: 0, hasPR: 0, errors: 0 },
+    };
+  }
+
+  // 2. Vet each available issue in parallel with concurrency limit
+  const discovery = new IssueDiscovery(token);
+  const results: VetListOutput['results'] = [];
+
+  // Simple concurrency limiter
+  const items = parsed.available;
+  let index = 0;
+
+  async function processNext(): Promise<void> {
+    while (index < items.length) {
+      const item = items[index++];
+      try {
+        const candidate = await discovery.vetIssue(item.url);
+        const vetResult: VetOutput = {
+          issue: {
+            repo: candidate.issue.repo,
+            number: candidate.issue.number,
+            title: candidate.issue.title,
+            url: candidate.issue.url,
+            labels: candidate.issue.labels,
+          },
+          recommendation: candidate.recommendation,
+          reasonsToApprove: candidate.reasonsToApprove,
+          reasonsToSkip: candidate.reasonsToSkip,
+          projectHealth: candidate.projectHealth,
+          vettingResult: candidate.vettingResult,
+        };
+
+        results.push({
+          ...vetResult,
+          listStatus: classifyListStatus(vetResult),
+        });
+      } catch (error) {
+        // Per-issue errors don't fail the batch
+        results.push({
+          issue: { repo: item.repo, number: item.number, title: item.title, url: item.url, labels: [] },
+          recommendation: 'skip',
+          reasonsToApprove: [],
+          reasonsToSkip: [`Error: ${error instanceof Error ? error.message : String(error)}`],
+          projectHealth: {},
+          vettingResult: {},
+          listStatus: 'error',
+          errorMessage: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  }
+
+  // Start `concurrency` workers
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, () => processNext());
+  await Promise.all(workers);
+
+  // 3. Compute summary
+  const summary = {
+    total: results.length,
+    stillAvailable: results.filter((r) => r.listStatus === 'still_available').length,
+    claimed: results.filter((r) => r.listStatus === 'claimed').length,
+    closed: results.filter((r) => r.listStatus === 'closed').length,
+    hasPR: results.filter((r) => r.listStatus === 'has_pr').length,
+    errors: results.filter((r) => r.listStatus === 'error').length,
+  };
+
+  return { results, summary };
+}

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -355,6 +355,27 @@ export interface CheckIntegrationOutput {
   unreferencedCount: number;
 }
 
+/** Status of a re-vetted issue from the curated list (#764). */
+export type VetListItemStatus = 'still_available' | 'claimed' | 'closed' | 'has_pr' | 'error';
+
+/** Output of the vet-list command (#764). */
+export interface VetListOutput {
+  results: Array<
+    VetOutput & {
+      listStatus: VetListItemStatus;
+      errorMessage?: string;
+    }
+  >;
+  summary: {
+    total: number;
+    stillAvailable: number;
+    claimed: number;
+    closed: number;
+    hasPR: number;
+    errors: number;
+  };
+}
+
 /** Output of the vet command */
 export interface VetOutput {
   issue: {


### PR DESCRIPTION
## Summary
- Adds `vet-list` CLI command that reads a curated issue list, extracts available issues, and re-vets each in parallel
- Returns consolidated results with per-issue status (`still_available`, `claimed`, `closed`, `has_pr`, `error`)
- Supports `--path` to override list file location and `--concurrency` to control parallelism (default: 5)
- Catches per-issue errors without failing the batch

## Test plan
- [x] Unit tests for `classifyListStatus()` function
- [x] Tests for empty list handling
- [x] Tests for mixed success/failure scenarios
- [x] All 2027 core tests pass (61 files including new test)

Closes #764