### PR TITLE
feat: warn when claiming issues while at PR capacity limit

### DIFF
--- a/packages/core/src/core/daily-logic.test.ts
+++ b/packages/core/src/core/daily-logic.test.ts
@@ -606,6 +606,24 @@ describe('computeActionMenu (core)', () => {
     const menu = computeActionMenu([], makeCapacity());
     expect(menu.items.find((i) => i.key === 'search')).toBeDefined();
   });
+
+  it('should add capacityWarning to search item when capacity.hasCapacity is false', () => {
+    const capacity = makeCapacity({ hasCapacity: false, activePRCount: 5, maxActivePRs: 5 });
+    const menu = computeActionMenu([], capacity);
+    const searchItem = menu.items.find((i) => i.key === 'search');
+
+    expect(searchItem).toBeDefined();
+    expect(searchItem!.capacityWarning).toBe("You're at 5/5 active PRs. Claiming a new issue will exceed your limit.");
+  });
+
+  it('should not add capacityWarning to search item when capacity.hasCapacity is true', () => {
+    const capacity = makeCapacity({ hasCapacity: true, activePRCount: 2, maxActivePRs: 5 });
+    const menu = computeActionMenu([], capacity);
+    const searchItem = menu.items.find((i) => i.key === 'search');
+
+    expect(searchItem).toBeDefined();
+    expect(searchItem!.capacityWarning).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/core/daily-logic.ts
+++ b/packages/core/src/core/daily-logic.ts
@@ -393,11 +393,23 @@ export function computeActionMenu(
   // The orchestration layer (commands/oss.md Action Menu section) may insert issue-list
   // options before the search item when a curated list is available.
 
-  items.push({
+  const searchItem: ActionMenuItem = {
     key: 'search',
     label: 'Search for new issues',
     description: 'Look for new contribution opportunities',
-  });
+  };
+  if (!capacity.hasCapacity) {
+    const atLimit = capacity.activePRCount >= capacity.maxActivePRs;
+    const hasCritical = capacity.criticalIssueCount > 0;
+    if (atLimit && hasCritical) {
+      searchItem.capacityWarning = `You're at ${capacity.activePRCount}/${capacity.maxActivePRs} active PRs and have ${capacity.criticalIssueCount} critical issue(s). Resolve existing work before claiming new issues.`;
+    } else if (atLimit) {
+      searchItem.capacityWarning = `You're at ${capacity.activePRCount}/${capacity.maxActivePRs} active PRs. Claiming a new issue will exceed your limit.`;
+    } else {
+      searchItem.capacityWarning = `You have ${capacity.criticalIssueCount} critical issue(s) needing attention. Resolve them before claiming new issues.`;
+    }
+  }
+  items.push(searchItem);
 
   items.push({
     key: 'done',

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -65,6 +65,8 @@ export interface ActionMenuItem {
   label: string;
   /** Explanation shown below the label. */
   description: string;
+  /** Present when the action would exceed the user's PR capacity limit (#765). */
+  capacityWarning?: string;
 }
 
 /**

--- a/workflows/action-menu.md
+++ b/workflows/action-menu.md
@@ -93,6 +93,10 @@ Use `data.daily.actionMenu.items` directly as AskUserQuestion options. Each item
 
 When inserting issue-list items, keep within the 4-option limit (the 5th is the auto "Other").
 
+**Capacity warning:** If any menu item has a `capacityWarning` field, display the warning prominently before presenting the options:
+> ⚠️ {capacityWarning}
+The option remains available (override), but the warning provides friction before claiming new issues.
+
 **"Replenish your issue list"** routes to **Handle "Find New Issues"** (same as search), but agents should be told to suggest issues suitable for adding to the curated list.
 
 ### Example AskUserQuestion


### PR DESCRIPTION
## Summary
- Adds optional `capacityWarning` field to `ActionMenuItem` interface
- `computeActionMenu()` now injects a warning on the `search` item when `!capacity.hasCapacity`
- Action menu workflow displays the warning prominently before claim-related options
- Warning provides friction without blocking — users can still override

## Test plan
- [x] Unit test: capacity warning added when at/above limit
- [x] Unit test: no warning when under capacity
- [x] All 2011 core tests pass

Closes #765