### PR TITLE
feat: add investigation verification checkpoint before implementation

### DIFF
--- a/workflows/draft-first-workflow.md
+++ b/workflows/draft-first-workflow.md
@@ -200,6 +200,8 @@ mergeBase=$(git merge-base "origin/$baseBranch" HEAD 2>/dev/null) || true
 
 Use `git diff $mergeBase..HEAD` for the full branch diff. If `$mergeBase` is empty, fall back to `origin/$baseBranch...HEAD`. If neither works, report error — do NOT dispatch agents without diff context. Read `CONTRIBUTING.md` and lint configs if not already loaded.
 
+**Investigation verification:** If investigation findings from Phase A are available in session context, the user was offered a verification checkpoint before implementation began (see `work-through-issues.md` — Investigation Verification Checkpoint). Verified findings should be trusted; flagged concerns should be monitored during review.
+
 ### 2. Dispatch Scope-Aware Review Agents
 
 **Dispatch ALL agents in a SINGLE message.** Always use the full Large tier (code-reviewer, silent-failure-hunter, code-simplifier, pr-test-analyzer + conditional agents) regardless of diff size. Include `Working directory: {local repo path}` in every prompt.

--- a/workflows/work-through-issues.md
+++ b/workflows/work-through-issues.md
@@ -176,6 +176,63 @@ Populate the table using data from the Phase A agent results:
 
 **Key findings**: 1-line summary per PR from the agent investigation results. Focus on what the maintainer is asking and what code change is needed.
 
+### Investigation Verification Checkpoint
+
+After presenting Phase B results, before the user selects a PR to work on in Phase C, offer a verification option for any Tier 2 item they select:
+
+When the user selects a PR from the Phase C options, before executing the recommended action, present:
+
+```
+Question: "Would you like to verify the investigation before implementing?"
+Header: "Verification"
+
+Options:
+1. "Verify diagnosis (Recommended)" — "Re-read the relevant code and cross-check the investigation's claims before coding"
+2. "Proceed to implement" — "The diagnosis looks correct, start coding"
+3. "Skip this issue" — "Move to the next item"
+```
+
+**When user selects "Verify diagnosis":**
+
+1. **Re-read the specific code** mentioned in the Phase A investigation — not just grep results, but the actual function/method bodies
+2. **Cross-check each claim from the investigation:**
+   - If the investigation says "function X does Y" → read function X and verify
+   - If it says "the bug is in line N" → read that line with surrounding context
+   - If it proposes "change X to Y" → verify callers won't break
+3. **Check for edge cases** the investigation may have missed:
+   - Empty/null inputs to the modified code
+   - Other callers of the modified function
+   - Whether the fix matches the issue's expected behavior
+4. **Present verification results:**
+
+```
+## Verification Results
+
+✅ Confirmed: {list of claims that match the code}
+⚠️ Concerns: {list of potential issues found}
+❌ Incorrect: {list of claims contradicted by the code}
+
+Recommendation: {proceed / revise diagnosis / skip}
+```
+
+5. **Post-verification options:**
+
+If concerns or incorrect claims found:
+```
+Options:
+1. "Revise and re-investigate" — "Update the approach based on verification findings"
+2. "Proceed anyway" — "The concerns are minor"
+3. "Skip this issue"
+```
+
+If all claims verified:
+```
+Options:
+1. "Proceed to implement (Recommended)"
+2. "Skip this issue"
+3. "Done for now"
+```
+
 ### Phase C: Sequential Tier 2 Execution
 
 If no Tier 2 items remain after Phase A:


### PR DESCRIPTION
## Summary
- Adds a verification checkpoint in `work-through-issues.md` after selecting a PR in Phase C
- Users can cross-check investigation claims against actual code before implementing
- Verification produces results categorized as Confirmed/Concerns/Incorrect
- Adds a note in `draft-first-workflow.md` about trusting verified findings

## Test plan
- [x] Workflow-only change (markdown) — no TypeScript tests needed
- [x] Complements #766 (investigate-before-claim)

Closes #767