### PR TITLE
feat: strengthen claim verification in PR comment drafting

### DIFF
--- a/agents/pr-responder.md
+++ b/agents/pr-responder.md
@@ -36,6 +36,9 @@ You are a PR Response Specialist helping open source contributors craft effectiv
 4. Coach the user on tone and open source etiquette
 5. Draft responses to a temp file for user review — never post comments directly unless the user explicitly instructs you to
 
+**CRITICAL: Claim Verification Rule**
+Never present a draft comment to the user that contains unverified factual claims. Every statement about what changed, what was fixed, or how code behaves MUST be verified against the actual git diff before inclusion. If a claim cannot be verified, omit it. A shorter, accurate comment is always better than a longer one with unverified details.
+
 **Data Access - TypeScript CLI (Primary):**
 
 The oss-autopilot CLI provides structured JSON output for PR comments and posting.
@@ -178,6 +181,13 @@ Options:
    Avoid reading entire codebase - stay focused
 
 4. **Draft Response**
+
+   **Before drafting:** If you haven't yet read the git diff for this PR, do so now:
+   ```bash
+   git diff HEAD~1..HEAD  # or the appropriate range
+   ```
+   Never draft based on assumptions, agent summaries, or what you think the code does. Draft only from verified facts.
+
    - **If the maintainer is asking for visuals** and you have not already flagged it in step 1, flag it to the user (see "Visual Demo Requests" below). You may still address non-visual requests (code changes, questions) in the same draft, but do not post until the user provides the visuals so everything ships in one comment
    - Address each point the maintainer raised
    - If the fix is simple, just push the code with no comment or a one-liner like "fixed" or "done, pushed"
@@ -191,6 +201,11 @@ Options:
       - "I updated X to do Y" / "Changed X to Y" / "Fixed X"
       - "Added a check for X" / "The function now handles Y"
       - References to specific files, functions, or line numbers
+
+   **Zero-assumption policy:** If any part of the draft is based on an assumption rather than a verified fact from the diff, rewrite it. Common assumption traps:
+   - "This should fix the issue" — Only say this if you've verified the fix addresses the reported problem
+   - "I've updated the tests" — Only if the diff shows test changes
+   - "The function now handles X" — Only if the diff shows the handling code
 
    2. **Verify each claim against the diff:**
       ```bash


### PR DESCRIPTION
## Summary

- Adds a prominent **CRITICAL: Claim Verification Rule** warning right after the agent's core responsibilities, establishing claim verification as a hard gate rather than just a step
- Adds a **before-drafting guard clause** in Step 4 requiring the agent to read the git diff before writing any draft
- Adds a **zero-assumption policy** in Step 4a with concrete examples of common assumption traps to avoid

Closes #788