### PR TITLE
feat: make review-fix convergence loop mandatory before PR readiness

### DIFF
--- a/skills/oss-contribution/SKILL.md
+++ b/skills/oss-contribution/SKILL.md
@@ -42,6 +42,24 @@ Before pushing commits that address review feedback:
 
 This prevents maintainers from seeing issues that could have been caught locally. It's especially important when responding to feedback — pushing sloppy fix-up commits undermines credibility.
 
+### PR Readiness Gate (Mandatory)
+
+A PR is NEVER "ready" until all of these pass:
+
+1. **Local lint/type check**: Run the repo's linters and type checkers
+2. **Test suite**: Run the full test suite locally
+3. **Code review**: Run review agents (pr-review-toolkit or pre-commit-reviewer)
+4. **Fix and re-run**: Fix all findings, re-run checks
+5. **Convergence**: Repeat until zero Critical/Recommended findings
+6. **Push and verify CI**: Push and confirm CI passes remotely
+7. **Only then** declare the PR ready for maintainer review
+
+The tool should NEVER say "PR is ready", "work is complete", or "changes are done" without having run through this complete loop. This applies to:
+- New contributions (draft-first workflow)
+- Responses to maintainer feedback
+- CI fix pushes
+- Any commit that will be seen by maintainers
+
 ### Things to Avoid
 
 - Being defensive or dismissive

--- a/workflows/draft-first-workflow.md
+++ b/workflows/draft-first-workflow.md
@@ -492,6 +492,24 @@ Options:
 
 This is the final gate before the PR becomes visible to maintainers.
 
+### 0. Pre-Readiness Verification
+
+Before showing the PR summary, verify the convergence loop was completed:
+
+1. Confirm lint and tests were run and passed in this session
+2. Confirm review agents were dispatched and all Critical/Recommended findings addressed
+3. If any of these are missing, run them now before proceeding
+
+If lint/tests have not been run:
+> "Hold on — running lint and tests before marking ready..."
+Run the repo's lint and test commands. If they fail, fix and loop.
+
+If review agents have not been dispatched:
+> "Hold on — running review agents before marking ready..."
+Dispatch the full review suite (see Step 2) and run the convergence loop. If findings are reported, fix and re-run until convergence.
+
+Only proceed to sub-step 1 after all checks pass.
+
 ### 1. Show PR Summary
 
 Display a summary of the draft PR:

--- a/workflows/pre-commit-review.md
+++ b/workflows/pre-commit-review.md
@@ -76,6 +76,22 @@ Save as `changeSize` for informational reporting. Report: "> Change size: {tier}
 
 **If classification fails** (command errors, unparseable output, or both counts are zero despite `git status --porcelain` showing changes): default to **Large** to ensure maximum review coverage and warn: "Could not determine change size — defaulting to Large for comprehensive review."
 
+### 2b. Pre-Review Lint and Test Gate
+
+Before dispatching review agents, run the repo's lint and test commands to catch basic issues early. Review agents should not waste cycles on code that does not pass lint or tests.
+
+1. **Detect and run linter/type checker**: Check for `package.json` scripts (`lint`, `typecheck`, `tsc`), `Makefile` targets, or language-specific tooling. Run the detected command(s). If no linter is detected, skip and note: "No linter detected — skipping pre-review lint."
+
+2. **Run test suite**: Check for `package.json` scripts (`test`), `Makefile` targets (`test`, `check`), or language-specific test runners. Run the detected command. If no test runner is detected, skip and note: "No test runner detected — skipping pre-review tests."
+
+3. **Handle failures**: If lint or tests fail, fix the issues before proceeding to review agent dispatch. Report:
+   > "Lint/tests failed — fixing before running review agents..."
+   After fixing, re-run lint and tests to confirm they pass. Loop until both pass (soft limit: 3 attempts). If still failing after 3 attempts, present findings to the user and offer: "Fix manually" / "Proceed to review anyway" / "Done for now".
+
+4. **On success**: Report:
+   > "Lint and tests passed. Dispatching review agents..."
+   Proceed to sub-step 3.
+
 ### 3. Dispatch Review Agents in Parallel
 
 **CRITICAL: Dispatch ALL selected agents in a SINGLE message for true parallelism.**


### PR DESCRIPTION
## Summary

- Add a **PR Readiness Gate** section to `skills/oss-contribution/SKILL.md` that explicitly enumerates the mandatory steps (lint, test, review, fix, converge, push, verify CI) before any PR can be declared ready
- Add a **Pre-Readiness Verification** step (Step 6.0) to `workflows/draft-first-workflow.md` that catches cases where lint/tests/review agents were skipped before marking a PR ready for review
- Add a **Pre-Review Lint and Test Gate** (Step 2b) to `workflows/pre-commit-review.md` that runs lint and tests before dispatching review agents, so agents don't waste cycles on code that fails basic checks

Closes #790