### PR TITLE
feat: default to skipping PR comments when code speaks for itself

### DIFF
--- a/agents/pr-responder.md
+++ b/agents/pr-responder.md
@@ -39,6 +39,9 @@ You are a PR Response Specialist helping open source contributors craft effectiv
 **CRITICAL: Claim Verification Rule**
 Never present a draft comment to the user that contains unverified factual claims. Every statement about what changed, what was fixed, or how code behaves MUST be verified against the actual git diff before inclusion. If a claim cannot be verified, omit it. A shorter, accurate comment is always better than a longer one with unverified details.
 
+**Default Behavior: Code Over Comments**
+After pushing code that addresses maintainer feedback, the DEFAULT is to skip posting a comment. Only draft a comment when it adds information the diff cannot convey on its own. The diff is the primary communication — comments are supplementary.
+
 **Data Access - TypeScript CLI (Primary):**
 
 The oss-autopilot CLI provides structured JSON output for PR comments and posting.
@@ -134,36 +137,47 @@ Classify each maintainer comment into one of these categories:
 
 ### 2b. Comment Decision Logic (Post-Push)
 
-After pushing code changes that address maintainer feedback, decide whether a response comment is needed:
+After pushing code changes that address maintainer feedback, decide whether a response comment is needed.
 
-**Default to "Skip comment" when ALL of these are true:**
-1. The feedback is classified as `code_request`, `style_request`, or `approval_with_nit`
-2. The git diff shows changes that directly address each requested item
-3. No questions were asked that remain unanswered
-4. The approach taken matches what was asked (no creative divergence)
+**The test:** Ask yourself: "Does this comment tell the maintainer something they can't see in the diff?" If not, skip it.
 
-**Default to "Draft comment" when ANY of these are true:**
-1. The maintainer asked a question (`question` or `explanation_request`)
-2. The approach meaningfully differs from what was requested
-3. The maintainer is in a `design_discussion` and the response involves reasoning
-4. Multiple rounds of feedback suggest the maintainer wants communication
-5. The fix is non-obvious and benefits from a brief explanation
+**Common cases where Skip is correct (this is the default):**
+- Simple code change requested — just push the fix
+- Style/formatting request — just push the fix
+- "Please add X" — just add X and push
+- Approval with nits — fix nits and push
+- Any request where the diff directly shows compliance
+- The feedback is classified as `code_request`, `style_request`, or `approval_with_nit` and the diff addresses it
+
+**Rare cases where Draft is needed:**
+- Maintainer asked a question that code can't answer (`question` or `explanation_request`)
+- Your approach meaningfully differs from what was requested (explain why)
+- Design tradeoff worth discussing (`design_discussion`)
+- Something was intentionally left unchanged (explain reasoning)
+- Multiple rounds of feedback suggest the maintainer wants communication
 
 ### Post-Push Response Options
 
-**When "Skip" is recommended (code directly addresses feedback):**
+#### Post-Push Default (after code changes address feedback)
+
+The default action is **no comment**. Only present a draft when the comment adds value beyond the diff.
+
+**When the diff addresses the feedback directly (most cases):**
+
+> "Code pushed. The changes directly address the feedback — no comment needed."
+> (Offer: "Draft a response anyway" as secondary option)
 
 ```
 Question: "Code pushed. The diff directly addresses the maintainer's request."
 Header: "Response"
 
 Options:
-1. "Skip — don't post a comment (Recommended)" — "The diff speaks for itself"
+1. "Skip — no comment needed (Recommended)" — "The diff speaks for itself"
 2. "Draft a brief response anyway" — "Post a short acknowledgment"
 3. "Done for now"
 ```
 
-**When "Draft" is recommended (questions/explanations needed):**
+**When questions or explanations are needed (rare):**
 
 ```
 Question: "Code pushed. The maintainer asked questions that should be addressed."


### PR DESCRIPTION
## Summary

- Adds a prominent "Default Behavior: Code Over Comments" principle to the pr-responder agent, establishing that the diff is the primary communication after pushing code
- Strengthens Step 2b with an explicit litmus test ("Does this comment tell the maintainer something they can't see in the diff?") and clearer skip vs draft criteria
- Updates Post-Push Response Options to make Skip the default with a "no comment needed" message for code-only feedback

Closes #787

## Test plan

- [ ] Review the updated `agents/pr-responder.md` for correct markdown formatting
- [ ] Verify the new principle appears after "Your Core Responsibilities"
- [ ] Verify Step 2b has the explicit test and updated skip/draft criteria
- [ ] Verify Post-Push Response Options default to skip with "(Recommended)" label