### PR TITLE
feat: include full clickable repo URLs in search results

### DIFF
--- a/packages/core/src/commands/search.test.ts
+++ b/packages/core/src/commands/search.test.ts
@@ -73,6 +73,7 @@ describe('runSearch', () => {
           expect.objectContaining({
             issue: {
               repo: 'owner/repo',
+              repoUrl: 'https://github.com/owner/repo',
               number: 5,
               title: 'Fix bug',
               url: 'https://github.com/owner/repo/issues/5',
@@ -146,6 +147,30 @@ describe('runSearch', () => {
     const result = await runSearch({ maxResults: 10 });
 
     expect(result.candidates).toEqual([]);
+  });
+
+  it('should include repoUrl derived from repo name (#789)', async () => {
+    mockRequireGitHubToken.mockReturnValue('ghp_test123');
+    mockSearchIssues.mockResolvedValue([
+      {
+        issue: {
+          repo: 'facebook/react',
+          number: 42,
+          title: 'Some issue',
+          url: 'https://github.com/facebook/react/issues/42',
+          labels: [],
+        },
+        recommendation: 'approve',
+        reasonsToApprove: [],
+        reasonsToSkip: [],
+        searchPriority: 'high',
+        viabilityScore: 90,
+      },
+    ]);
+
+    const result = await runSearch({ maxResults: 5 });
+
+    expect(result.candidates[0].issue.repoUrl).toBe('https://github.com/facebook/react');
   });
 
   it('should propagate errors from searchIssues (#414)', async () => {

--- a/packages/core/src/commands/search.ts
+++ b/packages/core/src/commands/search.ts
@@ -47,6 +47,7 @@ export async function runSearch(options: SearchOptions): Promise<SearchOutput> {
       return {
         issue: {
           repo: c.issue.repo,
+          repoUrl: `https://github.com/${c.issue.repo}`,
           number: c.issue.number,
           title: c.issue.title,
           url: c.issue.url,

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -235,6 +235,7 @@ export interface SearchOutput {
   candidates: Array<{
     issue: {
       repo: string;
+      repoUrl: string;
       number: number;
       title: string;
       url: string;


### PR DESCRIPTION
## Summary

- Adds `repoUrl` field (e.g., `https://github.com/owner/repo`) to `SearchOutput` candidate issue objects so search results include full clickable repository URLs alongside issue links
- Updates the `SearchOutput` interface in `json.ts`, the candidate mapping in `search.ts`, and adds test coverage in `search.test.ts`

Closes #789

## Test plan

- [x] All existing search tests pass (6/6)
- [x] New dedicated test verifies `repoUrl` is correctly derived from repo name
- [x] TypeScript type checker passes (`tsc --noEmit`)
- [x] Linter passes (`pnpm run lint`)