### PR TITLE
feat: add daily PR status cron workflow and SessionStart hook integration

### DIFF
--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -101,6 +101,22 @@ if [ -n "$HEALTH" ]; then
   messages="${messages:+${messages}\n}${HEALTH}"
 fi
 
+# --- Step 4: Inject daily PR status report if fresh ---
+DAILY_REPORT="${HOME}/oss-daily.md"
+if [ -f "$DAILY_REPORT" ]; then
+  # Check if report was generated today
+  report_date=$(date -r "$DAILY_REPORT" +%Y-%m-%d 2>/dev/null || stat -c %y "$DAILY_REPORT" 2>/dev/null | cut -d' ' -f1)
+  today=$(date +%Y-%m-%d)
+  if [ "$report_date" = "$today" ]; then
+    report_content=$(cat "$DAILY_REPORT" 2>/dev/null | head -50)
+    if [ -n "$report_content" ]; then
+      messages="${messages:+${messages}\n}Daily PR status report (generated today):\n${report_content}"
+    fi
+  else
+    messages="${messages:+${messages}\n}Note: Daily PR status report exists but is from ${report_date} (stale). Run the daily cron job or /oss to refresh."
+  fi
+fi
+
 # --- Output JSON ---
 if [ -n "$messages" ]; then
   # Escape for JSON: use jq if available, fall back to sed

--- a/workflows/daily-pr-status-cron.md
+++ b/workflows/daily-pr-status-cron.md
@@ -1,0 +1,48 @@
+# Daily PR Status Report (Headless Cron)
+
+> **Type:** Headless automation — runs without user interaction
+> **Output:** `~/oss-daily.md` — daily PR status summary
+> **Schedule:** Daily, before your first session (e.g., 8:00 AM local time)
+
+## Purpose
+
+Generate a daily PR status report so Claude has PR context at session start, eliminating the "check my PRs" warmup step.
+
+## Cron Setup
+
+### macOS / Linux (crontab)
+
+```bash
+# 8:00 AM PT — daily OSS PR status report
+0 15 * * * claude -p "Check all my open PRs with gh. For each: CI status, review state, days since last activity. Flag anything actionable. Write the summary to ~/oss-daily.md" --allowedTools "Bash,Read,Write" > ~/oss-daily.log 2>&1
+```
+
+### What the report includes
+
+For each open PR:
+- Repository and PR number
+- CI status (passing/failing/pending)
+- Review state (approved/changes requested/pending)
+- Days since last activity
+- Whether it needs attention (merge conflict, unresponded comment, etc.)
+
+Summary section:
+- Total active PRs
+- PRs needing attention (count + list)
+- PRs waiting on maintainer
+- Any PRs approaching dormancy
+
+### Integration
+
+- The SessionStart hook reads `~/oss-daily.md` and surfaces it to Claude
+- Claude can proactively suggest actions based on the report
+- Pairs with: weekly PR audit (#785), dependabot triage (#783)
+
+### Disabling
+
+Remove the crontab entry:
+```bash
+crontab -e  # Remove the relevant line
+```
+
+Or use `/setup-automation` to manage all automation settings.


### PR DESCRIPTION
## Summary

- Add `workflows/daily-pr-status-cron.md` documenting how to set up a headless cron job that runs Claude daily to generate a PR status report to `~/oss-daily.md`
- Update `hooks/session-start.sh` with a new Step 4 that auto-injects the daily report into the SessionStart context if the file exists and was generated today; shows a staleness note if the report is from a previous day

## Test plan

- [ ] Verify shell script syntax passes (`bash -n hooks/session-start.sh`)
- [ ] Verify `pnpm test` passes (core + dashboard suites)
- [ ] Verify `pnpm run lint` passes
- [ ] Manual test: create a fresh `~/oss-daily.md` and confirm the hook surfaces it
- [ ] Manual test: touch `~/oss-daily.md` with an old date and confirm the stale warning appears
- [ ] Manual test: remove `~/oss-daily.md` and confirm no output from Step 4

Closes #782