### PR TITLE
fix: exclude private repos and orgs from PR tracking

### DIFF
--- a/packages/core/src/core/github-stats.test.ts
+++ b/packages/core/src/core/github-stats.test.ts
@@ -546,3 +546,149 @@ describe('fetchRecentlyClosedPRs', () => {
     expect(result[0].closedAt).toBe('2025-07-01T10:00:00Z');
   });
 });
+
+describe('fetchRecentlyMergedPRs — excludeRepos/excludeOrgs filtering (#792)', () => {
+  beforeEach(() => {
+    testCacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oss-cache-recent-merged-exclude-test-'));
+    testCache = new HttpCache(testCacheDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(testCacheDir, { recursive: true, force: true });
+  });
+
+  it('should exclude PRs from excluded repos', async () => {
+    const items = [
+      {
+        html_url: 'https://github.com/excluded-org/private-repo/pull/5',
+        title: 'Private repo PR',
+        pull_request: { merged_at: '2025-06-15T12:00:00Z' },
+        closed_at: '2025-06-15T12:00:00Z',
+      },
+      {
+        html_url: 'https://github.com/oss-org/public-repo/pull/6',
+        title: 'Public repo PR',
+        pull_request: { merged_at: '2025-06-16T12:00:00Z' },
+        closed_at: '2025-06-16T12:00:00Z',
+      },
+    ];
+    const octokit = makeOctokit(items);
+
+    const result = await fetchRecentlyMergedPRs(
+      octokit,
+      { githubUsername: 'testuser', excludeRepos: ['excluded-org/private-repo'], excludeOrgs: [] },
+      7,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].repo).toBe('oss-org/public-repo');
+  });
+
+  it('should exclude PRs from excluded orgs', async () => {
+    const items = [
+      {
+        html_url: 'https://github.com/private-org/repo-a/pull/10',
+        title: 'Private org PR',
+        pull_request: { merged_at: '2025-06-15T12:00:00Z' },
+        closed_at: '2025-06-15T12:00:00Z',
+      },
+      {
+        html_url: 'https://github.com/oss-org/public-repo/pull/11',
+        title: 'Public repo PR',
+        pull_request: { merged_at: '2025-06-16T12:00:00Z' },
+        closed_at: '2025-06-16T12:00:00Z',
+      },
+    ];
+    const octokit = makeOctokit(items);
+
+    const result = await fetchRecentlyMergedPRs(
+      octokit,
+      { githubUsername: 'testuser', excludeRepos: [], excludeOrgs: ['private-org'] },
+      7,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].repo).toBe('oss-org/public-repo');
+  });
+
+  it('should be case-insensitive for org exclusion', async () => {
+    const items = [
+      {
+        html_url: 'https://github.com/PrivateOrg/repo/pull/1',
+        title: 'Mixed case org PR',
+        pull_request: { merged_at: '2025-06-15T12:00:00Z' },
+        closed_at: '2025-06-15T12:00:00Z',
+      },
+    ];
+    const octokit = makeOctokit(items);
+
+    const result = await fetchRecentlyMergedPRs(
+      octokit,
+      { githubUsername: 'testuser', excludeRepos: [], excludeOrgs: ['privateorg'] },
+      7,
+    );
+
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe('fetchRecentlyClosedPRs — excludeRepos/excludeOrgs filtering (#792)', () => {
+  beforeEach(() => {
+    testCacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oss-cache-recent-closed-exclude-test-'));
+    testCache = new HttpCache(testCacheDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(testCacheDir, { recursive: true, force: true });
+  });
+
+  it('should exclude PRs from excluded repos', async () => {
+    const items = [
+      {
+        html_url: 'https://github.com/excluded-org/private-repo/pull/5',
+        title: 'Private repo PR',
+        closed_at: '2025-06-15T12:00:00Z',
+      },
+      {
+        html_url: 'https://github.com/oss-org/public-repo/pull/6',
+        title: 'Public repo PR',
+        closed_at: '2025-06-16T12:00:00Z',
+      },
+    ];
+    const octokit = makeOctokit(items);
+
+    const result = await fetchRecentlyClosedPRs(
+      octokit,
+      { githubUsername: 'testuser', excludeRepos: ['excluded-org/private-repo'], excludeOrgs: [] },
+      7,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].repo).toBe('oss-org/public-repo');
+  });
+
+  it('should exclude PRs from excluded orgs', async () => {
+    const items = [
+      {
+        html_url: 'https://github.com/private-org/repo-a/pull/10',
+        title: 'Private org PR',
+        closed_at: '2025-06-15T12:00:00Z',
+      },
+      {
+        html_url: 'https://github.com/oss-org/public-repo/pull/11',
+        title: 'Public repo PR',
+        closed_at: '2025-06-16T12:00:00Z',
+      },
+    ];
+    const octokit = makeOctokit(items);
+
+    const result = await fetchRecentlyClosedPRs(
+      octokit,
+      { githubUsername: 'testuser', excludeRepos: [], excludeOrgs: ['private-org'] },
+      7,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].repo).toBe('oss-org/public-repo');
+  });
+});

--- a/packages/core/src/core/github-stats.ts
+++ b/packages/core/src/core/github-stats.ts
@@ -262,7 +262,7 @@ export function fetchUserClosedPRCounts(
  */
 async function fetchRecentPRs<T>(
   octokit: Octokit,
-  config: { githubUsername: string },
+  config: { githubUsername: string; excludeRepos?: string[]; excludeOrgs?: string[] },
   query: string,
   label: string,
   days: number,
@@ -303,6 +303,16 @@ async function fetchRecentPRs<T>(
     // Skip own repos
     if (isOwnRepo(parsed.owner, config.githubUsername)) continue;
 
+    // Exclude configured repos and orgs (#792)
+    if (config.excludeRepos?.includes(repo)) {
+      debug(MODULE, `Skipping excluded repo: ${repo}`);
+      continue;
+    }
+    if (config.excludeOrgs?.some((org) => org.toLowerCase() === parsed.owner.toLowerCase())) {
+      debug(MODULE, `Skipping excluded org: ${parsed.owner}`);
+      continue;
+    }
+
     results.push(mapItem(item, { owner: parsed.owner, repo, number: parsed.number }));
   }
 
@@ -316,7 +326,7 @@ async function fetchRecentPRs<T>(
  */
 export async function fetchRecentlyClosedPRs(
   octokit: Octokit,
-  config: { githubUsername: string },
+  config: { githubUsername: string; excludeRepos?: string[]; excludeOrgs?: string[] },
   days: number = 7,
 ): Promise<ClosedPR[]> {
   return fetchRecentPRs<ClosedPR>(
@@ -341,7 +351,7 @@ export async function fetchRecentlyClosedPRs(
  */
 export async function fetchRecentlyMergedPRs(
   octokit: Octokit,
-  config: { githubUsername: string },
+  config: { githubUsername: string; excludeRepos?: string[]; excludeOrgs?: string[] },
   days: number = 7,
 ): Promise<MergedPR[]> {
   return fetchRecentPRs<MergedPR>(

--- a/packages/core/src/core/pr-monitor.test.ts
+++ b/packages/core/src/core/pr-monitor.test.ts
@@ -909,7 +909,7 @@ describe('PRMonitor fetchRecentlyMergedPRs', () => {
     expect(result).toHaveLength(0);
   });
 
-  it('should include PRs from excluded repos (#591)', async () => {
+  it('should exclude PRs from excluded repos (#792)', async () => {
     mockOctokitInstance = {
       search: {
         issuesAndPullRequests: vi.fn().mockResolvedValue({
@@ -930,11 +930,10 @@ describe('PRMonitor fetchRecentlyMergedPRs', () => {
     const monitor = new PRMonitor('fake-token');
     const result = await monitor.fetchRecentlyMergedPRs();
 
-    expect(result).toHaveLength(1);
-    expect(result[0].repo).toBe('excluded/repo');
+    expect(result).toHaveLength(0);
   });
 
-  it('should include PRs from excluded orgs (#591)', async () => {
+  it('should exclude PRs from excluded orgs (#792)', async () => {
     mockOctokitInstance = {
       search: {
         issuesAndPullRequests: vi.fn().mockResolvedValue({
@@ -955,8 +954,7 @@ describe('PRMonitor fetchRecentlyMergedPRs', () => {
     const monitor = new PRMonitor('fake-token');
     const result = await monitor.fetchRecentlyMergedPRs();
 
-    expect(result).toHaveLength(1);
-    expect(result[0].repo).toBe('excludedorg/repo');
+    expect(result).toHaveLength(0);
   });
 
   it('should return empty array when no username configured', async () => {
@@ -1655,7 +1653,7 @@ describe('isConditionalChecklistItem (#152)', () => {
   });
 });
 
-describe('fetchUserOpenPRs does not filter by excludeRepos/excludeOrgs (#591)', () => {
+describe('fetchUserOpenPRs filters by excludeRepos/excludeOrgs (#792)', () => {
   const makeSearchItem = (url: string) => ({
     html_url: url,
     title: 'Test PR',
@@ -1707,7 +1705,7 @@ describe('fetchUserOpenPRs does not filter by excludeRepos/excludeOrgs (#591)', 
     mockOctokitInstance = {};
   });
 
-  it('should include PR from excluded repo', async () => {
+  it('should exclude PR from excluded repo', async () => {
     const prUrl = 'https://github.com/excluded/repo/pull/99';
 
     vi.mocked(getStateManager).mockReturnValue(
@@ -1732,11 +1730,10 @@ describe('fetchUserOpenPRs does not filter by excludeRepos/excludeOrgs (#591)', 
     const monitor = new PRMonitor('fake-token');
     const { prs } = await monitor.fetchUserOpenPRs();
 
-    expect(prs).toHaveLength(1);
-    expect(prs[0].url).toBe(prUrl);
+    expect(prs).toHaveLength(0);
   });
 
-  it('should include PR from excluded org', async () => {
+  it('should exclude PR from excluded org', async () => {
     const prUrl = 'https://github.com/excludedorg/somerepo/pull/77';
 
     vi.mocked(getStateManager).mockReturnValue(
@@ -1761,8 +1758,35 @@ describe('fetchUserOpenPRs does not filter by excludeRepos/excludeOrgs (#591)', 
     const monitor = new PRMonitor('fake-token');
     const { prs } = await monitor.fetchUserOpenPRs();
 
-    expect(prs).toHaveLength(1);
-    expect(prs[0].url).toBe(prUrl);
+    expect(prs).toHaveLength(0);
+  });
+
+  it('should exclude PR from excluded org case-insensitively', async () => {
+    const prUrl = 'https://github.com/ExcludedOrg/somerepo/pull/77';
+
+    vi.mocked(getStateManager).mockReturnValue(
+      makeStateManagerMock({
+        config: { excludeRepos: [], excludeOrgs: ['excludedorg'] },
+      }),
+    );
+
+    const detailMocks = makePRDetailMocks(prUrl);
+    mockOctokitInstance = {
+      search: {
+        issuesAndPullRequests: vi.fn().mockResolvedValue({
+          data: {
+            total_count: 1,
+            items: [makeSearchItem(prUrl)],
+          },
+        }),
+      },
+      ...detailMocks,
+    };
+
+    const monitor = new PRMonitor('fake-token');
+    const { prs } = await monitor.fetchUserOpenPRs();
+
+    expect(prs).toHaveLength(0);
   });
 });
 

--- a/packages/core/src/core/pr-monitor.ts
+++ b/packages/core/src/core/pr-monitor.ts
@@ -162,6 +162,15 @@ export class PRMonitor {
         return false;
       }
       if (isOwnRepo(parsed.owner, config.githubUsername)) return false;
+      // Exclude configured repos and orgs (#792)
+      if (config.excludeRepos.includes(`${parsed.owner}/${parsed.repo}`)) {
+        debug('pr-monitor', `Skipping excluded repo: ${parsed.owner}/${parsed.repo}`);
+        return false;
+      }
+      if (config.excludeOrgs?.some((org) => org.toLowerCase() === parsed.owner.toLowerCase())) {
+        debug('pr-monitor', `Skipping excluded org: ${parsed.owner}`);
+        return false;
+      }
       return true;
     });
 


### PR DESCRIPTION
## Summary

- Apply `excludeRepos`/`excludeOrgs` config filtering to PR monitoring (not just issue discovery), so private repos and orgs no longer appear in open PR stats, recently merged/closed lists, or actionable issue counts
- Add filtering to `fetchUserOpenPRs()` in `pr-monitor.ts` after the existing `isOwnRepo` filter
- Add filtering to `fetchRecentlyMergedPRs()` and `fetchRecentlyClosedPRs()` via the shared `fetchRecentPRs()` helper in `github-stats.ts`
- Org exclusion is case-insensitive to match GitHub's behavior

## Test plan

- [x] Updated existing `fetchUserOpenPRs` tests (previously asserted inclusion per #591) to verify PRs from excluded repos/orgs are now filtered out
- [x] Added case-insensitive org exclusion test for `fetchUserOpenPRs`
- [x] Updated `fetchRecentlyMergedPRs` tests to verify excluded repos/orgs are filtered
- [x] Added new test suites in `github-stats.test.ts` for `fetchRecentlyMergedPRs` and `fetchRecentlyClosedPRs` exclude filtering
- [x] All 2053 tests pass, lint and type-check clean

Fixes #792