### PR TITLE
fix: resolve flatted prototype pollution vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "overrides": {
       "hono": ">=4.12.7",
       "@hono/node-server": ">=1.19.10",
-      "express-rate-limit": ">=8.2.2"
+      "express-rate-limit": ">=8.2.2",
+      "flatted": ">=3.4.2"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   hono: '>=4.12.7'
   '@hono/node-server': '>=1.19.10'
   express-rate-limit: '>=8.2.2'
+  flatted: '>=3.4.2'
 
 importers:
 
@@ -1469,8 +1470,8 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.4.1:
-    resolution: {integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==}
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -3780,10 +3781,10 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.4.1
+      flatted: 3.4.2
       keyv: 4.5.4
 
-  flatted@3.4.1: {}
+  flatted@3.4.2: {}
 
   for-each@0.3.5:
     dependencies:


### PR DESCRIPTION
## Summary

Add pnpm override for `flatted>=3.4.2` to fix a high-severity prototype pollution vulnerability (GHSA-rf6f-7fwh-wjgh).

## Problem

`flatted<=3.4.1` has a prototype pollution vulnerability via `parse()`. It's a transitive dependency: `eslint > file-entry-cache > flat-cache > flatted`. This was blocking CI on all branches.

## Solution

Added `"flatted": ">=3.4.2"` to the pnpm overrides in `package.json`, forcing the patched version.

## Test plan

- `pnpm audit --audit-level=high` now passes with 0 vulnerabilities
- All existing tests continue to pass