### PR TITLE
fix: use is:public query to exclude private repos instead of excludeRepos/excludeOrgs

### DIFF
--- a/packages/core/src/core/github-stats.test.ts
+++ b/packages/core/src/core/github-stats.test.ts
@@ -547,9 +547,9 @@ describe('fetchRecentlyClosedPRs', () => {
   });
 });
 
-describe('fetchRecentlyMergedPRs — excludeRepos/excludeOrgs filtering (#792)', () => {
+describe('fetchRecentlyMergedPRs uses is:public query (#792)', () => {
   beforeEach(() => {
-    testCacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oss-cache-recent-merged-exclude-test-'));
+    testCacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oss-cache-recent-merged-public-test-'));
     testCache = new HttpCache(testCacheDir);
   });
 
@@ -557,84 +557,36 @@ describe('fetchRecentlyMergedPRs — excludeRepos/excludeOrgs filtering (#792)',
     fs.rmSync(testCacheDir, { recursive: true, force: true });
   });
 
-  it('should exclude PRs from excluded repos', async () => {
+  it('should include is:public in the search query', async () => {
+    const octokit = makeOctokit([]);
+
+    await fetchRecentlyMergedPRs(octokit, { githubUsername: 'testuser' }, 7);
+
+    const searchCall = vi.mocked(octokit.search.issuesAndPullRequests).mock.calls[0][0];
+    expect(searchCall.q).toContain('is:public');
+  });
+
+  it('should not filter by excludeRepos — those only affect issue discovery (#591)', async () => {
     const items = [
       {
         html_url: 'https://github.com/excluded-org/private-repo/pull/5',
-        title: 'Private repo PR',
+        title: 'Excluded repo PR',
         pull_request: { merged_at: '2025-06-15T12:00:00Z' },
         closed_at: '2025-06-15T12:00:00Z',
-      },
-      {
-        html_url: 'https://github.com/oss-org/public-repo/pull/6',
-        title: 'Public repo PR',
-        pull_request: { merged_at: '2025-06-16T12:00:00Z' },
-        closed_at: '2025-06-16T12:00:00Z',
       },
     ];
     const octokit = makeOctokit(items);
 
-    const result = await fetchRecentlyMergedPRs(
-      octokit,
-      { githubUsername: 'testuser', excludeRepos: ['excluded-org/private-repo'], excludeOrgs: [] },
-      7,
-    );
+    // excludeRepos is not even accepted by fetchRecentlyMergedPRs — it only takes githubUsername
+    const result = await fetchRecentlyMergedPRs(octokit, { githubUsername: 'testuser' }, 7);
 
     expect(result).toHaveLength(1);
-    expect(result[0].repo).toBe('oss-org/public-repo');
-  });
-
-  it('should exclude PRs from excluded orgs', async () => {
-    const items = [
-      {
-        html_url: 'https://github.com/private-org/repo-a/pull/10',
-        title: 'Private org PR',
-        pull_request: { merged_at: '2025-06-15T12:00:00Z' },
-        closed_at: '2025-06-15T12:00:00Z',
-      },
-      {
-        html_url: 'https://github.com/oss-org/public-repo/pull/11',
-        title: 'Public repo PR',
-        pull_request: { merged_at: '2025-06-16T12:00:00Z' },
-        closed_at: '2025-06-16T12:00:00Z',
-      },
-    ];
-    const octokit = makeOctokit(items);
-
-    const result = await fetchRecentlyMergedPRs(
-      octokit,
-      { githubUsername: 'testuser', excludeRepos: [], excludeOrgs: ['private-org'] },
-      7,
-    );
-
-    expect(result).toHaveLength(1);
-    expect(result[0].repo).toBe('oss-org/public-repo');
-  });
-
-  it('should be case-insensitive for org exclusion', async () => {
-    const items = [
-      {
-        html_url: 'https://github.com/PrivateOrg/repo/pull/1',
-        title: 'Mixed case org PR',
-        pull_request: { merged_at: '2025-06-15T12:00:00Z' },
-        closed_at: '2025-06-15T12:00:00Z',
-      },
-    ];
-    const octokit = makeOctokit(items);
-
-    const result = await fetchRecentlyMergedPRs(
-      octokit,
-      { githubUsername: 'testuser', excludeRepos: [], excludeOrgs: ['privateorg'] },
-      7,
-    );
-
-    expect(result).toHaveLength(0);
   });
 });
 
-describe('fetchRecentlyClosedPRs — excludeRepos/excludeOrgs filtering (#792)', () => {
+describe('fetchRecentlyClosedPRs uses is:public query (#792)', () => {
   beforeEach(() => {
-    testCacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oss-cache-recent-closed-exclude-test-'));
+    testCacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oss-cache-recent-closed-public-test-'));
     testCache = new HttpCache(testCacheDir);
   });
 
@@ -642,53 +594,12 @@ describe('fetchRecentlyClosedPRs — excludeRepos/excludeOrgs filtering (#792)',
     fs.rmSync(testCacheDir, { recursive: true, force: true });
   });
 
-  it('should exclude PRs from excluded repos', async () => {
-    const items = [
-      {
-        html_url: 'https://github.com/excluded-org/private-repo/pull/5',
-        title: 'Private repo PR',
-        closed_at: '2025-06-15T12:00:00Z',
-      },
-      {
-        html_url: 'https://github.com/oss-org/public-repo/pull/6',
-        title: 'Public repo PR',
-        closed_at: '2025-06-16T12:00:00Z',
-      },
-    ];
-    const octokit = makeOctokit(items);
+  it('should include is:public in the search query', async () => {
+    const octokit = makeOctokit([]);
 
-    const result = await fetchRecentlyClosedPRs(
-      octokit,
-      { githubUsername: 'testuser', excludeRepos: ['excluded-org/private-repo'], excludeOrgs: [] },
-      7,
-    );
+    await fetchRecentlyClosedPRs(octokit, { githubUsername: 'testuser' }, 7);
 
-    expect(result).toHaveLength(1);
-    expect(result[0].repo).toBe('oss-org/public-repo');
-  });
-
-  it('should exclude PRs from excluded orgs', async () => {
-    const items = [
-      {
-        html_url: 'https://github.com/private-org/repo-a/pull/10',
-        title: 'Private org PR',
-        closed_at: '2025-06-15T12:00:00Z',
-      },
-      {
-        html_url: 'https://github.com/oss-org/public-repo/pull/11',
-        title: 'Public repo PR',
-        closed_at: '2025-06-16T12:00:00Z',
-      },
-    ];
-    const octokit = makeOctokit(items);
-
-    const result = await fetchRecentlyClosedPRs(
-      octokit,
-      { githubUsername: 'testuser', excludeRepos: [], excludeOrgs: ['private-org'] },
-      7,
-    );
-
-    expect(result).toHaveLength(1);
-    expect(result[0].repo).toBe('oss-org/public-repo');
+    const searchCall = vi.mocked(octokit.search.issuesAndPullRequests).mock.calls[0][0];
+    expect(searchCall.q).toContain('is:public');
   });
 });

--- a/packages/core/src/core/github-stats.ts
+++ b/packages/core/src/core/github-stats.ts
@@ -262,7 +262,7 @@ export function fetchUserClosedPRCounts(
  */
 async function fetchRecentPRs<T>(
   octokit: Octokit,
-  config: { githubUsername: string; excludeRepos?: string[]; excludeOrgs?: string[] },
+  config: { githubUsername: string },
   query: string,
   label: string,
   days: number,
@@ -298,21 +298,10 @@ async function fetchRecentPRs<T>(
       continue;
     }
 
-    const repo = `${parsed.owner}/${parsed.repo}`;
-
     // Skip own repos
     if (isOwnRepo(parsed.owner, config.githubUsername)) continue;
 
-    // Exclude configured repos and orgs (#792)
-    if (config.excludeRepos?.includes(repo)) {
-      debug(MODULE, `Skipping excluded repo: ${repo}`);
-      continue;
-    }
-    if (config.excludeOrgs?.some((org) => org.toLowerCase() === parsed.owner.toLowerCase())) {
-      debug(MODULE, `Skipping excluded org: ${parsed.owner}`);
-      continue;
-    }
-
+    const repo = `${parsed.owner}/${parsed.repo}`;
     results.push(mapItem(item, { owner: parsed.owner, repo, number: parsed.number }));
   }
 
@@ -326,13 +315,13 @@ async function fetchRecentPRs<T>(
  */
 export async function fetchRecentlyClosedPRs(
   octokit: Octokit,
-  config: { githubUsername: string; excludeRepos?: string[]; excludeOrgs?: string[] },
+  config: { githubUsername: string },
   days: number = 7,
 ): Promise<ClosedPR[]> {
   return fetchRecentPRs<ClosedPR>(
     octokit,
     config,
-    'is:pr is:closed is:unmerged author:{username} closed:>={since}',
+    'is:pr is:closed is:unmerged is:public author:{username} closed:>={since}',
     'closed',
     days,
     (item, { repo, number }) => ({
@@ -351,13 +340,13 @@ export async function fetchRecentlyClosedPRs(
  */
 export async function fetchRecentlyMergedPRs(
   octokit: Octokit,
-  config: { githubUsername: string; excludeRepos?: string[]; excludeOrgs?: string[] },
+  config: { githubUsername: string },
   days: number = 7,
 ): Promise<MergedPR[]> {
   return fetchRecentPRs<MergedPR>(
     octokit,
     config,
-    'is:pr is:merged author:{username} merged:>={since}',
+    'is:pr is:merged is:public author:{username} merged:>={since}',
     'merged',
     days,
     (item, { repo, number }) => {

--- a/packages/core/src/core/pr-monitor.test.ts
+++ b/packages/core/src/core/pr-monitor.test.ts
@@ -849,7 +849,7 @@ describe('PRMonitor fetchRecentlyMergedPRs', () => {
     mockOctokitInstance = {};
     vi.mocked(getStateManager).mockReturnValue(
       makeStateManagerMock({
-        config: { excludeRepos: ['excluded/repo'], excludeOrgs: ['excludedorg'] },
+        config: {},
       }),
     );
   });
@@ -909,7 +909,12 @@ describe('PRMonitor fetchRecentlyMergedPRs', () => {
     expect(result).toHaveLength(0);
   });
 
-  it('should exclude PRs from excluded repos (#792)', async () => {
+  it('should include PRs from excluded repos in merged results (#591)', async () => {
+    vi.mocked(getStateManager).mockReturnValue(
+      makeStateManagerMock({
+        config: { excludeRepos: ['excluded/repo'] },
+      }),
+    );
     mockOctokitInstance = {
       search: {
         issuesAndPullRequests: vi.fn().mockResolvedValue({
@@ -930,31 +935,8 @@ describe('PRMonitor fetchRecentlyMergedPRs', () => {
     const monitor = new PRMonitor('fake-token');
     const result = await monitor.fetchRecentlyMergedPRs();
 
-    expect(result).toHaveLength(0);
-  });
-
-  it('should exclude PRs from excluded orgs (#792)', async () => {
-    mockOctokitInstance = {
-      search: {
-        issuesAndPullRequests: vi.fn().mockResolvedValue({
-          data: {
-            items: [
-              {
-                html_url: 'https://github.com/excludedorg/repo/pull/1',
-                title: 'Excluded org PR',
-                pull_request: { merged_at: '2026-02-15T12:00:00Z' },
-                closed_at: '2026-02-15T12:00:00Z',
-              },
-            ],
-          },
-        }),
-      },
-    };
-
-    const monitor = new PRMonitor('fake-token');
-    const result = await monitor.fetchRecentlyMergedPRs();
-
-    expect(result).toHaveLength(0);
+    // excludeRepos only affects issue discovery, not PR tracking
+    expect(result).toHaveLength(1);
   });
 
   it('should return empty array when no username configured', async () => {
@@ -1653,140 +1635,29 @@ describe('isConditionalChecklistItem (#152)', () => {
   });
 });
 
-describe('fetchUserOpenPRs filters by excludeRepos/excludeOrgs (#792)', () => {
-  const makeSearchItem = (url: string) => ({
-    html_url: url,
-    title: 'Test PR',
-    pull_request: { html_url: url },
-    created_at: '2026-02-01T00:00:00Z',
-    updated_at: '2026-02-07T00:00:00Z',
-  });
-
-  // Minimal mock for fetchPRDetails — just enough for the PR to pass through
-  const makePRDetailMocks = (prUrl: string) => {
-    const match = prUrl.match(/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
-    if (!match) throw new Error(`Bad URL: ${prUrl}`);
-    const [, _owner, _repo, num] = match;
-    return {
-      pulls: {
-        get: vi.fn().mockResolvedValue({
-          data: {
-            id: Number(num),
-            title: 'Test PR',
-            created_at: '2026-02-01T00:00:00Z',
-            updated_at: '2026-02-07T00:00:00Z',
-            head: { sha: 'abc123' },
-            mergeable: true,
-            mergeable_state: 'clean',
-            body: '',
-            draft: false,
-            review_comments: 0,
-            commits: 1,
-          },
-        }),
-        listReviews: vi.fn().mockResolvedValue({ data: [] }),
-        listReviewComments: vi.fn().mockResolvedValue({ data: [] }),
-      },
-      issues: {
-        listComments: vi.fn().mockResolvedValue({ data: [] }),
-      },
-      repos: {
-        getCombinedStatusForRef: vi.fn().mockResolvedValue({
-          data: { state: 'success', statuses: [] },
-        }),
-      },
-      checks: {
-        listForRef: vi.fn().mockResolvedValue({ data: { check_runs: [] } }),
-      },
-    };
-  };
-
-  beforeEach(() => {
-    mockOctokitInstance = {};
-  });
-
-  it('should exclude PR from excluded repo', async () => {
-    const prUrl = 'https://github.com/excluded/repo/pull/99';
-
+describe('fetchUserOpenPRs does not filter by excludeRepos/excludeOrgs (#591)', () => {
+  it('should use is:public in the search query to exclude private repos (#792)', async () => {
     vi.mocked(getStateManager).mockReturnValue(
       makeStateManagerMock({
-        config: { excludeRepos: ['excluded/repo'], excludeOrgs: [] },
+        config: { excludeRepos: ['excluded/repo'], excludeOrgs: ['excludedorg'] },
       }),
     );
 
-    const detailMocks = makePRDetailMocks(prUrl);
     mockOctokitInstance = {
       search: {
         issuesAndPullRequests: vi.fn().mockResolvedValue({
-          data: {
-            total_count: 1,
-            items: [makeSearchItem(prUrl)],
-          },
+          data: { total_count: 0, items: [] },
         }),
       },
-      ...detailMocks,
     };
 
     const monitor = new PRMonitor('fake-token');
-    const { prs } = await monitor.fetchUserOpenPRs();
+    await monitor.fetchUserOpenPRs();
 
-    expect(prs).toHaveLength(0);
-  });
-
-  it('should exclude PR from excluded org', async () => {
-    const prUrl = 'https://github.com/excludedorg/somerepo/pull/77';
-
-    vi.mocked(getStateManager).mockReturnValue(
-      makeStateManagerMock({
-        config: { excludeRepos: [], excludeOrgs: ['excludedorg'] },
-      }),
-    );
-
-    const detailMocks = makePRDetailMocks(prUrl);
-    mockOctokitInstance = {
-      search: {
-        issuesAndPullRequests: vi.fn().mockResolvedValue({
-          data: {
-            total_count: 1,
-            items: [makeSearchItem(prUrl)],
-          },
-        }),
-      },
-      ...detailMocks,
-    };
-
-    const monitor = new PRMonitor('fake-token');
-    const { prs } = await monitor.fetchUserOpenPRs();
-
-    expect(prs).toHaveLength(0);
-  });
-
-  it('should exclude PR from excluded org case-insensitively', async () => {
-    const prUrl = 'https://github.com/ExcludedOrg/somerepo/pull/77';
-
-    vi.mocked(getStateManager).mockReturnValue(
-      makeStateManagerMock({
-        config: { excludeRepos: [], excludeOrgs: ['excludedorg'] },
-      }),
-    );
-
-    const detailMocks = makePRDetailMocks(prUrl);
-    mockOctokitInstance = {
-      search: {
-        issuesAndPullRequests: vi.fn().mockResolvedValue({
-          data: {
-            total_count: 1,
-            items: [makeSearchItem(prUrl)],
-          },
-        }),
-      },
-      ...detailMocks,
-    };
-
-    const monitor = new PRMonitor('fake-token');
-    const { prs } = await monitor.fetchUserOpenPRs();
-
-    expect(prs).toHaveLength(0);
+    const searchCall = vi.mocked(mockOctokitInstance.search.issuesAndPullRequests).mock.calls[0][0];
+    expect(searchCall.q).toContain('is:public');
+    expect(searchCall.q).not.toContain('excludeRepos');
+    expect(searchCall.q).not.toContain('excludeOrgs');
   });
 });
 

--- a/packages/core/src/core/pr-monitor.ts
+++ b/packages/core/src/core/pr-monitor.ts
@@ -124,7 +124,7 @@ export class PRMonitor {
     const perPage = 100;
 
     const firstPage = await this.octokit.search.issuesAndPullRequests({
-      q: `is:pr is:open author:${config.githubUsername}`,
+      q: `is:pr is:open is:public author:${config.githubUsername}`,
       sort: 'updated',
       order: 'desc',
       per_page: perPage,
@@ -140,7 +140,7 @@ export class PRMonitor {
     while (page < totalPages) {
       page++;
       const nextPage = await this.octokit.search.issuesAndPullRequests({
-        q: `is:pr is:open author:${config.githubUsername}`,
+        q: `is:pr is:open is:public author:${config.githubUsername}`,
         sort: 'updated',
         order: 'desc',
         per_page: perPage,
@@ -162,15 +162,6 @@ export class PRMonitor {
         return false;
       }
       if (isOwnRepo(parsed.owner, config.githubUsername)) return false;
-      // Exclude configured repos and orgs (#792)
-      if (config.excludeRepos.includes(`${parsed.owner}/${parsed.repo}`)) {
-        debug('pr-monitor', `Skipping excluded repo: ${parsed.owner}/${parsed.repo}`);
-        return false;
-      }
-      if (config.excludeOrgs?.some((org) => org.toLowerCase() === parsed.owner.toLowerCase())) {
-        debug('pr-monitor', `Skipping excluded org: ${parsed.owner}`);
-        return false;
-      }
       return true;
     });
 


### PR DESCRIPTION
## Summary

Fixes the approach from PR #802 which incorrectly repurposed `excludeRepos`/`excludeOrgs` to filter PR monitoring. Those settings are scoped to **issue discovery only** — PRs from excluded repos should still appear in tracking if they're public repos.

## Problem

`excludeRepos`/`excludeOrgs` means "don't search for new issues in these repos." It does **not** mean "hide my PRs from these repos." If you have active PRs or merged PRs in an excluded repo, they should still count in your stats and dashboard (#591).

The real problem (#792) was private repos (like `execonline-inc`) appearing in OSS tracking. The fix should be based on **repo visibility**, not on the exclusion config.

## Solution

- Add `is:public` to all GitHub Search API queries (`fetchUserOpenPRs`, `fetchRecentlyMergedPRs`, `fetchRecentlyClosedPRs`) — private repos are now excluded at the API level
- Revert `excludeRepos`/`excludeOrgs` filtering from PR monitoring, restoring the #591 design
- Revert the config type expansion in `fetchRecentPRs()` back to `{ githubUsername: string }`

## Test plan

- All 2,067 core tests pass
- New test verifies `is:public` appears in the search query
- Restored #591 test verifies PRs from excluded repos are **not** filtered from merged results
- Lint and typecheck clean

Fixes #792