### PR TITLE
Add PreToolUse hook to guard against unauthorized public posts

### DIFF
--- a/hooks/guard-public-posts.sh
+++ b/hooks/guard-public-posts.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block Bash commands that post to public platforms
+# (gh pr comment, gh issue comment, oss-autopilot post) unless the user
+# has explicitly approved. Returns "ask" so Claude Code prompts the user
+# for confirmation rather than silently blocking.
+
+set -euo pipefail
+
+input=$(cat)
+
+command=$(echo "$input" | jq -r '.tool_input.command // empty')
+
+if [ -z "$command" ]; then
+  exit 0
+fi
+
+# Patterns that post publicly
+if echo "$command" | grep -qE '(gh\s+(pr|issue)\s+comment|gh\s+pr\s+review|cli\.bundle\.cjs.*\bpost\b)'; then
+  cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "ask",
+    "updatedInput": {}
+  },
+  "systemMessage": "This command posts a public comment. The user must explicitly approve before posting to GitHub PRs, issues, or any public platform. Draft the comment text and present it to the user first."
+}
+EOF
+  exit 0
+fi
+
+exit 0

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -10,6 +10,18 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/guard-public-posts.sh",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary

- Adds a Bash PreToolUse hook that intercepts commands posting to public platforms (`gh pr comment`, `gh issue comment`, `gh pr review`, oss-autopilot `post`)
- Returns `permissionDecision: "ask"` so Claude Code prompts for confirmation rather than silently posting
- Closes a gap where the pr-responder agent has guardrails but the main agent can bypass them by running gh commands directly

## Test plan

- [x] Verified hook catches `gh pr comment`, `gh issue comment`, `gh pr review`, and `cli.bundle.cjs post`
- [x] Verified hook allows through non-posting commands (`gh pr view`, `gh api` GET requests)
- [x] Verified hook returns valid JSON with `permissionDecision: "ask"`