### PR TITLE
fix: always branch from upstream default, not stale local branches

### DIFF
--- a/commands/oss-search.md
+++ b/commands/oss-search.md
@@ -198,4 +198,4 @@ Use AskUserQuestion (if `availableCount >= 5` and advisory shown, place list opt
 - `isNewContribution = true`
 - `issueContext = { title, url, description }`
 
-This activates the draft-first workflow (see Pre-Commit Review in `/oss`).
+Before writing code, follow the **Branch Setup Protocol** in `${CLAUDE_PLUGIN_ROOT}/workflows/work-through-issues.md` Step 6 to create the feature branch from the upstream default branch. This activates the draft-first workflow (see Pre-Commit Review in `/oss`).

--- a/commands/oss.md
+++ b/commands/oss.md
@@ -273,7 +273,7 @@ This is a quality gate that catches issues before they reach the maintainer.
 
 **Check `isNewContribution`** (set in Execute when the user selects an issue and starts implementing):
 
-- **If `isNewContribution === true`:** Read `${CLAUDE_PLUGIN_ROOT}/workflows/draft-first-workflow.md` and follow the Draft-First Path. This covers Steps 1 (draft creation) → 2 (review cycle) → 3 (integration check) → 4 (manual testing) → 5 (squash) → 6 (mark ready) → 7 (compliance) → 8 (list updates).
+- **If `isNewContribution === true`:** The feature branch MUST have been created from the upstream default branch per the Branch Setup Protocol in `${CLAUDE_PLUGIN_ROOT}/workflows/work-through-issues.md` Step 6. If no feature branch exists yet (e.g., the user started coding on the default branch), create one before proceeding. Read `${CLAUDE_PLUGIN_ROOT}/workflows/draft-first-workflow.md` and follow the Draft-First Path. This covers Steps 1 (draft creation) → 2 (review cycle) → 3 (integration check) → 4 (manual testing) → 5 (squash) → 6 (mark ready) → 7 (compliance) → 8 (list updates).
 - **If `isNewContribution === false` (or not set):** Read `${CLAUDE_PLUGIN_ROOT}/workflows/pre-commit-review.md` and follow the Standard Path for existing PR updates.
 
 ---

--- a/workflows/draft-first-workflow.md
+++ b/workflows/draft-first-workflow.md
@@ -17,6 +17,39 @@ git status --porcelain
 
 **If output is empty:** Report no changes and return to the core router (`commands/oss.md`).
 
+### 1a-bis. Branch Base Validation
+
+Verify the current branch is based on the latest upstream default. This is a safety net for cases where the branch was created outside the Branch Setup Protocol.
+
+```bash
+upstreamRepo=$(echo "{issueContext.url}" | sed -n 's|https://github.com/\([^/]*/[^/]*\)/.*|\1|p')
+upstreamDefault=$(gh repo view "$upstreamRepo" --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null)
+
+# Determine remote
+remote="upstream"
+git remote get-url upstream 2>/dev/null || remote="origin"
+git fetch "$remote" "$upstreamDefault" 2>/dev/null
+
+mergeBase=$(git merge-base "$remote/$upstreamDefault" HEAD 2>/dev/null)
+upstreamHead=$(git rev-parse "$remote/$upstreamDefault" 2>/dev/null)
+```
+
+**If `$mergeBase` != `$upstreamHead`** (branch is behind upstream):
+
+```bash
+behindCount=$(git rev-list --count "$mergeBase".."$remote/$upstreamDefault" 2>/dev/null || echo "unknown")
+```
+
+> **Warning:** Your branch is {behindCount} commit(s) behind `{remote}/{upstreamDefault}`. This can cause merge conflicts that re-introduce deleted code.
+
+Offer:
+1. "Rebase onto upstream (Recommended)" — `git rebase $remote/$upstreamDefault`
+2. "Proceed anyway" — "I know the base is correct"
+
+**If validation commands fail** (no network, gh CLI error): Note "Could not verify branch base — proceeding." Continue to Step 1b.
+
+**If branch is up to date:** Proceed to Step 1b.
+
 ### 1b. CONTRIBUTING.md Compliance Check
 
 Before committing, verify the changes satisfy the target repo's contribution requirements. This checks repo-specific requirements (tests, docs, changelog, etc.); Step 7's compliance check covers general open-source best practices via the `pr-compliance-checker` agent.

--- a/workflows/work-through-issues.md
+++ b/workflows/work-through-issues.md
@@ -458,6 +458,52 @@ When the user selects an issue and starts implementing, set:
   - Documentation-only changes → `docs/` branch, `docs:` commit
   - If ambiguous, prefer `fix/` for correcting existing behavior and `feat/` for adding new capabilities
 
+#### Branch Setup Protocol
+
+Before writing any code, create the feature branch from the upstream default branch. This prevents merge conflicts from stale local branches (see [#821](https://github.com/costajohnt/oss-autopilot/issues/821)).
+
+**1. Determine upstream repo and default branch:**
+
+```bash
+# Parse owner/repo from issue URL
+upstreamRepo=$(echo "{issueContext.url}" | sed -n 's|https://github.com/\([^/]*/[^/]*\)/.*|\1|p')
+upstreamDefault=$(gh repo view "$upstreamRepo" --json defaultBranchRef --jq '.defaultBranchRef.name')
+```
+
+**If either command fails:** Report the error. Offer: "Retry" / "Specify default branch manually" / "Done for now". Do NOT guess.
+
+**2. Determine the correct remote:**
+
+```bash
+isFork=$(gh repo view --json isFork --jq '.isFork')
+```
+
+- **Fork (`true`):** Check for `upstream` remote (`git remote get-url upstream 2>/dev/null`). If missing, add it: `git remote add upstream "https://github.com/$upstreamRepo.git"`. Fetch: `git fetch upstream`. Base ref: `upstream/$upstreamDefault`.
+- **Same-repo (`false`):** Fetch: `git fetch origin`. Base ref: `origin/$upstreamDefault`.
+- **Detection fails:** Check `git remote -v` for an `upstream` remote. If found, use it. If not, use `origin`. Report which remote is being used.
+
+**If `git fetch` fails:** Report the error. Do NOT proceed — creating a branch from a stale local ref is the bug this protocol prevents. Offer: "Retry" / "Specify a different remote URL" / "Done for now".
+
+**3. Create the feature branch:**
+
+```bash
+git checkout -b {branchPrefix}{branchSuffix} {remote}/{upstreamDefault}
+```
+
+- `{branchPrefix}` comes from the change type logic above (`fix/`, `feat/`, `docs/`)
+- `{branchSuffix}` is a short kebab-case descriptor from the issue title
+
+**If checkout fails:**
+- Branch already exists → Offer "Delete and recreate" / "Switch to existing" / "Different name"
+- Uncommitted changes → Offer "Stash first" / "Discard changes" / "Done for now"
+- Invalid ref → Re-check remote/branch, offer "Specify manually" / "Done for now"
+
+**4. Confirm:**
+
+> Feature branch `{branchName}` created from `{remote}/{upstreamDefault}` (at {short hash}).
+
+Store in session context: `featureBranch`, `upstreamRemote`, `upstreamDefault`.
+
 After implementation, the flow proceeds through the **draft-first workflow** (`${CLAUDE_PLUGIN_ROOT}/workflows/draft-first-workflow.md`):
 1. Step 1 creates the draft PR
 2. Step 2 runs iterative review cycle (scope-aware, tied to `issueContext`)


### PR DESCRIPTION
## Summary

- Adds a **Branch Setup Protocol** to Step 6 of `work-through-issues.md` that determines the upstream default branch, fetches from the correct remote (detecting fork vs same-repo), and creates the feature branch from it
- Adds a lightweight **branch base validation guard** (Step 1a-bis) in `draft-first-workflow.md` as a safety net that warns if the branch is behind upstream before committing
- Adds cross-references in `oss-search.md` and `oss.md` so all entry points to implementation route through the protocol

## Test plan

- [ ] Clone a fork, let local main fall behind upstream, run through the workflow — verify the feature branch is created from upstream HEAD
- [ ] Test in a non-fork repo to verify `origin` is used correctly
- [ ] Clone manually (not via `gh repo clone`) to verify the protocol adds the `upstream` remote when missing
- [ ] Verify cross-references: run `/oss-search`, select an issue, confirm Branch Setup Protocol is referenced

Closes #821