### PR TITLE
fix: auto-investigate issues instead of prompting

### DIFF
--- a/workflows/work-through-issues.md
+++ b/workflows/work-through-issues.md
@@ -396,10 +396,10 @@ Task(issue-scout, "Vet this issue from the user's curated list:
 
 Show the vetting summary, then automatically proceed to investigate the issue. Investigation catches scope issues, identifies the right files, and prevents wasted effort.
 
-1. **Clone/update the repo** — Check local repo registry (`local-repos --json`), clone if needed to `~/Documents/oss/<repo-name>`
-2. **Read the issue context** — Parse the issue body for code references, error messages, expected behavior
-3. **Analyze relevant code** — Use Grep/Read to find the relevant source files and understand the code path involved
-4. **Attempt diagnosis** — Identify root cause, propose a fix approach
+1. **Clone/update the repo** — Check local repo registry (`local-repos --json`), clone if needed to `~/Documents/oss/<repo-name>`. **If clone/update fails** (network error, auth failure, repo deleted, disk full), report the error and offer: "Retry" / "Pick a different issue" / "Done for now". Do NOT proceed to sub-step 2 without a local repo.
+2. **Read the issue context** — Parse the issue body for code references, error messages, expected behavior. If the issue cannot be fetched (rate limit, deleted), note the gap and continue with limited context.
+3. **Analyze relevant code** — Use Grep/Read to find the relevant source files and understand the code path involved. If no relevant files can be identified, note "Could not identify relevant source files" in the assessment.
+4. **Attempt diagnosis** — Identify root cause, propose a fix approach. If diagnosis is inconclusive, set Confidence to "Low" and explicitly state what could not be determined.
 5. **Assess complexity** — Estimate effort (small/medium/large), identify risks and unknowns
 6. **Report findings:**
 


### PR DESCRIPTION
## Summary

- Removes the "Investigate feasibility first?" AskUserQuestion from Step 5 of `work-through-issues.md`
- Investigation now runs automatically after vetting — no extra prompt needed
- Post-investigation prompt (substep 7) already provides all options: start implementing, skip, pick different, done

## Test plan

- [ ] Read Steps 4→5→6 flow to verify coherence
- [ ] Verify post-investigation AskUserQuestion still offers all options
- [ ] Grep for "5a" and "Investigate feasibility first" — should find zero matches

Closes #817