### PR TITLE
fix: include full GitHub URLs in issue list picker options

### DIFF
--- a/commands/oss-search.md
+++ b/commands/oss-search.md
@@ -172,7 +172,7 @@ Use AskUserQuestion:
 6. Present summary, then proceed to **Diminishing Returns Check**
 
 **"Pick one to vet now":**
-- Display results as numbered list, use AskUserQuestion with up to 3 + "Done for now"
+- Display results as numbered list, use AskUserQuestion with up to 3 + "Done for now". Include the full GitHub issue URL in each option's description field.
 - Dispatch single `issue-scout` agent, present result
 - Offer: "Start working on this issue" / "Pick a different one" / "Done for now"
 - Record score: `searchRoundScores.push(score)` → **Diminishing Returns Check**

--- a/workflows/work-through-issues.md
+++ b/workflows/work-through-issues.md
@@ -371,9 +371,9 @@ Use AskUserQuestion with up to 4 options (dynamically chosen from the top of the
 Question: "Which issue would you like to work on?"
 Header: "Issue"
 
-Options:
-1. "{repo}#{number} — {brief title}" (top priority issue)
-2. "{repo}#{number} — {brief title}" (second)
+Options (include full GitHub URL in each description):
+1. Label: "{repo}#{number} — {brief title}", Description: "Score {score}/10. {brief context}. https://github.com/{repo}/issues/{number}"
+2. Label: "{repo}#{number} — {brief title}", Description: "Score {score}/10. {brief context}. https://github.com/{repo}/issues/{number}"
 3. "Search GitHub instead"
 4. "Done for now"
 ```


### PR DESCRIPTION
## Summary

- Adds full clickable GitHub URLs to AskUserQuestion option descriptions when presenting issue lists
- Updates `work-through-issues.md` Step 3 issue picker format to include URL, score, and context in descriptions
- Updates `oss-search.md` "Pick one to vet now" to require URLs in option descriptions

## Test plan

- [ ] Verify issue picker options in work-through-issues.md include URL format guidance
- [ ] Verify oss-search.md "Pick one to vet now" mentions URL requirement

Closes #814