### PR TITLE
fix: use fetch+reset for marketplace refresh to handle divergent branches

### DIFF
--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -12,10 +12,12 @@ messages=""
 # --- Step 0: Auto-refresh marketplace cache (non-blocking) ---
 # Claude Code caches third-party marketplace repos as git clones but never
 # auto-refreshes them, so plugin updates aren't discoverable. A background
-# pull on every session keeps the cache current without blocking startup.
+# fetch+reset on every session keeps the cache current without blocking startup.
+# Uses fetch+reset instead of pull to handle divergent branches gracefully
+# (e.g. if a local commit was accidentally made in the marketplace clone).
 MARKETPLACE_DIR="$HOME/.claude/plugins/marketplaces/oss-autopilot"
 if [ -d "$MARKETPLACE_DIR/.git" ]; then
-  (cd "$MARKETPLACE_DIR" && git pull --quiet origin main 2>/dev/null) &
+  (cd "$MARKETPLACE_DIR" && git fetch --quiet origin main 2>/dev/null && git reset --hard origin/main --quiet 2>/dev/null) &
 fi
 
 # --- Step 1: Rebuild stale CLI bundle (if needed) ---


### PR DESCRIPTION
## Summary

- Step 0 in `session-start.sh` used `git pull` to refresh the marketplace clone, which fails silently when the clone has divergent branches (e.g. from an accidental local commit)
- Switches to `git fetch` + `git reset --hard origin/main` to match what Step 2 already uses
- This ensures the marketplace clone always syncs to origin regardless of local state

## Context

The marketplace clone at `~/.claude/plugins/marketplaces/oss-autopilot/` had a local commit that diverged from origin, causing every background `git pull` to fail silently (stderr goes to `/dev/null`). This prevented `/plugin` from detecting the 1.6.0 release.

## Test plan

- [x] Verify the edit is correct by reading the file
- [ ] Confirm `session-start.sh` still runs without errors after the change