### PR TITLE
fix: skip acknowledgment filter for reviews with inline comments

### DIFF
--- a/packages/core/src/core/review-analysis.test.ts
+++ b/packages/core/src/core/review-analysis.test.ts
@@ -8,6 +8,7 @@ import {
   getLatestChangesRequestedDate,
   isAllSelfReplies,
   getInlineCommentBody,
+  reviewHasInlineComments,
   checkUnrespondedComments,
 } from './review-analysis.js';
 
@@ -219,6 +220,28 @@ describe('getInlineCommentBody', () => {
   });
 });
 
+describe('reviewHasInlineComments', () => {
+  it('should return true when review has inline comments', () => {
+    expect(
+      reviewHasInlineComments(100, [
+        { id: 1, user: null, body: 'Fix this', created_at: '2026-02-07T10:00:00Z', pull_request_review_id: 100 },
+      ]),
+    ).toBe(true);
+  });
+
+  it('should return false when review has no inline comments', () => {
+    expect(reviewHasInlineComments(100, [])).toBe(false);
+  });
+
+  it('should return false when inline comments belong to different review', () => {
+    expect(
+      reviewHasInlineComments(100, [
+        { id: 1, user: null, body: 'Fix this', created_at: '2026-02-07T10:00:00Z', pull_request_review_id: 200 },
+      ]),
+    ).toBe(false);
+  });
+});
+
 describe('checkUnrespondedComments', () => {
   it('should return false when no comments or reviews', () => {
     const result = checkUnrespondedComments([], [], [], 'testuser');
@@ -328,6 +351,97 @@ describe('checkUnrespondedComments', () => {
       [{ user: { login: 'TestUser' }, body: 'My PR', created_at: '2026-02-07T10:00:00Z' }],
       [],
       [],
+      'testuser',
+    );
+    expect(result.hasUnrespondedComment).toBe(false);
+  });
+
+  it('should NOT filter as acknowledgment when review has inline comments (#829)', () => {
+    const result = checkUnrespondedComments(
+      [{ user: { login: 'testuser' }, body: 'My PR', created_at: '2026-02-07T10:00:00Z' }],
+      [
+        {
+          user: { login: 'reviewer' },
+          body: 'Looks good so far, some comments, thanks!',
+          submitted_at: '2026-02-07T12:00:00Z',
+          state: 'COMMENTED',
+          id: 100,
+        },
+      ],
+      [
+        {
+          id: 1000,
+          user: { login: 'reviewer' },
+          body: 'Please rename this variable for clarity',
+          created_at: '2026-02-07T12:00:00Z',
+          pull_request_review_id: 100,
+        },
+        {
+          id: 1001,
+          user: { login: 'reviewer' },
+          body: 'This needs error handling',
+          created_at: '2026-02-07T12:00:00Z',
+          pull_request_review_id: 100,
+        },
+      ],
+      'testuser',
+    );
+    expect(result.hasUnrespondedComment).toBe(true);
+    expect(result.lastMaintainerComment?.author).toBe('reviewer');
+  });
+
+  it('should still filter pure acknowledgment review without inline comments (#829)', () => {
+    const result = checkUnrespondedComments(
+      [{ user: { login: 'testuser' }, body: 'My PR', created_at: '2026-02-07T10:00:00Z' }],
+      [
+        {
+          user: { login: 'reviewer' },
+          body: 'Looks good, thanks!',
+          submitted_at: '2026-02-07T12:00:00Z',
+          state: 'APPROVED',
+          id: 100,
+        },
+      ],
+      [],
+      'testuser',
+    );
+    expect(result.hasUnrespondedComment).toBe(false);
+  });
+
+  it('should still filter acknowledgment issue comments without review context (#829)', () => {
+    const result = checkUnrespondedComments(
+      [
+        { user: { login: 'testuser' }, body: 'My PR', created_at: '2026-02-07T10:00:00Z' },
+        { user: { login: 'maintainer' }, body: 'Thanks, will review', created_at: '2026-02-07T12:00:00Z' },
+      ],
+      [],
+      [],
+      'testuser',
+    );
+    expect(result.hasUnrespondedComment).toBe(false);
+  });
+
+  it('should filter ack review when inline comments belong to a different review (#829)', () => {
+    const result = checkUnrespondedComments(
+      [{ user: { login: 'testuser' }, body: 'My PR', created_at: '2026-02-07T10:00:00Z' }],
+      [
+        {
+          user: { login: 'reviewer' },
+          body: 'Thanks for this!',
+          submitted_at: '2026-02-07T12:00:00Z',
+          state: 'COMMENTED',
+          id: 100,
+        },
+      ],
+      [
+        {
+          id: 1000,
+          user: { login: 'reviewer' },
+          body: 'Fix this',
+          created_at: '2026-02-07T11:00:00Z',
+          pull_request_review_id: 200,
+        },
+      ],
       'testuser',
     );
     expect(result.hasUnrespondedComment).toBe(false);

--- a/packages/core/src/core/review-analysis.ts
+++ b/packages/core/src/core/review-analysis.ts
@@ -114,6 +114,15 @@ export function getInlineCommentBody(reviewId: number, reviewComments: ReviewCom
 }
 
 /**
+ * Check whether a review has any associated inline comments.
+ * Used to prevent the acknowledgment filter from discarding reviews
+ * that also posted inline comments (#829).
+ */
+export function reviewHasInlineComments(reviewId: number, reviewComments: ReviewComment[]): boolean {
+  return reviewComments.some((c) => c.pull_request_review_id === reviewId);
+}
+
+/**
  * Check if there are unresponded comments from maintainers.
  * Combines issue comments and review comments into a timeline,
  * then finds maintainer comments after the user's last comment.
@@ -131,7 +140,7 @@ export function checkUnrespondedComments(
   username: string,
 ): { hasUnrespondedComment: boolean; lastMaintainerComment?: FetchedPR['lastMaintainerComment'] } {
   // Combine comments and reviews into a timeline
-  const timeline: Array<{ author: string; body: string; createdAt: string; isUser: boolean }> = [];
+  const timeline: Array<{ author: string; body: string; createdAt: string; isUser: boolean; reviewId?: number }> = [];
   const usernameLower = username.toLowerCase();
 
   for (const comment of comments) {
@@ -175,6 +184,7 @@ export function checkUnrespondedComments(
       body: resolvedBody,
       createdAt: review.submitted_at,
       isUser: author.toLowerCase() === usernameLower,
+      reviewId: review.id,
     });
   }
 
@@ -191,6 +201,7 @@ export function checkUnrespondedComments(
 
   // Find maintainer comments after the user's last comment
   let lastMaintainerComment: FetchedPR['lastMaintainerComment'] | undefined;
+  let lastMaintainerReviewId: number | undefined;
 
   for (const item of timeline) {
     if (item.isUser) continue; // Skip user's own comments
@@ -204,11 +215,16 @@ export function checkUnrespondedComments(
         body: item.body.slice(0, 200) + (item.body.length > 200 ? '...' : ''),
         createdAt: item.createdAt,
       };
+      lastMaintainerReviewId = item.reviewId;
     }
   }
 
-  // Filter out pure acknowledgment comments that don't require a response
-  if (lastMaintainerComment && isAcknowledgmentComment(lastMaintainerComment.body)) {
+  // Filter out pure acknowledgment comments that don't require a response.
+  // Skip the filter when the review has inline comments — those indicate
+  // feedback beyond the summary body that likely needs a response (#829).
+  const lastReviewHasInlineComments =
+    lastMaintainerReviewId != null && reviewHasInlineComments(lastMaintainerReviewId, reviewComments);
+  if (lastMaintainerComment && isAcknowledgmentComment(lastMaintainerComment.body) && !lastReviewHasInlineComments) {
     lastMaintainerComment = undefined;
   }
 


### PR DESCRIPTION
## Summary

Fixes #829

- The acknowledgment filter in `checkUnrespondedComments()` only examined a review's top-level body text, causing it to discard reviews with brief polite summaries (e.g., "Looks good so far, some comments, thanks!") that also had substantive inline comments requesting code changes
- Added `reviewHasInlineComments()` helper and threaded the review ID through the timeline so the ack filter can check for associated inline comments before discarding
- Reviews with inline comments are never treated as pure acknowledgments

## Test plan

- [x] New unit tests for `reviewHasInlineComments` helper (3 cases)
- [x] Integration test: review with ack body + inline comments is NOT filtered
- [x] Regression test: pure ack review without inline comments still filtered
- [x] Regression test: ack issue comments (no review context) still filtered
- [x] Edge case: inline comments belonging to a different review don't prevent filtering
- [x] All 2429 existing tests pass
- [x] Lint and type check clean