### PR TITLE
chore(mcp-server): add mcpName and publish to official MCP Registry

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@oss-autopilot/mcp",
-  "version": "2.0.0",
+  "version": "2.0.1",
+  "mcpName": "io.github.costajohnt/oss-autopilot",
   "description": "MCP server for OSS Autopilot — exposes PR tracking, issue discovery, and contribution management as MCP tools",
   "type": "module",
   "bin": {

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.costajohnt/oss-autopilot",
+  "description": "Open source contribution manager with PR tracking, issue discovery, and CI diagnosis",
+  "repository": {
+    "url": "https://github.com/costajohnt/oss-autopilot",
+    "source": "github",
+    "subfolder": "packages/mcp-server"
+  },
+  "version": "2.0.1",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@oss-autopilot/mcp",
+      "version": "2.0.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "description": "GitHub personal access token or token from `gh auth token`",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": true,
+          "name": "GITHUB_TOKEN"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `mcpName` field to `packages/mcp-server/package.json` for MCP Registry verification
- Add `server.json` for `mcp-publisher` CLI
- Published `@oss-autopilot/mcp@2.0.1` to npm
- Server is now listed on the official MCP Registry as `io.github.costajohnt/oss-autopilot`

## Test plan
- [x] Verified server appears in registry: `curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=oss-autopilot"`
- [x] npm package published successfully with mcpName field