### PR TITLE
fix: reuse existing dashboard tab instead of opening a new one

### DIFF
--- a/packages/core/src/commands/startup.test.ts
+++ b/packages/core/src/commands/startup.test.ts
@@ -477,19 +477,65 @@ describe('runStartup behavior', () => {
     expect(result.daily?.briefSummary).toContain('Dashboard opened in browser');
   });
 
-  it('should reuse existing SPA server without launching new one', async () => {
+  it('should refresh existing dashboard instead of opening new tab (#830)', async () => {
     const daily = makeDailyOutput(3);
     executeDailyCheck.mockResolvedValue(daily);
     launchDashboardServer.mockResolvedValue({ url: 'http://oss.localhost:3001', port: 3001, alreadyRunning: true });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 200 }));
 
     const result = await runStartup();
 
     expect(result.dashboardUrl).toBe('http://oss.localhost:3001');
-    expect(execFile).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.arrayContaining(['http://oss.localhost:3001']),
-      expect.any(Function),
+    // Should NOT open a new browser tab
+    expect(execFile).not.toHaveBeenCalled();
+    // Should trigger a refresh on the running server
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'http://127.0.0.1:3001/api/refresh',
+      expect.objectContaining({ method: 'POST' }),
     );
+    expect(result.daily?.briefSummary).toContain('Dashboard refreshed');
+    expect(result.daily?.briefSummary).not.toContain('Dashboard opened in browser');
+    fetchSpy.mockRestore();
+  });
+
+  it('should still succeed when dashboard refresh fails (#830)', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const daily = makeDailyOutput(3);
+    executeDailyCheck.mockResolvedValue(daily);
+    launchDashboardServer.mockResolvedValue({ url: 'http://oss.localhost:3001', port: 3001, alreadyRunning: true });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Connection refused'));
+
+    const result = await runStartup();
+
+    // Startup should succeed despite refresh failure
+    expect(result.dashboardUrl).toBe('http://oss.localhost:3001');
+    expect(execFile).not.toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Could not trigger dashboard refresh'));
+    // Should say "running" not "refreshed" when refresh fails
+    expect(result.daily?.briefSummary).toContain('Dashboard running');
+    expect(result.daily?.briefSummary).not.toContain('Dashboard refreshed');
+    fetchSpy.mockRestore();
+    consoleSpy.mockRestore();
+  });
+
+  it('should log when dashboard refresh returns non-200 (#830)', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const daily = makeDailyOutput(3);
+    executeDailyCheck.mockResolvedValue(daily);
+    launchDashboardServer.mockResolvedValue({ url: 'http://oss.localhost:3001', port: 3001, alreadyRunning: true });
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('Too many requests', { status: 429 }));
+
+    const result = await runStartup();
+
+    expect(result.dashboardUrl).toBe('http://oss.localhost:3001');
+    expect(execFile).not.toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Dashboard refresh returned 429'));
+    // Should say "running" not "refreshed" on non-200
+    expect(result.daily?.briefSummary).toContain('Dashboard running');
+    fetchSpy.mockRestore();
+    consoleSpy.mockRestore();
   });
 
   it('should not launch SPA when totalActivePRs is 0', async () => {

--- a/packages/core/src/commands/startup.ts
+++ b/packages/core/src/commands/startup.ts
@@ -146,6 +146,31 @@ export function openInBrowser(url: string): void {
 }
 
 /**
+ * Trigger a data refresh on a running dashboard server.
+ * Hits POST /api/refresh so the SPA picks up fresh data on its next poll.
+ * Non-fatal: errors are logged but don't propagate (#830).
+ */
+async function triggerDashboardRefresh(port: number): Promise<boolean> {
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/api/refresh`, {
+      method: 'POST',
+      headers: { Origin: `http://oss.localhost:${port}` },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      console.error(`[STARTUP] Dashboard refresh returned ${res.status}: ${body}`);
+      return false;
+    }
+    await res.text().catch(() => {});
+    return true;
+  } catch (error) {
+    console.error(`[STARTUP] Could not trigger dashboard refresh: ${errorMessage(error)}`);
+    return false;
+  }
+}
+
+/**
  * Run startup checks and return structured output.
  * Returns StartupOutput with one of three shapes:
  * 1. Setup incomplete: `{ version, setupComplete: false }`
@@ -196,15 +221,20 @@ export async function runStartup(): Promise<StartupOutput> {
   // 4. Launch interactive SPA dashboard
   // Skip opening on first run (0 PRs) — the welcome flow handles onboarding
   let dashboardUrl: string | undefined;
-  let dashboardOpened = false;
+  let dashboardStatus: 'opened' | 'refreshed' | 'running' | undefined;
 
   if (daily.digest.summary.totalActivePRs > 0) {
     try {
       const spaResult = await launchDashboardServer();
       if (spaResult) {
         dashboardUrl = spaResult.url;
-        openInBrowser(spaResult.url);
-        dashboardOpened = true;
+        if (spaResult.alreadyRunning) {
+          const refreshed = await triggerDashboardRefresh(spaResult.port);
+          dashboardStatus = refreshed ? 'refreshed' : 'running';
+        } else {
+          openInBrowser(spaResult.url);
+          dashboardStatus = 'opened';
+        }
       } else {
         console.error('[STARTUP] Dashboard SPA assets not found. Build with: cd packages/dashboard && pnpm run build');
       }
@@ -213,9 +243,13 @@ export async function runStartup(): Promise<StartupOutput> {
     }
   }
 
-  // Append dashboard status to brief summary (only startup opens the browser, not daily)
-  if (dashboardOpened) {
+  // Append dashboard status to brief summary
+  if (dashboardStatus === 'opened') {
     daily.briefSummary += ' | Dashboard opened in browser';
+  } else if (dashboardStatus === 'refreshed') {
+    daily.briefSummary += ' | Dashboard refreshed';
+  } else if (dashboardStatus === 'running') {
+    daily.briefSummary += ' | Dashboard running';
   }
 
   // 5. Detect issue list


### PR DESCRIPTION
## Summary

Fixes #830

- When the dashboard server is already running, skip `openInBrowser()` and instead trigger `POST /api/refresh` on the running server
- The SPA's existing 5-second polling picks up the fresh data automatically — no new tab needed
- `triggerDashboardRefresh()` is non-fatal: network errors and non-200 responses are logged but don't break startup
- Brief summary now distinguishes three states: "Dashboard opened in browser", "Dashboard refreshed", "Dashboard running" (refresh failed)

No SPA changes, no WebSocket/SSE, no new dependencies. The `LaunchResult.alreadyRunning` flag and `/api/refresh` endpoint already existed — this just wires them together.

## Test plan

- [x] Existing test fixed: `alreadyRunning: true` no longer calls `execFile`
- [x] New test: successful refresh triggers fetch, summary says "Dashboard refreshed"
- [x] New test: network error logged, startup succeeds, summary says "Dashboard running"
- [x] New test: non-200 response logged with body, summary says "Dashboard running"
- [x] All 2076 core tests pass
- [x] Lint and type check clean