### PR TITLE
fix(mcp-server): republish with resolved workspace dependency

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
   ".": "1.6.2",
-  "packages/mcp-server": "2.0.0"
+  "packages/mcp-server": "2.0.2"
 }

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oss-autopilot/mcp",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "mcpName": "io.github.costajohnt/oss-autopilot",
   "description": "MCP server for OSS Autopilot — exposes PR tracking, issue discovery, and contribution management as MCP tools",
   "type": "module",

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -7,12 +7,12 @@
     "source": "github",
     "subfolder": "packages/mcp-server"
   },
-  "version": "2.0.1",
+  "version": "2.0.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@oss-autopilot/mcp",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

v2.0.1 was published manually with `npm publish` which didn't convert pnpm's `workspace:^` protocol for `@oss-autopilot/core`. This causes `npx @oss-autopilot/mcp` to fail with:

```
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:^
```

Bumps to 2.0.2 so the CI pipeline can republish via `pnpm publish`, which correctly resolves `workspace:^` to `^1.6.2`.

## Test plan

- [x] `pnpm pack` confirms dependency resolves to `^1.6.2` (not `workspace:^`)
- [x] All tests pass
- [x] After merge + release-please + npm publish: `npx @oss-autopilot/mcp@latest` should work