### PR TITLE
chore: add glama.json for MCP server quality scoring

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["costajohnt"]
+}


### PR DESCRIPTION
## Summary
- Adds `glama.json` metadata file to enable Glama inspection and scoring of the MCP server

## Context
Required for [awesome-mcp-servers PR #3788](https://github.com/punkpeye/awesome-mcp-servers/pull/3788) — the maintainer needs Quality and Security A ratings on Glama before merging.

## Test plan
- [x] `pnpm test` passes (2375 tests)
- [x] `pnpm run lint` clean
- [ ] Verify Glama picks up the file and begins scoring