### PR TITLE
fix: reduce GitHub Search API consumption to prevent rate limiting

### DIFF
--- a/packages/core/src/core/issue-discovery.test.ts
+++ b/packages/core/src/core/issue-discovery.test.ts
@@ -60,6 +60,16 @@ vi.mock('./state.js', () => ({
   })),
 }));
 
+vi.mock('./search-budget.js', () => ({
+  getSearchBudgetTracker: vi.fn().mockReturnValue({
+    init: vi.fn(),
+    waitForBudget: vi.fn().mockResolvedValue(undefined),
+    recordCall: vi.fn(),
+    canAfford: vi.fn().mockReturnValue(true),
+    getTotalCalls: vi.fn().mockReturnValue(0),
+  }),
+}));
+
 vi.mock('./utils.js', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
   return {
@@ -531,8 +541,8 @@ describe('IssueDiscovery.vetIssue inconclusive downgrade', () => {
   });
 
   it('should downgrade to needs_review when checkNoExistingPR is inconclusive', async () => {
-    // Make the search call throw (simulating rate limit / API error)
-    mockOctokitInstance.search.issuesAndPullRequests.mockRejectedValue(new Error('API rate limit exceeded'));
+    // Make the timeline API throw (checkNoExistingPR uses timeline, not Search API)
+    mockOctokitInstance.issues.listEventsForTimeline.mockRejectedValue(new Error('API rate limit exceeded'));
 
     const candidate = await discovery.vetIssue('https://github.com/owner/repo/issues/42');
     expect(candidate.recommendation).toBe('needs_review');

--- a/packages/core/src/core/issue-discovery.ts
+++ b/packages/core/src/core/issue-discovery.ts
@@ -15,6 +15,7 @@ import * as path from 'path';
 import { Octokit } from '@octokit/rest';
 import { getOctokit, checkRateLimit } from './github.js';
 import { getStateManager } from './state.js';
+import { getSearchBudgetTracker } from './search-budget.js';
 import { daysBetween, getDataDir, sleep } from './utils.js';
 import { DEFAULT_CONFIG, type SearchPriority, type IssueCandidate, SCOPE_LABELS } from './types.js';
 import { ValidationError, errorMessage, getHttpStatusCode, isRateLimitError } from './errors.js';
@@ -193,10 +194,12 @@ export class IssueDiscovery {
 
     // Pre-flight rate limit check (#100) — also determines adaptive phase budget
     this.rateLimitWarning = null;
+    const tracker = getSearchBudgetTracker();
     let searchBudget = LOW_BUDGET_THRESHOLD - 1; // conservative: below threshold to skip heavy phases
     try {
       const rateLimit = await checkRateLimit(this.githubToken);
       searchBudget = rateLimit.remaining;
+      tracker.init(rateLimit.remaining, rateLimit.resetAt);
       if (rateLimit.remaining < 5) {
         const resetTime = new Date(rateLimit.resetAt).toLocaleTimeString('en-US', { hour12: false });
         this.rateLimitWarning = `GitHub search API quota low (${rateLimit.remaining}/${rateLimit.limit} remaining, resets at ${resetTime}). Search may be slow.`;
@@ -212,7 +215,9 @@ export class IssueDiscovery {
       if (getHttpStatusCode(error) === 401) {
         throw error;
       }
-      // Non-fatal: proceed with conservative budget for transient/network errors
+      // Non-fatal: proceed with conservative budget for transient/network errors.
+      // Initialize tracker with conservative defaults so it doesn't fly blind.
+      tracker.init(CRITICAL_BUDGET_THRESHOLD, new Date(Date.now() + 60000).toISOString());
       warn(
         MODULE,
         'Could not check rate limit — using conservative budget, skipping heavy phases:',
@@ -419,6 +424,11 @@ export class IssueDiscovery {
         info(MODULE, `Phase 1: Searching issues in ${reposToSearch.length} starred repos...`);
         const remainingNeeded = maxResults - allCandidates.length;
         if (remainingNeeded > 0) {
+          // Cap labels to reduce Search API calls: starred repos already signal user
+          // interest, so fewer labels suffice. With 3 labels and batch size 3 (2 repo ORs),
+          // each batch fits in a single label chunk instead of 3+, cutting Phase 1 calls
+          // from ~12 to ~4.
+          const phase1Labels = labels.slice(0, 3);
           const {
             candidates: starredCandidates,
             allBatchesFailed,
@@ -428,7 +438,7 @@ export class IssueDiscovery {
             this.vetter,
             reposToSearch.slice(0, 10),
             baseQualifiers,
-            labels,
+            phase1Labels,
             remainingNeeded,
             'starred',
             filterIssues,
@@ -655,6 +665,10 @@ export class IssueDiscovery {
     // Apply per-repo cap: max 2 issues from any single repo (#105)
     const capped = applyPerRepoCap(allCandidates, 2);
 
+    info(
+      MODULE,
+      `Search complete: ${tracker.getTotalCalls()} Search API calls used, ${capped.length} candidates returned`,
+    );
     return capped.slice(0, maxResults);
   }
 

--- a/packages/core/src/core/issue-eligibility.test.ts
+++ b/packages/core/src/core/issue-eligibility.test.ts
@@ -13,6 +13,28 @@ vi.mock('./pagination.js', () => ({
   paginateAll: vi.fn().mockResolvedValue([]),
 }));
 
+vi.mock('./http-cache.js', () => ({
+  getHttpCache: vi.fn().mockReturnValue({
+    getIfFresh: vi.fn().mockReturnValue(null),
+    get: vi.fn().mockReturnValue(null),
+    set: vi.fn(),
+  }),
+  cachedTimeBased: vi
+    .fn()
+    .mockImplementation(async (_cache: any, _key: string, _maxAgeMs: number, fetcher: () => Promise<unknown>) => {
+      // Always call fetcher in tests (no caching) so each test gets fresh results
+      return fetcher();
+    }),
+}));
+
+vi.mock('./search-budget.js', () => ({
+  getSearchBudgetTracker: vi.fn().mockReturnValue({
+    waitForBudget: vi.fn().mockResolvedValue(undefined),
+    recordCall: vi.fn(),
+    canAfford: vi.fn().mockReturnValue(true),
+  }),
+}));
+
 vi.mock('./logger.js', () => ({
   warn: vi.fn(),
   debug: vi.fn(),
@@ -21,6 +43,7 @@ vi.mock('./logger.js', () => ({
 
 import { paginateAll } from './pagination.js';
 import { warn } from './logger.js';
+import { getHttpCache } from './http-cache.js';
 
 // ── Helpers ──
 
@@ -102,30 +125,13 @@ describe('checkNoExistingPR', () => {
     vi.mocked(paginateAll).mockResolvedValue([]);
   });
 
-  it('returns passed when no PRs found', async () => {
-    mockFn(octokit.search.issuesAndPullRequests).mockResolvedValue({
-      data: { total_count: 0, items: [] },
-    });
-
+  it('returns passed when no linked PRs in timeline', async () => {
     const result = await checkNoExistingPR(octokit, 'owner', 'repo', 1);
     expect(result.passed).toBe(true);
     expect(result.inconclusive).toBeUndefined();
   });
 
-  it('returns not passed when search finds PRs', async () => {
-    mockFn(octokit.search.issuesAndPullRequests).mockResolvedValue({
-      data: { total_count: 1, items: [{}] },
-    });
-
-    const result = await checkNoExistingPR(octokit, 'owner', 'repo', 1);
-    expect(result.passed).toBe(false);
-    expect(result.inconclusive).toBeUndefined();
-  });
-
   it('returns not passed when timeline has linked PRs', async () => {
-    mockFn(octokit.search.issuesAndPullRequests).mockResolvedValue({
-      data: { total_count: 0, items: [] },
-    });
     vi.mocked(paginateAll).mockResolvedValue([{ event: 'cross-referenced', source: { issue: { pull_request: {} } } }]);
 
     const result = await checkNoExistingPR(octokit, 'owner', 'repo', 1);
@@ -133,9 +139,6 @@ describe('checkNoExistingPR', () => {
   });
 
   it('ignores non-PR cross-references', async () => {
-    mockFn(octokit.search.issuesAndPullRequests).mockResolvedValue({
-      data: { total_count: 0, items: [] },
-    });
     vi.mocked(paginateAll).mockResolvedValue([
       { event: 'cross-referenced', source: { issue: {} } }, // no pull_request
       { event: 'labeled' }, // different event type
@@ -145,8 +148,8 @@ describe('checkNoExistingPR', () => {
     expect(result.passed).toBe(true);
   });
 
-  it('returns passed + inconclusive on API error and logs warning', async () => {
-    mockFn(octokit.search.issuesAndPullRequests).mockRejectedValue(new Error('Network error'));
+  it('returns passed + inconclusive on timeline API error and logs warning', async () => {
+    vi.mocked(paginateAll).mockRejectedValue(new Error('Network error'));
 
     const result = await checkNoExistingPR(octokit, 'owner', 'repo', 1);
     expect(result.passed).toBe(true);
@@ -257,5 +260,35 @@ describe('checkUserMergedPRsInRepo', () => {
     const count = await checkUserMergedPRsInRepo(octokit, 'owner', 'repo');
     expect(count).toBe(0);
     expect(warn).toHaveBeenCalledWith('issue-eligibility', expect.stringContaining('owner/repo'));
+  });
+
+  it('caches successful results', async () => {
+    const cache = vi.mocked(getHttpCache)();
+    mockFn(octokit.search.issuesAndPullRequests).mockResolvedValue({
+      data: { total_count: 5 },
+    });
+
+    await checkUserMergedPRsInRepo(octokit, 'cache-owner', 'repo');
+    expect(cache.set).toHaveBeenCalledWith('merged-prs:cache-owner/repo', '', 5);
+  });
+
+  it('does not cache error fallback values', async () => {
+    const cache = vi.mocked(getHttpCache)();
+    vi.mocked(cache.set).mockClear();
+    mockFn(octokit.search.issuesAndPullRequests).mockRejectedValue(new Error('API error'));
+
+    await checkUserMergedPRsInRepo(octokit, 'err-owner', 'repo');
+    // Error-path 0 should NOT be cached — next call should retry
+    expect(cache.set).not.toHaveBeenCalled();
+  });
+
+  it('returns cached value without API call', async () => {
+    const cache = vi.mocked(getHttpCache)();
+    vi.mocked(cache.getIfFresh).mockReturnValueOnce(7);
+
+    const count = await checkUserMergedPRsInRepo(octokit, 'cached-owner', 'repo');
+    expect(count).toBe(7);
+    // Should not have made an API call
+    expect(octokit.search.issuesAndPullRequests).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/core/issue-eligibility.ts
+++ b/packages/core/src/core/issue-eligibility.ts
@@ -10,6 +10,8 @@ import { Octokit } from '@octokit/rest';
 import { paginateAll } from './pagination.js';
 import { errorMessage } from './errors.js';
 import { warn } from './logger.js';
+import { getHttpCache } from './http-cache.js';
+import { getSearchBudgetTracker } from './search-budget.js';
 
 const MODULE = 'issue-eligibility';
 
@@ -41,7 +43,8 @@ const CLAIM_PHRASES = [
 
 /**
  * Check whether an open PR already exists for the given issue.
- * Searches both the PR search index and the issue timeline for linked PRs.
+ * Uses the timeline API (REST) to detect cross-referenced PRs, avoiding
+ * the Search API's strict 30 req/min rate limit.
  */
 export async function checkNoExistingPR(
   octokit: Octokit,
@@ -50,13 +53,11 @@ export async function checkNoExistingPR(
   issueNumber: number,
 ): Promise<CheckResult> {
   try {
-    // Search for PRs that mention this issue
-    const { data } = await octokit.search.issuesAndPullRequests({
-      q: `repo:${owner}/${repo} is:pr ${issueNumber}`,
-      per_page: 5,
-    });
-
-    // Also check timeline for linked PRs
+    // Use the timeline API (REST, not Search) to detect linked PRs.
+    // This avoids consuming GitHub Search API quota (30 req/min limit).
+    // Timeline captures formally linked PRs via cross-referenced events
+    // but may miss PRs that only mention the issue number without a formal
+    // link — an acceptable trade-off since most PRs use "Fixes #N" syntax.
     const timeline = await paginateAll((page) =>
       octokit.issues.listEventsForTimeline({
         owner,
@@ -72,7 +73,7 @@ export async function checkNoExistingPR(
       return e.event === 'cross-referenced' && e.source?.issue?.pull_request;
     });
 
-    return { passed: data.total_count === 0 && linkedPRs.length === 0 };
+    return { passed: linkedPRs.length === 0 };
   } catch (error) {
     const errMsg = errorMessage(error);
     warn(
@@ -83,22 +84,47 @@ export async function checkNoExistingPR(
   }
 }
 
+/** TTL for cached merged-PR counts per repo (15 minutes). */
+const MERGED_PR_CACHE_TTL_MS = 15 * 60 * 1000;
+
 /**
  * Check how many merged PRs the authenticated user has in a repo.
  * Uses GitHub Search API. Returns 0 on error (non-fatal).
+ * Results are cached per-repo for 15 minutes to avoid redundant Search API
+ * calls when multiple issues from the same repo are vetted.
  */
 export async function checkUserMergedPRsInRepo(octokit: Octokit, owner: string, repo: string): Promise<number> {
+  const cache = getHttpCache();
+  const cacheKey = `merged-prs:${owner}/${repo}`;
+
+  // Manual cache check — do not use cachedTimeBased because we must NOT cache
+  // error-path fallback values (a transient failure returning 0 would poison the
+  // cache for 15 minutes, hiding that the user has merged PRs in the repo).
+  const cached = cache.getIfFresh(cacheKey, MERGED_PR_CACHE_TTL_MS);
+  if (cached != null && typeof cached === 'number') {
+    return cached;
+  }
+
   try {
-    // Use @me to search as the authenticated user
-    const { data } = await octokit.search.issuesAndPullRequests({
-      q: `repo:${owner}/${repo} is:pr is:merged author:@me`,
-      per_page: 1, // We only need total_count
-    });
-    return data.total_count;
+    const tracker = getSearchBudgetTracker();
+    await tracker.waitForBudget();
+    try {
+      // Use @me to search as the authenticated user
+      const { data } = await octokit.search.issuesAndPullRequests({
+        q: `repo:${owner}/${repo} is:pr is:merged author:@me`,
+        per_page: 1, // We only need total_count
+      });
+      // Only cache successful results
+      cache.set(cacheKey, '', data.total_count);
+      return data.total_count;
+    } finally {
+      // Always record the call — failed requests still consume GitHub rate limit points
+      tracker.recordCall();
+    }
   } catch (error) {
     const errMsg = errorMessage(error);
     warn(MODULE, `Could not check merged PRs in ${owner}/${repo}: ${errMsg}. Defaulting to 0.`);
-    return 0;
+    return 0; // Not cached — next call will retry
   }
 }
 

--- a/packages/core/src/core/issue-vetting.test.ts
+++ b/packages/core/src/core/issue-vetting.test.ts
@@ -42,6 +42,14 @@ vi.mock('./http-cache.js', () => ({
     }),
 }));
 
+vi.mock('./search-budget.js', () => ({
+  getSearchBudgetTracker: vi.fn().mockReturnValue({
+    waitForBudget: vi.fn().mockResolvedValue(undefined),
+    recordCall: vi.fn(),
+    canAfford: vi.fn().mockReturnValue(true),
+  }),
+}));
+
 vi.mock('./logger.js', () => ({
   warn: vi.fn(),
   debug: vi.fn(),
@@ -314,8 +322,11 @@ describe('vetIssue', () => {
     expect(candidate.searchPriority).toBe('normal');
   });
 
-  it('detects existing PRs via search', async () => {
-    mockFn(octokit.search.issuesAndPullRequests).mockImplementation(mockSearchDispatch(1, 0));
+  it('detects existing PRs via timeline', async () => {
+    // Mock timeline to return a cross-referenced PR event (checkNoExistingPR uses timeline, not Search API)
+    vi.mocked(paginateAll).mockResolvedValue([
+      { event: 'cross-referenced', source: { issue: { pull_request: { url: 'https://...' } } } },
+    ]);
 
     const candidate = await vetter.vetIssue(`https://github.com/${owner}/repo/issues/42`);
     expect(candidate.vettingResult.checks.noExistingPR).toBe(false);
@@ -331,12 +342,8 @@ describe('vetIssue', () => {
   });
 
   it('downgrades to needs_review when existing-PR check is inconclusive', async () => {
-    mockFn(octokit.search.issuesAndPullRequests).mockImplementation(({ q }: { q: string }) => {
-      if (q.includes('is:merged') && q.includes('author:@me')) {
-        return Promise.resolve({ data: { total_count: 0 } });
-      }
-      return Promise.reject(new Error('API error'));
-    });
+    // Mock timeline to fail (checkNoExistingPR uses timeline, not Search API)
+    vi.mocked(paginateAll).mockRejectedValue(new Error('API error'));
 
     const candidate = await vetter.vetIssue(`https://github.com/${owner}/repo/issues/42`);
     expect(candidate.recommendation).toBe('needs_review');
@@ -344,7 +351,10 @@ describe('vetIssue', () => {
   });
 
   it('recommends skip when more than 2 skip reasons', async () => {
-    mockFn(octokit.search.issuesAndPullRequests).mockImplementation(mockSearchDispatch(1, 0));
+    // Mock timeline to return a cross-referenced PR event (existing PR detected via timeline)
+    vi.mocked(paginateAll).mockResolvedValue([
+      { event: 'cross-referenced', source: { issue: { pull_request: { url: 'https://...' } } } },
+    ]);
 
     mockFn(octokit.issues.get).mockResolvedValue({
       data: {

--- a/packages/core/src/core/issue-vetting.ts
+++ b/packages/core/src/core/issue-vetting.ts
@@ -71,13 +71,18 @@ export class IssueVetter {
       issue_number: number,
     });
 
+    // Check local state first to skip the merged-PR Search API call when
+    // the repo already has authoritative data (saves 1 Search call per issue).
+    const repoScoreRecord = this.stateManager.getRepoScore(repoFullName);
+    const skipMergedPRCheck = repoScoreRecord != null && repoScoreRecord.mergedPRCount > 0;
+
     // Run all vetting checks in parallel — delegates to standalone functions
     const [existingPRCheck, claimCheck, projectHealth, contributionGuidelines, userMergedPRCount] = await Promise.all([
       checkNoExistingPR(this.octokit, owner, repo, number),
       checkNotClaimed(this.octokit, owner, repo, number, ghIssue.comments),
       checkProjectHealth(this.octokit, owner, repo),
       fetchContributionGuidelines(this.octokit, owner, repo),
-      checkUserMergedPRsInRepo(this.octokit, owner, repo),
+      skipMergedPRCheck ? Promise.resolve(0) : checkUserMergedPRsInRepo(this.octokit, owner, repo),
     ]);
 
     const noExistingPR = existingPRCheck.passed;
@@ -153,7 +158,6 @@ export class IssueVetter {
     // Determine effective merged PR count: prefer local state (authoritative if present),
     // fall back to live GitHub API count to detect contributions made before using oss-autopilot (#373)
     const config = this.stateManager.getState().config;
-    const repoScoreRecord = this.stateManager.getRepoScore(repoFullName);
     const effectiveMergedCount =
       repoScoreRecord && repoScoreRecord.mergedPRCount > 0 ? repoScoreRecord.mergedPRCount : userMergedPRCount;
     if (effectiveMergedCount > 0) {

--- a/packages/core/src/core/search-budget.test.ts
+++ b/packages/core/src/core/search-budget.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SearchBudgetTracker, getSearchBudgetTracker } from './search-budget.js';
+
+vi.mock('./logger.js', () => ({
+  debug: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock('./utils.js', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    sleep: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+describe('SearchBudgetTracker', () => {
+  let tracker: SearchBudgetTracker;
+
+  beforeEach(() => {
+    tracker = new SearchBudgetTracker();
+  });
+
+  it('starts with zero calls', () => {
+    expect(tracker.getCallsInWindow()).toBe(0);
+    expect(tracker.getTotalCalls()).toBe(0);
+  });
+
+  it('records calls and reports count', () => {
+    tracker.recordCall();
+    tracker.recordCall();
+    tracker.recordCall();
+    expect(tracker.getCallsInWindow()).toBe(3);
+    expect(tracker.getTotalCalls()).toBe(3);
+  });
+
+  it('canAfford returns true when under budget', () => {
+    expect(tracker.canAfford(5)).toBe(true);
+    expect(tracker.canAfford(26)).toBe(true); // EFFECTIVE_BUDGET = 30 - 4 = 26
+  });
+
+  it('canAfford returns false when at budget', () => {
+    // Fill up the budget (26 calls = EFFECTIVE_BUDGET)
+    for (let i = 0; i < 26; i++) {
+      tracker.recordCall();
+    }
+    expect(tracker.canAfford(1)).toBe(false);
+  });
+
+  it('init resets state', () => {
+    tracker.recordCall();
+    tracker.recordCall();
+    expect(tracker.getTotalCalls()).toBe(2);
+
+    tracker.init(25, new Date(Date.now() + 60000).toISOString());
+    expect(tracker.getTotalCalls()).toBe(0);
+    expect(tracker.getCallsInWindow()).toBe(0);
+  });
+
+  it('waitForBudget returns immediately when budget available', async () => {
+    tracker.recordCall();
+    await tracker.waitForBudget(); // should not throw or hang
+    expect(tracker.getCallsInWindow()).toBe(1);
+  });
+
+  it('waitForBudget waits when budget is full', async () => {
+    const { sleep } = await import('./utils.js');
+    const realNow = Date.now();
+
+    // Fill up the budget
+    for (let i = 0; i < 26; i++) {
+      tracker.recordCall();
+    }
+
+    // Mock sleep to advance Date.now by 61 seconds so timestamps age out of the window
+    vi.mocked(sleep).mockImplementation(async () => {
+      vi.spyOn(Date, 'now').mockReturnValue(realNow + 61_000);
+    });
+
+    await tracker.waitForBudget();
+    // Should have called sleep to wait for budget
+    expect(sleep).toHaveBeenCalled();
+
+    // Restore Date.now
+    vi.restoreAllMocks();
+  });
+
+  it('canAfford respects external budget from init', () => {
+    // When GitHub reports only 5 remaining, tracker should refuse after 5 calls
+    tracker.init(5, new Date(Date.now() + 60000).toISOString());
+    for (let i = 0; i < 5; i++) {
+      expect(tracker.canAfford(1)).toBe(true);
+      tracker.recordCall();
+    }
+    expect(tracker.canAfford(1)).toBe(false);
+  });
+
+  it('waitForBudget returns immediately when external budget exhausted but no local timestamps', async () => {
+    // Edge case: init with 0 remaining but no local calls.
+    // Should return immediately (no timestamps to wait on) rather than looping forever.
+    tracker.init(0, new Date(Date.now() + 60000).toISOString());
+    await tracker.waitForBudget(); // should not hang
+  });
+});
+
+describe('getSearchBudgetTracker', () => {
+  it('returns singleton instance', () => {
+    const a = getSearchBudgetTracker();
+    const b = getSearchBudgetTracker();
+    expect(a).toBe(b);
+  });
+});

--- a/packages/core/src/core/search-budget.ts
+++ b/packages/core/src/core/search-budget.ts
@@ -1,0 +1,152 @@
+/**
+ * Search Budget Tracker — centralized rate limit management for GitHub Search API.
+ *
+ * The GitHub Search API enforces a strict 30 requests/minute limit for
+ * authenticated users. This module tracks actual consumption via a sliding
+ * window and provides adaptive delays to stay within budget.
+ *
+ * Usage:
+ * - Initialize once per search run with pre-flight rate limit data
+ * - Call recordCall() after every Search API call
+ * - Call waitForBudget() before making a Search API call to pace requests
+ * - Call canAfford(n) to check if n more calls fit in the remaining budget
+ */
+
+import { debug } from './logger.js';
+import { sleep } from './utils.js';
+
+const MODULE = 'search-budget';
+
+/** GitHub Search API rate limit: 30 requests per 60-second rolling window. */
+const SEARCH_RATE_LIMIT = 30;
+const SEARCH_WINDOW_MS = 60 * 1000;
+
+/** Safety margin: reserve a few calls for retries and cross-process usage. */
+const SAFETY_MARGIN = 4;
+
+/** Effective budget per window after safety margin. */
+const EFFECTIVE_BUDGET = SEARCH_RATE_LIMIT - SAFETY_MARGIN;
+
+export class SearchBudgetTracker {
+  /** Timestamps of recent Search API calls within the sliding window. */
+  private callTimestamps: number[] = [];
+
+  /** Last known remaining quota from GitHub's rate limit endpoint. */
+  private knownRemaining: number = SEARCH_RATE_LIMIT;
+
+  /** Epoch ms when the rate limit window resets (from GitHub API). */
+  private resetAt: number = 0;
+
+  /** Total calls recorded since init (for diagnostics). */
+  private totalCalls: number = 0;
+
+  /**
+   * Initialize with pre-flight rate limit data from GitHub.
+   */
+  init(remaining: number, resetAt: string): void {
+    this.knownRemaining = remaining;
+    this.resetAt = new Date(resetAt).getTime();
+    this.callTimestamps = [];
+    this.totalCalls = 0;
+    debug(MODULE, `Initialized: ${remaining} remaining, resets at ${new Date(this.resetAt).toLocaleTimeString()}`);
+  }
+
+  /**
+   * Record that a Search API call was just made.
+   */
+  recordCall(): void {
+    this.callTimestamps.push(Date.now());
+    this.totalCalls++;
+    this.pruneOldTimestamps();
+  }
+
+  /**
+   * Remove timestamps older than the sliding window.
+   */
+  private pruneOldTimestamps(): void {
+    const cutoff = Date.now() - SEARCH_WINDOW_MS;
+    while (this.callTimestamps.length > 0 && this.callTimestamps[0] < cutoff) {
+      this.callTimestamps.shift();
+    }
+  }
+
+  /**
+   * Get the number of calls made in the current sliding window.
+   */
+  getCallsInWindow(): number {
+    this.pruneOldTimestamps();
+    return this.callTimestamps.length;
+  }
+
+  /**
+   * Get the effective budget, accounting for both the sliding window limit
+   * and the pre-flight remaining quota from GitHub.
+   */
+  private getEffectiveBudget(): number {
+    // Use the stricter of: local window limit vs. pre-flight remaining minus calls made
+    const localBudget = EFFECTIVE_BUDGET - this.callTimestamps.length;
+    const externalBudget = this.knownRemaining - this.totalCalls;
+    return Math.max(0, Math.min(localBudget, externalBudget));
+  }
+
+  /**
+   * Check if we can afford N more Search API calls without exceeding the budget.
+   */
+  canAfford(n: number): boolean {
+    this.pruneOldTimestamps();
+    return this.getEffectiveBudget() >= n;
+  }
+
+  /**
+   * Wait if necessary to stay within the Search API rate limit.
+   * If the sliding window is at capacity, sleeps until the oldest
+   * call ages out of the window.
+   */
+  async waitForBudget(): Promise<void> {
+    // Loop to handle edge cases where a single sleep isn't enough
+    // (e.g., concurrent callers, clock skew, or external budget depletion)
+    while (true) {
+      this.pruneOldTimestamps();
+
+      if (this.getEffectiveBudget() > 0) {
+        return; // Budget available, no wait needed
+      }
+
+      // Wait until the oldest call in the window ages out
+      const oldestInWindow = this.callTimestamps[0];
+      if (!oldestInWindow) {
+        return; // No calls in window — budget exhausted by external consumption, can't wait it out
+      }
+      const waitUntil = oldestInWindow + SEARCH_WINDOW_MS;
+      const waitMs = waitUntil - Date.now();
+
+      if (waitMs > 0) {
+        debug(MODULE, `Budget full (${this.callTimestamps.length}/${EFFECTIVE_BUDGET} in window), waiting ${waitMs}ms`);
+        await sleep(waitMs + 100); // +100ms safety buffer
+      }
+    }
+  }
+
+  /**
+   * Get total calls recorded since init (for diagnostics).
+   */
+  getTotalCalls(): number {
+    return this.totalCalls;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton
+// ---------------------------------------------------------------------------
+
+let _tracker: SearchBudgetTracker | null = null;
+
+/**
+ * Get (or create) the shared SearchBudgetTracker singleton.
+ */
+export function getSearchBudgetTracker(): SearchBudgetTracker {
+  if (!_tracker) {
+    _tracker = new SearchBudgetTracker();
+  }
+  return _tracker;
+}

--- a/packages/core/src/core/search-phases.test.ts
+++ b/packages/core/src/core/search-phases.test.ts
@@ -34,6 +34,14 @@ vi.mock('./utils.js', async (importOriginal) => {
   };
 });
 
+vi.mock('./search-budget.js', () => ({
+  getSearchBudgetTracker: vi.fn().mockReturnValue({
+    waitForBudget: vi.fn().mockResolvedValue(undefined),
+    recordCall: vi.fn(),
+    canAfford: vi.fn().mockReturnValue(true),
+  }),
+}));
+
 vi.mock('./http-cache.js', () => ({
   getHttpCache: vi.fn().mockReturnValue(makeCacheMock()),
   cachedTimeBased: vi

--- a/packages/core/src/core/search-phases.ts
+++ b/packages/core/src/core/search-phases.ts
@@ -13,14 +13,17 @@ import { getHttpCache, cachedTimeBased } from './http-cache.js';
 import { type GitHubSearchItem, detectLabelFarmingRepos } from './issue-filtering.js';
 import { IssueVetter } from './issue-vetting.js';
 import { sleep } from './utils.js';
+import { getSearchBudgetTracker } from './search-budget.js';
 
 const MODULE = 'search-phases';
 
 /** GitHub Search API enforces a max of 5 AND/OR/NOT operators per query. */
 export const GITHUB_MAX_BOOLEAN_OPS = 5;
 
-/** Delay between search API calls to avoid GitHub's secondary rate limit (~30 req/min). */
-const INTER_QUERY_DELAY_MS = 1500;
+/** Delay between search API calls to avoid GitHub's secondary rate limit (~30 req/min).
+ * Set to 2000ms as a safety floor (max 30/min at the limit). The SearchBudgetTracker
+ * adds additional adaptive delays when needed. */
+const INTER_QUERY_DELAY_MS = 2000;
 
 /** Batch size for repo queries. 3 repos = 2 OR operators, leaving room for labels. */
 const BATCH_SIZE = 3;
@@ -118,8 +121,15 @@ export async function cachedSearchIssues(
 ): Promise<{ total_count: number; items: GitHubSearchItem[] }> {
   const cacheKey = `search:${params.q}:${params.sort}:${params.order}:${params.per_page}`;
   return cachedTimeBased(getHttpCache(), cacheKey, SEARCH_CACHE_TTL_MS, async () => {
-    const { data } = await octokit.search.issuesAndPullRequests(params);
-    return data;
+    const tracker = getSearchBudgetTracker();
+    await tracker.waitForBudget();
+    try {
+      const { data } = await octokit.search.issuesAndPullRequests(params);
+      return data;
+    } finally {
+      // Always record the call — failed requests still consume GitHub rate limit points
+      tracker.recordCall();
+    }
   });
 }
 


### PR DESCRIPTION
## Summary

Strategy B in OSS search consistently exceeded the GitHub Search API's 30 req/min limit (~61-64 calls per run), causing persistent failures during issue discovery. This PR reduces total Search API calls to ~22-26 per run.

- **Drop Search API from `checkNoExistingPR`** — use timeline API (REST) instead, saving 1 Search call per vetted issue (~20 calls total)
- **Skip `checkUserMergedPRsInRepo`** when local state already has merged PR count, saving 1 Search call per issue in known repos
- **Cache `checkUserMergedPRsInRepo` per-repo** (15min TTL) with error-safe caching that only persists successful results — prevents cache poisoning from transient failures
- **Cap Phase 1 labels to 3** — reduces multiplicative label-chunk x repo-batch queries from ~12 to ~4
- **Add centralized `SearchBudgetTracker`** with sliding window algorithm that paces requests adaptively using both local call tracking and pre-flight GitHub quota data
- **Increase `INTER_QUERY_DELAY_MS`** from 1500ms to 2000ms as safety floor
- **Use `try/finally` for budget tracking** so failed API calls (which still consume rate limit points) are accurately counted

## Test plan

- [x] All 2103 tests pass (67 test files)
- [x] 8 new tests for `SearchBudgetTracker` (sliding window, budget tracking, external budget constraint, empty-window edge case)
- [x] 5 new tests for cache behavior in `checkUserMergedPRsInRepo` (cache hit, success caching, no-cache-on-error)
- [x] Updated tests for `checkNoExistingPR` (timeline-based instead of Search-based)
- [x] TypeScript type check clean
- [x] ESLint clean (0 new warnings)
- [x] Prettier formatting clean