### PR TITLE
fix: add .mcpregistry token files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ data/
 .claude/*.local.md
 .claude/settings.json
 
+# Registry tokens
+.mcpregistry_*
+
 # Logs
 *.log
 
@@ -33,5 +36,4 @@ Thumbs.db
 packages/core/docs/
 
 # Worktrees
-.worktrees/
 .worktrees/


### PR DESCRIPTION
## Summary

- Adds `.mcpregistry_*` pattern to root `.gitignore` to prevent accidental commit of MCP registry token files
- Removes duplicate `.worktrees/` entry

Token files were never committed (verified via `git log`), so no rotation needed.

Closes #851