### PR TITLE
Add git operation guards to prevent overwriting remote commits

### DIFF
--- a/hooks/guard-git-operations.sh
+++ b/hooks/guard-git-operations.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# PreToolUse hook: prevent unsafe git operations that can overwrite remote work.
+#
+# 1. Blocks bare `git push --force` (must use --force-with-lease)
+# 2. Requires explicit fetch before rebase
+# 3. Requires explicit fetch before force-with-lease push
+#
+# Returns "ask" to prompt user confirmation, or a systemMessage reminder.
+
+set -euo pipefail
+
+input=$(cat)
+
+command=$(echo "$input" | jq -r '.tool_input.command // empty')
+
+if [ -z "$command" ]; then
+  exit 0
+fi
+
+# Block `git push --force` (without --force-with-lease)
+# Match --force or -f but NOT --force-with-lease
+if echo "$command" | grep -qE 'git\s+push\b' && echo "$command" | grep -qE '(\s--force\b|\s-f\b)' && ! echo "$command" | grep -qE '\s--force-with-lease'; then
+  cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "deny",
+    "updatedInput": {}
+  },
+  "systemMessage": "BLOCKED: Never use `git push --force`. Use `git push --force-with-lease` instead — it prevents overwriting commits pushed by others. Before pushing, always fetch the remote branch first: `git fetch <remote> <branch>`."
+}
+EOF
+  exit 0
+fi
+
+# Warn before rebase: remind to fetch first
+if echo "$command" | grep -qE 'git\s+rebase\b'; then
+  cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "ask",
+    "updatedInput": {}
+  },
+  "systemMessage": "Before rebasing, you MUST fetch the remote tracking branch to avoid overwriting commits pushed by others (e.g. maintainer cleanup commits). Run `git fetch <remote> <branch>` first and verify no new remote commits exist. If the remote has commits you don't have locally, incorporate them before rebasing."
+}
+EOF
+  exit 0
+fi
+
+# Warn before force-with-lease push: remind to fetch first
+if echo "$command" | grep -qE 'git\s+push\b.*--force-with-lease'; then
+  cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "ask",
+    "updatedInput": {}
+  },
+  "systemMessage": "Before force-pushing (even with --force-with-lease), verify you fetched the remote branch and incorporated any new commits. Maintainers may push directly to your PR branch. If you haven't fetched, --force-with-lease may still overwrite their work if your local remote-tracking ref is stale."
+}
+EOF
+  exit 0
+fi
+
+exit 0

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -19,6 +19,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/guard-public-posts.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/guard-git-operations.sh",
+            "timeout": 5
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Adds a new `guard-git-operations.sh` PreToolUse hook that intercepts dangerous git commands
- Blocks `git push --force` entirely (must use `--force-with-lease`)
- Prompts before `git rebase` with a reminder to fetch the remote branch first
- Prompts before `git push --force-with-lease` to verify remote was fetched and incorporated

## Motivation

A rebase was run on a PR branch without fetching remote changes first. The maintainer had pushed cleanup commits directly to the branch after approving. The force push overwrote all their work. This hook prevents that from happening again by injecting reminders at the point of action.

## Test plan

- [x] `git push --force` is denied with explanation
- [x] `git rebase` triggers ask prompt with fetch reminder
- [x] `git push --force-with-lease` triggers ask prompt with fetch verification
- [x] Normal `git push` passes through with no interference
- [x] hooks.json is valid JSON