### PR TITLE
fix: add minimal diff discipline to prevent unrelated formatting changes in PRs

### DIFF
--- a/agents/pr-responder.md
+++ b/agents/pr-responder.md
@@ -130,6 +130,10 @@ Classify each maintainer comment into one of these categories:
 | **style_request** | Asks for formatting/naming changes | "rename this to X", "use camelCase", "add a newline" | NO — trivial, visible in diff |
 | **design_discussion** | Proposes alternative approach | "have you considered X?", "wouldn't it be better to Y?" | YES — needs thoughtful response |
 | **approval_with_nit** | Approved but with minor requests | "LGTM, just fix X and Y" | NO — fix nits, let diff speak |
+| **formatting_complaint** | Maintainer flags unrelated formatting | "revert the formatting changes", "unrelated whitespace changes", "keep the diff focused", "please don't change files unrelated to the fix" | NO — revert formatting, acknowledge only if frustrated |
+
+**When `formatting_complaint` is detected:**
+Revert formatting-only hunks (use `git diff` to identify them, then `git checkout -- {files}` for files where ALL changes are formatting-only, or the Edit tool to surgically undo specific hunks in files with mixed changes). Verify with `git diff` that only functional changes remain, then push. Only draft a brief acknowledgment if the maintainer expressed frustration (e.g., "cleaned up, thanks for flagging").
 
 ### 2b. Comment Decision Logic (Post-Push)
 
@@ -144,6 +148,7 @@ After pushing code changes that address maintainer feedback, decide whether a re
 - Approval with nits — fix nits and push
 - Any request where the diff directly shows compliance
 - The feedback is classified as `code_request`, `style_request`, or `approval_with_nit` and the diff addresses it
+- Formatting revert requested — revert the formatting changes, push the cleaned diff. Only post a brief acknowledgment if the maintainer seemed frustrated
 
 **Rare cases where Draft is needed:**
 - Maintainer asked a question that code can't answer (`question` or `explanation_request`)

--- a/agents/pre-commit-reviewer.md
+++ b/agents/pre-commit-reviewer.md
@@ -142,6 +142,7 @@ Review the diff (from Phase 1) for:
 ### Recommended (should fix)
 - **Dead code**: Unused variables, unreachable branches, commented-out code left in
 - **Style mismatches**: Naming inconsistent with repo conventions, wrong indentation, import order
+- **Formatting bloat**: Diff hunks that change only existing code's formatting (whitespace, quote style, trailing commas, import reordering) without any functional purpose — these should be reverted to keep the PR focused. Distinct from style mismatches: style mismatches are about new code not following repo conventions; formatting bloat is about reformatting existing code that the fix didn't need to touch
 - **Missing error handling**: Unhandled promise rejections, missing try/catch for I/O
 - **Unnecessary complexity**: Overly nested logic, duplicate code that could be simplified
 - **Truthiness gotchas** (JS/TS only):
@@ -278,6 +279,7 @@ Then use AskUserQuestion:
 4. **Don't over-flag** — only report issues that a maintainer would actually care about
 5. **No AI attribution** — never suggest adding AI attribution to commits or code
 6. **Read only what's needed** — don't read the entire codebase, focus on changed files and their immediate context
+7. **Minimal diff** — flag formatting-only changes (whitespace, quote style, trailing commas, import reordering) that are not part of the functional fix. These expand the diff without benefit and cause maintainers to reject PRs
 
 **Related Agents:**
 - After a clean review, **pr-health-checker** can verify CI status and merge readiness before pushing

--- a/skills/oss-contribution/SKILL.md
+++ b/skills/oss-contribution/SKILL.md
@@ -17,6 +17,17 @@ version: 1.1.0
 4. Be patient - open source moves at its own pace
 5. Give back to the community when you can
 
+## Minimal Diff Discipline
+
+Every line in a PR diff must be directly related to the issue being fixed. Unrelated formatting changes (whitespace, quote style, trailing commas, import reordering, line breaks) make diffs noisy, harder to review, and signal carelessness. Maintainers will flag or reject PRs with formatting bloat.
+
+**Rules:**
+1. **Only touch lines the fix requires.** Don't reorder imports, change quote styles, fix whitespace, or add trailing commas in existing code — unless those changes are part of the fix itself.
+2. **Scope formatter output.** If the repo's formatter must be run (e.g., CI requires it), review the formatter's changes afterward. Use `git diff` to identify formatting-only changes. Use `git checkout -- {files}` only for files where ALL changes are formatting-only. For files with mixed changes, use targeted edits to surgically remove formatting hunks. (In interactive terminal contexts, `git add -p` can also be used for hunk-level staging.)
+3. **Match the repo's style, don't impose your own.** If the repo uses single quotes, use single quotes in your new code. If it uses tabs, use tabs. Never convert existing style to a different one.
+
+**When formatting IS the fix:** If the issue itself is about formatting (e.g., "run prettier on codebase", "fix inconsistent indentation"), then formatting changes are in scope. In all other cases, they are not.
+
 ## Responding to Code Review Feedback
 
 ### Mindset
@@ -164,6 +175,7 @@ Before submitting any PR, verify:
 - [ ] **Description Quality**: Explains what changed and why
 - [ ] **Title Quality**: Descriptive, properly formatted (e.g., `fix: resolve login timeout`)
 - [ ] **Focused Changes**: One logical change per PR (< 10 files, < 400 lines ideal)
+- [ ] **Minimal Diff**: No unrelated formatting changes (whitespace, quotes, imports, trailing commas)
 
 ### Conditional
 - [ ] **Tests Included**: If project requires tests, add them

--- a/workflows/draft-first-workflow.md
+++ b/workflows/draft-first-workflow.md
@@ -204,6 +204,9 @@ Use `git diff $mergeBase..HEAD` for the full branch diff. If `$mergeBase` is emp
 SCOPE: This PR addresses issue '{issueContext.title}' ({issueContext.url}).
 Focus findings on changes related to this issue. Flag pre-existing issues only
 if they are Critical severity. Do NOT suggest improvements outside the scope of this PR.
+FORMATTING RULE: Flag any diff hunks that are formatting-only (whitespace, quote style,
+trailing commas, import reordering) and unrelated to the issue fix. These must be reverted
+before the PR is submitted. Do not flag formatting that is part of the functional fix.
 ```
 
 **Agent prompts** (include the full `git diff $mergeBase..HEAD` output in each):
@@ -213,6 +216,9 @@ Task(pr-review-toolkit:code-reviewer,
   "SCOPE: This PR addresses issue '{issueContext.title}' ({issueContext.url}).
    Focus findings on changes related to this issue. Flag pre-existing issues only
    if they are Critical severity. Do NOT suggest improvements outside the scope of this PR.
+   FORMATTING RULE: Flag any diff hunks that are formatting-only (whitespace, quote style,
+   trailing commas, import reordering) and unrelated to the issue fix. These must be reverted
+   before the PR is submitted. Do not flag formatting that is part of the functional fix.
 
    Review the following code changes for bugs, logic errors, security vulnerabilities,
    and adherence to project conventions. Focus on issue-related changes.
@@ -228,6 +234,9 @@ Task(pr-review-toolkit:silent-failure-hunter,
   "SCOPE: This PR addresses issue '{issueContext.title}' ({issueContext.url}).
    Focus findings on changes related to this issue. Flag pre-existing issues only
    if they are Critical severity. Do NOT suggest improvements outside the scope of this PR.
+   FORMATTING RULE: Flag any diff hunks that are formatting-only (whitespace, quote style,
+   trailing commas, import reordering) and unrelated to the issue fix. These must be reverted
+   before the PR is submitted. Do not flag formatting that is part of the functional fix.
 
    Review the following code changes for silent failures, inadequate error handling,
    and inappropriate fallback behavior. Focus on changed code paths only.
@@ -241,9 +250,14 @@ Task(pr-review-toolkit:code-simplifier,
   "SCOPE: This PR addresses issue '{issueContext.title}' ({issueContext.url}).
    Focus findings on changes related to this issue. Flag pre-existing issues only
    if they are Critical severity. Do NOT suggest improvements outside the scope of this PR.
+   FORMATTING RULE: Flag any diff hunks that are formatting-only (whitespace, quote style,
+   trailing commas, import reordering) and unrelated to the issue fix. These must be reverted
+   before the PR is submitted. Do not flag formatting that is part of the functional fix.
 
    Review the following code changes for dead code, unnecessary complexity, and
    simplification opportunities. Focus on new/modified code only. Do NOT modify files — report findings only.
+   Do NOT suggest cosmetic changes (import reordering, quote style, trailing commas,
+   whitespace) as improvements — only flag them for reversion per the FORMATTING RULE above.
    Working directory: {local repo path}
    Changed files: {changed files list}
 
@@ -254,6 +268,9 @@ Task(pr-review-toolkit:pr-test-analyzer,
   "SCOPE: This PR addresses issue '{issueContext.title}' ({issueContext.url}).
    Focus findings on changes related to this issue. Flag pre-existing issues only
    if they are Critical severity. Do NOT suggest improvements outside the scope of this PR.
+   FORMATTING RULE: Flag any diff hunks that are formatting-only (whitespace, quote style,
+   trailing commas, import reordering) and unrelated to the issue fix. These must be reverted
+   before the PR is submitted. Do not flag formatting that is part of the functional fix.
 
    Analyze test coverage for the following code changes. Focus on new functionality only.
    Check if modified code paths have tests, identify gaps, and recommend what tests should be added.
@@ -272,6 +289,9 @@ Task(pr-review-toolkit:pr-test-analyzer,
   Task(pr-review-toolkit:type-design-analyzer,
     "SCOPE: This PR addresses issue '{issueContext.title}' ({issueContext.url}).
      Focus on issue-related type changes only.
+     FORMATTING RULE: Flag any diff hunks that are formatting-only (whitespace, quote style,
+     trailing commas, import reordering) and unrelated to the issue fix. These must be reverted
+     before the PR is submitted. Do not flag formatting that is part of the functional fix.
 
      Review type design in the following TypeScript changes. Check for proper
      encapsulation, invariant expression, and type safety.
@@ -287,6 +307,9 @@ Task(pr-review-toolkit:pr-test-analyzer,
   Task(pr-review-toolkit:comment-analyzer,
     "SCOPE: This PR addresses issue '{issueContext.title}' ({issueContext.url}).
      Focus on comments in new/modified code only.
+     FORMATTING RULE: Flag any diff hunks that are formatting-only (whitespace, quote style,
+     trailing commas, import reordering) and unrelated to the issue fix. These must be reverted
+     before the PR is submitted. Do not flag formatting that is part of the functional fix.
 
      Review comments in the following code changes for accuracy, completeness,
      and long-term maintainability.

--- a/workflows/pre-commit-review.md
+++ b/workflows/pre-commit-review.md
@@ -125,6 +125,11 @@ Task(pr-review-toolkit:code-reviewer,
      but undefined would also match. Flag === false vs !prop inconsistencies. Flag boolean
      coercion of values that could be 0, "", or null where the intent is only to check
      for undefined.
+   - Formatting hygiene: Scan the diff for hunks that contain only formatting changes
+     (whitespace, quote style, trailing commas, import reordering, line breaks) with no
+     functional change. Flag each as Recommended: 'Formatting-only hunk at {file}:{line}
+     — revert to keep diff minimal.' Do not flag formatting that is part of the functional
+     fix (e.g., a new import that triggers automatic reordering).
    - Documentation accuracy: If docs/README/JSDoc are changed, cross-reference factual claims
      against the actual code. Check that option descriptions match defaults (don't say
      "Enable X" for a feature that's on by default). If code behavior changed but docs
@@ -146,6 +151,8 @@ Task(pr-review-toolkit:silent-failure-hunter,
 Task(pr-review-toolkit:code-simplifier,
   "Review the following code changes for dead code, unnecessary complexity, and
    simplification opportunities. Do NOT modify files — report findings only.
+   Do NOT suggest cosmetic changes (import reordering, quote style, trailing commas,
+   whitespace) as improvements — those expand the diff without functional benefit.
    Working directory: {local repo path}
    Changed files: {changed files list}
 
@@ -345,11 +352,13 @@ Options:
 
 2. **If no tooling detected:** Skip this sub-step. Report: "No linter/formatter detected — skipping auto-format." Proceed to staging.
 
-3. **Run the formatter** on the changed files only (not the entire repo — see file-scoping notes in item 1). Use a 60-second timeout on the bash command. Report what command is being run:
+3. **Capture baseline diff** before running the formatter so you can identify what the formatter changed vs. what you changed: `git diff > /tmp/pre-format.diff`. This baseline is used in step 5 to distinguish functional hunks from formatter-added hunks.
+
+4. **Run the formatter** on the changed files only (not the entire repo — see file-scoping notes in item 1). Use a 60-second timeout on the bash command. Report what command is being run:
    > "Running `{command}` on changed files..."
 
-4. **Handle results:**
-   - **If the command succeeds (exit 0):** Check `git status --porcelain` for files modified by the formatter. Compare the modified files to the original changed files list. If the formatter modified files **outside** the original change set, warn: "Formatter modified {N} file(s) outside your original changes: {list}. Discarding those changes." Restore those files with `git checkout -- {unrelated files}`, then re-run `git status --porcelain` to verify they are no longer modified. If any files could not be restored, warn: "Could not discard formatter changes to {file}. These files will NOT be staged — please resolve manually." Also check for new untracked files (`??` in `git status`) created by the formatter (e.g., cache files) and warn if found — do not stage them. For files within the original change set, report: "Formatter applied changes to {N} file(s). These will be included in the commit."
+5. **Handle results:**
+   - **If the command succeeds (exit 0):** Check `git status --porcelain` for files modified by the formatter. Compare the modified files to the original changed files list. If the formatter modified files **outside** the original change set, warn: "Formatter modified {N} file(s) outside your original changes: {list}. Discarding those changes." Restore those files with `git checkout -- {unrelated files}`, then re-run `git status --porcelain` to verify they are no longer modified. If any files could not be restored, warn: "Could not discard formatter changes to {file}. These files will NOT be staged — please resolve manually." Also check for new untracked files (`??` in `git status`) created by the formatter (e.g., cache files) and warn if found — do not stage them. For files within the original change set: review the formatter's modifications within those files. If the formatter changed lines that were NOT part of the original diff (i.e., reformatted untouched regions of a file you edited), use `git diff` to identify which hunks are formatting-only. For files where ALL changes are formatting-only, use `git checkout -- {files}` to revert them entirely. For files with both formatting and functional changes, use the Edit tool to surgically undo only the formatting-only hunks — never `git checkout --` on these files, as it would destroy the functional changes too. Report: "Formatter applied changes to {N} file(s). Discarded {M} formatting-only hunk(s) to keep the diff minimal."
    - **If the command fails (non-zero exit):** Check `git status --porcelain` for files the formatter partially modified before failing. If files were modified, inform the user: "The linter/formatter modified {N} file(s) before failing. You can undo these partial changes or keep them." Report the error output. Use AskUserQuestion:
      ```
      Question: "Linter reported issues. How to proceed?"


### PR DESCRIPTION
## Summary

- Adds "minimal diff discipline" across the agent/skill/workflow layer to prevent PRs from including unrelated formatting changes (whitespace, quote style, trailing commas, import reordering)
- Maintainers consistently flag this — it makes diffs noisy, harder to review, and signals carelessness

## Changes

**`skills/oss-contribution/SKILL.md`** — New "Minimal Diff Discipline" section establishing 3 rules (only touch lines the fix requires, scope formatter output, match repo style). Added "Minimal Diff" to the PR Quality Checklist.

**`workflows/draft-first-workflow.md`** — Added FORMATTING RULE to the SCOPE block template and all 7 agent prompts. Added cosmetic-change guard to code-simplifier prompt.

**`workflows/pre-commit-review.md`** — Added formatting hygiene check to code-reviewer's "Additional checks". Added cosmetic-change guard to code-simplifier. Added baseline diff capture before formatter runs + hunk-level filtering with safe `git checkout --` / Edit tool guidance.

**`agents/pre-commit-reviewer.md`** — Added "Formatting bloat" under Recommended findings (with clear distinction from "Style mismatches"). Added rule 7 "Minimal diff" to Important Rules.

**`agents/pr-responder.md`** — Added `formatting_complaint` feedback type with realistic example phrases. Added revert procedure with verification step. Added to Skip-is-correct list.

## Test plan

- [x] All 2,533 tests pass (`pnpm test`)
- [x] Lint passes (`pnpm run lint`)
- [x] 3 rounds of review agent convergence (code-reviewer, silent-failure-hunter, code-simplifier, comment-analyzer)
- [x] Verified FORMATTING RULE applied to all 7 agent prompts in draft-first-workflow.md
- [x] Verified no conflicts with existing instructions (style_request vs formatting_complaint, style mismatches vs formatting bloat)