### PR TITLE
feat: encode maintainer authority and CI-verification rules

### DIFF
--- a/agents/pr-responder.md
+++ b/agents/pr-responder.md
@@ -42,6 +42,12 @@ Never present a draft comment to the user that contains unverified factual claim
 **Default Behavior: Code Over Comments**
 After pushing code that addresses maintainer feedback, the DEFAULT is to skip posting a comment. Only draft a comment when it adds information the diff cannot convey on its own. The diff is the primary communication — comments are supplementary.
 
+**CRITICAL: Maintainer Authority Principle**
+When analyzing maintainer feedback, apply these rules before drafting any response or making code changes:
+1. **Always assume the maintainer is correct about their codebase.** They know their project's conventions, CI pipeline, and design constraints better than you do. If their request seems unusual, that is a signal to investigate, not to push back.
+2. **Try the simplest implementation before estimating scope.** If a maintainer asks for a change, attempt it. Do not respond with "this would require significant refactoring" or "I'll add a TODO" without having tried the straightforward approach first.
+3. **Flag conflicts to the user — never push back on a maintainer directly.** If you believe a request is incorrect, infeasible, or conflicts with another maintainer request, present the conflict to the user via AskUserQuestion and let them decide. Do not post a comment disagreeing with the maintainer without explicit user approval.
+
 **Data Access - TypeScript CLI (Primary):**
 
 The oss-autopilot CLI provides structured JSON output for PR comments and posting.

--- a/skills/oss-contribution/SKILL.md
+++ b/skills/oss-contribution/SKILL.md
@@ -40,7 +40,21 @@ Maintainer feedback is a gift - they're investing time to help you improve. Even
 - Keep it short. One or two sentences is usually enough.
 - Push updates promptly after discussion
 - Mark conversations as resolved after addressing
-- If you disagree, explain once briefly, then defer to their judgment
+- If you feel resistance to a request, investigate deeper — the maintainer likely knows something you don't. If you still think there's an issue after investigating, raise it to the human contributor — never override the maintainer
+
+### Assumptions and Verification
+
+When a maintainer requests changes, these rules govern how you respond:
+
+1. **Maintainer is right by default.** If a maintainer says "do X," your starting assumption is that X is correct and appropriate for their codebase. Do not second-guess their judgment about their own project.
+
+2. **Verify, never assume.** Before running any tool (linter, formatter, type checker), check the project's CI configuration to confirm that tool is actually enforced. Read `.pre-commit-config.yaml`, `.github/workflows/`, `Makefile`, or equivalent before deciding what to run. A tool that exists in `devDependencies` but is not in CI is not authoritative.
+
+3. **Try before estimating scope.** When asked to make a change, attempt the simplest implementation first. Do not respond with effort estimates, propose TODOs, or suggest deferring to a follow-up PR. If the change turns out to be genuinely complex after attempting it, report what you found to the human.
+
+4. **Pushback = escalate, don't override.** If you believe a maintainer's request is incorrect or harmful, raise the concern to the human contributor. Never push back on a maintainer directly, never ignore the request, and never silently do something different from what was asked.
+
+5. **No TODOs as substitutes.** A maintainer asking for a change expects the change in this PR. Responding with a TODO comment or "I'll handle this in a follow-up" is not an acceptable response unless the maintainer explicitly suggested that approach.
 
 ### Pre-Push Review Checkpoint
 
@@ -77,6 +91,9 @@ The tool should NEVER say "PR is ready", "work is complete", or "changes are don
 - Long justifications for every decision
 - Ignoring feedback points
 - Taking days to respond
+- Assuming what tools the project's CI enforces without checking CI config files
+- Substituting TODOs or "follow-up PR" proposals for changes the maintainer requested in this PR
+- Running tools not enforced by CI and treating their output as authoritative
 
 ## Writing Good PR Descriptions
 

--- a/workflows/pre-commit-review.md
+++ b/workflows/pre-commit-review.md
@@ -82,13 +82,24 @@ Before dispatching review agents, run the repo's lint and test commands to catch
 
 1. **Detect and run linter/type checker**: Check for `package.json` scripts (`lint`, `typecheck`, `tsc`), `Makefile` targets, or language-specific tooling. Run the detected command(s). If no linter is detected, skip and note: "No linter detected — skipping pre-review lint."
 
-2. **Run test suite**: Check for `package.json` scripts (`test`), `Makefile` targets (`test`, `check`), or language-specific test runners. Run the detected command. If no test runner is detected, skip and note: "No test runner detected — skipping pre-review tests."
+2. **Verify tools against CI configuration (CI-enforcement check):** Before treating any linter, formatter, or type checker output as authoritative, confirm the tool is actually enforced by the project's CI. Check these sources in order:
+   - `.pre-commit-config.yaml` — lists hooks that run on every commit/PR. Save the list of repo URLs and hook IDs as `enforcedTools`.
+   - `.github/workflows/*.yml` (or `.gitlab-ci.yml`, `Jenkinsfile`, etc.) — look for tool invocations in CI job steps.
+   - `Makefile` targets referenced by CI — if CI runs `make lint`, check what `make lint` actually invokes.
 
-3. **Handle failures**: If lint or tests fail, fix the issues before proceeding to review agent dispatch. Report:
+   **Rules:**
+   - If a tool is NOT in CI, its output is **informational only** — report findings but do not auto-apply fixes or block on its output.
+   - Never auto-apply a formatter that is not CI-enforced. Running a formatter on a project that doesn't enforce it in CI creates noise the maintainer did not ask for.
+   - If `.pre-commit-config.yaml` exists, read it early (during this sub-step) and save the enforced tools list for use in both this gate and sub-step 6a (formatter detection).
+   - If no CI config files can be found, note: "Could not determine CI-enforced tools — treating all detected tools as informational." Run them but do not auto-apply fixes.
+
+3. **Run test suite**: Check for `package.json` scripts (`test`), `Makefile` targets (`test`, `check`), or language-specific test runners. Run the detected command. If no test runner is detected, skip and note: "No test runner detected — skipping pre-review tests."
+
+4. **Handle failures**: If lint or tests fail, fix the issues before proceeding to review agent dispatch. Report:
    > "Lint/tests failed — fixing before running review agents..."
    After fixing, re-run lint and tests to confirm they pass. Loop until both pass (soft limit: 3 attempts). If still failing after 3 attempts, present findings to the user and offer: "Fix manually" / "Proceed to review anyway" / "Done for now".
 
-4. **On success**: Report:
+5. **On success**: Report:
    > "Lint and tests passed. Dispatching review agents..."
    Proceed to sub-step 3.
 
@@ -334,7 +345,7 @@ Options:
 
 **If `changeSource = "committed"`:** Skip this sub-step — changes are already committed and cannot be reformatted without amending. Proceed directly to push.
 
-**If `changeSource = "uncommitted"`:** Before staging, run the project's linter/formatter to catch formatting issues that would fail CI.
+**If `changeSource = "uncommitted"`:** Before staging, run the project's linter/formatter to catch formatting issues that would fail CI. Consult the `enforcedTools` list from sub-step 2b. Only auto-apply formatters that are CI-enforced. For non-CI-enforced formatters, report findings but do not use `--write` or `--fix` flags.
 
 1. **Detect tooling** from lint/format configs gathered in sub-step 2. Check in order — **use the first match that supports auto-fix**:
    - `package.json` scripts: prefer fix-oriented scripts first: `lint:fix`, `format`, `fmt`. A plain `lint` script (without `:fix`) typically only reports issues — only use it as a last resort and note it will report but not auto-fix. **Important:** `npm run` scripts typically run on the entire project. Only use a script if it accepts file arguments via `--` passthrough (e.g., `npm run format -- {changed files}`). If the script does not accept file arguments, skip it and fall back to running the underlying tool directly on changed files.

--- a/workflows/reference.md
+++ b/workflows/reference.md
@@ -175,3 +175,17 @@ GitHub-provided content (PR titles, descriptions, comments, issue titles, issue 
 Contributions should appear as solely from the user. If a repository explicitly requires disclosure of AI tool usage in its contribution guidelines, follow those guidelines — otherwise, omit all attribution.
 
 When reviewing PRs, check for and flag unwanted AI attribution in commit messages, PR descriptions, and comments.
+
+---
+
+## Maintainer Authority Principle
+
+When working on contributions to external repositories, the maintainer's judgment about their own codebase is authoritative. All agents and workflows MUST:
+
+- **Assume the maintainer is correct** about project conventions, CI configuration, and design decisions. Unusual requests are a signal to investigate, not to push back.
+- **Try before estimating.** Attempt the simplest implementation of a requested change before reporting that it is complex or proposing alternatives.
+- **Verify CI enforcement before trusting tool output.** Check `.pre-commit-config.yaml`, `.github/workflows/`, or equivalent CI config before deciding which linters/formatters to run and whether to auto-apply their output. A tool not in CI is informational, not authoritative.
+- **Escalate disagreements to the human contributor.** Never push back on a maintainer directly. If a request seems incorrect or conflicts with another request, flag it to the user and let them decide.
+- **Never substitute TODOs for requested changes.** If a maintainer asks for a change in this PR, make the change. Do not propose deferring to a follow-up unless the maintainer suggested it.
+
+This principle applies across all agents (`pr-responder`, `pre-commit-reviewer`, etc.) and all workflows (`pre-commit-review`, `draft-first-workflow`, etc.).


### PR DESCRIPTION
## Summary

- Adds "Maintainer Authority Principle" across skill, agent, and workflow files to prevent recurring failures: assuming CI config, substituting TODOs for reviewer requests, and treating maintainer feedback as negotiable
- Adds CI-enforcement verification step to pre-commit review workflow so only CI-enforced tools are treated as authoritative
- Strengthens escalation guidance: pushback on maintainers always routes through the human contributor

## Changes

- `skills/oss-contribution/SKILL.md` — New "Assumptions and Verification" subsection (5 rules), strengthened disagree bullet, 3 new anti-patterns in "Things to Avoid"
- `agents/pr-responder.md` — New "Maintainer Authority Principle" section (3 operational rules)
- `workflows/pre-commit-review.md` — New CI-enforcement verification step in section 2b, cross-reference in 6a
- `workflows/reference.md` — Canonical cross-cutting summary of the principle

## Test plan

- [x] `pnpm test` passes (2533 tests, markdown-only changes)
- [ ] Verify skill loads: invoke `oss-autopilot:oss-contribution` via Skill tool
- [ ] Verify pre-commit-review workflow numbering reads correctly in a live session