### PR TITLE
feat: activate Gist persistence layer

### DIFF
--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -113,6 +113,62 @@ export const commands: CLICommandDef[] = [
     },
   },
 
+  // ── State ──────────────────────────────────────────────────────────────
+  {
+    name: 'state',
+    register(program) {
+      program
+        .command('state')
+        .description('Manage state persistence (local/gist)')
+        .option('--show', 'Display current persistence mode and Gist ID')
+        .option('--sync', 'Force push state to Gist (no-op if not in Gist mode)')
+        .option('--unlink', 'Switch from Gist back to local persistence')
+        .option('--json', 'Output as JSON')
+        .action(async (options) => {
+          try {
+            if (options.unlink) {
+              const { runStateUnlink } = await import('./commands/state-cmd.js');
+              const data = await runStateUnlink();
+              if (options.json) {
+                outputJson(data);
+              } else {
+                console.log(`State written to ${data.localStatePath}`);
+                console.log('Persistence switched to local mode.');
+                if (data.previousGistId) {
+                  console.log(`Previous Gist (${data.previousGistId}) was NOT deleted.`);
+                }
+                console.log('Restart any running processes (e.g. dashboard server) to pick up the change.');
+              }
+            } else if (options.sync) {
+              const { runStateSync } = await import('./commands/state-cmd.js');
+              const data = await runStateSync();
+              if (options.json) {
+                outputJson(data);
+              } else if (data.pushed) {
+                console.log(`State pushed to Gist ${data.gistId}`);
+              } else {
+                console.log('Not in Gist mode. Nothing to sync.');
+              }
+            } else {
+              // Default: --show
+              const { runStateShow } = await import('./commands/state-cmd.js');
+              const data = await runStateShow();
+              if (options.json) {
+                outputJson(data);
+              } else {
+                console.log(`\nPersistence: ${data.persistence}`);
+                if (data.gistId) console.log(`Gist ID: ${data.gistId}`);
+                if (data.gistDegraded) console.log('Status: DEGRADED (using local cache)');
+                console.log(`Last run: ${data.lastRunAt ?? 'Never'}\n`);
+              }
+            }
+          } catch (err) {
+            handleCommandError(err, options.json);
+          }
+        });
+    },
+  },
+
   // ── Search ─────────────────────────────────────────────────────────────
   {
     name: 'search',

--- a/packages/core/src/cli.test.ts
+++ b/packages/core/src/cli.test.ts
@@ -123,6 +123,7 @@ describe('LOCAL_ONLY_COMMANDS (derived from registry)', () => {
     'init',
     'claim',
     'pr-template',
+    'state',
   ];
 
   it.each(expectedLocalOnly)('should contain local-only command "%s"', (cmd) => {
@@ -370,6 +371,7 @@ describe('Command registration', () => {
       'override',
       'clear-override',
       'stats',
+      'state',
     ];
 
     for (const name of expectedCommands) {

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -58,6 +58,23 @@ program.hook('preAction', async (thisCommand, actionCommand) => {
       console.error('Then run your command again.');
       process.exit(1);
     }
+
+    // Activate Gist persistence if configured, before any command runs.
+    // Peek at the config file directly to avoid creating a local-only singleton
+    // (getStateManager() would lock in local mode before getStateManagerAsync runs).
+    let persistence: string | undefined;
+    try {
+      const { getStatePath } = await import('./core/index.js');
+      const fs = await import('fs');
+      const raw = fs.readFileSync(getStatePath(), 'utf-8');
+      persistence = JSON.parse(raw)?.config?.persistence;
+    } catch {
+      // No state file or unreadable — local mode, lazy init
+    }
+    if (persistence === 'gist' && token) {
+      const { getStateManagerAsync } = await import('./core/index.js');
+      await getStateManagerAsync(token);
+    }
   }
 });
 

--- a/packages/core/src/commands/dashboard-server.test.ts
+++ b/packages/core/src/commands/dashboard-server.test.ts
@@ -66,6 +66,8 @@ const mockStateManager = {
   getMergedPRs: vi.fn().mockReturnValue([]),
   getClosedPRs: vi.fn().mockReturnValue([]),
   reloadIfChanged: vi.fn().mockReturnValue(false),
+  isGistMode: vi.fn().mockReturnValue(false),
+  refreshFromGist: vi.fn().mockResolvedValue(false),
 };
 
 // Create a temp dir for PID file tests (needs to exist before mock is evaluated)

--- a/packages/core/src/commands/dashboard-server.ts
+++ b/packages/core/src/commands/dashboard-server.ts
@@ -314,8 +314,14 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
           sendError(res, 429, 'Too many requests');
           return;
         }
-        // Re-read state.json if CLI commands modified it externally
-        if (stateManager.reloadIfChanged()) {
+        // Re-read state if modified externally (file mtime for local, Gist API for Gist mode)
+        let stateChanged = false;
+        if (stateManager.isGistMode()) {
+          stateChanged = await stateManager.refreshFromGist();
+        } else {
+          stateChanged = stateManager.reloadIfChanged();
+        }
+        if (stateChanged) {
           try {
             cachedJsonData = buildDashboardJson(cachedDigest, stateManager.getState(), cachedCommentedIssues);
           } catch (error) {
@@ -377,7 +383,11 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
   // ── POST /api/action handler ─────────────────────────────────────────────
   async function handleAction(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
     // Reload state before mutating to avoid overwriting external CLI changes
-    stateManager.reloadIfChanged();
+    if (stateManager.isGistMode()) {
+      await stateManager.refreshFromGist();
+    } else {
+      stateManager.reloadIfChanged();
+    }
 
     let body: ActionRequest;
     try {
@@ -447,7 +457,11 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
     }
 
     try {
-      stateManager.reloadIfChanged();
+      if (stateManager.isGistMode()) {
+        await stateManager.refreshFromGist();
+      } else {
+        stateManager.reloadIfChanged();
+      }
       warn(MODULE, 'Refreshing dashboard data from GitHub...');
       const result = await fetchDashboardData(currentToken);
       cachedDigest = result.digest;
@@ -573,8 +587,12 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
   // so subsequent /api/data requests get live data instead of cached state.
   if (token) {
     fetchDashboardData(token)
-      .then((result) => {
-        stateManager.reloadIfChanged();
+      .then(async (result) => {
+        if (stateManager.isGistMode()) {
+          await stateManager.refreshFromGist();
+        } else {
+          stateManager.reloadIfChanged();
+        }
         cachedDigest = result.digest;
         cachedCommentedIssues = result.commentedIssues;
         cachedJsonData = buildDashboardJson(

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -67,6 +67,15 @@ export { runSetup } from './setup.js';
 /** Check whether setup has been completed. */
 export { runCheckSetup } from './setup.js';
 
+// ── State Persistence ────────────────────────────────────────────────────────
+
+/** Show current persistence mode, Gist ID, and sync status. */
+export { runStateShow } from './state-cmd.js';
+/** Force push state to the backing Gist (no-op in local mode). */
+export { runStateSync } from './state-cmd.js';
+/** Disconnect from Gist persistence and switch to local-only mode. */
+export { runStateUnlink } from './state-cmd.js';
+
 // ── Utilities ───────────────────────────────────────────────────────────────
 
 /** Parse a curated markdown issue list file into structured issue items. */
@@ -107,3 +116,4 @@ export type {
   CheckSetupOutput,
 } from './setup.js';
 export type { DailyCheckResult } from './daily.js';
+export type { StateShowOutput, StateSyncOutput, StateUnlinkOutput } from './state-cmd.js';

--- a/packages/core/src/commands/setup.ts
+++ b/packages/core/src/commands/setup.ts
@@ -40,6 +40,7 @@ export interface SetupCompleteOutput {
     projectCategories: ProjectCategory[];
     preferredOrgs: string[];
     scope: IssueScope[];
+    persistence: 'local' | 'gist';
   };
 }
 
@@ -241,6 +242,13 @@ export async function runSetup(options: SetupOptions): Promise<SetupOutput> {
             results[key] = dedupedScopes.length > 0 ? dedupedScopes.join(', ') : '(empty — using labels only)';
             break;
           }
+          case 'persistence':
+            if (value !== 'local' && value !== 'gist') {
+              throw new ValidationError(`Invalid value for persistence: "${value}". Must be "local" or "gist".`);
+            }
+            stateManager.updateConfig({ persistence: value as 'local' | 'gist' });
+            results[key] = value;
+            break;
           case 'issueListPath':
             stateManager.updateConfig({ issueListPath: value || undefined });
             results[key] = value || '(cleared)';
@@ -274,6 +282,7 @@ export async function runSetup(options: SetupOptions): Promise<SetupOutput> {
         projectCategories: config.projectCategories ?? [],
         preferredOrgs: config.preferredOrgs ?? [],
         scope: config.scope ?? [],
+        persistence: config.persistence ?? 'local',
       },
     };
   }
@@ -353,6 +362,13 @@ export async function runSetup(options: SetupOptions): Promise<SetupOutput> {
         current: config.preferredOrgs ?? [],
         default: [],
         type: 'list',
+      },
+      {
+        setting: 'persistence',
+        prompt: 'Where should state be stored? "local" for file only, "gist" for GitHub Gist (survives device loss)',
+        current: config.persistence ?? 'local',
+        default: 'local',
+        type: 'string',
       },
     ],
   };

--- a/packages/core/src/commands/state-cmd.ts
+++ b/packages/core/src/commands/state-cmd.ts
@@ -1,0 +1,92 @@
+/**
+ * State persistence management commands.
+ * Provides --show, --sync, and --unlink subcommands for the Gist persistence layer.
+ */
+
+import * as fs from 'fs';
+import { getStateManager, resetStateManager } from '../core/state.js';
+import { atomicWriteFileSync } from '../core/state-persistence.js';
+import { getStatePath, getGistIdPath } from '../core/utils.js';
+import { warn } from '../core/logger.js';
+
+const MODULE = 'state-cmd';
+
+export interface StateShowOutput {
+  persistence: 'local' | 'gist';
+  gistId: string | null;
+  gistDegraded: boolean;
+  lastRunAt: string | undefined;
+}
+
+export interface StateSyncOutput {
+  pushed: boolean;
+  gistId: string | null;
+}
+
+export interface StateUnlinkOutput {
+  unlinked: boolean;
+  localStatePath: string;
+  previousGistId: string | null;
+}
+
+export async function runStateShow(): Promise<StateShowOutput> {
+  const sm = getStateManager();
+  const state = sm.getState();
+  return {
+    persistence: state.config.persistence ?? 'local',
+    gistId: state.gistId ?? null,
+    gistDegraded: sm.isGistDegraded(),
+    lastRunAt: state.lastRunAt,
+  };
+}
+
+export async function runStateSync(): Promise<StateSyncOutput> {
+  const sm = getStateManager();
+  if (!sm.isGistMode()) {
+    return { pushed: false, gistId: null };
+  }
+  const pushed = await sm.checkpoint();
+  if (!pushed) {
+    throw new Error('Failed to push state to Gist after retry. Check network connectivity and token permissions.');
+  }
+  return { pushed: true, gistId: sm.getState().gistId ?? null };
+}
+
+export async function runStateUnlink(): Promise<StateUnlinkOutput> {
+  const sm = getStateManager();
+  const state = sm.getState();
+  const previousGistId = state.gistId ?? null;
+  const statePath = getStatePath();
+
+  // Refresh from Gist to get the latest state before unlinking
+  if (sm.isGistMode()) {
+    await sm.refreshFromGist();
+  }
+
+  // Write current state to local state.json with persistence set to local
+  const localState = JSON.parse(JSON.stringify(sm.getState()));
+  delete localState.gistId;
+  localState.config.persistence = 'local';
+  atomicWriteFileSync(statePath, JSON.stringify(localState, null, 2), 0o600);
+
+  // Remove the gist-id file so future startups don't try to use the Gist
+  const gistIdPath = getGistIdPath();
+  try {
+    if (fs.existsSync(gistIdPath)) {
+      fs.unlinkSync(gistIdPath);
+    }
+  } catch (err) {
+    warn(MODULE, `Failed to remove gist-id file: ${err}`);
+  }
+
+  // Do NOT delete the remote Gist — the user may want it as a backup
+
+  // Reset the singleton so subsequent calls in this process use local mode
+  resetStateManager();
+
+  return {
+    unlinked: true,
+    localStatePath: statePath,
+    previousGistId,
+  };
+}

--- a/packages/core/src/core/errors.ts
+++ b/packages/core/src/core/errors.ts
@@ -42,6 +42,21 @@ export class ValidationError extends OssAutopilotError {
 }
 
 /**
+ * Gist API scope error (token lacks the "gist" scope).
+ */
+export class GistPermissionError extends ConfigurationError {
+  constructor(message?: string) {
+    super(
+      message ??
+        'Your GitHub token does not have Gist permissions. ' +
+          'Run `gh auth refresh -s gist` to add the required scope, ' +
+          'or create a token with the "gist" scope.',
+    );
+    this.name = 'GistPermissionError';
+  }
+}
+
+/**
  * Extract a human-readable message from an unknown error value.
  */
 export function errorMessage(e: unknown): string {

--- a/packages/core/src/core/gist-state-store.test.ts
+++ b/packages/core/src/core/gist-state-store.test.ts
@@ -105,7 +105,7 @@ function makeMockOctokit(): OctokitLike & {
   return {
     gists: {
       get: vi.fn(),
-      list: vi.fn(),
+      list: vi.fn().mockResolvedValue({ data: [] }),
       create: vi.fn(),
       update: vi.fn(),
     },
@@ -146,7 +146,9 @@ describe('GistStateStore', () => {
       expect(result.created).toBe(false);
       expect(result.state.version).toBe(3);
       expect(octokit.gists.get).toHaveBeenCalledWith({ gist_id: gistId });
-      expect(octokit.gists.list).not.toHaveBeenCalled();
+      // list is called once for the preflight scope check, but not for search
+      expect(octokit.gists.list).toHaveBeenCalledTimes(1);
+      expect(octokit.gists.list).toHaveBeenCalledWith({ per_page: 1, page: 1 });
       expect(octokit.gists.create).not.toHaveBeenCalled();
     });
 
@@ -249,6 +251,9 @@ describe('GistStateStore', () => {
       const gistId = 'page-2-gist';
       const stateJson = makeStateJson();
 
+      // Preflight scope check
+      octokit.gists.list.mockResolvedValueOnce({ data: [] });
+
       // Page 1: 100 unrelated Gists (not empty, so search continues)
       const page1 = Array.from({ length: 100 }, (_, i) => ({
         id: `unrelated-${i}`,
@@ -267,7 +272,8 @@ describe('GistStateStore', () => {
       const result = await store.bootstrap();
 
       expect(result.gistId).toBe(gistId);
-      expect(octokit.gists.list).toHaveBeenCalledTimes(2);
+      // 1 preflight + 2 search pages
+      expect(octokit.gists.list).toHaveBeenCalledTimes(3);
     });
   });
 

--- a/packages/core/src/core/gist-state-store.ts
+++ b/packages/core/src/core/gist-state-store.ts
@@ -21,6 +21,7 @@ import { AgentStateSchema } from './state-schema.js';
 import { atomicWriteFileSync, createFreshState, migrateV1ToV2, migrateV2ToV3 } from './state-persistence.js';
 import { getGistIdPath, getStateCachePath } from './utils.js';
 import { debug, warn } from './logger.js';
+import { GistPermissionError, isRateLimitError } from './errors.js';
 
 const MODULE = 'gist-store';
 
@@ -80,6 +81,8 @@ export class GistStateStore {
   readonly cachedFiles: Map<string, string> = new Map();
   readonly dirtyFiles: Set<string> = new Set();
   private readonly octokit: OctokitLike;
+  private lastRefreshAt = 0;
+  private static readonly REFRESH_THROTTLE_MS = 30_000;
 
   constructor(octokit: OctokitLike) {
     this.octokit = octokit;
@@ -91,6 +94,8 @@ export class GistStateStore {
    */
   async bootstrap(): Promise<BootstrapResult> {
     try {
+      await this.checkGistScope();
+
       // Step 1: Try loading Gist ID from local file
       const localId = this.readLocalGistId();
       if (localId) {
@@ -121,6 +126,9 @@ export class GistStateStore {
       this.writeLocalGistId(id);
       return { gistId: id, state, created: true };
     } catch (err) {
+      // Configuration errors (e.g. GistPermissionError) must surface, not degrade
+      if (err instanceof GistPermissionError) throw err;
+
       // All API paths failed — enter degraded mode
       warn(MODULE, 'All Gist API paths failed, entering degraded mode', err);
 
@@ -159,6 +167,8 @@ export class GistStateStore {
    */
   async bootstrapWithMigration(existingState: AgentState): Promise<BootstrapResult & { migrated: boolean }> {
     try {
+      await this.checkGistScope();
+
       // Step 1: Try loading Gist ID from local file
       const localId = this.readLocalGistId();
       if (localId) {
@@ -189,6 +199,9 @@ export class GistStateStore {
       this.writeLocalGistId(id);
       return { gistId: id, state, created: true, migrated: true };
     } catch (err) {
+      // Configuration errors (e.g. GistPermissionError) must surface, not degrade
+      if (err instanceof GistPermissionError) throw err;
+
       // All API paths failed — enter degraded mode
       warn(MODULE, 'bootstrapWithMigration: all Gist API paths failed, entering degraded mode', err);
 
@@ -330,7 +343,42 @@ export class GistStateStore {
     return true;
   }
 
+  /**
+   * Re-fetch the Gist and update the in-memory cache.
+   * Throttled to at most once per 30 seconds.
+   */
+  async refreshFromGist(): Promise<boolean> {
+    if (!this.gistId) return false;
+    const now = Date.now();
+    if (now - this.lastRefreshAt < GistStateStore.REFRESH_THROTTLE_MS) return false;
+    try {
+      await this.fetchAndCache(this.gistId);
+      this.lastRefreshAt = now;
+      return true;
+    } catch (err) {
+      warn(MODULE, `refreshFromGist failed: ${err}`);
+      return false;
+    }
+  }
+
   // ── Private helpers ─────────────────────────────────────────────────
+
+  /**
+   * Preflight check: verify the token has Gist API scope.
+   * Costs one cheap API call; catches permission issues early with a clear message.
+   */
+  private async checkGistScope(): Promise<void> {
+    try {
+      await this.octokit.gists.list({ per_page: 1, page: 1 });
+    } catch (err) {
+      if (isRateLimitError(err)) throw err;
+      const status = (err as { status?: number }).status;
+      if (status === 401 || status === 403) {
+        throw new GistPermissionError();
+      }
+      throw err;
+    }
+  }
 
   /**
    * Fetch a Gist by ID, populate the in-memory cache, parse state,

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -42,6 +42,7 @@ export {
   OssAutopilotError,
   ConfigurationError,
   ValidationError,
+  GistPermissionError,
   errorMessage,
   getHttpStatusCode,
   isRateLimitError,

--- a/packages/core/src/core/state-schema.ts
+++ b/packages/core/src/core/state-schema.ts
@@ -144,6 +144,8 @@ export const AgentConfigSchema = z.object({
   setupComplete: z.boolean().default(false),
   setupCompletedAt: z.string().optional(),
 
+  persistence: z.enum(['local', 'gist']).default('local'),
+
   maxActivePRs: z.number().default(10),
   dormantThresholdDays: z.number().default(30),
   approachingDormantDays: z.number().default(25),

--- a/packages/core/src/core/state.ts
+++ b/packages/core/src/core/state.ts
@@ -17,6 +17,7 @@ import {
   StoredMergedPR,
   StoredClosedPR,
 } from './types.js';
+import { AgentStateSchema } from './state-schema.js';
 import {
   loadState,
   saveState,
@@ -27,7 +28,7 @@ import {
 import * as repoScoring from './repo-score-manager.js';
 import type { Stats } from './repo-score-manager.js';
 import { debug, warn } from './logger.js';
-import { errorMessage } from './errors.js';
+import { errorMessage, ConfigurationError } from './errors.js';
 import { GistStateStore, type OctokitLike } from './gist-state-store.js';
 import { getStatePath, getStateCachePath } from './utils.js';
 
@@ -264,6 +265,30 @@ export class StateManager {
     this.lastLoadedMtimeMs = result.mtimeMs;
     this.tryReconcilePRCounts();
     return true;
+  }
+
+  /**
+   * Re-fetch state from the backing Gist (if in Gist mode).
+   * Throttled to once per 30 seconds by GistStateStore. Returns true if state was refreshed.
+   */
+  async refreshFromGist(): Promise<boolean> {
+    if (!this.gistStore) return false;
+    const refreshed = await this.gistStore.refreshFromGist();
+    if (refreshed) {
+      const raw = this.gistStore.cachedFiles.get('state.json');
+      if (!raw) {
+        warn(MODULE, 'Gist refreshed but state.json missing from cache');
+        return false;
+      }
+      try {
+        this.state = AgentStateSchema.parse(JSON.parse(raw));
+        this.tryReconcilePRCounts();
+      } catch (err) {
+        warn(MODULE, `Failed to parse refreshed Gist state: ${errorMessage(err)}`);
+        return false;
+      }
+    }
+    return refreshed;
   }
 
   // === Dashboard Data Setters ===
@@ -750,11 +775,10 @@ export async function getStateManagerAsync(token?: string): Promise<StateManager
       })
       .catch((err) => {
         asyncManagerPromise = null;
-        warn(
-          MODULE,
-          `Unhandled Gist initialization error, falling back to local-only mode (not a normal degraded bootstrap): ${err}`,
-        );
-        return getStateManager(); // fall back to sync/local
+        // Configuration errors (e.g. GistPermissionError) must surface to the user
+        if (err instanceof ConfigurationError) throw err;
+        warn(MODULE, `Gist initialization failed, falling back to local-only mode: ${err}`);
+        return getStateManager(); // fall back to sync/local for transient errors
       });
     return asyncManagerPromise;
   }

--- a/packages/mcp-server/src/index.test.ts
+++ b/packages/mcp-server/src/index.test.ts
@@ -123,7 +123,7 @@ describe('MCP server stdio transport', { timeout: 30_000 }, () => {
   it('lists tools via stdio', async () => {
     client = await createStdioClient();
     const { tools } = await client.listTools();
-    expect(tools.length).toBe(20);
+    expect(tools.length).toBe(23);
     expect(tools.some((t) => t.name === 'daily')).toBe(true);
   });
 

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -3,7 +3,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { createServer } from './server.js';
 
-/** All 20 tool names that must be registered. */
+/** All 23 tool names that must be registered. */
 const EXPECTED_TOOLS = [
   'daily',
   'status',
@@ -25,6 +25,9 @@ const EXPECTED_TOOLS = [
   'dismiss',
   'undismiss',
   'move',
+  'state-show',
+  'state-sync',
+  'state-unlink',
 ] as const;
 
 describe('MCP tool registrations', () => {
@@ -53,8 +56,8 @@ describe('MCP tool registrations', () => {
     await client.close();
   });
 
-  it('registers exactly 20 tools', () => {
-    expect(tools).toHaveLength(20);
+  it('registers exactly 23 tools', () => {
+    expect(tools).toHaveLength(23);
   });
 
   it('registers all expected tool names', () => {

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -30,6 +30,31 @@ import {
 } from '@oss-autopilot/core/commands';
 import { errorMessage } from '@oss-autopilot/core';
 
+/** One-shot Gist persistence activation (checked once per process). */
+let gistInitDone = false;
+async function ensureGistInit(): Promise<void> {
+  if (gistInitDone) return;
+  gistInitDone = true;
+
+  // Read config file — may legitimately fail (no state file yet)
+  let persistence: string | undefined;
+  try {
+    const { getStatePath } = await import('@oss-autopilot/core');
+    const fs = await import('fs');
+    const raw = fs.readFileSync(getStatePath(), 'utf-8');
+    persistence = JSON.parse(raw)?.config?.persistence;
+  } catch {
+    return;
+  }
+
+  if (persistence === 'gist') {
+    // Gist init errors (GistPermissionError, network) propagate to wrapTool's catch
+    const { getStateManagerAsync, getGitHubTokenAsync } = await import('@oss-autopilot/core');
+    const token = await getGitHubTokenAsync();
+    if (token) await getStateManagerAsync(token);
+  }
+}
+
 /** Standard MCP text content result. */
 function ok(data: unknown) {
   return {
@@ -49,6 +74,7 @@ function err(e: unknown) {
 function wrapTool<A>(fn: (args: A) => Promise<unknown>): (args: A) => Promise<ReturnType<typeof ok | typeof err>> {
   return async (args: A) => {
     try {
+      await ensureGistInit();
       return ok(await fn(args));
     } catch (e) {
       console.error('[MCP] Tool error:', e);
@@ -58,7 +84,7 @@ function wrapTool<A>(fn: (args: A) => Promise<unknown>): (args: A) => Promise<Re
 }
 
 /**
- * Registers all 20 OSS Autopilot CLI commands as MCP tools on the given server.
+ * Registers all OSS Autopilot CLI commands as MCP tools on the given server.
  */
 export function registerTools(server: McpServer): void {
   // 1. daily — Run daily PR check
@@ -346,5 +372,47 @@ export function registerTools(server: McpServer): void {
       annotations: { readOnlyHint: false, destructiveHint: false },
     },
     wrapTool(runMove),
+  );
+
+  // 21. state-show — Show persistence mode
+  server.registerTool(
+    'state-show',
+    {
+      description: 'Show current state persistence mode (local or gist), Gist ID, and sync status.',
+      inputSchema: {},
+      annotations: { readOnlyHint: true },
+    },
+    wrapTool(async () => {
+      const { runStateShow } = await import('@oss-autopilot/core/commands');
+      return runStateShow();
+    }),
+  );
+
+  // 22. state-sync — Force push to Gist
+  server.registerTool(
+    'state-sync',
+    {
+      description: 'Force push current state to the backing Gist. No-op if not in Gist mode.',
+      inputSchema: {},
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    wrapTool(async () => {
+      const { runStateSync } = await import('@oss-autopilot/core/commands');
+      return runStateSync();
+    }),
+  );
+
+  // 23. state-unlink — Switch from Gist to local persistence
+  server.registerTool(
+    'state-unlink',
+    {
+      description: 'Disconnect from Gist persistence and switch to local-only mode. The remote Gist is preserved.',
+      inputSchema: {},
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    wrapTool(async () => {
+      const { runStateUnlink } = await import('@oss-autopilot/core/commands');
+      return runStateUnlink();
+    }),
   );
 }


### PR DESCRIPTION
## Summary

Activates the dormant Gist persistence infrastructure (#878) with a full opt-in user flow:

- **Config flag**: `persistence: 'local' | 'gist'` field in `AgentConfigSchema` (defaults to `local`)
- **Preflight check**: `GistPermissionError` with actionable message when token lacks `gist` scope
- **CLI/MCP activation**: Gist mode initialized in CLI `preAction` hook and MCP `wrapTool` before any command runs
- **Setup wizard**: `setup set persistence=gist` and interactive prompt
- **Dashboard refresh**: `refreshFromGist()` with 30s throttle replaces `reloadIfChanged()` in Gist mode at all 4 reload sites
- **State command**: `state --show`, `state --sync`, `state --unlink` CLI commands and MCP tools
- **Error handling**: `GistPermissionError` propagates through bootstrap, `getStateManagerAsync`, and CLI/MCP entry points; rate-limit 403s are not misclassified

## Test plan

- [ ] `oss-autopilot setup set persistence=gist` creates Gist on next command
- [ ] `oss-autopilot state --show` displays Gist mode and ID
- [ ] `oss-autopilot daily` checkpoints to Gist
- [ ] `oss-autopilot state --sync` force-pushes
- [ ] Dashboard refreshes from Gist in Gist mode
- [ ] `oss-autopilot state --unlink` writes local file, preserves remote Gist
- [ ] Token without `gist` scope shows clear error with `gh auth refresh -s gist` guidance
- [ ] All existing tests pass (77 files, 2289 tests)

Closes #883