### PR TITLE
feat(dashboard): split active PRs into Need Attention and Waiting cards

### DIFF
--- a/packages/dashboard/src/app.tsx
+++ b/packages/dashboard/src/app.tsx
@@ -92,6 +92,7 @@ function AppContent() {
   const { theme, toggleTheme } = useTheme();
   const [filters, setFilters] = useState<Filters>({ status: 'all', repo: 'all', search: '' });
   const [selectedUrl, setSelectedUrl] = useState<string | null>(null);
+  const [shelvedOpen, setShelvedOpen] = useState(false);
   const { path, route } = useLocation();
 
   const shelvedUrls = useMemo(() => new Set(data?.shelvedPRUrls ?? []), [data?.shelvedPRUrls]);
@@ -214,6 +215,15 @@ function AppContent() {
 
   const selectedPR = selectedUrl ? (data.activePRs.find((pr) => pr.url === selectedUrl) ?? null) : null;
 
+  const activePRs = data.activePRs.filter((pr) => !shelvedUrls.has(pr.url));
+  const needAttentionCount = activePRs.filter((pr) => pr.status === 'needs_addressing').length;
+  const waitingCount = activePRs.filter((pr) => pr.status === 'waiting_on_maintainer').length;
+
+  const scrollTo = (id: string) => {
+    const el = document.getElementById(id);
+    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
   return (
     <div class="dashboard">
       <DashboardHeader
@@ -239,6 +249,15 @@ function AppContent() {
         <div class="animate-in delay-1">
           <StatsBar
             stats={data.stats}
+            needAttentionCount={needAttentionCount}
+            waitingCount={waitingCount}
+            onNeedAttentionClick={() => scrollTo('section-action')}
+            onWaitingClick={() => scrollTo('section-waiting')}
+            onShelvedClick={() => {
+              setShelvedOpen(true);
+              // Delay scroll slightly so the section renders before scrolling
+              setTimeout(() => scrollTo('section-shelved'), 50);
+            }}
             onMergedClick={() => route('/merged')}
             onClosedClick={() => route('/closed')}
             onIssuesClick={() => route('/issues')}
@@ -256,7 +275,14 @@ function AppContent() {
         </div>
 
         <div class="dashboard-content animate-in delay-3">
-          <PRList prs={filteredPRs} selectedUrl={selectedUrl} onSelect={setSelectedUrl} shelvedUrls={shelvedUrls} />
+          <PRList
+            prs={filteredPRs}
+            selectedUrl={selectedUrl}
+            onSelect={setSelectedUrl}
+            shelvedUrls={shelvedUrls}
+            shelvedOpen={shelvedOpen}
+            onShelvedToggle={() => setShelvedOpen(!shelvedOpen)}
+          />
           {selectedPR && (
             <PRDetail
               pr={selectedPR}

--- a/packages/dashboard/src/components/pr-list.test.tsx
+++ b/packages/dashboard/src/components/pr-list.test.tsx
@@ -9,12 +9,30 @@ interface PRListOptions {
   selectedUrl?: string | null;
   onSelect?: (url: string) => void;
   shelvedUrls?: Set<string>;
+  shelvedOpen?: boolean;
+  onShelvedToggle?: () => void;
 }
 
 function renderPRList(options: PRListOptions = {}) {
-  const { prs = [], selectedUrl = null, onSelect = vi.fn(), shelvedUrls = new Set<string>() } = options;
+  const {
+    prs = [],
+    selectedUrl = null,
+    onSelect = vi.fn(),
+    shelvedUrls = new Set<string>(),
+    shelvedOpen = false,
+    onShelvedToggle = vi.fn(),
+  } = options;
 
-  return render(<PRList prs={prs} selectedUrl={selectedUrl} onSelect={onSelect} shelvedUrls={shelvedUrls} />);
+  return render(
+    <PRList
+      prs={prs}
+      selectedUrl={selectedUrl}
+      onSelect={onSelect}
+      shelvedUrls={shelvedUrls}
+      shelvedOpen={shelvedOpen}
+      onShelvedToggle={onShelvedToggle}
+    />,
+  );
 }
 
 describe('PRList', () => {
@@ -119,15 +137,16 @@ describe('PRList', () => {
     expect(shelvedHeader?.querySelector('.pr-section-count')?.textContent).toBe('1');
   });
 
-  it('sets aria-expanded on shelved section toggle', () => {
+  it('sets aria-expanded on shelved section based on shelvedOpen prop', () => {
     const prs = [makePR({ url: 'https://github.com/o/r/pull/1', status: 'needs_addressing' })];
     const shelvedUrls = new Set(['https://github.com/o/r/pull/1']);
-    const { container } = renderPRList({ prs, shelvedUrls });
+    const onToggle = vi.fn();
+    const { container } = renderPRList({ prs, shelvedUrls, shelvedOpen: false, onShelvedToggle: onToggle });
     const header = container.querySelector('.pr-section-header--collapsible');
     expect(header?.getAttribute('aria-expanded')).toBe('false');
     expect(header?.getAttribute('aria-controls')).toBe('shelved-pr-list');
     fireEvent.click(header!);
-    expect(header?.getAttribute('aria-expanded')).toBe('true');
+    expect(onToggle).toHaveBeenCalledOnce();
   });
 
   it('displays PR title, repo#number, and activity age', () => {

--- a/packages/dashboard/src/components/pr-list.tsx
+++ b/packages/dashboard/src/components/pr-list.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'preact/hooks';
 import type { FetchedPR, FetchedPRStatus } from '../types';
 import { truncate, statusColor, stripBrackets, pillColorClass } from '../utils';
 
@@ -7,6 +6,8 @@ interface PRListProps {
   selectedUrl: string | null;
   onSelect: (url: string) => void;
   shelvedUrls: Set<string>;
+  shelvedOpen: boolean;
+  onShelvedToggle: () => void;
 }
 
 /** Statuses that belong in the "Need Attention" section. */
@@ -74,7 +75,7 @@ function Section({
   onSelect: (url: string) => void;
 }) {
   return (
-    <div class="pr-section">
+    <div class="pr-section" id={`section-${section.id}`}>
       <div class="pr-section-header">
         <span class={`pr-section-dot ${section.dotClass}`} />
         <span class="pr-section-title">{section.title}</span>
@@ -87,9 +88,7 @@ function Section({
   );
 }
 
-export function PRList({ prs, selectedUrl, onSelect, shelvedUrls }: PRListProps) {
-  const [shelvedOpen, setShelvedOpen] = useState(false);
-
+export function PRList({ prs, selectedUrl, onSelect, shelvedUrls, shelvedOpen, onShelvedToggle }: PRListProps) {
   const activePRs = prs.filter((pr) => !shelvedUrls.has(pr.url));
   const shelvedPRs = prs.filter((pr) => shelvedUrls.has(pr.url));
 
@@ -115,10 +114,10 @@ export function PRList({ prs, selectedUrl, onSelect, shelvedUrls }: PRListProps)
         <Section key={section.id} section={section} selectedUrl={selectedUrl} onSelect={onSelect} />
       ))}
       {shelvedPRs.length > 0 && (
-        <div class="pr-section pr-section--shelved">
+        <div class="pr-section pr-section--shelved" id="section-shelved">
           <div
             class="pr-section-header pr-section-header--collapsible"
-            onClick={() => setShelvedOpen(!shelvedOpen)}
+            onClick={onShelvedToggle}
             aria-expanded={shelvedOpen}
             aria-controls="shelved-pr-list"
             role="button"
@@ -126,7 +125,7 @@ export function PRList({ prs, selectedUrl, onSelect, shelvedUrls }: PRListProps)
             onKeyDown={(e) => {
               if (e.key === 'Enter' || e.key === ' ') {
                 e.preventDefault();
-                setShelvedOpen(!shelvedOpen);
+                onShelvedToggle();
               }
             }}
           >

--- a/packages/dashboard/src/components/stats-bar.test.tsx
+++ b/packages/dashboard/src/components/stats-bar.test.tsx
@@ -4,75 +4,69 @@ import { StatsBar } from './stats-bar';
 
 describe('StatsBar', () => {
   const stats = { activePRs: 5, shelvedPRs: 2, mergedPRs: 10, closedPRs: 3, mergeRate: '76.9%' };
+  const baseProps = { stats, needAttentionCount: 3, waitingCount: 2 };
 
   it('renders all stat cards', () => {
-    const { container } = render(<StatsBar stats={stats} />);
+    const { container } = render(<StatsBar {...baseProps} />);
     const cards = container.querySelectorAll('.stat-card');
     expect(cards).toHaveLength(5);
   });
 
   it('displays correct values', () => {
-    const { container } = render(<StatsBar stats={stats} />);
+    const { container } = render(<StatsBar {...baseProps} />);
     const values = [...container.querySelectorAll('.stat-value')].map((el) => el.textContent);
-    expect(values).toEqual(['5', '2', '10', '3', '76.9%']);
+    expect(values).toEqual(['3', '2', '2', '10', '3']);
   });
 
   it('displays correct labels', () => {
-    const { container } = render(<StatsBar stats={stats} />);
+    const { container } = render(<StatsBar {...baseProps} />);
     const labels = [...container.querySelectorAll('.stat-label')].map((el) => el.textContent);
-    expect(labels).toEqual(['Active PRs', 'Shelved PRs', 'Merged PRs', 'Closed PRs', 'Merge Rate']);
+    expect(labels).toEqual(['Need Attention', 'Waiting on Others', 'Shelved', 'Merged PRs', 'Closed PRs']);
   });
 
-  it('renders merged card as clickable button when onMergedClick provided', () => {
+  it('renders need attention card as clickable when handler provided', () => {
     const onClick = vi.fn();
-    const { container } = render(<StatsBar stats={stats} onMergedClick={onClick} />);
+    const { container } = render(<StatsBar {...baseProps} onNeedAttentionClick={onClick} />);
     const clickable = container.querySelectorAll('.stat-card--clickable');
-    expect(clickable).toHaveLength(1);
-    expect(clickable[0].tagName).toBe('BUTTON');
-    expect(clickable[0].querySelector('.stat-label')?.textContent).toBe('Merged PRs');
+    expect(clickable.length).toBeGreaterThanOrEqual(1);
+    const attentionBtn = [...clickable].find((el) => el.querySelector('.stat-label')?.textContent === 'Need Attention');
+    expect(attentionBtn?.tagName).toBe('BUTTON');
   });
 
   it('calls onMergedClick when merged card is clicked', () => {
     const onClick = vi.fn();
-    const { container } = render(<StatsBar stats={stats} onMergedClick={onClick} />);
-    const clickable = container.querySelector('.stat-card--clickable') as HTMLButtonElement;
+    const { container } = render(<StatsBar {...baseProps} onMergedClick={onClick} />);
+    const clickable = [...container.querySelectorAll('.stat-card--clickable')].find(
+      (el) => el.querySelector('.stat-label')?.textContent === 'Merged PRs',
+    ) as HTMLButtonElement;
     fireEvent.click(clickable);
     expect(onClick).toHaveBeenCalledOnce();
   });
 
-  it('renders all cards as divs when onMergedClick not provided', () => {
-    const { container } = render(<StatsBar stats={stats} />);
+  it('renders cards as divs when no click handlers provided', () => {
+    const { container } = render(<StatsBar {...baseProps} />);
     const clickable = container.querySelectorAll('.stat-card--clickable');
     expect(clickable).toHaveLength(0);
-    const buttons = container.querySelectorAll('button');
-    expect(buttons).toHaveLength(0);
-  });
-
-  it('renders closed card as clickable button when onClosedClick provided', () => {
-    const onClick = vi.fn();
-    const { container } = render(<StatsBar stats={stats} onClosedClick={onClick} />);
-    const clickable = container.querySelectorAll('.stat-card--clickable');
-    expect(clickable).toHaveLength(1);
-    expect(clickable[0].tagName).toBe('BUTTON');
-    expect(clickable[0].querySelector('.stat-label')?.textContent).toBe('Closed PRs');
   });
 
   it('calls onClosedClick when closed card is clicked', () => {
     const onClick = vi.fn();
-    const { container } = render(<StatsBar stats={stats} onClosedClick={onClick} />);
-    const clickable = container.querySelector('.stat-card--clickable') as HTMLButtonElement;
+    const { container } = render(<StatsBar {...baseProps} onClosedClick={onClick} />);
+    const clickable = [...container.querySelectorAll('.stat-card--clickable')].find(
+      (el) => el.querySelector('.stat-label')?.textContent === 'Closed PRs',
+    ) as HTMLButtonElement;
     fireEvent.click(clickable);
     expect(onClick).toHaveBeenCalledOnce();
   });
 
-  it('renders both merged and closed as clickable when both handlers provided', () => {
+  it('renders multiple clickable cards when multiple handlers provided', () => {
     const onMerged = vi.fn();
     const onClosed = vi.fn();
-    const { container } = render(<StatsBar stats={stats} onMergedClick={onMerged} onClosedClick={onClosed} />);
+    const onAttention = vi.fn();
+    const { container } = render(
+      <StatsBar {...baseProps} onMergedClick={onMerged} onClosedClick={onClosed} onNeedAttentionClick={onAttention} />,
+    );
     const clickable = container.querySelectorAll('.stat-card--clickable');
-    expect(clickable).toHaveLength(2);
-    const labels = [...clickable].map((el) => el.querySelector('.stat-label')?.textContent);
-    expect(labels).toContain('Merged PRs');
-    expect(labels).toContain('Closed PRs');
+    expect(clickable.length).toBeGreaterThanOrEqual(3);
   });
 });

--- a/packages/dashboard/src/components/stats-bar.tsx
+++ b/packages/dashboard/src/components/stats-bar.tsx
@@ -2,6 +2,11 @@ import type { DashboardStats } from '../types';
 
 interface StatsBarProps {
   stats: DashboardStats;
+  needAttentionCount: number;
+  waitingCount: number;
+  onNeedAttentionClick?: () => void;
+  onWaitingClick?: () => void;
+  onShelvedClick?: () => void;
   onMergedClick?: () => void;
   onClosedClick?: () => void;
   onIssuesClick?: () => void;
@@ -14,13 +19,23 @@ interface StatCardDef {
   onClick?: () => void;
 }
 
-export function StatsBar({ stats, onMergedClick, onClosedClick, onIssuesClick }: StatsBarProps) {
+export function StatsBar({
+  stats,
+  needAttentionCount,
+  waitingCount,
+  onNeedAttentionClick,
+  onWaitingClick,
+  onShelvedClick,
+  onMergedClick,
+  onClosedClick,
+  onIssuesClick,
+}: StatsBarProps) {
   const cards: StatCardDef[] = [
-    { label: 'Active PRs', value: stats.activePRs, colorClass: 'green' },
-    { label: 'Shelved PRs', value: stats.shelvedPRs, colorClass: 'blue' },
+    { label: 'Need Attention', value: needAttentionCount, colorClass: 'red', onClick: onNeedAttentionClick },
+    { label: 'Waiting on Others', value: waitingCount, colorClass: 'blue', onClick: onWaitingClick },
+    { label: 'Shelved', value: stats.shelvedPRs, colorClass: 'muted', onClick: onShelvedClick },
     { label: 'Merged PRs', value: stats.mergedPRs, colorClass: 'purple', onClick: onMergedClick },
     { label: 'Closed PRs', value: stats.closedPRs, colorClass: 'red', onClick: onClosedClick },
-    { label: 'Merge Rate', value: stats.mergeRate, colorClass: 'amber' },
   ];
   if (stats.availableIssues !== undefined) {
     cards.push({ label: 'Vetted Issues', value: stats.availableIssues, colorClass: 'teal', onClick: onIssuesClick });

--- a/packages/dashboard/src/styles.css
+++ b/packages/dashboard/src/styles.css
@@ -590,6 +590,15 @@ a:hover {
 .stat-card.teal .stat-value {
   color: var(--teal);
 }
+.stat-card.muted {
+  border-left-color: var(--text-muted);
+}
+.stat-card.muted::before {
+  background: linear-gradient(135deg, var(--text-muted), transparent 60%);
+}
+.stat-card.muted .stat-value {
+  color: var(--text-secondary);
+}
 
 .stat-value {
   font-size: 1.75rem;


### PR DESCRIPTION
## Summary
- Replace single "Active PRs" stat card with "Need Attention" and "Waiting on Others" cards showing counts per group
- Add "Shelved" card with muted styling that works in both light and dark mode
- All three cards scroll to their corresponding PR list section when clicked; Shelved also expands the collapsed section
- Remove "Merge Rate" from stat cards (already shown in header bar)

## Test plan
- [x] Dashboard builds successfully
- [x] All 194 tests pass
- [x] Prettier formatting passes
- [x] Verified locally: cards display correct counts, scroll-to-section works, shelved expand works, dark mode styling correct