### PR TITLE
fix: remove verification checkpoint — always auto-investigate before implementing

### DIFF
--- a/workflows/work-through-issues.md
+++ b/workflows/work-through-issues.md
@@ -176,63 +176,6 @@ Populate the table using data from the Phase A agent results:
 
 **Key findings**: 1-line summary per PR from the agent investigation results. Focus on what the maintainer is asking and what code change is needed.
 
-### Investigation Verification Checkpoint
-
-After presenting Phase B results, before the user selects a PR to work on in Phase C, offer a verification option for any Tier 2 item they select:
-
-When the user selects a PR from the Phase C options, before executing the recommended action, present:
-
-```
-Question: "Would you like to verify the investigation before implementing?"
-Header: "Verification"
-
-Options:
-1. "Verify diagnosis (Recommended)" — "Re-read the relevant code and cross-check the investigation's claims before coding"
-2. "Proceed to implement" — "The diagnosis looks correct, start coding"
-3. "Skip this issue" — "Move to the next item"
-```
-
-**When user selects "Verify diagnosis":**
-
-1. **Re-read the specific code** mentioned in the Phase A investigation — not just grep results, but the actual function/method bodies
-2. **Cross-check each claim from the investigation:**
-   - If the investigation says "function X does Y" → read function X and verify
-   - If it says "the bug is in line N" → read that line with surrounding context
-   - If it proposes "change X to Y" → verify callers won't break
-3. **Check for edge cases** the investigation may have missed:
-   - Empty/null inputs to the modified code
-   - Other callers of the modified function
-   - Whether the fix matches the issue's expected behavior
-4. **Present verification results:**
-
-```
-## Verification Results
-
-✅ Confirmed: {list of claims that match the code}
-⚠️ Concerns: {list of potential issues found}
-❌ Incorrect: {list of claims contradicted by the code}
-
-Recommendation: {proceed / revise diagnosis / skip}
-```
-
-5. **Post-verification options:**
-
-If concerns or incorrect claims found:
-```
-Options:
-1. "Revise and re-investigate" — "Update the approach based on verification findings"
-2. "Proceed anyway" — "The concerns are minor"
-3. "Skip this issue"
-```
-
-If all claims verified:
-```
-Options:
-1. "Proceed to implement (Recommended)"
-2. "Skip this issue"
-3. "Done for now"
-```
-
 ### Phase C: Sequential Tier 2 Execution
 
 If no Tier 2 items remain after Phase A:
@@ -257,8 +200,16 @@ Options (ordered by priority, up to 3 PRs + Done — limited to 4 options for As
 
 The user selects a PR, and you:
 1. Use the findings from Phase A (do NOT re-investigate, unless staleness warning triggered and user opts to re-check)
-2. Execute the recommended action for that specific PR
-3. After completing the action, if code was changed, route to Pre-Commit Review in the core router — it will read the appropriate workflow file based on `isNewContribution`. After the review completes, return here to Phase C's loop.
+2. **Auto-verify the investigation** before implementing (no user prompt needed):
+   - Re-read the specific code mentioned in the Phase A investigation — read actual function/method bodies, not just grep results
+   - Cross-check each claim against the code:
+     - "function X does Y" → read function X and verify
+     - "the bug is in line N" → read that line with surrounding context
+     - "change X to Y" → verify callers won't break
+   - Check for edge cases: empty/null inputs, other callers, expected behavior match
+   - If any claims are contradicted by the code, revise the approach before proceeding
+3. Execute the recommended action for that specific PR
+4. After completing the action, if code was changed, route to Pre-Commit Review in the core router — it will read the appropriate workflow file based on `isNewContribution`. After the review completes, return here to Phase C's loop.
 
 **Action failure handling:** After executing the action for a PR:
 - **If successful**: Show "Completed: [repo#123]({url}) — response posted + code pushed."


### PR DESCRIPTION
## Summary

- Removes the interactive "Investigation Verification Checkpoint" from Phase C that prompted users every time with zero value (answer was always "Verify diagnosis")
- Verification now happens automatically as part of Phase C execution — same checks (re-read code, cross-check claims, check edge cases) but without the user prompt
- Net reduction of 49 lines of workflow verbosity

Closes #887

## Test plan

- [ ] Run `/oss` workflow and confirm Phase C proceeds directly to auto-verification without prompting
- [ ] Verify that investigation claims are still cross-checked against actual code before implementation