### PR TITLE
fix: display full URLs instead of markdown links in CLI output

### DIFF
--- a/commands/oss.md
+++ b/commands/oss.md
@@ -229,8 +229,10 @@ const waitingPRs = data.daily.digest.waitingOnMaintainerPRs.map(url =>
 ```
 Waiting on Others (no action needed):
 
-- [owner/repo#123](https://github.com/owner/repo/pull/123) - Title here (approved, CI passing)
-- [owner/repo#456](https://github.com/owner/repo/pull/456) - Title here (waiting for review)
+- owner/repo#123 - Title here (approved, CI passing)
+  https://github.com/owner/repo/pull/123
+- owner/repo#456 - Title here (waiting for review)
+  https://github.com/owner/repo/pull/456
 ...
 
 These PRs are progressing normally. Focus on the {count} issues that need attention.

--- a/workflows/action-menu.md
+++ b/workflows/action-menu.md
@@ -39,11 +39,13 @@ Then show the enriched format using the resolved PR's fields:
 ```
 {count} PRs Need Attention (in priority order):
 
-1. {issue.label} [{pr.repo}#{pr.number}]({pr.url}) — {pr.title} ({pr.daysSinceActivity}d)
+1. {issue.label} {pr.repo}#{pr.number} — {pr.title} ({pr.daysSinceActivity}d)
+   {pr.url}
    └─ @{pr.lastMaintainerComment.author}: {formatted maintainerActionHints}
    └─ Effort: {effort} — {action summary}
 
-2. {issue.label} [{pr.repo}#{pr.number}]({pr.url}) — {pr.title} ({pr.daysSinceActivity}d)
+2. {issue.label} {pr.repo}#{pr.number} — {pr.title} ({pr.daysSinceActivity}d)
+   {pr.url}
    └─ @{pr.lastMaintainerComment.author}: {formatted maintainerActionHints}
    └─ Effort: {effort} — {action summary}
 
@@ -74,7 +76,8 @@ If `data.daily.digest.recentlyClosedPRs` has entries, display them **after** the
 
 ```
 Recently closed (informational):
-- [{repo}#{number}]({url}) — {title} (closed without merge on {closedAt date})
+- {repo}#{number} — {title} (closed without merge on {closedAt date})
+  {url}
 ```
 
 These do not require any action. They exist so the user knows what was closed. The Auto-Exclude prompt (in the work-through-issues workflow) may offer to exclude these repos from future searches.

--- a/workflows/review-issue-replies.md
+++ b/workflows/review-issue-replies.md
@@ -16,11 +16,13 @@ When there are issues to review, display each one:
 
 Maintainers responded to your comments on these issues:
 
-1. [**owner/repo#123**](https://github.com/owner/repo/issues/123) — Issue title
+1. **owner/repo#123** — Issue title
+   https://github.com/owner/repo/issues/123
    └─ @maintainer: "Go for it! Feel free to submit a PR..."
    └─ Your comment: 5 days ago
 
-2. [**owner/repo#456**](https://github.com/owner/repo/issues/456) — Another issue title
+2. **owner/repo#456** — Another issue title
+   https://github.com/owner/repo/issues/456
    └─ @maintainer: "Thanks for the interest. Here's what..."
    └─ Your comment: 2 days ago
 ```

--- a/workflows/work-through-issues.md
+++ b/workflows/work-through-issues.md
@@ -167,18 +167,18 @@ Only show this section if there are Tier 2 items remaining after Phase A:
 
 | # | PR | Issue Type | Maintainer Ask | Effort | Recommended Action |
 |---|-----|-----------|---------------|--------|-------------------|
-| 1 | [repo#123]({url}) | needs_response | Requested shortcut change + tooltip | Small | Code change + respond |
-| 2 | [repo#456]({url}) | needs_changes | Fix trailing newline, sync docs | Medium | Code changes + push |
-| 3 | [repo#789]({url}) | incomplete_checklist | Missing changelog entry | Small | Add changeset file |
+| 1 | repo#123 | needs_response | Requested shortcut change + tooltip | Small | Code change + respond |
+| 2 | repo#456 | needs_changes | Fix trailing newline, sync docs | Medium | Code changes + push |
+| 3 | repo#789 | incomplete_checklist | Missing changelog entry | Small | Add changeset file |
 
 **Key findings:**
-- [**repo#123**]({url}): Maintainer wants X. 2-line fix in `file.ts`.
-- [**repo#456**]({url}): 3 changes requested. Tests need updating.
-- [**repo#789**]({url}): Missing changelog entry required by changeset-bot.
+- **repo#123** ({url}): Maintainer wants X. 2-line fix in `file.ts`.
+- **repo#456** ({url}): 3 changes requested. Tests need updating.
+- **repo#789** ({url}): Missing changelog entry required by changeset-bot.
 ```
 
 Populate the table using data from the Phase A agent results:
-- **PR**: `[{repo}#{number}]({url})` — clickable link to PR
+- **PR**: `{repo}#{number}` with the full URL on the next line or in parentheses — must be a bare URL so terminal emulators can detect and click it
 - **Issue Type**: From `issue.type` (needs_response, needs_changes, ci_failing, merge_conflict, incomplete_checklist)
 - **Maintainer Ask**: 1-line summary of what the maintainer requested (from agent investigation findings)
 - **Effort**: Use the same heuristic as the Action Menu display (Small/Medium/Large)
@@ -222,8 +222,8 @@ The user selects a PR, and you:
 4. After completing the action, if code was changed, route to Pre-Commit Review in the core router — it will read the appropriate workflow file based on `isNewContribution`. After the review completes, return here to Phase C's loop.
 
 **Action failure handling:** After executing the action for a PR:
-- **If successful**: Show "Completed: [repo#123]({url}) — response posted + code pushed."
-- **If failed**: Show "Failed: [repo#123]({url}) — {specific error message}. This PR was not addressed."
+- **If successful**: Show "Completed: repo#123 — response posted + code pushed." with the full PR URL on the next line
+- **If failed**: Show "Failed: repo#123 — {specific error message}. This PR was not addressed." with the full PR URL on the next line
   - If the error appears transient (network timeout, rate limit, auth token expired): Offer "Retry" / "Skip and move to next" / "Done for now"
   - If the error appears persistent (merge conflict during apply, file not found, branch deleted): Offer "Investigate the error" / "Skip and move to next" / "Done for now" — do NOT offer "Retry" for errors that will deterministically fail again
 - Track completed, failed, and remaining counts separately in the progress display


### PR DESCRIPTION
## Summary

- Replaces markdown link syntax `[text](url)` with bare URLs in all CLI display templates across 4 files
- URLs now appear on their own line so terminal emulators can auto-detect and make them clickable
- Preserves markdown links in files that write to actual `.md` files (oss-search.md, draft-first-workflow.md)

**Files changed:** action-menu.md, work-through-issues.md, review-issue-replies.md, oss.md

Closes #889

## Test plan

- [ ] Run `/oss` and verify PR list displays full clickable URLs instead of raw markdown syntax
- [ ] Verify action menu, Phase B results, Phase C progress, and session summary all show bare URLs
- [ ] Confirm curated issue list file format examples still use markdown links (they write to .md files)