### PR TITLE
feat: add configurable diff viewer preference

### DIFF
--- a/commands/setup-oss.md
+++ b/commands/setup-oss.md
@@ -200,6 +200,24 @@ Extract the number from the selected option and apply:
 node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" setup --set scoreThreshold=NUMBER --json
 ```
 
+**Question 12: Diff Viewer Preference**
+- "How would you like to review diffs before committing?"
+- Options: "Inline (default) — print diff in CLI", "SourceTree — open repo in SourceTree", "VS Code — open diff in VS Code", "Custom command"
+
+Apply based on selection:
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" setup --set diffTool=VALUE --json
+```
+
+Where VALUE is `inline`, `sourcetree`, `vscode`, or `custom`.
+
+If user selects "Custom command", ask for the command string:
+- "What command should I run? (The repo path will be appended as the last argument)"
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" setup --set diffToolCustomCommand="COMMAND" --json
+```
+
 ## Step 4-CLI: Verify GitHub Access
 
 Before marking setup complete, verify that the token actually works by making a lightweight API call:

--- a/packages/core/src/commands/config.ts
+++ b/packages/core/src/commands/config.ts
@@ -4,7 +4,7 @@
  */
 
 import { getStateManager } from '../core/index.js';
-import { ISSUE_SCOPES, type IssueScope } from '../core/types.js';
+import { ISSUE_SCOPES, type IssueScope, DIFF_TOOLS, type DiffTool } from '../core/types.js';
 import type { ConfigOutput } from '../formatters/json.js';
 import { validateGitHubUsername } from './validation.js';
 
@@ -130,6 +130,18 @@ export async function runConfig(options: ConfigOptions): Promise<ConfigCommandOu
     }
     case 'issueListPath':
       stateManager.updateConfig({ issueListPath: value || undefined });
+      break;
+    case 'diffTool': {
+      if (!(DIFF_TOOLS as readonly string[]).includes(value)) {
+        throw new Error(`Invalid diffTool "${value}". Valid options: ${DIFF_TOOLS.join(', ')}`);
+      }
+      stateManager.updateConfig({ diffTool: value as DiffTool });
+      break;
+    }
+    case 'diffToolCustomCommand':
+      stateManager.updateConfig({
+        diffToolCustomCommand: value || undefined,
+      });
       break;
     default:
       throw new Error(`Unknown config key: ${options.key}`);

--- a/packages/core/src/commands/setup.ts
+++ b/packages/core/src/commands/setup.ts
@@ -6,7 +6,14 @@
 import { getStateManager, DEFAULT_CONFIG } from '../core/index.js';
 import { ValidationError } from '../core/errors.js';
 import { validateGitHubUsername } from './validation.js';
-import { PROJECT_CATEGORIES, type ProjectCategory, ISSUE_SCOPES, type IssueScope } from '../core/types.js';
+import {
+  PROJECT_CATEGORIES,
+  type ProjectCategory,
+  ISSUE_SCOPES,
+  type IssueScope,
+  DIFF_TOOLS,
+  type DiffTool,
+} from '../core/types.js';
 
 /** Parse and validate a positive integer setting value. */
 function parsePositiveInt(value: string, settingName: string): number {
@@ -251,6 +258,19 @@ export async function runSetup(options: SetupOptions): Promise<SetupOutput> {
             break;
           case 'issueListPath':
             stateManager.updateConfig({ issueListPath: value || undefined });
+            results[key] = value || '(cleared)';
+            break;
+          case 'diffTool': {
+            if (!(DIFF_TOOLS as readonly string[]).includes(value)) {
+              warnings.push(`Invalid diffTool "${value}". Valid: ${DIFF_TOOLS.join(', ')}`);
+              break;
+            }
+            stateManager.updateConfig({ diffTool: value as DiffTool });
+            results[key] = value;
+            break;
+          }
+          case 'diffToolCustomCommand':
+            stateManager.updateConfig({ diffToolCustomCommand: value || undefined });
             results[key] = value || '(cleared)';
             break;
           case 'complete':

--- a/packages/core/src/core/state-schema.ts
+++ b/packages/core/src/core/state-schema.ts
@@ -27,6 +27,8 @@ export const ProjectCategorySchema = z.enum([
 
 export const IssueScopeSchema = z.enum(['beginner', 'intermediate', 'advanced']);
 
+export const DiffToolSchema = z.enum(['inline', 'sourcetree', 'vscode', 'custom']);
+
 // ── 2. Leaf schemas ──────────────────────────────────────────────────
 
 export const RepoSignalsSchema = z.object({
@@ -189,6 +191,9 @@ export const AgentConfigSchema = z.object({
   projectCategories: z.array(ProjectCategorySchema).default([]),
 
   preferredOrgs: z.array(z.string()).default([]),
+
+  diffTool: DiffToolSchema.default('inline'),
+  diffToolCustomCommand: z.string().optional(),
 });
 
 // ── 6. Cache schemas ─────────────────────────────────────────────────
@@ -285,6 +290,7 @@ export type IssueStatus = z.infer<typeof IssueStatusSchema>;
 export type FetchedPRStatus = z.infer<typeof FetchedPRStatusSchema>;
 export type ProjectCategory = z.infer<typeof ProjectCategorySchema>;
 export type IssueScope = z.infer<typeof IssueScopeSchema>;
+export type DiffTool = z.infer<typeof DiffToolSchema>;
 export type RepoSignals = z.infer<typeof RepoSignalsSchema>;
 export type RepoScore = z.infer<typeof RepoScoreSchema>;
 export type StoredMergedPR = z.infer<typeof StoredMergedPRSchema>;

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -2,7 +2,13 @@
  * Core types for the Open Source Contribution Agent
  */
 
-import { AgentConfigSchema, AgentStateSchema, ProjectCategorySchema, IssueScopeSchema } from './state-schema.js';
+import {
+  AgentConfigSchema,
+  AgentStateSchema,
+  ProjectCategorySchema,
+  IssueScopeSchema,
+  DiffToolSchema,
+} from './state-schema.js';
 
 import type {
   FetchedPRStatus,
@@ -10,6 +16,7 @@ import type {
   TrackedIssue,
   IssueVettingResult,
   IssueScope,
+  DiffTool,
   AgentConfig,
   AgentState,
 } from './state-schema.js';
@@ -22,6 +29,7 @@ export type {
   FetchedPRStatus,
   ProjectCategory,
   IssueScope,
+  DiffTool,
   RepoSignals,
   RepoScore,
   StoredMergedPR,
@@ -341,6 +349,8 @@ export const INITIAL_STATE = AgentStateSchema.parse({ version: 3 }) as AgentStat
 export const PROJECT_CATEGORIES = ProjectCategorySchema.options;
 
 export const ISSUE_SCOPES = IssueScopeSchema.options;
+
+export const DIFF_TOOLS: readonly DiffTool[] = DiffToolSchema.options;
 
 export const SCOPE_LABELS: Record<IssueScope, string[]> = {
   beginner: ['good first issue', 'help wanted', 'easy', 'up-for-grabs', 'first-timers-only', 'beginner'],

--- a/workflows/pre-commit-review.md
+++ b/workflows/pre-commit-review.md
@@ -326,8 +326,22 @@ Options:
 ```
 
 **"Show full diff" / "Show full diff first":**
-- Run the appropriate diff command based on `changeSource` (`git diff` for uncommitted, or the same `diffRange` that succeeded during the gather phase for committed-but-not-pushed) and **output the full diff as a markdown code block in your text response** so the user can read it
-- **If `git diff` fails**, report the error and offer: "Retry" / "Continue without diff" / "Done for now". If the user selects "Continue without diff", skip the diff display and present the follow-up prompt directly (the user has explicitly chosen to proceed without reviewing the raw diff).
+
+Check the user's configured diff viewer preference:
+```bash
+GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" config --json
+```
+
+Read `data.config.diffTool` (defaults to `inline` if not set):
+
+| diffTool | Action |
+|----------|--------|
+| `inline` | Run the appropriate diff command based on `changeSource` and **output the full diff as a markdown code block in your text response** |
+| `sourcetree` | Run `stree .` to open the repo in SourceTree. Tell the user: "Opened in SourceTree — review the diff there." |
+| `vscode` | Run `code --diff` for each changed file against its HEAD version. Tell the user: "Opened diffs in VS Code." |
+| `custom` | Read `data.config.diffToolCustomCommand` and run it with the repo path appended. If the command is not configured, fall back to `inline` and warn. |
+
+- **If the diff command or external tool fails**, report the error and offer: "Retry" / "Continue without diff" / "Done for now". If the user selects "Continue without diff", skip the diff display and present the follow-up prompt directly (the user has explicitly chosen to proceed without reviewing the raw diff).
 - **After** the diff is visible in your response (or user chose to continue without), use AskUserQuestion:
   ```
   Question: "Diff reviewed. Ready to proceed?"


### PR DESCRIPTION
## Summary

- Adds `diffTool` config preference with four options: `inline` (default), `sourcetree`, `vscode`, `custom`
- When "Show full diff" is selected during pre-commit review, the configured tool opens instead of printing inline
- Full integration across all layers: Zod schema, CLI config/setup commands, setup wizard (Question 12), and pre-commit workflow
- `DiffToolSchema` extracted as a named schema following existing `IssueScopeSchema`/`ProjectCategorySchema` pattern

Closes #890

## Test plan

- [ ] Run `oss-autopilot config diffTool sourcetree --json` and verify config updates
- [ ] Run `oss-autopilot setup --set diffTool=vscode --json` and verify
- [ ] Run `/setup-oss` and verify Question 12 appears with diff viewer options
- [ ] With `diffTool=inline`, verify "Show full diff" prints diff in CLI as before
- [ ] With `diffTool=sourcetree`, verify `stree .` is executed
- [ ] With `diffTool=custom` but no command set, verify fallback to inline with warning