### PR TITLE
fix: enforce scope discipline — only implement what the maintainer asked for

### DIFF
--- a/workflows/pre-commit-review.md
+++ b/workflows/pre-commit-review.md
@@ -267,6 +267,23 @@ If NO issues found across all agents:
 All agents passed. No issues found — changes are clean and ready to commit.
 ```
 
+### 4b. Scope Discipline Check
+
+**When responding to maintainer review feedback, cross-check the changes against what was actually requested before entering the convergence loop.** Skip this step for new contributions where you authored the original change.
+
+1. **Compare requested vs. changed:** Extract the specific asks from the maintainer's latest review comments, then summarize each modified file/hunk. Any change that does not map to a specific request is a scope addition (e.g., unrequested test cases, docstrings, adjacent refactoring, or formatting changes).
+
+2. **Report:**
+```
+### Scope Check
+- Requested: {numbered list of maintainer asks}
+- Implemented: {numbered list of changes made}
+- Scope additions: {list of changes not mapping to a request, or "None"}
+```
+
+3. **Remove scope additions** before proceeding. Only do what was requested. If a removal seems risky, note it for the user but still remove it:
+   > "Removed {count} scope addition(s) not in the maintainer's request. You can add them back after review."
+
 ### 5. Automatic Convergence Loop
 
 After consolidating findings (sub-step 4), automatically fix and re-review until convergence. **Do not prompt the user during this loop** — it runs fully autonomously.

--- a/workflows/work-through-issues.md
+++ b/workflows/work-through-issues.md
@@ -109,6 +109,8 @@ After a successful rebase, you MUST follow these steps in order:
   for. Only report items that are outstanding in the latest round.
 - If you cannot verify a claim (file not found, command fails), say so explicitly rather
   than guessing.
+- Report ONLY what the maintainer asked for in the latest review round. Do not suggest
+  additional improvements, extra test cases, or code cleanup beyond what was requested.
 
 Report back:
 (a) Commits behind / rebase result


### PR DESCRIPTION
## Summary

- Adds step 4b (Scope Discipline Check) to pre-commit-review.md between findings consolidation and convergence loop
- Cross-checks changes against maintainer's actual review comments; auto-removes scope additions (unrequested tests, docstrings, refactoring)
- Reinforces in Phase A agent dispatch: "Report ONLY what the maintainer asked for in the latest review round"
- Only applies when responding to maintainer feedback, not for new contributions

Closes #891

## Test plan

- [ ] Run pre-commit review workflow on a PR response and verify scope check appears
- [ ] Confirm unrequested additions are flagged and removed with user notification
- [ ] Verify the check is skipped for new contributions (draft-first workflow path)