### PR TITLE
chore: update @oss-scout/core to ^0.2.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@octokit/plugin-throttling": "^11.0.3",
     "@octokit/rest": "^22.0.1",
-    "@oss-scout/core": "^0.1.1",
+    "@oss-scout/core": "^0.2.0",
     "commander": "^14.0.3",
     "zod": "^4.3.6"
   },

--- a/packages/core/src/commands/scout-bridge.ts
+++ b/packages/core/src/commands/scout-bridge.ts
@@ -22,10 +22,7 @@ export function buildScoutState(): ScoutState {
       labels: config.labels,
       scope: config.scope,
       excludeRepos: config.excludeRepos,
-      // Forward excludeOrgs when @oss-scout/core supports it (>= 0.2.0).
-      // Zod's .default() parser passes unknown keys through at runtime,
-      // so this is safe even if the installed scout version is older.
-      ...(config.excludeOrgs?.length ? { excludeOrgs: config.excludeOrgs } : {}),
+      excludeOrgs: config.excludeOrgs ?? [],
       aiPolicyBlocklist: config.aiPolicyBlocklist,
       preferredOrgs: config.preferredOrgs ?? [],
       projectCategories: config.projectCategories ?? [],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,8 +44,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@oss-scout/core':
-        specifier: ^0.1.1
-        version: 0.1.1(@octokit/core@7.0.6)
+        specifier: ^0.2.0
+        version: 0.2.0(@octokit/core@7.0.6)
       commander:
         specifier: ^14.0.3
         version: 14.0.3
@@ -630,8 +630,8 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@oss-scout/core@0.1.1':
-    resolution: {integrity: sha512-1RG9eloSdchPTgpoxqMijRjgB/J47jJ+WY0Y6cZpVvDfyVXGjcvxjOT87vavYQ9un4aX5NzlFyUpnW9/a6bdhg==}
+  '@oss-scout/core@0.2.0':
+    resolution: {integrity: sha512-Jo8D26oFLP+Q97gW5I+RWdqnbTdJ0z6hgiftlMobasONMhUxYLVooaSpmTHl5wth6qMtNo3YkfeWmQgqLAI5Dw==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
@@ -2891,7 +2891,7 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@oss-scout/core@0.1.1(@octokit/core@7.0.6)':
+  '@oss-scout/core@0.2.0(@octokit/core@7.0.6)':
     dependencies:
       '@octokit/plugin-throttling': 11.0.3(@octokit/core@7.0.6)
       '@octokit/rest': 22.0.1


### PR DESCRIPTION
## Summary

- Update @oss-scout/core dependency from ^0.1.1 to ^0.2.0
- Fix scout-bridge.ts to always provide excludeOrgs (now a required field in 0.2.0)

v0.2.0 adds excludeOrgs support, improved error handling, and SKILL.md accuracy fixes.