### PR TITLE
chore: bump @oss-scout/core to ^0.4.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@octokit/plugin-throttling": "^11.0.3",
     "@octokit/rest": "^22.0.1",
-    "@oss-scout/core": "^0.2.0",
+    "@oss-scout/core": "^0.4.0",
     "commander": "^14.0.3",
     "zod": "^4.3.6"
   },

--- a/packages/core/src/commands/scout-bridge.test.ts
+++ b/packages/core/src/commands/scout-bridge.test.ts
@@ -69,7 +69,6 @@ describe('buildScoutState', () => {
     expect(result.preferences.excludeRepos).toEqual(['owner/excluded']);
     expect(result.preferences.excludeOrgs).toEqual(['bad-org']);
     expect(result.preferences.aiPolicyBlocklist).toEqual(['matplotlib/matplotlib']);
-    expect(result.preferences.preferredOrgs).toEqual(['microsoft', 'vercel']);
     expect(result.preferences.projectCategories).toEqual(['web', 'cli']);
     expect(result.preferences.minStars).toBe(100);
     expect(result.preferences.maxIssueAgeDays).toBe(30);
@@ -85,7 +84,6 @@ describe('buildScoutState', () => {
 
   it.each([
     ['excludeOrgs', 'excludeOrgs'],
-    ['preferredOrgs', 'preferredOrgs'],
     ['projectCategories', 'projectCategories'],
   ] as const)('should default %s to [] when undefined in config', (field) => {
     const state = makeAgentState({ config: { [field]: undefined } });

--- a/packages/core/src/commands/scout-bridge.ts
+++ b/packages/core/src/commands/scout-bridge.ts
@@ -24,12 +24,14 @@ export function buildScoutState(): ScoutState {
       excludeRepos: config.excludeRepos,
       excludeOrgs: config.excludeOrgs ?? [],
       aiPolicyBlocklist: config.aiPolicyBlocklist,
-      preferredOrgs: config.preferredOrgs ?? [],
       projectCategories: config.projectCategories ?? [],
       minStars: config.minStars,
       maxIssueAgeDays: config.maxIssueAgeDays,
       includeDocIssues: config.includeDocIssues,
       minRepoScoreThreshold: config.minRepoScoreThreshold,
+      interPhaseDelayMs: 30000,
+      broadPhaseDelayMs: 90000,
+      skipBroadWhenSufficientResults: 15,
       persistence: config.persistence as 'local' | 'gist',
     },
     repoScores: state.repoScores,
@@ -46,6 +48,7 @@ export function buildScoutState(): ScoutState {
       closedAt: pr.closedAt,
     })),
     savedResults: [],
+    skippedIssues: [],
     lastRunAt: state.lastRunAt,
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@oss-scout/core':
-        specifier: ^0.2.0
-        version: 0.2.0(@octokit/core@7.0.6)
+        specifier: ^0.4.0
+        version: 0.4.0(@octokit/core@7.0.6)
       commander:
         specifier: ^14.0.3
         version: 14.0.3
@@ -631,8 +631,8 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@oss-scout/core@0.2.0':
-    resolution: {integrity: sha512-Jo8D26oFLP+Q97gW5I+RWdqnbTdJ0z6hgiftlMobasONMhUxYLVooaSpmTHl5wth6qMtNo3YkfeWmQgqLAI5Dw==}
+  '@oss-scout/core@0.4.0':
+    resolution: {integrity: sha512-PRioyk8LVRHsYvTP6MsA4sxuSpw7Nc6PWBXcv4/WBePJZDCnIq8g9UL/P9T7xgTlTQDwYpAYs7vfvbduXxufOQ==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
@@ -2892,7 +2892,7 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@oss-scout/core@0.2.0(@octokit/core@7.0.6)':
+  '@oss-scout/core@0.4.0(@octokit/core@7.0.6)':
     dependencies:
       '@octokit/plugin-throttling': 11.0.3(@octokit/core@7.0.6)
       '@octokit/rest': 22.0.1


### PR DESCRIPTION
## Summary

Upgrades `@oss-scout/core` from `^0.2.0` to `^0.4.0` to pick up rate limit improvements:

- Phase 0/1 now use REST Issues API instead of Search API (no search quota consumed)
- Phase 3 uses REST API for starred repos with Search API fallback
- Configurable inter-phase delays (default 30s between phases, 90s before broad search)
- Skip broad search when enough candidates found (default threshold: 15)

## Changes

- Bump `@oss-scout/core` in `packages/core/package.json`
- Remove `preferredOrgs` from scout bridge (dropped from scout schema)
- Add `skippedIssues: []` to state mapping (new required field)
- Add rate limit preference defaults to bridge (`interPhaseDelayMs`, `broadPhaseDelayMs`, `skipBroadWhenSufficientResults`)
- Update bridge tests to match

## Test plan

- [x] 1767 tests pass
- [x] TypeScript compiles
- [x] Lint clean
- [x] Format check passes