### PR TITLE
feat(dashboard): celebration animation when new PRs are merged

### DIFF
--- a/packages/dashboard/src/app.tsx
+++ b/packages/dashboard/src/app.tsx
@@ -109,7 +109,7 @@ function AppContent() {
   const [selectedUrl, setSelectedUrl] = useState<string | null>(null);
   const [shelvedOpen, setShelvedOpen] = useState(false);
   const { path, route } = useLocation();
-  const { celebrating, newMergeCount, dismiss: dismissCelebration } = useCelebration(data?.stats.mergedPRs);
+  const { newMergeCount, dismiss: dismissCelebration } = useCelebration(data?.stats.mergedPRs);
   const [celebrationsOn, setCelebrationsOn] = useState(() => {
     try {
       return localStorage.getItem(CELEBRATIONS_KEY) !== 'false';

--- a/packages/dashboard/src/app.tsx
+++ b/packages/dashboard/src/app.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'preact/hooks';
+import { useState, useMemo, useCallback } from 'preact/hooks';
 import { LocationProvider, useLocation } from 'preact-iso';
 import { useDashboard } from './hooks/use-dashboard';
 import { useTheme, type Theme } from './hooks/use-theme';
@@ -14,6 +14,8 @@ import { ClosedPRList } from './components/closed-pr-list';
 import { VettedIssueList } from './components/vetted-issue-list';
 import { SkeletonLoader } from './components/skeleton-loader';
 import { ThemeToggle } from './components/theme-toggle';
+import { CelebrationToast } from './components/celebration-toast';
+import { useCelebration } from './hooks/use-celebration';
 import { formatRelativeTime, refreshLabel } from './utils';
 import type { DashboardStats } from './types';
 
@@ -25,6 +27,8 @@ interface DashboardHeaderProps {
   onRefresh: () => void;
   theme: Theme;
   onToggleTheme: () => void;
+  celebrationsOn: boolean;
+  onToggleCelebrations: () => void;
 }
 
 function RefreshIcon() {
@@ -44,6 +48,8 @@ function DashboardHeader({
   onRefresh,
   theme,
   onToggleTheme,
+  celebrationsOn,
+  onToggleCelebrations,
 }: DashboardHeaderProps) {
   return (
     <header class="dashboard-header">
@@ -76,6 +82,15 @@ function DashboardHeader({
         </div>
         <div class="header-right">
           {lastUpdated && <span class="last-updated">{formatRelativeTime(lastUpdated)}</span>}
+          <button
+            class={`celebrations-toggle${celebrationsOn ? '' : ' celebrations-toggle--off'}`}
+            onClick={onToggleCelebrations}
+            title={celebrationsOn ? 'Celebrations on' : 'Celebrations off'}
+            aria-label={celebrationsOn ? 'Disable merge celebrations' : 'Enable merge celebrations'}
+            type="button"
+          >
+            🎉
+          </button>
           <ThemeToggle theme={theme} onToggle={onToggleTheme} />
           <button class="refresh-btn" onClick={onRefresh} disabled={loading || refreshing}>
             {loading || refreshing ? <span class="spinner" /> : <RefreshIcon />}
@@ -94,6 +109,26 @@ function AppContent() {
   const [selectedUrl, setSelectedUrl] = useState<string | null>(null);
   const [shelvedOpen, setShelvedOpen] = useState(false);
   const { path, route } = useLocation();
+  const { celebrating, newMergeCount, dismiss: dismissCelebration } = useCelebration(data?.stats.mergedPRs);
+  const [celebrationsOn, setCelebrationsOn] = useState(() => {
+    try {
+      return localStorage.getItem('oss-autopilot-celebrations') !== 'false';
+    } catch {
+      return true;
+    }
+  });
+
+  const toggleCelebrations = useCallback(() => {
+    setCelebrationsOn((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem('oss-autopilot-celebrations', String(next));
+      } catch {
+        // Ignore
+      }
+      return next;
+    });
+  }, []);
 
   const shelvedUrls = useMemo(() => new Set(data?.shelvedPRUrls ?? []), [data?.shelvedPRUrls]);
 
@@ -135,6 +170,8 @@ function AppContent() {
           onRefresh={refresh}
           theme={theme}
           onToggleTheme={toggleTheme}
+          celebrationsOn={celebrationsOn}
+          onToggleCelebrations={toggleCelebrations}
         />
         <MergedPRList mergedPRs={mergedPRs} repoMetadata={data.repoMetadata} onBack={() => route('/')} />
       </div>
@@ -154,6 +191,8 @@ function AppContent() {
           onRefresh={refresh}
           theme={theme}
           onToggleTheme={toggleTheme}
+          celebrationsOn={celebrationsOn}
+          onToggleCelebrations={toggleCelebrations}
         />
         <ClosedPRList closedPRs={closedPRs} onBack={() => route('/')} />
       </div>
@@ -172,6 +211,8 @@ function AppContent() {
           onRefresh={refresh}
           theme={theme}
           onToggleTheme={toggleTheme}
+          celebrationsOn={celebrationsOn}
+          onToggleCelebrations={toggleCelebrations}
         />
         {data.vettedIssues ? (
           <VettedIssueList
@@ -234,7 +275,13 @@ function AppContent() {
         onRefresh={refresh}
         theme={theme}
         onToggleTheme={toggleTheme}
+        celebrationsOn={celebrationsOn}
+        onToggleCelebrations={toggleCelebrations}
       />
+
+      {celebrating && newMergeCount !== null && (
+        <CelebrationToast count={newMergeCount} onDismiss={dismissCelebration} />
+      )}
 
       {error && (
         <div class="error-banner" role="alert">

--- a/packages/dashboard/src/app.tsx
+++ b/packages/dashboard/src/app.tsx
@@ -15,7 +15,7 @@ import { VettedIssueList } from './components/vetted-issue-list';
 import { SkeletonLoader } from './components/skeleton-loader';
 import { ThemeToggle } from './components/theme-toggle';
 import { CelebrationToast } from './components/celebration-toast';
-import { useCelebration } from './hooks/use-celebration';
+import { useCelebration, CELEBRATIONS_KEY } from './hooks/use-celebration';
 import { formatRelativeTime, refreshLabel } from './utils';
 import type { DashboardStats } from './types';
 
@@ -112,8 +112,9 @@ function AppContent() {
   const { celebrating, newMergeCount, dismiss: dismissCelebration } = useCelebration(data?.stats.mergedPRs);
   const [celebrationsOn, setCelebrationsOn] = useState(() => {
     try {
-      return localStorage.getItem('oss-autopilot-celebrations') !== 'false';
-    } catch {
+      return localStorage.getItem(CELEBRATIONS_KEY) !== 'false';
+    } catch (err) {
+      console.warn('[celebrations] Could not read preference from localStorage:', err);
       return true;
     }
   });
@@ -122,9 +123,9 @@ function AppContent() {
     setCelebrationsOn((prev) => {
       const next = !prev;
       try {
-        localStorage.setItem('oss-autopilot-celebrations', String(next));
-      } catch {
-        // Ignore
+        localStorage.setItem(CELEBRATIONS_KEY, String(next));
+      } catch (err) {
+        console.warn('[celebrations] Failed to persist celebration preference:', err);
       }
       return next;
     });
@@ -279,7 +280,7 @@ function AppContent() {
         onToggleCelebrations={toggleCelebrations}
       />
 
-      {celebrating && newMergeCount !== null && (
+      {celebrationsOn && newMergeCount !== null && (
         <CelebrationToast count={newMergeCount} onDismiss={dismissCelebration} />
       )}
 

--- a/packages/dashboard/src/components/celebration-toast.test.tsx
+++ b/packages/dashboard/src/components/celebration-toast.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/preact';
+import { CelebrationToast } from './celebration-toast';
+
+describe('CelebrationToast', () => {
+  it('renders singular message for 1 merge', () => {
+    const { getByText } = render(<CelebrationToast count={1} onDismiss={() => {}} />);
+    expect(getByText('1 new PR merged. Great work!')).toBeTruthy();
+  });
+
+  it('renders plural message for multiple merges', () => {
+    const { getByText } = render(<CelebrationToast count={3} onDismiss={() => {}} />);
+    expect(getByText('3 new PRs merged. Great work!')).toBeTruthy();
+  });
+
+  it('calls onDismiss when dismiss button is clicked', () => {
+    const onDismiss = vi.fn();
+    const { getByLabelText } = render(<CelebrationToast count={2} onDismiss={onDismiss} />);
+    fireEvent.click(getByLabelText('Dismiss notification'));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it('has role="status" for accessibility', () => {
+    const { container } = render(<CelebrationToast count={1} onDismiss={() => {}} />);
+    expect(container.querySelector('[role="status"]')).toBeTruthy();
+  });
+
+  it('renders confetti pieces', () => {
+    const { container } = render(<CelebrationToast count={1} onDismiss={() => {}} />);
+    const pieces = container.querySelectorAll('.confetti-piece');
+    expect(pieces.length).toBe(12);
+  });
+
+  it('confetti container has aria-hidden', () => {
+    const { container } = render(<CelebrationToast count={1} onDismiss={() => {}} />);
+    const confetti = container.querySelector('.celebration-confetti');
+    expect(confetti?.getAttribute('aria-hidden')).toBe('true');
+  });
+});

--- a/packages/dashboard/src/components/celebration-toast.tsx
+++ b/packages/dashboard/src/components/celebration-toast.tsx
@@ -20,6 +20,8 @@ export function CelebrationToast({ count, onDismiss }: CelebrationToastProps) {
     [],
   );
 
+  if (count < 1) return null;
+
   const message = count === 1 ? '1 new PR merged. Great work!' : `${count} new PRs merged. Great work!`;
 
   return (

--- a/packages/dashboard/src/components/celebration-toast.tsx
+++ b/packages/dashboard/src/components/celebration-toast.tsx
@@ -1,0 +1,52 @@
+import { useMemo } from 'preact/hooks';
+
+interface CelebrationToastProps {
+  count: number;
+  onDismiss: () => void;
+}
+
+const CONFETTI_COLORS = ['var(--green)', 'var(--purple)', 'var(--amber)', 'var(--blue)', 'var(--red)', 'var(--teal)'];
+const CONFETTI_COUNT = 12;
+
+export function CelebrationToast({ count, onDismiss }: CelebrationToastProps) {
+  const confettiPieces = useMemo(
+    () =>
+      Array.from({ length: CONFETTI_COUNT }, (_, i) => ({
+        color: CONFETTI_COLORS[i % CONFETTI_COLORS.length],
+        left: `${5 + (i * 90) / CONFETTI_COUNT + Math.random() * 5}%`,
+        delay: `${i * 0.12}s`,
+        duration: `${1.2 + Math.random() * 0.8}s`,
+      })),
+    [],
+  );
+
+  const message = count === 1 ? '1 new PR merged. Great work!' : `${count} new PRs merged. Great work!`;
+
+  return (
+    <div class="celebration-toast" role="status" aria-live="polite">
+      <div class="celebration-confetti" aria-hidden="true">
+        {confettiPieces.map((piece, i) => (
+          <span
+            key={i}
+            class="confetti-piece"
+            style={{
+              backgroundColor: piece.color,
+              left: piece.left,
+              animationDelay: piece.delay,
+              animationDuration: piece.duration,
+            }}
+          />
+        ))}
+      </div>
+      <div class="celebration-content">
+        <span class="celebration-emoji" aria-hidden="true">
+          🎉
+        </span>
+        <span class="celebration-message">{message}</span>
+        <button class="celebration-dismiss" onClick={onDismiss} aria-label="Dismiss notification">
+          ×
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard/src/hooks/use-celebration.test.ts
+++ b/packages/dashboard/src/hooks/use-celebration.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/preact';
+import { useCelebration } from './use-celebration';
+
+const MERGED_COUNT_KEY = 'oss-autopilot-merged-count';
+const CELEBRATIONS_KEY = 'oss-autopilot-celebrations';
+
+describe('useCelebration', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('stores count and does not celebrate on first visit (no stored count)', () => {
+    const { result } = renderHook(() => useCelebration(10));
+    expect(result.current.celebrating).toBe(false);
+    expect(result.current.newMergeCount).toBe(null);
+    expect(localStorage.getItem(MERGED_COUNT_KEY)).toBe('10');
+  });
+
+  it('celebrates when current count exceeds stored count', () => {
+    localStorage.setItem(MERGED_COUNT_KEY, '8');
+    const { result } = renderHook(() => useCelebration(11));
+    expect(result.current.celebrating).toBe(true);
+    expect(result.current.newMergeCount).toBe(3);
+    expect(localStorage.getItem(MERGED_COUNT_KEY)).toBe('11');
+  });
+
+  it('does not celebrate when count is unchanged', () => {
+    localStorage.setItem(MERGED_COUNT_KEY, '10');
+    const { result } = renderHook(() => useCelebration(10));
+    expect(result.current.celebrating).toBe(false);
+    expect(result.current.newMergeCount).toBe(null);
+  });
+
+  it('does not celebrate when count decreased (edge case)', () => {
+    localStorage.setItem(MERGED_COUNT_KEY, '15');
+    const { result } = renderHook(() => useCelebration(12));
+    expect(result.current.celebrating).toBe(false);
+    expect(localStorage.getItem(MERGED_COUNT_KEY)).toBe('12');
+  });
+
+  it('does not celebrate when celebrations are disabled', () => {
+    localStorage.setItem(MERGED_COUNT_KEY, '5');
+    localStorage.setItem(CELEBRATIONS_KEY, 'false');
+    const { result } = renderHook(() => useCelebration(8));
+    expect(result.current.celebrating).toBe(false);
+    expect(localStorage.getItem(MERGED_COUNT_KEY)).toBe('8');
+  });
+
+  it('auto-dismisses after 5 seconds', async () => {
+    localStorage.setItem(MERGED_COUNT_KEY, '5');
+    const { result } = renderHook(() => useCelebration(7));
+    expect(result.current.celebrating).toBe(true);
+
+    await act(async () => {
+      vi.advanceTimersByTime(5_000);
+    });
+
+    expect(result.current.celebrating).toBe(false);
+  });
+
+  it('dismiss() clears celebration immediately', () => {
+    localStorage.setItem(MERGED_COUNT_KEY, '5');
+    const { result } = renderHook(() => useCelebration(7));
+    expect(result.current.celebrating).toBe(true);
+
+    act(() => {
+      result.current.dismiss();
+    });
+
+    expect(result.current.celebrating).toBe(false);
+  });
+
+  it('does not re-trigger when mergedCount updates after initial check', () => {
+    localStorage.setItem(MERGED_COUNT_KEY, '5');
+    const { result, rerender } = renderHook(({ count }) => useCelebration(count), {
+      initialProps: { count: 7 },
+    });
+    expect(result.current.celebrating).toBe(true);
+
+    act(() => {
+      result.current.dismiss();
+    });
+
+    // Simulate auto-refresh delivering a higher count
+    rerender({ count: 9 });
+    expect(result.current.celebrating).toBe(false);
+  });
+
+  it('does nothing when mergedCount is undefined (data not yet loaded)', () => {
+    const { result } = renderHook(() => useCelebration(undefined));
+    expect(result.current.celebrating).toBe(false);
+    expect(localStorage.getItem(MERGED_COUNT_KEY)).toBe(null);
+  });
+
+  it('cleans up timer on unmount', () => {
+    localStorage.setItem(MERGED_COUNT_KEY, '5');
+    const { result, unmount } = renderHook(() => useCelebration(7));
+    expect(result.current.celebrating).toBe(true);
+    unmount();
+    // Should not throw — timer cleared
+    vi.advanceTimersByTime(5_000);
+  });
+});

--- a/packages/dashboard/src/hooks/use-celebration.ts
+++ b/packages/dashboard/src/hooks/use-celebration.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'preact/hooks';
 
 const MERGED_COUNT_KEY = 'oss-autopilot-merged-count';
-const CELEBRATIONS_KEY = 'oss-autopilot-celebrations';
+export const CELEBRATIONS_KEY = 'oss-autopilot-celebrations';
 const AUTO_DISMISS_MS = 5_000;
 
 export function useCelebration(mergedCount: number | undefined) {
@@ -25,8 +25,8 @@ export function useCelebration(mergedCount: number | undefined) {
           timerRef.current = setTimeout(() => setNewMergeCount(null), AUTO_DISMISS_MS);
         }
       }
-    } catch {
-      // localStorage unavailable — skip silently
+    } catch (err) {
+      console.warn('[useCelebration] localStorage unavailable, skipping celebration check:', err);
     }
   }, [mergedCount]);
 

--- a/packages/dashboard/src/hooks/use-celebration.ts
+++ b/packages/dashboard/src/hooks/use-celebration.ts
@@ -1,0 +1,45 @@
+import { useState, useEffect, useCallback, useRef } from 'preact/hooks';
+
+const MERGED_COUNT_KEY = 'oss-autopilot-merged-count';
+const CELEBRATIONS_KEY = 'oss-autopilot-celebrations';
+const AUTO_DISMISS_MS = 5_000;
+
+export function useCelebration(mergedCount: number | undefined) {
+  const [newMergeCount, setNewMergeCount] = useState<number | null>(null);
+  const checkedRef = useRef(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    if (mergedCount === undefined || checkedRef.current) return;
+    checkedRef.current = true;
+
+    try {
+      const enabled = localStorage.getItem(CELEBRATIONS_KEY) !== 'false';
+      const prev = localStorage.getItem(MERGED_COUNT_KEY);
+      localStorage.setItem(MERGED_COUNT_KEY, String(mergedCount));
+
+      if (prev !== null && enabled) {
+        const delta = mergedCount - Number(prev);
+        if (delta > 0) {
+          setNewMergeCount(delta);
+          timerRef.current = setTimeout(() => setNewMergeCount(null), AUTO_DISMISS_MS);
+        }
+      }
+    } catch {
+      // localStorage unavailable — skip silently
+    }
+  }, [mergedCount]);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const dismiss = useCallback(() => {
+    setNewMergeCount(null);
+    if (timerRef.current) clearTimeout(timerRef.current);
+  }, []);
+
+  return { celebrating: newMergeCount !== null, newMergeCount, dismiss };
+}

--- a/packages/dashboard/src/styles.css
+++ b/packages/dashboard/src/styles.css
@@ -251,6 +251,118 @@
   animation-delay: 0.36s;
 }
 
+/* === Celebration Toast === */
+
+@keyframes slideInRight {
+  from {
+    opacity: 0;
+    transform: translateX(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes confettiFall {
+  0% {
+    transform: translateY(0) rotate(0deg);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(60px) rotate(360deg);
+    opacity: 0;
+  }
+}
+
+.celebration-toast {
+  position: fixed;
+  top: var(--sp-4);
+  right: var(--sp-4);
+  z-index: 1000;
+  overflow: hidden;
+  border-radius: var(--radius);
+  animation: slideInRight 0.4s var(--ease) forwards;
+}
+
+.celebration-content {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  padding: var(--sp-3) var(--sp-4);
+  background: var(--surface);
+  border: 1px solid var(--purple);
+  border-radius: var(--radius);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 4px 24px rgba(192, 132, 252, 0.15);
+}
+
+.celebration-emoji {
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.celebration-message {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+}
+
+.celebration-dismiss {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 1.1rem;
+  padding: var(--sp-1);
+  line-height: 1;
+  transition: color 0.15s var(--ease);
+}
+
+.celebration-dismiss:hover {
+  color: var(--text-primary);
+}
+
+.celebration-confetti {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+.confetti-piece {
+  position: absolute;
+  top: -8px;
+  width: 6px;
+  height: 6px;
+  border-radius: 1px;
+  animation: confettiFall 1.5s var(--ease) forwards;
+}
+
+/* === Celebrations Toggle === */
+
+.celebrations-toggle {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: var(--sp-1) var(--sp-2);
+  cursor: pointer;
+  font-size: 0.95rem;
+  line-height: 1;
+  transition: all 0.15s var(--ease);
+}
+
+.celebrations-toggle:hover {
+  border-color: var(--border-hover);
+  background: var(--hover-bg);
+}
+
+.celebrations-toggle--off {
+  opacity: 0.4;
+  filter: grayscale(1);
+}
+
 /* === Base Reset & Layout === */
 
 *,


### PR DESCRIPTION
## Summary

- Add celebratory toast with confetti animation when the dashboard detects new PR merges since last visit
- Compare `stats.mergedPRs` against a localStorage-stored baseline on each page load
- Include a toggleable 🎉 button in the header to enable/disable celebrations

## Details

- `useCelebration` hook: one-shot localStorage comparison on page load, 5s auto-dismiss timer
- `CelebrationToast` component: fixed-position toast with 12 CSS-animated confetti pieces
- Accessible: `role="status"`, `aria-live="polite"`, `aria-hidden` on decorative elements
- First-time visitors see no celebration (no stored baseline)
- 15 new tests covering hook logic, component rendering, and edge cases

## Test plan

- [ ] Load dashboard with no prior localStorage — verify no celebration, count stored
- [ ] Set `oss-autopilot-merged-count` in localStorage to a value lower than current merged count, reload — verify toast appears with correct delta message
- [ ] Verify toast auto-dismisses after ~5 seconds
- [ ] Click the × button on the toast — verify it dismisses immediately
- [ ] Click the 🎉 toggle in the header to disable — verify it goes gray/muted
- [ ] With celebrations disabled, set a lower count and reload — verify no toast appears
- [ ] Re-enable celebrations, set lower count, reload — verify toast appears again
- [ ] Run `pnpm --filter @oss-autopilot/dashboard test` — all 210 tests pass

Closes #923