### PR TITLE
chore: ignore pnpm/action-setup major bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,6 @@ updates:
       actions:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "pnpm/action-setup"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

- Add dependabot ignore rule for `pnpm/action-setup` major version bumps
- v6 dropped support for reading the `packageManager` field from `package.json` and bootstraps pnpm 11 by default
- This broke lockfile parsing (`ERR_PNPM_BROKEN_LOCKFILE`) on our `lockfileVersion: '9.0'` lockfile, which closed #942

We can revisit v6+ later by adding an explicit `version:` input (or a `devEngines.packageManager` field) to each `pnpm/action-setup` step.

## Test plan
- [ ] CI green on this PR (config-only change, no runtime impact)