### PR TITLE
fix: exclude Skip sub-bullet items from availableCount (#907)

### DIFF
--- a/packages/core/src/commands/startup.test.ts
+++ b/packages/core/src/commands/startup.test.ts
@@ -134,8 +134,8 @@ Just some text, no issue list items.
   });
 
   it('should detect strikethrough as completed', () => {
-    const content = `- ~~[#1](url) — Done item~~
-- [#2](url) — Active item
+    const content = `- ~~[#1](https://github.com/o/r/issues/1) — Done item~~
+- [#2](https://github.com/o/r/issues/2) — Active item
 `;
     const result = countIssueListItems(content);
     expect(result.availableCount).toBe(1);
@@ -143,8 +143,8 @@ Just some text, no issue list items.
   });
 
   it('should detect **Done** marker as completed', () => {
-    const content = `- [#1](url) — Item with **Done** marker
-- [#2](url) — Active item
+    const content = `- [#1](https://github.com/o/r/issues/1) — Item with **Done** marker
+- [#2](https://github.com/o/r/issues/2) — Active item
 `;
     const result = countIssueListItems(content);
     expect(result.availableCount).toBe(1);
@@ -152,37 +152,49 @@ Just some text, no issue list items.
   });
 
   it('should handle indented list items', () => {
-    const content = `  - [#1](url) — Indented available
-  - ~~[#2](url) — Indented done~~
+    const content = `  - [#1](https://github.com/o/r/issues/1) — Indented available
+  - ~~[#2](https://github.com/o/r/issues/2) — Indented done~~
 `;
     const result = countIssueListItems(content);
     expect(result.availableCount).toBe(1);
     expect(result.completedCount).toBe(1);
   });
 
-  it('should not count lines that do not start with - [', () => {
+  it('should not count lines without GitHub URLs', () => {
     const content = `- Some regular list item
 - Another item
-- [#1](url) — Real issue list item
-  - Sub-item that starts with - [but is indented sub-bullet
+- [#1](https://github.com/o/r/issues/1) — Real issue list item
 `;
     const result = countIssueListItems(content);
-    // Only "- [#1]" matches — "  - Sub-item..." has "S" not "[" after "- "
     expect(result.availableCount).toBe(1);
     expect(result.completedCount).toBe(0);
   });
 
   it('should handle mixed available and completed items', () => {
-    const content = `- [#1](url) — Available 1
-- ~~[#2](url) — Done 1~~
-- [#3](url) — Available 2
-- [#4](url) — Has **Done** in text
-- ~~[#5](url) — Done 2~~
-- [#6](url) — Available 3
+    const content = `- [#1](https://github.com/o/r/issues/1) — Available 1
+- ~~[#2](https://github.com/o/r/issues/2) — Done 1~~
+- [#3](https://github.com/o/r/issues/3) — Available 2
+- [#4](https://github.com/o/r/issues/4) — Has **Done** in text
+- ~~[#5](https://github.com/o/r/issues/5) — Done 2~~
+- [#6](https://github.com/o/r/issues/6) — Available 3
 `;
     const result = countIssueListItems(content);
     expect(result.availableCount).toBe(3);
     expect(result.completedCount).toBe(3);
+  });
+
+  it('excludes items with **Skip** sub-bullet from availableCount (#907)', () => {
+    const content = `### Repo
+- [#1](https://github.com/owner/repo/issues/1) — Actionable
+  - **Maybe** — Score 8/10
+- [#2](https://github.com/owner/repo/issues/2) — Already vetted out
+  - **Skip** — Score 3/10. Existing PR.
+- [#3](https://github.com/owner/repo/issues/3) — Merged elsewhere
+  - **Merged** — PR merged upstream.
+`;
+    const result = countIssueListItems(content);
+    expect(result.availableCount).toBe(1);
+    expect(result.completedCount).toBe(2);
   });
 });
 
@@ -224,7 +236,7 @@ describe('detectIssueList', () => {
       if (path === '.claude/oss-autopilot/config.md') {
         return '---\nissueListPath: custom/issues.md\n---\n';
       }
-      return '- [#1](url) — Issue\n';
+      return '- [#1](https://github.com/o/r/issues/1) — Issue\n';
     });
 
     const result = detectIssueList();
@@ -255,7 +267,11 @@ describe('detectIssueList', () => {
     existsSyncMock.mockImplementation((path: string) => {
       return typeof path === 'string' && path === 'issues.md';
     });
-    (fsImport as any).readFileSync = vi.fn().mockReturnValue('- [#1](url) — Issue\n- ~~[#2](url) — Done~~\n');
+    (fsImport as any).readFileSync = vi
+      .fn()
+      .mockReturnValue(
+        '- [#1](https://github.com/o/r/issues/1) — Issue\n- ~~[#2](https://github.com/o/r/issues/2) — Done~~\n',
+      );
 
     const result = detectIssueList();
 
@@ -276,7 +292,7 @@ describe('detectIssueList', () => {
     existsSyncMock.mockImplementation((p: string) => {
       return typeof p === 'string' && p === 'state/issues.md';
     });
-    (fsImport as any).readFileSync = vi.fn().mockReturnValue('- [#1](url) — Issue\n');
+    (fsImport as any).readFileSync = vi.fn().mockReturnValue('- [#1](https://github.com/o/r/issues/1) — Issue\n');
 
     const result = detectIssueList();
 
@@ -302,7 +318,7 @@ describe('detectIssueList', () => {
       if (path === '.claude/oss-autopilot/config.md') {
         return '---\nissueListPath: config/issues.md\n---\n';
       }
-      return '- [#1](url) — Issue\n';
+      return '- [#1](https://github.com/o/r/issues/1) — Issue\n';
     });
 
     const result = detectIssueList();
@@ -318,7 +334,7 @@ describe('detectIssueList', () => {
       if (typeof p === 'string' && p === 'open-source/skipped-issues.md') return true;
       return false;
     });
-    (fsImport as any).readFileSync = vi.fn().mockReturnValue('- [#1](url) — Issue\n');
+    (fsImport as any).readFileSync = vi.fn().mockReturnValue('- [#1](https://github.com/o/r/issues/1) — Issue\n');
 
     // Override getStateManager to return issueListPath pointing to our probe path
     const { getStateManager } = await import('../core/index.js');
@@ -338,7 +354,7 @@ describe('detectIssueList', () => {
     existsSyncMock.mockImplementation((p: string) => {
       return typeof p === 'string' && p === 'issues.md';
     });
-    (fsImport as any).readFileSync = vi.fn().mockReturnValue('- [#1](url) — Issue\n');
+    (fsImport as any).readFileSync = vi.fn().mockReturnValue('- [#1](https://github.com/o/r/issues/1) — Issue\n');
 
     const result = detectIssueList();
 

--- a/packages/core/src/commands/startup.ts
+++ b/packages/core/src/commands/startup.ts
@@ -16,6 +16,7 @@ import { warn } from '../core/logger.js';
 import { type StartupOutput, type IssueListInfo } from '../formatters/json.js';
 import { executeDailyCheck } from './daily.js';
 import { launchDashboardServer } from './dashboard-lifecycle.js';
+import { parseIssueList } from './parse-list.js';
 
 /**
  * Parse issueListPath from a config file's YAML frontmatter.
@@ -32,26 +33,13 @@ export function parseIssueListPathFromConfig(configContent: string): string | un
 
 /**
  * Count available and completed items in an issue list file.
- * Available: list items (`- [`) NOT struck through or marked Done.
- * Completed: list items that ARE struck through or marked Done.
- *
- * @param content - Raw markdown content of the issue list
- * @returns Counts of available and completed items
+ * Available items exclude any vetting status that moves an item out of the
+ * actionable pool — strikethrough, `**Done**`, and sub-bullet markers like
+ * `**Skip**`, `**Merged**`, `**Dropped**`, `**Closed**`, `**In Progress**`,
+ * `**Waiting**`. Matches the parse-issue-list command's classification (#907).
  */
 export function countIssueListItems(content: string): { availableCount: number; completedCount: number } {
-  let availableCount = 0;
-  let completedCount = 0;
-  const lines = content.split('\n');
-  for (const line of lines) {
-    // Match list items: "- [" or "- ~~[" (strikethrough completed items)
-    if (/^\s*- (?:~~)?\[/.test(line)) {
-      if (/~~|\*\*Done\*\*/.test(line)) {
-        completedCount++;
-      } else {
-        availableCount++;
-      }
-    }
-  }
+  const { availableCount, completedCount } = parseIssueList(content);
   return { availableCount, completedCount };
 }
 


### PR DESCRIPTION
## Summary

Fixes #907 — `startup --json` reported an inflated `availableCount` because it had its own parser that missed sub-bullet vetting markers.

- `startup.ts` had an inline `countIssueListItems()` that only checked the main list line for `~~` strikethrough or `**Done**`
- Items with sub-bullet markers like `**Skip**`, `**Merged**`, `**Dropped**`, `**Closed**`, `**In Progress**`, `**Waiting**` were counted as available
- The dashboard (via `parseIssueList()` in `parse-list.ts`) already handled these correctly, so the two counts diverged
- Fix: `countIssueListItems()` now delegates to `parseIssueList()`, the canonical parser

## Test plan
- [x] Added regression test covering Skip + Merged sub-bullets (`startup.test.ts:186`)
- [x] Updated existing tests to use real GitHub URLs (`parseIssueList` requires them — old placeholder `(url)` was a workaround for the simpler regex)
- [x] All 2148 tests pass (`pnpm test`)
- [x] Lint clean (`pnpm run lint`)
- [x] Verified on real issue list: `availableCount` went from inflated → 16, matching the dashboard