### PR TITLE
chore: audit quick wins — tool count, dashboard engines, dead try/catch

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ A Preact SPA that auto-opens when you run `/oss` — PR management, charts, cont
 │  │ @oss-auto-   │  │ @oss-autopilot/dashboard │  │
 │  │ pilot/mcp    │  │ Preact + Vite             │  │
 │  │              │  │ PR management, charts,    │  │
-│  │ 25 tools     │  │ actions                   │  │
+│  │ 24 tools     │  │ actions                   │  │
 │  │ 5 resources  │  │                           │  │
 │  │ 3 prompts    │  │                           │  │
 │  └──────┬───────┘  └────────────┬─────────────┘  │
@@ -143,7 +143,7 @@ Then add to your MCP client config:
 }
 ```
 
-The MCP server exposes 25 tools, 5 resources, and 3 prompts — the full OSS Autopilot feature set.
+The MCP server exposes 24 tools, 5 resources, and 3 prompts — the full OSS Autopilot feature set.
 
 </details>
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -18,6 +18,9 @@
   "files": [
     "dist/"
   ],
+  "engines": {
+    "node": ">=20"
+  },
   "license": "MIT",
   "dependencies": {
     "@oss-autopilot/core": "workspace:*",

--- a/packages/dashboard/src/hooks/use-celebration.ts
+++ b/packages/dashboard/src/hooks/use-celebration.ts
@@ -111,11 +111,7 @@ export function useCelebration(mergedCount: number | undefined): {
       typeof window !== 'undefined' && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true;
 
     if (!reducedMotion) {
-      try {
-        fireConfetti();
-      } catch (err) {
-        console.warn('[useCelebration] confetti setup failed:', err);
-      }
+      fireConfetti();
     }
 
     const message = delta === 1 ? '1 new PR merged. Great work!' : `${delta} new PRs merged. Great work!`;


### PR DESCRIPTION
## Summary

Three trivial audit findings bundled:

- **Closes #961** — README said \"25 tools\" in two places; actual is **24** (verified by counting \`server.registerTool\` calls in \`mcp-server/src/tools.ts\`). The audit also flagged a broken CHANGELOG link, but \`packages/core/CHANGELOG.md\` actually exists — that part of the issue was a false positive and is resolved without change.
- **Closes #962** — \`packages/dashboard/package.json\` had no \`engines\` field. Added \`\"node\": \">=20\"\` to match the other workspace packages.
- **Closes #964** — \`use-celebration.ts\` wrapped \`fireConfetti()\` in an outer try/catch, but \`fireConfetti\` internally catches every exception from \`confetti()\` and never re-throws. Dropped the dead outer catch.

## Test plan
- [x] All 2148 tests pass (\`pnpm test\`)
- [x] Lint clean (\`pnpm run lint\`)
- [x] Prettier format clean