### PR TITLE
fix(mcp): propagate resource errors as JSON-RPC errors (#957)

### DIFF
--- a/packages/mcp-server/src/resources.test.ts
+++ b/packages/mcp-server/src/resources.test.ts
@@ -204,13 +204,8 @@ describe('MCP resource registrations', () => {
       expect(data.title).toBe('Fix typo in README');
     });
 
-    it('returns error for an unknown PR', async () => {
-      const result = await client.readResource({
-        uri: 'oss://pr/octocat/hello-world/999',
-      });
-      expect(result.contents).toHaveLength(1);
-      const data = JSON.parse(result.contents[0].text as string);
-      expect(data.error).toContain('not found');
+    it('rejects read for an unknown PR (#957)', async () => {
+      await expect(client.readResource({ uri: 'oss://pr/octocat/hello-world/999' })).rejects.toThrow(/not found/);
     });
 
     it('lists known PRs via the template list callback', async () => {
@@ -224,52 +219,38 @@ describe('MCP resource registrations', () => {
       expect(uris).toContain('oss://pr/octocat/spoon-knife/7');
     });
 
-    it('returns error for invalid PR number (NaN)', async () => {
-      const result = await client.readResource({
-        uri: 'oss://pr/octocat/hello-world/abc',
-      });
-      expect(result.contents).toHaveLength(1);
-      const data = JSON.parse(result.contents[0].text as string);
-      expect(data.error).toContain('Invalid PR number');
+    it('rejects read for invalid PR number (NaN) (#957)', async () => {
+      await expect(client.readResource({ uri: 'oss://pr/octocat/hello-world/abc' })).rejects.toThrow(
+        /Invalid PR number/,
+      );
     });
   });
 
-  describe('resource error handling', () => {
-    it('wrapResource returns error JSON when runStatus rejects', async () => {
+  describe('resource error handling (#957)', () => {
+    // Resource failures now propagate as JSON-RPC errors instead of being
+    // swallowed as 200 OK payloads with `{ error: "..." }` in the body.
+    // Clients that do not introspect the JSON no longer mistake failures for
+    // successful reads.
+
+    it('wrapResource rejects readResource when the underlying command throws', async () => {
       vi.mocked(runStatus).mockRejectedValueOnce(new Error('State file not found'));
-
-      const result = await client.readResource({ uri: 'oss://status' });
-
-      expect(result.contents).toHaveLength(1);
-      const data = JSON.parse(result.contents[0].text as string);
-      expect(data.error).toContain('State file not found');
+      await expect(client.readResource({ uri: 'oss://status' })).rejects.toThrow(/State file not found/);
     });
 
-    it('template list returns empty resources on error', async () => {
+    it('template list propagates state errors instead of returning an empty list', async () => {
       vi.mocked(getStateManager).mockImplementationOnce(() => {
         throw new Error('State corrupted');
       });
-
-      const result = await client.listResources();
-
-      // Should not throw — the template list catch returns { resources: [] }
-      // Static resources should still be listed
-      const staticUris = result.resources.filter((r) => !r.uri.startsWith('oss://pr/')).map((r) => r.uri);
-      expect(staticUris).toContain('oss://status');
+      await expect(client.listResources()).rejects.toThrow(/State corrupted/);
     });
 
-    it('pr-detail read handler catches thrown errors', async () => {
+    it('pr-detail read propagates unexpected exceptions', async () => {
       vi.mocked(getStateManager).mockImplementationOnce(() => {
         throw new Error('Unexpected state error');
       });
-
-      const result = await client.readResource({
-        uri: 'oss://pr/octocat/hello-world/42',
-      });
-
-      expect(result.contents).toHaveLength(1);
-      const data = JSON.parse(result.contents[0].text as string);
-      expect(data.error).toContain('Unexpected state error');
+      await expect(client.readResource({ uri: 'oss://pr/octocat/hello-world/42' })).rejects.toThrow(
+        /Unexpected state error/,
+      );
     });
   });
 });

--- a/packages/mcp-server/src/resources.ts
+++ b/packages/mcp-server/src/resources.ts
@@ -8,7 +8,6 @@ import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { runStatus, runConfig } from '@oss-autopilot/core/commands';
 import { getStateManager, splitRepo } from '@oss-autopilot/core';
-import { errorMessage } from '@oss-autopilot/core';
 
 /** Build a standard MCP resource response with a single JSON content entry. */
 function resourceContent(uri: URL, data: unknown) {
@@ -17,14 +16,22 @@ function resourceContent(uri: URL, data: unknown) {
   };
 }
 
-/** Wrap an async data-fetching function with error handling for use as an MCP resource callback. */
+/**
+ * Wrap an async data-fetching function for use as an MCP resource callback.
+ *
+ * Logs failures and rethrows so the MCP SDK produces a proper JSON-RPC error
+ * response. Previously this swallowed errors and returned them as a 200 OK
+ * resource payload with `{ error: "..." }` in the body — clients that did not
+ * introspect the JSON saw a successful read and treated the error string as
+ * resource data (#957).
+ */
 function wrapResource(fn: () => Promise<unknown>): (uri: URL) => Promise<ReturnType<typeof resourceContent>> {
   return async (uri: URL) => {
     try {
       return resourceContent(uri, await fn());
     } catch (e) {
       console.error('[MCP] Resource error:', e);
-      return resourceContent(uri, { error: errorMessage(e) });
+      throw e;
     }
   };
 }
@@ -114,7 +121,9 @@ export function registerResources(server: McpServer): void {
           };
         } catch (e) {
           console.error('[MCP] Failed to list PR resources:', e);
-          return { resources: [] };
+          // Rethrow so the MCP client sees a failed list request rather than
+          // an empty list that hides the API / state error (#957).
+          throw e;
         }
       },
     }),
@@ -125,20 +134,25 @@ export function registerResources(server: McpServer): void {
       mimeType: 'application/json',
     },
     async (uri, { owner, repo, number }) => {
+      // Validate input before touching state. Any of these throws produces a
+      // proper JSON-RPC error response to the MCP client, rather than a 200
+      // OK payload with an `{ error: "..." }` body that clients could mistake
+      // for valid resource content (#957).
+      const prNumber = parseInt(String(number), 10);
+      if (Number.isNaN(prNumber)) {
+        throw new Error(`Invalid PR number: ${String(number)}`);
+      }
       try {
         const openPRs = getStateManager().getState().lastDigest?.openPRs ?? [];
-        const prNumber = parseInt(String(number), 10);
-        if (Number.isNaN(prNumber)) {
-          return resourceContent(uri, { error: `Invalid PR number: ${String(number)}` });
-        }
         const fullRepo = `${String(owner)}/${String(repo)}`;
         const pr = openPRs.find((p) => p.repo === fullRepo && p.number === prNumber);
         if (!pr) {
-          return resourceContent(uri, { error: `PR ${fullRepo}#${prNumber} not found in last daily digest` });
+          throw new Error(`PR ${fullRepo}#${prNumber} not found in last daily digest`);
         }
         return resourceContent(uri, pr);
       } catch (e) {
-        return resourceContent(uri, { error: errorMessage(e) });
+        console.error('[MCP] PR detail error:', e);
+        throw e;
       }
     },
   );


### PR DESCRIPTION
## Summary

Closes #957. MCP resources previously swallowed errors and returned them as successful reads with \`{ error: \"...\" }\` in the body. Clients that did not introspect the JSON saw 200 OK and treated the error string as valid resource content. The tools module already handles this correctly via \`err()\` with \`isError: true\` — resources just never got the same treatment.

- \`wrapResource\` now logs then rethrows
- \`pr-detail\` template list callback rethrows on state errors instead of returning \`{ resources: [] }\` (which hid API / state failures)
- \`pr-detail\` read callback throws for invalid PR numbers, PR-not-found, and unexpected exceptions — all three are \"this read failed\" cases, not valid resource content
- 5 tests in \`resources.test.ts\` updated to expect rejection rather than error-in-content
- Removed now-unused \`errorMessage\` import from \`resources.ts\`

## Test plan
- [x] All 2148 tests pass (\`pnpm test\`)
- [x] Lint clean
- [x] The MCP SDK's JSON-RPC layer converts thrown errors into proper error responses automatically — client sees rejection with the error message rather than a success with embedded error text