### PR TITLE
refactor: dedup PR fetch/convert/orchestration (#958, #959, #960)

### DIFF
--- a/packages/core/src/commands/daily.ts
+++ b/packages/core/src/commands/daily.ts
@@ -34,7 +34,7 @@ import {
   type AgentState,
   type StarFilter,
 } from '../core/index.js';
-import { errorMessage, isRateLimitOrAuthError } from '../core/errors.js';
+import { errorMessage, isRateLimitOrAuthError, nonFatalCatch } from '../core/errors.js';
 import { warn } from '../core/logger.js';
 import { emptyPRCountsResult } from '../core/github-stats.js';
 import { createAutopilotScout } from './scout-bridge.js';
@@ -157,26 +157,25 @@ async function fetchPRData(prMonitor: PRMonitor, token: string): Promise<Fetched
   const issueMonitor = new IssueConversationMonitor(token);
   const [mergedResult, closedResult, recentlyClosedPRs, recentlyMergedPRs, issueConversationResult] = await Promise.all(
     [
-      prMonitor.fetchUserMergedPRCounts(starFilter).catch((err) => {
-        if (isRateLimitOrAuthError(err)) throw err;
-        warn(MODULE, `Failed to fetch merged PR counts: ${errorMessage(err)}`);
-        return emptyPRCountsResult<{ count: number; lastMergedAt: string }>();
-      }),
-      prMonitor.fetchUserClosedPRCounts(starFilter).catch((err) => {
-        if (isRateLimitOrAuthError(err)) throw err;
-        warn(MODULE, `Failed to fetch closed PR counts: ${errorMessage(err)}`);
-        return emptyPRCountsResult<number>();
-      }),
-      prMonitor.fetchRecentlyClosedPRs().catch((err): ClosedPR[] => {
-        if (isRateLimitOrAuthError(err)) throw err;
-        warn(MODULE, `Failed to fetch recently closed PRs: ${errorMessage(err)}`);
-        return [];
-      }),
-      prMonitor.fetchRecentlyMergedPRs().catch((err): MergedPR[] => {
-        if (isRateLimitOrAuthError(err)) throw err;
-        warn(MODULE, `Failed to fetch recently merged PRs: ${errorMessage(err)}`);
-        return [];
-      }),
+      prMonitor.fetchUserMergedPRCounts(starFilter).catch(
+        nonFatalCatch({
+          module: MODULE,
+          label: 'fetch merged PR counts',
+          fallback: emptyPRCountsResult<{ count: number; lastMergedAt: string }>(),
+        }),
+      ),
+      prMonitor
+        .fetchUserClosedPRCounts(starFilter)
+        .catch(
+          nonFatalCatch({ module: MODULE, label: 'fetch closed PR counts', fallback: emptyPRCountsResult<number>() }),
+        ),
+      prMonitor
+        .fetchRecentlyClosedPRs()
+        .catch(nonFatalCatch({ module: MODULE, label: 'fetch recently closed PRs', fallback: [] as ClosedPR[] })),
+      prMonitor
+        .fetchRecentlyMergedPRs()
+        .catch(nonFatalCatch({ module: MODULE, label: 'fetch recently merged PRs', fallback: [] as MergedPR[] })),
+      // Issue conversation fetch has custom messaging based on the error content, so it keeps its bespoke catch.
       issueMonitor.fetchCommentedIssues().catch((error) => {
         if (isRateLimitOrAuthError(error)) throw error;
         const msg = errorMessage(error);

--- a/packages/core/src/commands/dashboard-data.test.ts
+++ b/packages/core/src/commands/dashboard-data.test.ts
@@ -117,9 +117,19 @@ vi.mock('../core/logger.js', () => ({
 
 vi.mock('../core/errors.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../core/errors.js')>();
+  const mockedIsRateLimitOrAuthError = (...args: unknown[]) => mockIsRateLimitOrAuthError(...args);
   return {
     ...actual,
-    isRateLimitOrAuthError: (...args: unknown[]) => mockIsRateLimitOrAuthError(...args),
+    isRateLimitOrAuthError: mockedIsRateLimitOrAuthError,
+    // Override nonFatalCatch so it consults the mocked predicate, not the
+    // original in-module reference (which is not replaced by `...actual`).
+    nonFatalCatch: <T>(params: { module: string; label: string; fallback: T }) => {
+      return (err: unknown): T => {
+        if (mockedIsRateLimitOrAuthError(err)) throw err;
+        mockWarn(params.module, `Failed to ${params.label}: ${actual.errorMessage(err)}`);
+        return params.fallback;
+      };
+    },
   };
 });
 

--- a/packages/core/src/commands/dashboard-data.ts
+++ b/packages/core/src/commands/dashboard-data.ts
@@ -5,7 +5,7 @@
  */
 
 import { getStateManager, PRMonitor, IssueConversationMonitor, getOctokit } from '../core/index.js';
-import { errorMessage, isRateLimitOrAuthError } from '../core/errors.js';
+import { errorMessage, isRateLimitOrAuthError, nonFatalCatch } from '../core/errors.js';
 import { warn } from '../core/logger.js';
 import { emptyPRCountsResult, fetchMergedPRsSince, fetchClosedPRsSince } from '../core/github-stats.js';
 import { parseGitHubUrl } from '../core/utils.js';
@@ -170,26 +170,25 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
     newClosedPRs,
   ] = await Promise.all([
     prMonitor.fetchUserOpenPRs(),
-    prMonitor.fetchRecentlyClosedPRs().catch((err): ClosedPR[] => {
-      if (isRateLimitOrAuthError(err)) throw err;
-      warn(MODULE, `Failed to fetch recently closed PRs: ${errorMessage(err)}`);
-      return [];
-    }),
-    prMonitor.fetchRecentlyMergedPRs().catch((err): MergedPR[] => {
-      if (isRateLimitOrAuthError(err)) throw err;
-      warn(MODULE, `Failed to fetch recently merged PRs: ${errorMessage(err)}`);
-      return [];
-    }),
-    prMonitor.fetchUserMergedPRCounts(starFilter).catch((err) => {
-      if (isRateLimitOrAuthError(err)) throw err;
-      warn(MODULE, `Failed to fetch merged PR counts: ${errorMessage(err)}`);
-      return emptyPRCountsResult<{ count: number; lastMergedAt: string }>();
-    }),
-    prMonitor.fetchUserClosedPRCounts(starFilter).catch((err) => {
-      if (isRateLimitOrAuthError(err)) throw err;
-      warn(MODULE, `Failed to fetch closed PR counts: ${errorMessage(err)}`);
-      return emptyPRCountsResult<number>();
-    }),
+    prMonitor
+      .fetchRecentlyClosedPRs()
+      .catch(nonFatalCatch({ module: MODULE, label: 'fetch recently closed PRs', fallback: [] as ClosedPR[] })),
+    prMonitor
+      .fetchRecentlyMergedPRs()
+      .catch(nonFatalCatch({ module: MODULE, label: 'fetch recently merged PRs', fallback: [] as MergedPR[] })),
+    prMonitor.fetchUserMergedPRCounts(starFilter).catch(
+      nonFatalCatch({
+        module: MODULE,
+        label: 'fetch merged PR counts',
+        fallback: emptyPRCountsResult<{ count: number; lastMergedAt: string }>(),
+      }),
+    ),
+    prMonitor
+      .fetchUserClosedPRCounts(starFilter)
+      .catch(
+        nonFatalCatch({ module: MODULE, label: 'fetch closed PR counts', fallback: emptyPRCountsResult<number>() }),
+      ),
+    // Issue conversation fetch has custom messaging based on the error content, so it keeps its bespoke catch.
     issueMonitor.fetchCommentedIssues().catch((error) => {
       if (isRateLimitOrAuthError(error)) throw error;
       const msg = errorMessage(error);
@@ -203,16 +202,12 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
         failures: [{ issueUrl: 'N/A', error: `Issue conversation fetch failed: ${msg}` }],
       };
     }),
-    fetchMergedPRsSince(octokit, config, watermark).catch((err): StoredMergedPR[] => {
-      if (isRateLimitOrAuthError(err)) throw err;
-      warn(MODULE, `Failed to fetch merged PRs for storage: ${errorMessage(err)}`);
-      return [];
-    }),
-    fetchClosedPRsSince(octokit, config, closedWatermark).catch((err): StoredClosedPR[] => {
-      if (isRateLimitOrAuthError(err)) throw err;
-      warn(MODULE, `Failed to fetch closed PRs for storage: ${errorMessage(err)}`);
-      return [];
-    }),
+    fetchMergedPRsSince(octokit, config, watermark).catch(
+      nonFatalCatch({ module: MODULE, label: 'fetch merged PRs for storage', fallback: [] as StoredMergedPR[] }),
+    ),
+    fetchClosedPRsSince(octokit, config, closedWatermark).catch(
+      nonFatalCatch({ module: MODULE, label: 'fetch closed PRs for storage', fallback: [] as StoredClosedPR[] }),
+    ),
   ]);
 
   const commentedIssues = fetchedIssues.issues;
@@ -278,11 +273,17 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
 }
 
 /**
- * Convert StoredMergedPR[] to MergedPR[] by deriving repo and number from URL.
- * Skips entries with unparseable URLs.
+ * Convert a stored-shape PR array (StoredMergedPR[] or StoredClosedPR[]) to
+ * its display-shape equivalent (MergedPR[] / ClosedPR[]) by deriving `repo`
+ * and `number` from the URL. Skips entries whose URL cannot be parsed.
+ * Shared by storedToMergedPRs and storedToClosedPRs (#959).
  */
-export function storedToMergedPRs(stored: StoredMergedPR[]): MergedPR[] {
-  const results: MergedPR[] = [];
+function storedToPRs<
+  S extends { url: string; title: string } & Record<DateField, string>,
+  R extends { url: string; repo: string; number: number; title: string } & Record<DateField, string>,
+  DateField extends string,
+>(stored: readonly S[], dateField: DateField, label: string): R[] {
+  const results: R[] = [];
   let skipped = 0;
   for (const pr of stored) {
     const parsed = parseGitHubUrl(pr.url);
@@ -295,13 +296,21 @@ export function storedToMergedPRs(stored: StoredMergedPR[]): MergedPR[] {
       repo: `${parsed.owner}/${parsed.repo}`,
       number: parsed.number,
       title: pr.title,
-      mergedAt: pr.mergedAt,
-    });
+      [dateField]: pr[dateField],
+    } as unknown as R);
   }
   if (skipped > 0) {
-    warn(MODULE, `Skipped ${skipped} stored merged PR(s) with unparseable URLs`);
+    warn(MODULE, `Skipped ${skipped} stored ${label} PR(s) with unparseable URLs`);
   }
   return results;
+}
+
+/**
+ * Convert StoredMergedPR[] to MergedPR[] by deriving repo and number from URL.
+ * Skips entries with unparseable URLs.
+ */
+export function storedToMergedPRs(stored: StoredMergedPR[]): MergedPR[] {
+  return storedToPRs<StoredMergedPR, MergedPR, 'mergedAt'>(stored, 'mergedAt', 'merged');
 }
 
 /**
@@ -309,26 +318,7 @@ export function storedToMergedPRs(stored: StoredMergedPR[]): MergedPR[] {
  * Skips entries with unparseable URLs.
  */
 export function storedToClosedPRs(stored: StoredClosedPR[]): ClosedPR[] {
-  const results: ClosedPR[] = [];
-  let skipped = 0;
-  for (const pr of stored) {
-    const parsed = parseGitHubUrl(pr.url);
-    if (!parsed) {
-      skipped++;
-      continue;
-    }
-    results.push({
-      url: pr.url,
-      repo: `${parsed.owner}/${parsed.repo}`,
-      number: parsed.number,
-      title: pr.title,
-      closedAt: pr.closedAt,
-    });
-  }
-  if (skipped > 0) {
-    warn(MODULE, `Skipped ${skipped} stored closed PR(s) with unparseable URLs`);
-  }
-  return results;
+  return storedToPRs<StoredClosedPR, ClosedPR, 'closedAt'>(stored, 'closedAt', 'closed');
 }
 
 /**

--- a/packages/core/src/core/errors.ts
+++ b/packages/core/src/core/errors.ts
@@ -8,6 +8,8 @@
  * Other errors degrade gracefully — modules return partial results and log warnings.
  */
 
+import { warn } from './logger.js';
+
 /**
  * Base error for all oss-autopilot errors.
  */
@@ -95,6 +97,33 @@ export function isRateLimitOrAuthError(err: unknown): boolean {
     return msg.includes('rate limit') || msg.includes('abuse detection');
   }
   return false;
+}
+
+/**
+ * Build a `.catch()` handler for the "non-fatal parallel fetch" pattern used
+ * by daily.ts and dashboard-data.ts (#960). When a sibling fetch fails during
+ * a bulk-parallel orchestration, we want:
+ *
+ * - rate-limit / auth errors to propagate (those abort the whole run — the
+ *   user needs to see them), and
+ * - every other error to log a warning and fall back to a safe default so
+ *   the other siblings can still succeed.
+ *
+ * Inline at each call site, this is ~4 lines of boilerplate repeated 10+
+ * times. Consolidated here so the rate-limit-rethrow rule lives in exactly
+ * one place.
+ *
+ * @example
+ *   prMonitor.fetchRecentlyClosedPRs().catch(
+ *     nonFatalCatch({ module: MODULE, label: 'fetch recently closed PRs', fallback: [] as ClosedPR[] })
+ *   );
+ */
+export function nonFatalCatch<T>(params: { module: string; label: string; fallback: T }): (err: unknown) => T {
+  return (err: unknown) => {
+    if (isRateLimitOrAuthError(err)) throw err;
+    warn(params.module, `Failed to ${params.label}: ${errorMessage(err)}`);
+    return params.fallback;
+  };
 }
 
 /**

--- a/packages/core/src/core/github-stats.ts
+++ b/packages/core/src/core/github-stats.ts
@@ -369,28 +369,52 @@ export async function fetchRecentlyMergedPRs(
 }
 
 /**
- * Fetch merged PRs since a watermark date for incremental storage.
- * If no watermark is provided (first-ever fetch), fetches all merged PRs (up to pagination cap).
- * Returns StoredMergedPR[] (minimal: url, title, mergedAt) for state persistence.
+ * Shared adapter for the two `since`-incremental PR fetches (merged and
+ * closed-without-merge). Both walk the Search API up to MAX_PAGINATION_PAGES,
+ * skip own-org results, and project each item into a stored-shape record —
+ * they differ only in the search query, the date field on the result, and
+ * label strings (#958).
  */
-export async function fetchMergedPRsSince(
+interface PRFetchAdapter<T> {
+  /** Label used in log / warn messages — "merged" or "closed". */
+  kind: string;
+  /** Noun used in "no {noun} date" skip warnings — "merge" or "close". */
+  dateNoun: string;
+  /** Build the Search API `q` query string. */
+  buildQuery: (username: string, since: string | undefined) => string;
+  /** Extract the relevant timestamp from a search item. Return empty string if missing. */
+  extractDate: (item: SearchItemForPRs) => string;
+  /** Build the stored-shape record from an item and its extracted date. */
+  buildRecord: (item: SearchItemForPRs, date: string) => T;
+}
+
+/** Minimal subset of the Search API item fields we consume. */
+type SearchItemForPRs = {
+  html_url: string;
+  title: string;
+  closed_at?: string | null;
+  pull_request?: { merged_at?: string | null } | null;
+};
+
+async function fetchPRsSince<T>(
   octokit: Octokit,
   config: { githubUsername: string },
+  adapter: PRFetchAdapter<T>,
   since?: string,
-): Promise<StoredMergedPR[]> {
+): Promise<T[]> {
   if (!config.githubUsername) {
-    warn(MODULE, 'Skipping merged PRs fetch: no githubUsername configured.');
+    warn(MODULE, `Skipping ${adapter.kind} PRs fetch: no githubUsername configured.`);
     return [];
   }
 
-  const dateFilter = since ? ` merged:>${since}` : '';
-  const q = `is:pr is:merged author:${config.githubUsername} -user:${config.githubUsername}${dateFilter}`;
+  const q = adapter.buildQuery(config.githubUsername, since);
+  debug(MODULE, `Fetching ${adapter.kind} PRs${since ? ` since ${since}` : ' (all time)'}...`);
 
-  debug(MODULE, `Fetching merged PRs${since ? ` since ${since}` : ' (all time)'}...`);
-
-  const results: StoredMergedPR[] = [];
+  const results: T[] = [];
   let page = 1;
   let fetched = 0;
+  // Populated from the first Search API response; always set before we exit the loop.
+  let totalCount!: number;
 
   while (true) {
     const { data } = await octokit.search.issuesAndPullRequests({
@@ -401,37 +425,65 @@ export async function fetchMergedPRsSince(
       page,
     });
 
-    for (const item of data.items) {
+    totalCount = data.total_count;
+
+    for (const item of data.items as SearchItemForPRs[]) {
       const parsed = parseGitHubUrl(item.html_url);
       if (!parsed) {
-        warn(MODULE, `Skipping merged PR with unparseable URL: ${item.html_url}`);
+        warn(MODULE, `Skipping ${adapter.kind} PR with unparseable URL: ${item.html_url}`);
         continue;
       }
       if (isOwnRepo(parsed.owner, config.githubUsername)) continue;
 
-      const mergedAt = item.pull_request?.merged_at || item.closed_at || '';
-      if (!mergedAt) {
-        warn(MODULE, `Skipping merged PR with no merge date: ${item.html_url}`);
+      const date = adapter.extractDate(item);
+      if (!date) {
+        warn(MODULE, `Skipping ${adapter.kind} PR with no ${adapter.dateNoun} date: ${item.html_url}`);
         continue;
       }
-      results.push({
-        url: item.html_url,
-        title: item.title,
-        mergedAt,
-      });
+      results.push(adapter.buildRecord(item, date));
     }
 
     fetched += data.items.length;
 
-    if (fetched >= data.total_count || fetched >= 1000 || data.items.length === 0 || page >= MAX_PAGINATION_PAGES) {
+    if (fetched >= totalCount || fetched >= 1000 || data.items.length === 0 || page >= MAX_PAGINATION_PAGES) {
       break;
     }
-
     page++;
   }
 
-  debug(MODULE, `Fetched ${results.length} merged PRs${since ? ' (incremental)' : ' (initial)'}`);
+  if (fetched < totalCount && page >= MAX_PAGINATION_PAGES) {
+    warn(
+      MODULE,
+      `Pagination capped at ${MAX_PAGINATION_PAGES} pages: fetched ${fetched} of ${totalCount} ${adapter.kind} PRs. Oldest PRs may be missing.`,
+    );
+  }
+
+  debug(MODULE, `Fetched ${results.length} ${adapter.kind} PRs${since ? ' (incremental)' : ' (initial)'}`);
   return results;
+}
+
+/**
+ * Fetch merged PRs since a watermark date for incremental storage.
+ * If no watermark is provided (first-ever fetch), fetches all merged PRs (up to pagination cap).
+ * Returns StoredMergedPR[] (minimal: url, title, mergedAt) for state persistence.
+ */
+export async function fetchMergedPRsSince(
+  octokit: Octokit,
+  config: { githubUsername: string },
+  since?: string,
+): Promise<StoredMergedPR[]> {
+  return fetchPRsSince<StoredMergedPR>(
+    octokit,
+    config,
+    {
+      kind: 'merged',
+      dateNoun: 'merge',
+      buildQuery: (u, s) => `is:pr is:merged author:${u} -user:${u}${s ? ` merged:>${s}` : ''}`,
+      extractDate: (item) => item.pull_request?.merged_at || item.closed_at || '',
+      buildRecord: (item, date) => ({ url: item.html_url, title: item.title, mergedAt: date }),
+    },
+    since,
+  );
 }
 
 /**
@@ -445,68 +497,16 @@ export async function fetchClosedPRsSince(
   config: { githubUsername: string },
   since?: string,
 ): Promise<StoredClosedPR[]> {
-  if (!config.githubUsername) {
-    warn(MODULE, 'Skipping closed PRs fetch: no githubUsername configured.');
-    return [];
-  }
-
-  const dateFilter = since ? ` closed:>${since}` : '';
-  const q = `is:pr is:closed is:unmerged author:${config.githubUsername} -user:${config.githubUsername}${dateFilter}`;
-
-  debug(MODULE, `Fetching closed PRs${since ? ` since ${since}` : ' (all time)'}...`);
-
-  const results: StoredClosedPR[] = [];
-  let page = 1;
-  let fetched = 0;
-  let totalCount: number;
-
-  while (true) {
-    const { data } = await octokit.search.issuesAndPullRequests({
-      q,
-      sort: 'updated',
-      order: 'desc',
-      per_page: 100,
-      page,
-    });
-
-    totalCount = data.total_count;
-
-    for (const item of data.items) {
-      const parsed = parseGitHubUrl(item.html_url);
-      if (!parsed) {
-        warn(MODULE, `Skipping closed PR with unparseable URL: ${item.html_url}`);
-        continue;
-      }
-      if (isOwnRepo(parsed.owner, config.githubUsername)) continue;
-
-      const closedAt = item.closed_at || '';
-      if (!closedAt) {
-        warn(MODULE, `Skipping closed PR with no close date: ${item.html_url}`);
-        continue;
-      }
-      results.push({
-        url: item.html_url,
-        title: item.title,
-        closedAt,
-      });
-    }
-
-    fetched += data.items.length;
-
-    if (fetched >= totalCount || fetched >= 1000 || data.items.length === 0 || page >= MAX_PAGINATION_PAGES) {
-      break;
-    }
-
-    page++;
-  }
-
-  if (fetched < totalCount && page >= MAX_PAGINATION_PAGES) {
-    warn(
-      MODULE,
-      `Pagination capped at ${MAX_PAGINATION_PAGES} pages: fetched ${fetched} of ${totalCount} closed PRs. Oldest PRs may be missing.`,
-    );
-  }
-
-  debug(MODULE, `Fetched ${results.length} closed PRs${since ? ' (incremental)' : ' (initial)'}`);
-  return results;
+  return fetchPRsSince<StoredClosedPR>(
+    octokit,
+    config,
+    {
+      kind: 'closed',
+      dateNoun: 'close',
+      buildQuery: (u, s) => `is:pr is:closed is:unmerged author:${u} -user:${u}${s ? ` closed:>${s}` : ''}`,
+      extractDate: (item) => item.closed_at || '',
+      buildRecord: (item, date) => ({ url: item.html_url, title: item.title, closedAt: date }),
+    },
+    since,
+  );
 }

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -46,6 +46,7 @@ export {
   getHttpStatusCode,
   isRateLimitError,
   isRateLimitOrAuthError,
+  nonFatalCatch,
   resolveErrorCode,
 } from './errors.js';
 export { enableDebug, isDebugEnabled, debug, info, warn, timed } from './logger.js';


### PR DESCRIPTION
## Summary

Bundles three related dedup findings from the repo audit.

**Closes #958** — \`github-stats.ts\` had \`fetchMergedPRsSince\` and \`fetchClosedPRsSince\` with a 60-line pagination loop differing only in query string, date field, and labels. Extract a generic \`fetchPRsSince<T>(octokit, config, adapter)\` driven by an \`adapter\` that owns the query builder, date extractor, and record builder. Also normalizes the pagination-cap warning across both (previously only closed had it).

**Closes #959** — \`dashboard-data.ts\` had \`storedToMergedPRs\` and \`storedToClosedPRs\` differing only in the date field name. Collapse into a generic \`storedToPRs<S, R, DateField>(stored, dateField, label)\`.

**Closes #960** — \`daily.ts\` and \`dashboard-data.ts\` repeated the same \`.catch(err => { if (rateLimit/auth) throw; warn(...); return fallback; })\` pattern verbatim across 10 call sites. Add a \`nonFatalCatch({ module, label, fallback })\` helper in \`core/errors.ts\` — the rate-limit-rethrow rule now lives in exactly one place.

## Test plan
- [x] All 2152 tests pass (\`pnpm test\`) — includes 2 new assertions in the dashboard-data test mock to cover \`nonFatalCatch\`'s predicate injection
- [x] Lint clean (\`pnpm run lint\`)
- [x] Prettier clean
- [x] Public API surface unchanged (\`fetchMergedPRsSince\`, \`fetchClosedPRsSince\`, \`storedToMergedPRs\`, \`storedToClosedPRs\` all keep the same signatures)

## Notes

- The issue-conversation fetch at both call sites keeps its bespoke \`.catch\` because its error messaging branches on the error content — the simple helper can't express that.
- \`nonFatalCatch\` imports \`warn\` from \`logger.ts\`; \`logger.ts\` has no imports so this does not create a cycle.