### PR TITLE
chore: document pnpm.overrides rationale (#963)

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,16 @@
       "yaml": ">=2.8.3"
     }
   },
+  "_pnpmOverridesRationale": {
+    "_note": "Rationale for each entry in pnpm.overrides. Inert JSON — pnpm ignores unknown top-level keys. Revisit periodically with `pnpm why <pkg>` to confirm the override is still hit by the dep graph (#963).",
+    "hono": "Transitive via @modelcontextprotocol/sdk. Pin >=4.12.7 to avoid the pre-4.12.7 security advisory family. Confirmed still in tree.",
+    "@hono/node-server": "Transitive via @modelcontextprotocol/sdk. Pin >=1.19.10 alongside hono. Confirmed still in tree.",
+    "express-rate-limit": "Transitive via @modelcontextprotocol/sdk. Pin >=8.2.2 for known advisory. Confirmed still in tree.",
+    "flatted": "Dev-only, transitive via eslint -> flat-cache. Pin >=3.4.2 for ReDoS advisory. Confirmed still in tree.",
+    "picomatch": "Dev-only, transitive via typescript-eslint -> tinyglobby. Pin >=4.0.4 for ReDoS advisory. Confirmed still in tree.",
+    "path-to-regexp": "Transitive via @modelcontextprotocol/sdk -> express/router. Pin >=8.4.0 for ReDoS advisory. Confirmed still in tree.",
+    "yaml": "Dev-only, transitive via vitest -> vite. Pin >=2.8.3 for code-execution advisory. Confirmed still in tree."
+  },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "eslint": "^10.0.3",


### PR DESCRIPTION
## Summary

Closes #963. Audit confirmed all seven \`pnpm.overrides\` entries are still actively enforced by the dep graph — \`pnpm why\` shows each package is present.

- **Production deps** (via \`@modelcontextprotocol/sdk\`): \`hono\`, \`@hono/node-server\`, \`express-rate-limit\`, \`path-to-regexp\`
- **Dev-only**: \`flatted\` (eslint → flat-cache), \`picomatch\` (typescript-eslint → tinyglobby), \`yaml\` (vitest → vite)

None are cargo-culted; removing any would let the resolver pick pre-patch versions.

## Why a \`_pnpmOverridesRationale\` key

package.json is strict JSON, no comments. The \`_pnpmOverridesRationale\` sibling object lives next to \`overrides\` and pairs each package with its reason (advisory family, confirmation note). pnpm ignores unknown top-level keys so this is inert — it just gives future maintainers a place to read the \"why\" without digging through git history.

## Test plan
- [x] \`pnpm install\` succeeds (no new warnings)
- [x] Lint clean, all 2152 tests pass