### PR TITLE
feat: pass open-PR repos to oss-scout search

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@octokit/plugin-throttling": "^11.0.3",
     "@octokit/rest": "^22.0.1",
-    "@oss-scout/core": "^0.4.0",
+    "@oss-scout/core": "^0.5.0",
     "commander": "^14.0.3",
     "zod": "^4.3.6"
   },

--- a/packages/core/src/commands/scout-bridge.test.ts
+++ b/packages/core/src/commands/scout-bridge.test.ts
@@ -15,7 +15,7 @@ vi.mock('@oss-scout/core', () => ({
 
 import { getStateManager } from '../core/index.js';
 import { buildScoutState } from './scout-bridge.js';
-import { makeAgentState, makeStateManagerMock } from '../core/test-utils.js';
+import { makeAgentState, makeDailyDigest, makeFetchedPR, makeStateManagerMock } from '../core/test-utils.js';
 
 const mockGetStateManager = vi.mocked(getStateManager);
 
@@ -155,6 +155,51 @@ describe('buildScoutState', () => {
     const result = buildScoutState();
 
     expect(result[field]).toEqual([]);
+  });
+
+  it('should project ephemeral openPRs from last digest into scout openPRs (url, title, openedAt)', () => {
+    const state = makeAgentState({
+      lastDigest: makeDailyDigest({
+        openPRs: [
+          makeFetchedPR({
+            repo: 'owner/repo',
+            number: 42,
+            title: 'feat: add thing',
+            createdAt: '2026-03-01T00:00:00Z',
+          }),
+          makeFetchedPR({
+            repo: 'other/repo',
+            number: 7,
+            title: 'fix: bug',
+            createdAt: '2026-03-15T00:00:00Z',
+          }),
+        ],
+      }),
+    });
+    mockGetStateManager.mockReturnValue(makeStateManagerMock({ state, config: state.config }));
+
+    const result = buildScoutState();
+
+    expect(result.openPRs).toHaveLength(2);
+    expect(result.openPRs[0]).toEqual({
+      url: 'https://github.com/owner/repo/pull/42',
+      title: 'feat: add thing',
+      openedAt: '2026-03-01T00:00:00Z',
+    });
+    expect(result.openPRs[1]).toEqual({
+      url: 'https://github.com/other/repo/pull/7',
+      title: 'fix: bug',
+      openedAt: '2026-03-15T00:00:00Z',
+    });
+  });
+
+  it('should return [] for openPRs when no digest is present', () => {
+    const state = makeAgentState({ lastDigest: undefined });
+    mockGetStateManager.mockReturnValue(makeStateManagerMock({ state, config: state.config }));
+
+    const result = buildScoutState();
+
+    expect(result.openPRs).toEqual([]);
   });
 
   it('should always set savedResults to an empty array', () => {

--- a/packages/core/src/commands/scout-bridge.ts
+++ b/packages/core/src/commands/scout-bridge.ts
@@ -47,6 +47,13 @@ export function buildScoutState(): ScoutState {
       title: pr.title,
       closedAt: pr.closedAt,
     })),
+    // Map ephemeral openPRs (regenerated each daily run) from the last digest
+    // so oss-scout's Phase 0 also searches repos with active-but-unmerged PRs.
+    openPRs: (state.lastDigest?.openPRs ?? []).map((pr: { url: string; title: string; createdAt: string }) => ({
+      url: pr.url,
+      title: pr.title,
+      openedAt: pr.createdAt,
+    })),
     savedResults: [],
     skippedIssues: [],
     lastRunAt: state.lastRunAt,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@oss-scout/core':
-        specifier: ^0.4.0
-        version: 0.4.0(@octokit/core@7.0.6)
+        specifier: ^0.5.0
+        version: 0.5.0(@octokit/core@7.0.6)
       commander:
         specifier: ^14.0.3
         version: 14.0.3
@@ -640,8 +640,8 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@oss-scout/core@0.4.0':
-    resolution: {integrity: sha512-PRioyk8LVRHsYvTP6MsA4sxuSpw7Nc6PWBXcv4/WBePJZDCnIq8g9UL/P9T7xgTlTQDwYpAYs7vfvbduXxufOQ==}
+  '@oss-scout/core@0.5.0':
+    resolution: {integrity: sha512-oq30RyjgOrzSSA2Xl7pt9YPVP7aDWFD0gKAs2+5CkphBKXAPrSTa8pAPaa7QSC5w9reOMfkiqrzvv8JR/Ql/0w==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
@@ -2903,7 +2903,7 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@oss-scout/core@0.4.0(@octokit/core@7.0.6)':
+  '@oss-scout/core@0.5.0(@octokit/core@7.0.6)':
     dependencies:
       '@octokit/plugin-throttling': 11.0.3(@octokit/core@7.0.6)
       '@octokit/rest': 22.0.1


### PR DESCRIPTION
## Summary
- Bump `@oss-scout/core` from `^0.4.0` to `^0.5.0` (lockfile now resolves 0.5.0).
- Project the ephemeral `openPRs` from the last daily digest into the `ScoutState` the bridge hands to oss-scout, so its Phase 0 also searches repos where the user has an active-but-unmerged PR. Before this, Phase 0 only saw merged-PR repos, missing new relationships.
- Map `FetchedPR.createdAt → StoredOpenPR.openedAt`. Empty/undefined digest yields `[]` (graceful default).

## Why
This is the motivation behind oss-scout PR #65/#66 — oss-autopilot's historical Strategy A searched repos with open PRs directly. After migrating to oss-scout, that signal was lost until the 0.5.0 API shipped. This reconnects it.

## Test plan
- [x] `pnpm --filter @oss-autopilot/core test src/commands/scout-bridge.test.ts` — 12 passed (2 new)
- [x] `pnpm test` — full suite green across core/dashboard/mcp-server (all existing counts preserved)
- [x] `pnpm --filter @oss-autopilot/core run typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)