### PR TITLE
refactor: extract success-likelihood grade to core function (#967)

### DIFF
--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -416,19 +416,9 @@ A repo with a dormant PR should almost never be recommended unless the issue is 
 
 **Success Likelihood Grade (#858):**
 
-Alongside the numeric score, surface a letter grade that predicts how likely a contribution will be *accepted and merged*, using signals already gathered during vetting — no extra API calls. This helps contributors prioritize opportunities where maintainers actually merge external PRs.
+Alongside the numeric score, surface a letter grade that predicts how likely a contribution will be *accepted and merged*. This helps contributors prioritize opportunities where maintainers actually merge external PRs. The grade is separate from the numeric score — score answers "is this issue good to work on?", grade answers "will my PR actually merge?"
 
-Compute the grade from these three signals (all derived from data fetched in sections 1–3 of vetting):
-
-| Signal | A | B | C | F |
-|---|---|---|---|---|
-| Maintainer responsiveness | avg response < 3 days | 3–14 days | 14–60 days | unresponsive / > 60 days |
-| Repo merge rate (merged PRs / total PRs in recent window) | > 70% | 40–70% | 10–40% | < 10% or unknown with no merges in 90 days |
-| Activity (recent commits + releases) | commit in last 7 days | last 30 days | last 90 days | no commit in 90+ days |
-
-Take the **worst** of the three letters as the overall grade (a single failing signal dominates — one maintainer who never responds sinks the whole grade). If any signal is `Unknown` due to API errors or missing data, degrade the grade by one step rather than ignore it — missing data is a risk signal.
-
-Display as `{Letter} ({brief reason})`, e.g. `A (merges 85% of PRs, 2-day avg response)`, `C (40-day avg response)`, `F (unresponsive maintainer)`. The grade is separate from the numeric score — score answers "is this issue good to work on?", grade answers "will my PR actually merge?"
+The grade is computed by the CLI and returned in the `grade` field of `vet --json` output: `{ letter: 'A' | 'B' | 'C' | 'F', reason: string }`. Display it verbatim as `{letter} ({reason})` — e.g. `A (~2-day avg response)`, `C (40-day avg response)`, `F (unresponsive maintainers)`. The algorithm (worst-of-three-signals with unknown-degrades-one-step) lives in `packages/core/src/core/issue-grading.ts` with full unit tests.
 
 **Output Format:**
 

--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -247,10 +247,11 @@ export const commands: CLICommandDef[] = [
             if (options.json) {
               outputJson(data);
             } else {
-              const { issue, recommendation, reasonsToApprove, reasonsToSkip } = data;
+              const { issue, recommendation, reasonsToApprove, reasonsToSkip, grade } = data;
               console.log(`\nVetting issue: ${issueUrl}\n`);
               console.log(`[${recommendation.toUpperCase()}] ${issue.repo}#${issue.number}: ${issue.title}`);
               console.log(`  URL: ${issue.url}`);
+              console.log(`  Success grade: ${grade.letter} (${grade.reason})`);
               if (reasonsToApprove.length > 0) console.log(`  Approve: ${reasonsToApprove.join(', ')}`);
               if (reasonsToSkip.length > 0) console.log(`  Skip: ${reasonsToSkip.join(', ')}`);
             }

--- a/packages/core/src/commands/vet-list.ts
+++ b/packages/core/src/commands/vet-list.ts
@@ -8,6 +8,10 @@ import { createAutopilotScout } from './scout-bridge.js';
 import { type VetListOutput, type VetOutput, type VetListItemStatus } from '../formatters/json.js';
 import { runParseList, pruneIssueList } from './parse-list.js';
 import { detectIssueList } from './startup.js';
+import { computeSuccessGrade, gradeFromCandidate } from '../core/issue-grading.js';
+import { getStateManager } from '../core/index.js';
+
+const UNKNOWN_GRADE = computeSuccessGrade({ avgResponseDays: null, mergeRate: null, daysSinceLastCommit: null });
 
 interface VetListOptions {
   issueListPath?: string;
@@ -79,6 +83,11 @@ export async function runVetList(options: VetListOptions = {}): Promise<VetListO
       const item = items[index++];
       try {
         const candidate = await scout.vetIssue(item.url);
+        const grade = gradeFromCandidate({
+          repo: candidate.issue.repo,
+          projectHealth: candidate.projectHealth,
+          getRepoScore: (repo) => getStateManager().getRepoScore(repo),
+        });
         const vetResult: VetOutput = {
           issue: {
             repo: candidate.issue.repo,
@@ -92,6 +101,7 @@ export async function runVetList(options: VetListOptions = {}): Promise<VetListO
           reasonsToSkip: candidate.reasonsToSkip,
           projectHealth: candidate.projectHealth,
           vettingResult: candidate.vettingResult,
+          grade,
         };
 
         results.push({
@@ -107,6 +117,7 @@ export async function runVetList(options: VetListOptions = {}): Promise<VetListO
           reasonsToSkip: [`Error: ${error instanceof Error ? error.message : String(error)}`],
           projectHealth: {},
           vettingResult: {},
+          grade: UNKNOWN_GRADE,
           listStatus: 'error',
           errorMessage: error instanceof Error ? error.message : String(error),
         });

--- a/packages/core/src/commands/vet.test.ts
+++ b/packages/core/src/commands/vet.test.ts
@@ -5,12 +5,21 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockVetIssue = vi.fn();
+const mockGetRepoScore = vi.fn();
 
 vi.mock('./scout-bridge.js', () => ({
   createAutopilotScout: vi.fn(async () => ({
     vetIssue: mockVetIssue,
   })),
 }));
+
+vi.mock('../core/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../core/index.js')>('../core/index.js');
+  return {
+    ...actual,
+    getStateManager: () => ({ getRepoScore: mockGetRepoScore }),
+  };
+});
 
 import { runVet } from './vet.js';
 
@@ -27,22 +36,44 @@ describe('runVet', () => {
       recommendation: 'approve' as const,
       reasonsToApprove: ['Active maintainers', 'Good first issue label'],
       reasonsToSkip: [],
-      projectHealth: { stars: 1000, openIssues: 50 },
+      projectHealth: { avgIssueResponseDays: 2, daysSinceLastCommit: 1 },
       vettingResult: { isViable: true },
     };
     mockVetIssue.mockResolvedValue(candidate);
+    mockGetRepoScore.mockReturnValue({ mergedPRCount: 17, closedWithoutMergeCount: 3 });
 
     const result = await runVet({ issueUrl: TEST_ISSUE_URL });
 
     expect(mockVetIssue).toHaveBeenCalledWith(TEST_ISSUE_URL);
+    expect(mockGetRepoScore).toHaveBeenCalledWith('owner/repo');
     expect(result).toEqual({
       issue: { repo: 'owner/repo', number: 5, title: 'Fix bug', url: TEST_ISSUE_URL, labels: ['bug'] },
       recommendation: 'approve',
       reasonsToApprove: ['Active maintainers', 'Good first issue label'],
       reasonsToSkip: [],
-      projectHealth: { stars: 1000, openIssues: 50 },
+      projectHealth: { avgIssueResponseDays: 2, daysSinceLastCommit: 1 },
       vettingResult: { isViable: true },
+      grade: { letter: 'A', reason: expect.stringMatching(/respons|merge|commit/i) },
     });
+  });
+
+  it('includes grade with unknown merge rate when no repo score exists', async () => {
+    const candidate = {
+      issue: { repo: 'owner/repo', number: 5, title: 'Fix bug', url: TEST_ISSUE_URL, labels: [] },
+      recommendation: 'approve' as const,
+      reasonsToApprove: [],
+      reasonsToSkip: [],
+      projectHealth: { avgIssueResponseDays: 1, daysSinceLastCommit: 1 },
+      vettingResult: {},
+    };
+    mockVetIssue.mockResolvedValue(candidate);
+    mockGetRepoScore.mockReturnValue(undefined);
+
+    const result = await runVet({ issueUrl: TEST_ISSUE_URL });
+
+    // Two A signals + one unknown → degraded to B
+    expect(result.grade.letter).toBe('B');
+    expect(result.grade.reason).toMatch(/unknown/i);
   });
 
   it('should reject a non-GitHub issue URL', async () => {

--- a/packages/core/src/commands/vet.ts
+++ b/packages/core/src/commands/vet.ts
@@ -6,6 +6,8 @@
 import { createAutopilotScout } from './scout-bridge.js';
 import { type VetOutput } from '../formatters/json.js';
 import { ISSUE_URL_PATTERN, validateGitHubUrl, validateUrl } from './validation.js';
+import { gradeFromCandidate } from '../core/issue-grading.js';
+import { getStateManager } from '../core/index.js';
 
 export { type VetOutput } from '../formatters/json.js';
 
@@ -28,6 +30,12 @@ export async function runVet(options: VetOptions): Promise<VetOutput> {
   const scout = await createAutopilotScout();
   const candidate = await scout.vetIssue(options.issueUrl);
 
+  const grade = gradeFromCandidate({
+    repo: candidate.issue.repo,
+    projectHealth: candidate.projectHealth,
+    getRepoScore: (repo) => getStateManager().getRepoScore(repo),
+  });
+
   return {
     issue: {
       repo: candidate.issue.repo,
@@ -41,5 +49,6 @@ export async function runVet(options: VetOptions): Promise<VetOutput> {
     reasonsToSkip: candidate.reasonsToSkip,
     projectHealth: candidate.projectHealth,
     vettingResult: candidate.vettingResult,
+    grade,
   };
 }

--- a/packages/core/src/core/issue-grading.test.ts
+++ b/packages/core/src/core/issue-grading.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect } from 'vitest';
+import { computeSuccessGrade, deriveGradeSignals } from './issue-grading.js';
+
+describe('computeSuccessGrade', () => {
+  describe('responsiveness signal', () => {
+    it('grades A when maintainers respond in under 3 days', () => {
+      const result = computeSuccessGrade({
+        avgResponseDays: 2,
+        mergeRate: 0.9,
+        daysSinceLastCommit: 1,
+      });
+      expect(result.letter).toBe('A');
+    });
+
+    it('grades B for 3–14 day responsiveness', () => {
+      const result = computeSuccessGrade({
+        avgResponseDays: 10,
+        mergeRate: 0.9,
+        daysSinceLastCommit: 1,
+      });
+      expect(result.letter).toBe('B');
+    });
+
+    it('grades C for 14–60 day responsiveness', () => {
+      const result = computeSuccessGrade({
+        avgResponseDays: 40,
+        mergeRate: 0.9,
+        daysSinceLastCommit: 1,
+      });
+      expect(result.letter).toBe('C');
+    });
+
+    it('grades F when responsiveness exceeds 60 days', () => {
+      const result = computeSuccessGrade({
+        avgResponseDays: 90,
+        mergeRate: 0.9,
+        daysSinceLastCommit: 1,
+      });
+      expect(result.letter).toBe('F');
+    });
+
+    it('grades exactly 60 days as C (boundary inclusive)', () => {
+      const result = computeSuccessGrade({
+        avgResponseDays: 60,
+        mergeRate: 0.9,
+        daysSinceLastCommit: 1,
+      });
+      expect(result.letter).toBe('C');
+    });
+
+    it('treats NaN, negative, or infinite response days as unknown', () => {
+      const result = computeSuccessGrade({
+        avgResponseDays: NaN,
+        mergeRate: 0.9,
+        daysSinceLastCommit: 1,
+      });
+      expect(result.letter).toBe('B');
+      expect(result.reason).toMatch(/unknown/i);
+    });
+  });
+
+  describe('merge-rate signal', () => {
+    it('grades A when merge rate exceeds 70%', () => {
+      const result = computeSuccessGrade({
+        avgResponseDays: 1,
+        mergeRate: 0.85,
+        daysSinceLastCommit: 1,
+      });
+      expect(result.letter).toBe('A');
+    });
+
+    it('grades B for 40–70% merge rate', () => {
+      const result = computeSuccessGrade({
+        avgResponseDays: 1,
+        mergeRate: 0.55,
+        daysSinceLastCommit: 1,
+      });
+      expect(result.letter).toBe('B');
+    });
+
+    it('grades C for 10–40% merge rate', () => {
+      const result = computeSuccessGrade({
+        avgResponseDays: 1,
+        mergeRate: 0.2,
+        daysSinceLastCommit: 1,
+      });
+      expect(result.letter).toBe('C');
+    });
+
+    it('grades F below 10% merge rate', () => {
+      const result = computeSuccessGrade({
+        avgResponseDays: 1,
+        mergeRate: 0.05,
+        daysSinceLastCommit: 1,
+      });
+      expect(result.letter).toBe('F');
+    });
+  });
+
+  describe('activity signal', () => {
+    it('grades A for commits within 7 days', () => {
+      const result = computeSuccessGrade({
+        avgResponseDays: 1,
+        mergeRate: 0.9,
+        daysSinceLastCommit: 3,
+      });
+      expect(result.letter).toBe('A');
+    });
+
+    it('grades B for commits 7–30 days', () => {
+      const result = computeSuccessGrade({
+        avgResponseDays: 1,
+        mergeRate: 0.9,
+        daysSinceLastCommit: 20,
+      });
+      expect(result.letter).toBe('B');
+    });
+
+    it('grades C for commits 30–90 days', () => {
+      const result = computeSuccessGrade({
+        avgResponseDays: 1,
+        mergeRate: 0.9,
+        daysSinceLastCommit: 60,
+      });
+      expect(result.letter).toBe('C');
+    });
+
+    it('grades F for no commits in 90+ days', () => {
+      const result = computeSuccessGrade({
+        avgResponseDays: 1,
+        mergeRate: 0.9,
+        daysSinceLastCommit: 120,
+      });
+      expect(result.letter).toBe('F');
+    });
+  });
+
+  describe('worst-of-three aggregation', () => {
+    it('lets a single F dominate', () => {
+      const result = computeSuccessGrade({
+        avgResponseDays: 1,
+        mergeRate: 0.05,
+        daysSinceLastCommit: 1,
+      });
+      expect(result.letter).toBe('F');
+    });
+
+    it('picks worst across mixed letters', () => {
+      const result = computeSuccessGrade({
+        avgResponseDays: 10,
+        mergeRate: 0.2,
+        daysSinceLastCommit: 3,
+      });
+      expect(result.letter).toBe('C');
+    });
+  });
+
+  describe('unknown-degrades rule', () => {
+    it('degrades A to B when one signal is unknown', () => {
+      const result = computeSuccessGrade({
+        avgResponseDays: null,
+        mergeRate: 0.9,
+        daysSinceLastCommit: 1,
+      });
+      expect(result.letter).toBe('B');
+    });
+
+    it('degrades C to F when one signal is unknown', () => {
+      const result = computeSuccessGrade({
+        avgResponseDays: 40,
+        mergeRate: null,
+        daysSinceLastCommit: 1,
+      });
+      expect(result.letter).toBe('F');
+    });
+
+    it('leaves F at F when a signal is unknown', () => {
+      const result = computeSuccessGrade({
+        avgResponseDays: 90,
+        mergeRate: null,
+        daysSinceLastCommit: 1,
+      });
+      expect(result.letter).toBe('F');
+    });
+
+    it('treats multiple unknowns the same as a single unknown', () => {
+      const result = computeSuccessGrade({
+        avgResponseDays: null,
+        mergeRate: null,
+        daysSinceLastCommit: 1,
+      });
+      // Known signal is A, degrade once for unknowns → B
+      expect(result.letter).toBe('B');
+    });
+  });
+
+  describe('deriveGradeSignals', () => {
+    it('maps projectHealth fields straight through', () => {
+      const signals = deriveGradeSignals({
+        projectHealth: { avgIssueResponseDays: 5, daysSinceLastCommit: 2 },
+        repoScore: null,
+      });
+      expect(signals.avgResponseDays).toBe(5);
+      expect(signals.daysSinceLastCommit).toBe(2);
+    });
+
+    it('computes merge rate from repoScore counts', () => {
+      const signals = deriveGradeSignals({
+        projectHealth: { avgIssueResponseDays: 1, daysSinceLastCommit: 1 },
+        repoScore: { mergedPRCount: 17, closedWithoutMergeCount: 3 },
+      });
+      expect(signals.mergeRate).toBeCloseTo(17 / 20);
+    });
+
+    it('returns null mergeRate when no repoScore is available', () => {
+      const signals = deriveGradeSignals({
+        projectHealth: { avgIssueResponseDays: 1, daysSinceLastCommit: 1 },
+        repoScore: null,
+      });
+      expect(signals.mergeRate).toBeNull();
+    });
+
+    it('returns null mergeRate when repoScore has no PR history', () => {
+      const signals = deriveGradeSignals({
+        projectHealth: { avgIssueResponseDays: 1, daysSinceLastCommit: 1 },
+        repoScore: { mergedPRCount: 0, closedWithoutMergeCount: 0 },
+      });
+      expect(signals.mergeRate).toBeNull();
+    });
+
+    it('prefers repoScore.avgResponseDays over scout placeholder', () => {
+      const signals = deriveGradeSignals({
+        // Scout always returns 0 as a placeholder — see oss-scout repo-health.
+        projectHealth: { avgIssueResponseDays: 0, daysSinceLastCommit: 1 },
+        repoScore: { mergedPRCount: 5, closedWithoutMergeCount: 0, avgResponseDays: 12 },
+      });
+      expect(signals.avgResponseDays).toBe(12);
+    });
+
+    it('returns null avgResponseDays when neither source has real data', () => {
+      const signals = deriveGradeSignals({
+        projectHealth: { avgIssueResponseDays: 0, daysSinceLastCommit: 1 },
+        repoScore: { mergedPRCount: 5, closedWithoutMergeCount: 0, avgResponseDays: null },
+      });
+      expect(signals.avgResponseDays).toBeNull();
+    });
+
+    it('returns null signals when checkFailed is set', () => {
+      const signals = deriveGradeSignals({
+        projectHealth: { avgIssueResponseDays: 0, daysSinceLastCommit: 999, checkFailed: true },
+        repoScore: null,
+      });
+      expect(signals.avgResponseDays).toBeNull();
+      expect(signals.daysSinceLastCommit).toBeNull();
+    });
+
+    it('treats out-of-range mergeRate as null', () => {
+      const signals = deriveGradeSignals({
+        projectHealth: { avgIssueResponseDays: 1, daysSinceLastCommit: 1 },
+        repoScore: { mergedPRCount: -3, closedWithoutMergeCount: 10 },
+      });
+      expect(signals.mergeRate).toBeNull();
+    });
+  });
+
+  describe('reason string', () => {
+    it('mentions the driving signal for a failing grade', () => {
+      const result = computeSuccessGrade({
+        avgResponseDays: 90,
+        mergeRate: 0.9,
+        daysSinceLastCommit: 1,
+      });
+      expect(result.letter).toBe('F');
+      expect(result.reason).toMatch(/respons/i);
+    });
+
+    it('mentions the driving signal for a C', () => {
+      const result = computeSuccessGrade({
+        avgResponseDays: 40,
+        mergeRate: 0.9,
+        daysSinceLastCommit: 1,
+      });
+      expect(result.letter).toBe('C');
+      expect(result.reason).toMatch(/40.*day|respons/i);
+    });
+
+    it('mentions that data is missing when degraded by unknowns', () => {
+      const result = computeSuccessGrade({
+        avgResponseDays: null,
+        mergeRate: null,
+        daysSinceLastCommit: 1,
+      });
+      expect(result.letter).toBe('B');
+      expect(result.reason).toMatch(/unknown|missing/i);
+    });
+  });
+});

--- a/packages/core/src/core/issue-grading.ts
+++ b/packages/core/src/core/issue-grading.ts
@@ -1,0 +1,196 @@
+/**
+ * Issue success-likelihood grade (#858).
+ *
+ * Predicts the probability that a contribution to a given repo will be
+ * accepted and merged, using signals already collected during vetting.
+ *
+ * The grade is letter-based (A/B/C/F — no D). Each signal is graded
+ * independently; the overall grade is the worst of the three, and is
+ * further degraded one step if any signal is unknown (missing data is
+ * treated as a risk, not ignored). This matches the policy previously
+ * described as prose in agents/issue-scout.md.
+ */
+
+export type GradeLetter = 'A' | 'B' | 'C' | 'F';
+
+export interface GradeSignals {
+  /** Average maintainer response time in days; null if unknown. */
+  avgResponseDays: number | null;
+  /** Fraction of recent PRs that merged (0–1); null if unknown. */
+  mergeRate: number | null;
+  /** Days since the most recent commit on the default branch; null if unknown. */
+  daysSinceLastCommit: number | null;
+}
+
+export interface GradeResult {
+  letter: GradeLetter;
+  /** Short human-readable explanation of what drove the grade. */
+  reason: string;
+}
+
+type SignalGrade = { letter: GradeLetter; detail: string };
+
+const SEVERITY: Record<GradeLetter, number> = { A: 0, B: 1, C: 2, F: 3 };
+const LETTERS: readonly GradeLetter[] = ['A', 'B', 'C', 'F'];
+
+function worst(grades: SignalGrade[]): SignalGrade {
+  return grades.reduce((acc, g) => (SEVERITY[g.letter] > SEVERITY[acc.letter] ? g : acc));
+}
+
+function degradeOneStep(letter: GradeLetter): GradeLetter {
+  return LETTERS[Math.min(SEVERITY[letter] + 1, LETTERS.length - 1)];
+}
+
+/**
+ * Coerce a candidate numeric signal to `number` if it's finite and in
+ * the given range, otherwise `null`. Non-finite, NaN, and out-of-range
+ * values are treated as unknown (and therefore trigger the degrade
+ * rule) rather than silently producing bogus grades from garbage input.
+ */
+function sanitize(value: number | null | undefined, min: number, max: number): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  if (value < min || value > max) return null;
+  return value;
+}
+
+function gradeResponsiveness(avgResponseDays: number): SignalGrade {
+  if (avgResponseDays < 3) return { letter: 'A', detail: `~${Math.round(avgResponseDays)}-day avg response` };
+  if (avgResponseDays < 14) return { letter: 'B', detail: `${Math.round(avgResponseDays)}-day avg response` };
+  if (avgResponseDays <= 60) return { letter: 'C', detail: `${Math.round(avgResponseDays)}-day avg response` };
+  return { letter: 'F', detail: 'unresponsive maintainers' };
+}
+
+function gradeMergeRate(mergeRate: number): SignalGrade {
+  const pct = Math.round(mergeRate * 100);
+  if (mergeRate > 0.7) return { letter: 'A', detail: `merges ${pct}% of PRs` };
+  if (mergeRate >= 0.4) return { letter: 'B', detail: `merges ${pct}% of PRs` };
+  if (mergeRate >= 0.1) return { letter: 'C', detail: `merges ${pct}% of PRs` };
+  return { letter: 'F', detail: `merges ${pct}% of PRs` };
+}
+
+function gradeActivity(daysSinceLastCommit: number): SignalGrade {
+  if (daysSinceLastCommit < 7) return { letter: 'A', detail: 'commits in last week' };
+  if (daysSinceLastCommit < 30) return { letter: 'B', detail: 'commits in last month' };
+  if (daysSinceLastCommit < 90) return { letter: 'C', detail: 'commits in last 90 days' };
+  return { letter: 'F', detail: `no commits in ${daysSinceLastCommit}+ days` };
+}
+
+/**
+ * Build `GradeSignals` from a vet candidate's project health plus the
+ * optional autopilot-tracked repo score.
+ *
+ * Notes on each signal:
+ *
+ * - `avgResponseDays` — `@oss-scout/core`'s `projectHealth.avgIssueResponseDays`
+ *   is a hardcoded `0` placeholder (it doesn't yet make the additional API
+ *   calls needed to compute a real value). We therefore prefer
+ *   `repoScore.avgResponseDays`, which autopilot derives from its own PR
+ *   tracking, and fall back to `null` (unknown) if neither source has a
+ *   usable value.
+ * - `mergeRate` — derived from repoScore counts. Requires a non-empty PR
+ *   history; `0/0` is `null`, not `0`.
+ * - `daysSinceLastCommit` — taken from scout's `projectHealth`, but only
+ *   when scout's health check succeeded (`checkFailed` means scout filled
+ *   in sentinels and shouldn't be trusted).
+ */
+export function deriveGradeSignals(params: {
+  projectHealth: {
+    avgIssueResponseDays: number | null;
+    daysSinceLastCommit: number | null;
+    checkFailed?: boolean;
+  };
+  repoScore: {
+    mergedPRCount: number;
+    closedWithoutMergeCount: number;
+    avgResponseDays?: number | null;
+  } | null;
+}): GradeSignals {
+  const { projectHealth, repoScore } = params;
+  const healthTrusted = !projectHealth.checkFailed;
+
+  const avgResponseDays =
+    sanitize(repoScore?.avgResponseDays, 0, Number.MAX_SAFE_INTEGER) ??
+    (healthTrusted ? sanitize(projectHealth.avgIssueResponseDays, 0.001, Number.MAX_SAFE_INTEGER) : null);
+
+  const daysSinceLastCommit = healthTrusted
+    ? sanitize(projectHealth.daysSinceLastCommit, 0, Number.MAX_SAFE_INTEGER)
+    : null;
+
+  let mergeRate: number | null = null;
+  if (repoScore) {
+    const merged = sanitize(repoScore.mergedPRCount, 0, Number.MAX_SAFE_INTEGER);
+    const closed = sanitize(repoScore.closedWithoutMergeCount, 0, Number.MAX_SAFE_INTEGER);
+    if (merged !== null && closed !== null) {
+      const total = merged + closed;
+      mergeRate = total === 0 ? null : merged / total;
+    }
+  }
+
+  return { avgResponseDays, mergeRate, daysSinceLastCommit };
+}
+
+/**
+ * End-to-end helper for vet callers: reads the repo score, derives
+ * signals from a scout candidate, and returns the grade. Callers pass
+ * the `projectHealth` straight through from `scout.vetIssue()`.
+ */
+export function gradeFromCandidate(params: {
+  repo: string;
+  projectHealth: {
+    avgIssueResponseDays: number | null;
+    daysSinceLastCommit: number | null;
+    checkFailed?: boolean;
+  };
+  getRepoScore: (repo: string) =>
+    | {
+        mergedPRCount: number;
+        closedWithoutMergeCount: number;
+        avgResponseDays: number | null;
+      }
+    | undefined;
+}): GradeResult {
+  const repoScore = params.getRepoScore(params.repo);
+  return computeSuccessGrade(
+    deriveGradeSignals({
+      projectHealth: params.projectHealth,
+      repoScore: repoScore
+        ? {
+            mergedPRCount: repoScore.mergedPRCount,
+            closedWithoutMergeCount: repoScore.closedWithoutMergeCount,
+            avgResponseDays: repoScore.avgResponseDays,
+          }
+        : null,
+    }),
+  );
+}
+
+export function computeSuccessGrade(signals: GradeSignals): GradeResult {
+  const graded: SignalGrade[] = [];
+  const unknowns: string[] = [];
+
+  const resp = sanitize(signals.avgResponseDays, 0, Number.MAX_SAFE_INTEGER);
+  if (resp === null) unknowns.push('maintainer responsiveness');
+  else graded.push(gradeResponsiveness(resp));
+
+  const mr = sanitize(signals.mergeRate, 0, 1);
+  if (mr === null) unknowns.push('merge rate');
+  else graded.push(gradeMergeRate(mr));
+
+  const act = sanitize(signals.daysSinceLastCommit, 0, Number.MAX_SAFE_INTEGER);
+  if (act === null) unknowns.push('activity');
+  else graded.push(gradeActivity(act));
+
+  // No signal available at all — give F so callers see missing data as a
+  // strong negative rather than a neutral grade.
+  if (graded.length === 0) {
+    return { letter: 'F', reason: `unknown ${unknowns.join(', ')}` };
+  }
+
+  const worstKnown = worst(graded);
+  const finalLetter = unknowns.length > 0 ? degradeOneStep(worstKnown.letter) : worstKnown.letter;
+
+  const reasonParts = [worstKnown.detail];
+  if (unknowns.length > 0) reasonParts.push(`unknown ${unknowns.join(', ')}`);
+
+  return { letter: finalLetter, reason: reasonParts.join(', ') };
+}

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -409,6 +409,11 @@ export interface VetOutput {
   reasonsToSkip: string[];
   projectHealth: unknown;
   vettingResult: unknown;
+  /** Success-likelihood grade (#858): predicts whether a PR will merge. */
+  grade: {
+    letter: 'A' | 'B' | 'C' | 'F';
+    reason: string;
+  };
 }
 
 /** Output of the comments command */


### PR DESCRIPTION
## Summary

- Extract the "success-likelihood grade" algorithm from prose in `agents/issue-scout.md` into a pure function in `packages/core/src/core/issue-grading.ts` with 31 unit tests
- Surface `grade: { letter: 'A'|'B'|'C'|'F', reason: string }` as a first-class field on the JSON output of `vet` and `vet-list` CLI commands
- Trim the agent markdown to "read the `grade` field" instead of restating the worst-of-three-signals + unknown-degrades-one-step rules

## Scope note

Addresses item 1 of issue #967. The other two algorithms it lists — linked-PR classification and anti-LLM policy scan — are deliberately deferred because both need surface-area changes in \`@oss-scout/core\` (linked-PR metadata passthrough; formalizing the keyword scan). Will file follow-up issues against that package.

## Two signal-derivation bugs fixed while wiring this up

1. **Scout's \`avgIssueResponseDays\` is a placeholder.** \`@oss-scout/core\`'s \`projectHealth.avgIssueResponseDays\` is hardcoded to 0 (it would need extra API calls to compute a real value). Grading it straight through meant every issue scored "A (~0-day avg response)" regardless of reality. The grade now prefers \`state.repoScores[repo].avgResponseDays\`, which autopilot computes from its own PR tracking, and falls back to "unknown" rather than trusting the placeholder.
2. **\`projectHealth.checkFailed\` was not respected.** When scout sets \`checkFailed: true\` the remaining health fields are sentinel values (e.g. \`daysSinceLastCommit: 999\`). These were previously graded at face value, producing confidently-wrong Fs. The derive step now maps them to "unknown" so the degrade-one-step rule fires instead.

## Test plan

- [ ] \`pnpm test\` (core: 1824 tests pass including 31 new grade tests; dashboard + mcp-server unchanged)
- [ ] \`pnpm run lint\` clean
- [ ] \`pnpm run bundle\` builds cleanly at 691KB (under the 720KB cap)
- [ ] \`npx tsc --noEmit\` in packages/core clean
- [ ] Manual check: \`pnpm start -- vet <issue-url> --json\` includes \`grade\` field