### PR TITLE
refactor: extract linked-PR classification to core function (#978)

### DIFF
--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -268,12 +268,16 @@ gh issue view OWNER/REPO#NUMBER --json body,comments --jq '[.body, .comments[].b
 USER_LOGIN=$(gh api user --jq '.login')
 ```
 
-Classify the linked PR by `author.login`:
-- **Open PR authored by `$USER_LOGIN`** → the user is already working on this. **Mark the issue as "In Progress" with a link to their PR. Do NOT recommend Pursue/Maybe — this is already claimed by the user themselves.** In the curated list, update the entry to `**In Progress** — PR #XX` (user's own). Do NOT include the issue in "pick from your list" options.
-- **Open PR authored by someone else** → competition. Skip (someone is actively working).
-- **Closed PR authored by `$USER_LOGIN`** → the user's prior attempt was closed without merge. Note this as a relationship signal (possible friction); may still be worth Pursue if the issue is still open and the closure reason was unrelated.
-- **Closed PR authored by someone else** → note it; may indicate difficulty or maintainer preferences, but the issue is still technically available.
-- **No linked PR** → proceed to normal scoring.
+Classification is a pure function in `packages/core/src/core/linked-pr-classification.ts` — call `classifyLinkedPR({ linkedPR, userLogin })` with the first linked PR (or `null` if none) and the user's login. Map the returned value as follows:
+
+- `user_open` — the user is already working on this. **Mark the issue as "In Progress" with a link to their PR. Do NOT recommend Pursue/Maybe — this is already claimed by the user themselves.** In the curated list, update the entry to `**In Progress** — PR #XX` (user's own). Do NOT include the issue in "pick from your list" options.
+- `other_open` — competition. Skip (someone is actively working).
+- `user_closed` — the user's prior attempt was closed without merge. Note this as a relationship signal (possible friction); may still be worth Pursue if the issue is still open and the closure reason was unrelated.
+- `other_closed` — note it; may indicate difficulty or maintainer preferences, but the issue is still technically available.
+- `user_merged` / `other_merged` — a linked PR was merged. The issue is almost certainly resolved even if GitHub still shows it open; skip and flag the stale issue.
+- `none` — proceed to normal scoring.
+
+The pure function handles case-insensitive GitHub login matching, ghost-author edge cases, and both REST lowercase + GraphQL uppercase state values. Once scout surfaces linked-PR metadata on `IssueCandidate` (tracked in #978), the vet command will call this function and return the classification as a structured field in `vet --json`.
 
 ### 2. Contribution Guidelines Check
 

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -68,6 +68,12 @@ export {
 export { computeContributionStats, type ContributionStats, type ComputeStatsInput } from './stats.js';
 export { fetchPRTemplate, type PRTemplateResult } from './pr-template.js';
 export {
+  classifyLinkedPR,
+  type LinkedPR,
+  type LinkedPRClassification,
+  type LinkedPRState,
+} from './linked-pr-classification.js';
+export {
   detectFormatters,
   diagnoseCIFormatterFailure,
   getPreferredFormatter,

--- a/packages/core/src/core/linked-pr-classification.test.ts
+++ b/packages/core/src/core/linked-pr-classification.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { classifyLinkedPR } from './linked-pr-classification.js';
+
+describe('classifyLinkedPR', () => {
+  it('returns none when there is no linked PR', () => {
+    const result = classifyLinkedPR({ linkedPR: null, userLogin: 'costajohnt' });
+    expect(result).toBe('none');
+  });
+
+  it('returns user_open when the user authored the open linked PR', () => {
+    const result = classifyLinkedPR({
+      linkedPR: { author: { login: 'costajohnt' }, state: 'open' },
+      userLogin: 'costajohnt',
+    });
+    expect(result).toBe('user_open');
+  });
+
+  it('returns user_closed when the user authored the closed linked PR', () => {
+    const result = classifyLinkedPR({
+      linkedPR: { author: { login: 'costajohnt' }, state: 'closed' },
+      userLogin: 'costajohnt',
+    });
+    expect(result).toBe('user_closed');
+  });
+
+  it('returns other_open when someone else authored the open linked PR', () => {
+    const result = classifyLinkedPR({
+      linkedPR: { author: { login: 'dependabot[bot]' }, state: 'open' },
+      userLogin: 'costajohnt',
+    });
+    expect(result).toBe('other_open');
+  });
+
+  it('returns other_closed when someone else authored the closed linked PR', () => {
+    const result = classifyLinkedPR({
+      linkedPR: { author: { login: 'contributor' }, state: 'closed' },
+      userLogin: 'costajohnt',
+    });
+    expect(result).toBe('other_closed');
+  });
+
+  it('compares logins case-insensitively (GitHub usernames are case-insensitive)', () => {
+    const result = classifyLinkedPR({
+      linkedPR: { author: { login: 'CostaJohnt' }, state: 'open' },
+      userLogin: 'costajohnt',
+    });
+    expect(result).toBe('user_open');
+  });
+
+  it('treats empty userLogin as non-match (cannot be the user)', () => {
+    const result = classifyLinkedPR({
+      linkedPR: { author: { login: 'contributor' }, state: 'open' },
+      userLogin: '',
+    });
+    expect(result).toBe('other_open');
+  });
+
+  it('treats a missing author login as other_X (defensive — cannot prove it is the user)', () => {
+    const result = classifyLinkedPR({
+      linkedPR: { author: { login: '' }, state: 'closed' },
+      userLogin: 'costajohnt',
+    });
+    expect(result).toBe('other_closed');
+  });
+
+  describe('merged PRs', () => {
+    it('classifies a user-authored merged PR as user_merged', () => {
+      const result = classifyLinkedPR({
+        linkedPR: { author: { login: 'costajohnt' }, state: 'merged' },
+        userLogin: 'costajohnt',
+      });
+      expect(result).toBe('user_merged');
+    });
+
+    it("classifies someone else's merged PR as other_merged", () => {
+      const result = classifyLinkedPR({
+        linkedPR: { author: { login: 'contributor' }, state: 'merged' },
+        userLogin: 'costajohnt',
+      });
+      expect(result).toBe('other_merged');
+    });
+  });
+
+  describe('state casing and normalization', () => {
+    it('accepts uppercase state values (GraphQL PullRequestState enum)', () => {
+      // @ts-expect-error — runtime test for uppercase input
+      const result = classifyLinkedPR({
+        linkedPR: { author: { login: 'contributor' }, state: 'OPEN' },
+        userLogin: 'costajohnt',
+      });
+      expect(result).toBe('other_open');
+    });
+
+    it('accepts uppercase MERGED from GraphQL', () => {
+      // @ts-expect-error — runtime test for uppercase input
+      const result = classifyLinkedPR({
+        linkedPR: { author: { login: 'costajohnt' }, state: 'MERGED' },
+        userLogin: 'costajohnt',
+      });
+      expect(result).toBe('user_merged');
+    });
+  });
+
+  describe('ghost author handling', () => {
+    it('treats a null author (deleted GitHub account) as other_X', () => {
+      const result = classifyLinkedPR({
+        // @ts-expect-error — runtime test: GitHub returns null author for deleted accounts
+        linkedPR: { author: null, state: 'closed' },
+        userLogin: 'costajohnt',
+      });
+      expect(result).toBe('other_closed');
+    });
+
+    it('treats a missing author field as other_X', () => {
+      const result = classifyLinkedPR({
+        // @ts-expect-error — runtime test: malformed payload without author
+        linkedPR: { state: 'open' },
+        userLogin: 'costajohnt',
+      });
+      expect(result).toBe('other_open');
+    });
+  });
+});

--- a/packages/core/src/core/linked-pr-classification.ts
+++ b/packages/core/src/core/linked-pr-classification.ts
@@ -1,0 +1,73 @@
+/**
+ * Linked-PR classification (#910, #978).
+ *
+ * Given the first linked PR on an issue, decide how it affects whether
+ * the issue is actionable for the current user. Previously described as
+ * prose in agents/issue-scout.md; extracted here as a pure function so
+ * the classification is unit-testable and uniform across callers.
+ *
+ * Integration with the vet flow is deferred — scout does not yet surface
+ * linked-PR metadata on `IssueCandidate`, so consumers need to fetch the
+ * linked PR themselves (e.g. via Octokit) and hand the shape to this
+ * function. See #978 for the upstream data-contract work.
+ */
+
+export type LinkedPRClassification =
+  | 'none'
+  | 'user_open'
+  | 'user_closed'
+  | 'user_merged'
+  | 'other_open'
+  | 'other_closed'
+  | 'other_merged';
+
+export type LinkedPRState = 'open' | 'closed' | 'merged';
+
+export interface LinkedPR {
+  /**
+   * May be `null` for deleted GitHub accounts ("ghost" users); the
+   * declared type on GitHub's API allows null here even though the REST
+   * schema example typically shows a populated user.
+   */
+  author: { login: string } | null;
+  state: LinkedPRState;
+}
+
+/**
+ * Normalize a state value from either REST (lowercase `open`/`closed`
+ * plus a separate `merged` boolean) or GraphQL (uppercase `OPEN`/
+ * `CLOSED`/`MERGED` union) into our internal lowercase form. Callers
+ * converting from REST should pre-mix `merged` into the state before
+ * calling; see the tests for expected shapes.
+ */
+function normalizeState(state: string): LinkedPRState | null {
+  const lower = state.toLowerCase();
+  if (lower === 'open' || lower === 'closed' || lower === 'merged') return lower;
+  return null;
+}
+
+export function classifyLinkedPR(params: { linkedPR: LinkedPR | null; userLogin: string }): LinkedPRClassification {
+  const { linkedPR, userLogin } = params;
+  if (!linkedPR) return 'none';
+
+  const state = normalizeState(linkedPR.state);
+  // Unknown state (e.g., future-extended values) is safest to treat as
+  // "closed" — skip-worthy but non-fatal — rather than throwing and
+  // breaking the whole vetting pipeline on one malformed payload.
+  const effectiveState: LinkedPRState = state ?? 'closed';
+
+  // GitHub usernames are case-insensitive ASCII. Ghost authors (deleted
+  // accounts) return `null` or an empty login; in both cases we can't
+  // prove the PR is the user's own, so we classify it as "other_*".
+  const authorLogin = linkedPR.author?.login ?? '';
+  const isUserOwn = authorLogin !== '' && userLogin !== '' && authorLogin.toLowerCase() === userLogin.toLowerCase();
+
+  if (isUserOwn) {
+    if (effectiveState === 'open') return 'user_open';
+    if (effectiveState === 'merged') return 'user_merged';
+    return 'user_closed';
+  }
+  if (effectiveState === 'open') return 'other_open';
+  if (effectiveState === 'merged') return 'other_merged';
+  return 'other_closed';
+}


### PR DESCRIPTION
## Summary

- Extract the "classify the linked PR by author.login" algorithm from prose in `agents/issue-scout.md` into a pure function `classifyLinkedPR` in `packages/core/src/core/linked-pr-classification.ts`
- Adds 14 unit tests covering the five prose cases plus merged-state and data-contract edge cases surfaced during review
- Trims the corresponding section in the agent markdown to a mapping table keyed on the classification outputs

## Scope note

This is library-only in this PR. `@oss-scout/core`'s `IssueCandidate` output does not yet expose linked-PR metadata (only `vettingResult.checks.noExistingPR: boolean`), so integration into `vet --json` is deferred until the upstream data-contract work in #978 lands. Once scout surfaces the metadata, a follow-up PR wires the function into `runVet` / `runVetList` and adds a `linkedPRClassification` field to `VetOutput`.

## Classification outputs

\`\`\`
none | user_open | user_closed | user_merged | other_open | other_closed | other_merged
\`\`\`

The prose previously described only five outputs (no merged-state handling). The extraction adds \`user_merged\` / \`other_merged\` so callers can distinguish a merged linked PR from a closed-unmerged one — an issue still open with a merged linked PR is almost certainly stale and skip-worthy.

## Defensive handling from review

- **State normalization** — accepts both REST lowercase (\`open\`/\`closed\`/\`merged\`) and GraphQL uppercase (\`OPEN\`/\`CLOSED\`/\`MERGED\` from the \`PullRequestState\` enum)
- **Ghost authors** — null / missing author (GitHub returns this for deleted accounts) is classified as \`other_*\` rather than throwing
- **Unknown state** — anything outside the normalized set falls through to \`closed\` rather than breaking the vetting pipeline on one malformed payload

## Test plan

- [ ] \`pnpm test\` — 14 new tests, 1838 total passing
- [ ] \`pnpm run lint\` clean
- [ ] \`npx tsc --noEmit\` in packages/core clean