### PR TITLE
refactor: extract anti-LLM policy scan to core function (#979)

### DIFF
--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -158,16 +158,15 @@ Some repositories have anti-AI contribution policies that reject or hide AI-assi
 
 **During every vetting (CLI or manual), scan CONTRIBUTING.md, CODE_OF_CONDUCT.md, and README for anti-LLM/AI policy language. This is a hard skip — the entire OSS autopilot workflow is AI-assisted, so these repos are fundamentally incompatible.**
 
-Run this scan on the files already fetched in section 2 (Contribution Guidelines Check) — no extra API calls needed. Look for any of these patterns (case-insensitive) in the text:
+Run this scan on the files already fetched in section 2 (Contribution Guidelines Check) — no extra API calls needed. The keyword-match algorithm lives in `packages/core/src/core/anti-llm-policy.ts`: call `scanForAntiLLMPolicy(text)` with the concatenated contents of those files. The returned `AntiLLMScanResult` has `matched: boolean` and `matches: Array<{ category, phrase, excerpt }>`, where `category` is one of:
 
-| Signal | Example phrases |
-|---|---|
-| Explicit LLM ban | `do not submit code written by LLM`, `no LLM-generated`, `no LLM-authored`, `no AI-generated code`, `no AI-written`, `no AI contributions` |
-| Specific tool bans | `no Copilot`, `no ChatGPT`, `no Claude`, `no Cursor`, `no AI coding tools` |
-| Disclosure requirement framed as discouragement | `we do not accept AI-generated`, `AI contributions will be closed`, `AI-assisted PRs are rejected` |
-| Hidden/spammed signals | Comments hidden as spam on issues, policy PRs filed against AI-assisted contributions, maintainer comments about AI-generated code |
+- `explicit_ban` — phrases like "no AI-generated" / "no LLM-authored"
+- `tool_ban` — named-tool bans like "no Copilot" / "no ChatGPT"
+- `reject_framing` — "AI contributions will be closed", "we do not accept AI"
 
-**If any anti-LLM/AI signal is detected, this is a HARD SKIP regardless of the viability score:**
+Hidden/spammed signals (comments hidden as spam on issues, policy PRs against AI contributions, etc.) are not scannable from document text alone — note those manually when observed during vetting.
+
+**If `scanForAntiLLMPolicy` returns `matched: true`, this is a HARD SKIP regardless of the viability score:**
 
 1. Set recommendation to `skip` with reason `"anti-LLM policy"` (or `"anti-AI policy"` — match the repo's wording).
 2. Auto-exclude the repo from future searches by updating the blocklist:

--- a/packages/core/src/core/anti-llm-policy.test.ts
+++ b/packages/core/src/core/anti-llm-policy.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest';
+import { scanForAntiLLMPolicy } from './anti-llm-policy.js';
+
+describe('scanForAntiLLMPolicy', () => {
+  it('returns matched=false for empty text', () => {
+    const result = scanForAntiLLMPolicy('');
+    expect(result.matched).toBe(false);
+    expect(result.matches).toEqual([]);
+  });
+
+  it('returns matched=false for text with no policy signals', () => {
+    const result = scanForAntiLLMPolicy('Welcome! Please read our contributing guide.');
+    expect(result.matched).toBe(false);
+    expect(result.matches).toEqual([]);
+  });
+
+  describe('explicit LLM ban signals', () => {
+    it('matches "no AI-generated code"', () => {
+      const result = scanForAntiLLMPolicy('We do not accept no AI-generated code in this repo.');
+      expect(result.matched).toBe(true);
+      expect(
+        result.matches.some((m) => m.category === 'explicit_ban' && m.phrase.toLowerCase().includes('ai-generated')),
+      ).toBe(true);
+    });
+
+    it('matches "no LLM-generated"', () => {
+      const result = scanForAntiLLMPolicy('We accept no LLM-generated code.');
+      expect(result.matched).toBe(true);
+      expect(result.matches.some((m) => m.category === 'explicit_ban' && m.phrase.toLowerCase().includes('llm'))).toBe(
+        true,
+      );
+    });
+
+    it('matches "no AI contributions"', () => {
+      const result = scanForAntiLLMPolicy('This project does not accept no AI contributions.');
+      expect(result.matched).toBe(true);
+      expect(result.matches.some((m) => m.category === 'explicit_ban')).toBe(true);
+    });
+  });
+
+  describe('tool-specific bans', () => {
+    it('matches "no Copilot"', () => {
+      const result = scanForAntiLLMPolicy('Policy: no Copilot-generated code accepted.');
+      expect(result.matched).toBe(true);
+      expect(result.matches.some((m) => m.category === 'tool_ban')).toBe(true);
+    });
+
+    it('matches "no ChatGPT"', () => {
+      const result = scanForAntiLLMPolicy('Contributing: no ChatGPT or similar tools.');
+      expect(result.matched).toBe(true);
+      expect(result.matches.some((m) => m.category === 'tool_ban')).toBe(true);
+    });
+
+    it('matches tool bans case-insensitively', () => {
+      const result = scanForAntiLLMPolicy('NO COPILOT allowed here.');
+      expect(result.matched).toBe(true);
+      expect(result.matches.some((m) => m.category === 'tool_ban')).toBe(true);
+    });
+  });
+
+  describe('reject-framing signals', () => {
+    it('matches "AI contributions will be closed"', () => {
+      const result = scanForAntiLLMPolicy('Any AI contributions will be closed without review.');
+      expect(result.matched).toBe(true);
+      expect(result.matches.some((m) => m.category === 'reject_framing')).toBe(true);
+    });
+
+    it('matches "we do not accept AI"', () => {
+      const result = scanForAntiLLMPolicy('Please note: we do not accept AI-assisted PRs.');
+      expect(result.matched).toBe(true);
+      expect(result.matches.some((m) => m.category === 'reject_framing')).toBe(true);
+    });
+  });
+
+  describe('excerpt extraction', () => {
+    it('includes an excerpt showing the match in context', () => {
+      const text =
+        'Lorem ipsum dolor sit amet. We do not accept AI-generated code in this repo. Consectetur adipiscing elit.';
+      const result = scanForAntiLLMPolicy(text);
+      expect(result.matched).toBe(true);
+      expect(result.matches[0].excerpt).toContain('AI-generated');
+      expect(result.matches[0].excerpt.length).toBeLessThan(text.length);
+    });
+  });
+
+  describe('multiple matches', () => {
+    it('returns all matched patterns', () => {
+      const text = 'We do not accept AI-generated code. Also, no Copilot allowed.';
+      const result = scanForAntiLLMPolicy(text);
+      expect(result.matched).toBe(true);
+      const categories = new Set(result.matches.map((m) => m.category));
+      expect(categories.has('explicit_ban') || categories.has('reject_framing')).toBe(true);
+      expect(categories.has('tool_ban')).toBe(true);
+    });
+
+    it('deduplicates identical phrases that match multiple times in the same text', () => {
+      const text = 'no Copilot. no Copilot. no Copilot.';
+      const result = scanForAntiLLMPolicy(text);
+      expect(result.matched).toBe(true);
+      const copilotMatches = result.matches.filter((m) => m.phrase.toLowerCase().includes('copilot'));
+      expect(copilotMatches.length).toBe(1);
+    });
+  });
+
+  describe('false-positive resistance', () => {
+    it('does not match a positive statement about AI use', () => {
+      const result = scanForAntiLLMPolicy('We welcome AI-assisted contributions! Just disclose them.');
+      expect(result.matched).toBe(false);
+    });
+
+    it('does not match a mention of Copilot without negation', () => {
+      const result = scanForAntiLLMPolicy('This project supports GitHub Copilot integration.');
+      expect(result.matched).toBe(false);
+    });
+
+    it('does not match "AI will be closed" without a contribution-noun', () => {
+      // Business announcement, not a contribution policy.
+      const result = scanForAntiLLMPolicy('The AI division will be closed at the end of Q4.');
+      expect(result.matched).toBe(false);
+    });
+
+    it('does not match an unrelated mention of "closed" near "AI"', () => {
+      const result = scanForAntiLLMPolicy('We use AI. The issue tracker was closed for maintenance.');
+      expect(result.matched).toBe(false);
+    });
+
+    it('does not match "no copilot-style autocomplete"', () => {
+      const result = scanForAntiLLMPolicy('no copilot-style autocomplete is enabled by default.');
+      expect(result.matched).toBe(false);
+    });
+
+    it('does not match "AI PRs are closed to new comments"', () => {
+      const result = scanForAntiLLMPolicy('The old AI PRs are closed to new comments.');
+      expect(result.matched).toBe(false);
+    });
+
+    it('does not match "does not accept AI suggestions from your IDE"', () => {
+      const result = scanForAntiLLMPolicy('This plugin does not accept AI suggestions from your IDE as-is.');
+      expect(result.matched).toBe(false);
+    });
+  });
+
+  describe('unicode and whitespace normalization', () => {
+    it('matches across non-breaking hyphen (U+2011)', () => {
+      const result = scanForAntiLLMPolicy('Policy: no AI\u2011generated code accepted.');
+      expect(result.matched).toBe(true);
+    });
+
+    it('matches across non-breaking space', () => {
+      const result = scanForAntiLLMPolicy('Policy: no\u00a0Copilot allowed.');
+      expect(result.matched).toBe(true);
+    });
+  });
+
+  describe('input validation', () => {
+    it('throws on non-string input rather than silently returning matched=false', () => {
+      // @ts-expect-error — runtime contract check
+      expect(() => scanForAntiLLMPolicy(null)).toThrow(TypeError);
+      // @ts-expect-error — runtime contract check
+      expect(() => scanForAntiLLMPolicy(undefined)).toThrow(TypeError);
+      // @ts-expect-error — runtime contract check
+      expect(() => scanForAntiLLMPolicy(Buffer.from('hello'))).toThrow(TypeError);
+    });
+  });
+});

--- a/packages/core/src/core/anti-llm-policy.ts
+++ b/packages/core/src/core/anti-llm-policy.ts
@@ -1,0 +1,130 @@
+/**
+ * Anti-LLM policy scan (#108, #911, #979).
+ *
+ * Scan concatenated repo docs (CONTRIBUTING.md, CODE_OF_CONDUCT.md,
+ * README) for language that indicates the project does not accept
+ * AI/LLM-generated contributions. Previously described as a keyword
+ * table in prose in agents/issue-scout.md.
+ *
+ * The long-term home for this logic is `@oss-scout/core`, where the
+ * relevant files are already fetched during vetting. Keeping it here
+ * for now lets the agent invoke it directly and gives scout a
+ * reference implementation + test fixtures to adopt. See #979.
+ *
+ * Precision matters more than recall. False positives (flagging a
+ * project that actually welcomes AI help) silently shrink the user's
+ * contribution surface without recourse. We only match on phrases
+ * that combine a rejection keyword (no / reject / will be closed /
+ * don't accept) with an AI/LLM noun.
+ */
+
+export type AntiLLMCategory = 'explicit_ban' | 'tool_ban' | 'reject_framing';
+
+export interface AntiLLMMatch {
+  category: AntiLLMCategory;
+  /** The exact substring from the source text that triggered the match. */
+  phrase: string;
+  /** ~80 character window around the match, for surfacing to the user. */
+  excerpt: string;
+}
+
+export interface AntiLLMScanResult {
+  matched: boolean;
+  matches: AntiLLMMatch[];
+}
+
+interface Pattern {
+  category: AntiLLMCategory;
+  regex: RegExp;
+}
+
+const PATTERNS: Pattern[] = [
+  // Explicit "no X" bans against AI/LLM nouns.
+  { category: 'explicit_ban', regex: /\bno\s+(ai|llm)[-\s](generated|authored|written|assisted|contributions?)/i },
+  { category: 'explicit_ban', regex: /\b(ban|banned|banning)\s+(ai|llm)\b/i },
+
+  // Named-tool bans. Optionally match a "-generated/-authored/-…"
+  // continuation (clear ban wording), and use a negative lookahead to
+  // reject unrelated hyphen-words like "no copilot-style autocomplete"
+  // (which describes a feature, not a contribution policy).
+  {
+    category: 'tool_ban',
+    regex: /\bno\s+(copilot|chatgpt|claude|cursor)(-(generated|authored|assisted|written))?(?![a-z-])/i,
+  },
+  { category: 'tool_ban', regex: /\bno\s+ai\s+coding\s+tools?\b/i },
+
+  // Rejection framing. To avoid false positives like "AI PRs are closed
+  // to new comments" (closed means something else) or "AI suggestions
+  // from your IDE" (not a contribution), we require both an AI/LLM
+  // qualifier AND a contribution noun AND a rejection verb phrase. The
+  // two patterns cover "AI-generated code will be closed" (with
+  // participle) and "AI contributions will be closed" (without).
+  {
+    category: 'reject_framing',
+    regex:
+      /\b(ai|llm)[-\s](generated|assisted|authored|written)\s+(code|prs?|contributions?)\s+(will\s+be\s+(closed|rejected)|are\s+rejected)/i,
+  },
+  {
+    category: 'reject_framing',
+    regex: /\b(ai|llm)\s+(code|prs?|contributions?)\s+(will\s+be\s+(closed|rejected)|are\s+rejected)/i,
+  },
+  // "do/does not accept AI-{noun}" / "reject AI contributions" — both
+  // require a contribution noun to avoid matching "accept AI suggestions
+  // from your IDE" or similar incidental mentions.
+  {
+    category: 'reject_framing',
+    regex:
+      /\b(do|does)(\s+not|n't)\s+accept\s+(ai|llm)[-\s](generated|assisted|authored|written|contributions?|code|prs?)\b/i,
+  },
+  { category: 'reject_framing', regex: /\breject\s+(ai|llm)\s+contributions?\b/i },
+];
+
+const EXCERPT_RADIUS = 40;
+
+function makeExcerpt(text: string, matchIndex: number, matchLength: number): string {
+  const start = Math.max(0, matchIndex - EXCERPT_RADIUS);
+  const end = Math.min(text.length, matchIndex + matchLength + EXCERPT_RADIUS);
+  const prefix = start > 0 ? '…' : '';
+  const suffix = end < text.length ? '…' : '';
+  return `${prefix}${text.slice(start, end).replace(/\s+/g, ' ').trim()}${suffix}`;
+}
+
+/**
+ * Normalize exotic whitespace and hyphens so patterns written with plain
+ * ASCII still match real-world markdown. Covers non-breaking space,
+ * non-breaking hyphen, en dash, em dash, and figure dash — all of which
+ * show up in CONTRIBUTING files authored in rich-text editors.
+ */
+function normalizeText(text: string): string {
+  return text
+    .normalize('NFKC')
+    .replace(/[\u00A0]/g, ' ')
+    .replace(/[\u2010\u2011\u2012\u2013\u2014\u2015]/g, '-');
+}
+
+export function scanForAntiLLMPolicy(text: string): AntiLLMScanResult {
+  if (typeof text !== 'string') {
+    throw new TypeError(`scanForAntiLLMPolicy: expected string, received ${typeof text}`);
+  }
+  if (text === '') return { matched: false, matches: [] };
+
+  const normalized = normalizeText(text);
+  const seenLabels = new Set<string>();
+  const matches: AntiLLMMatch[] = [];
+
+  for (const pattern of PATTERNS) {
+    const hit = normalized.match(pattern.regex);
+    if (!hit || hit.index === undefined) continue;
+    const phrase = hit[0];
+    const key = `${pattern.category}:${phrase.toLowerCase()}`;
+    if (seenLabels.has(key)) continue;
+    seenLabels.add(key);
+    matches.push({
+      category: pattern.category,
+      phrase,
+      excerpt: makeExcerpt(normalized, hit.index, phrase.length),
+    });
+  }
+
+  return { matched: matches.length > 0, matches };
+}

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -74,6 +74,12 @@ export {
   type LinkedPRState,
 } from './linked-pr-classification.js';
 export {
+  scanForAntiLLMPolicy,
+  type AntiLLMCategory,
+  type AntiLLMMatch,
+  type AntiLLMScanResult,
+} from './anti-llm-policy.js';
+export {
   detectFormatters,
   diagnoseCIFormatterFailure,
   getPreferredFormatter,


### PR DESCRIPTION
## Summary

- Extract the anti-LLM/AI policy keyword-table scan from prose in `agents/issue-scout.md` into a pure function `scanForAntiLLMPolicy(text)` in `packages/core/src/core/anti-llm-policy.ts`
- 23 unit tests covering the three signal categories (`explicit_ban` / `tool_ban` / `reject_framing`), excerpt extraction, dedup, and false-positive regression cases
- Trims the agent markdown to "call scanForAntiLLMPolicy on concatenated doc text; if matched, hard-skip + add to blocklist"

## Scope note

Reference implementation in autopilot. Long-term home is the oss-scout package, which already fetches these files during vetting. Having a tested version here lets the agent use it today and gives scout test fixtures + a known-good implementation to adopt. Integration into vet output is deferred.

## Precision-first design

False positives silently shrink the user's contribution surface (we skip a repo that actually welcomes AI help), so every pattern requires both an AI/LLM qualifier AND a contribution noun (code / PRs / contributions) AND a rejection verb. Regression tests explicitly exclude:

- \`"no copilot-style autocomplete"\` — a feature reference, not a ban
- \`"AI PRs are closed to new comments"\` — "closed" = discussion-state close
- \`"does not accept AI suggestions from your IDE"\` — not a contribution
- \`"We welcome AI-assisted contributions"\` — positive statement

## Review-driven hardening

- Throws \`TypeError\` on non-string input (previously a \`Buffer\` or base64 string would have silently returned \`matched: false\` — the vetting gate would then miss real policies)
- Normalizes \`NFKC\` and rewrites non-breaking space / non-breaking hyphen / en-dash / em-dash / figure-dash to ASCII before scanning, so policies authored in rich-text editors (Docs, Notion) still match
- Tool-ban regex uses \`(?![a-z-])\` lookahead to accept \`"no Copilot."\` / \`"no Copilot-generated code"\` but reject \`"no copilot-style autocomplete"\`

## Test plan

- [ ] \`pnpm test\` — 23 new tests, 1847 total passing
- [ ] \`pnpm run lint\` clean
- [ ] \`npx tsc --noEmit\` in packages/core clean