### PR TITLE
fix(dashboard): align shelvedPRUrls with stats.shelvedPRs count

### DIFF
--- a/packages/core/src/commands/dashboard-server.test.ts
+++ b/packages/core/src/commands/dashboard-server.test.ts
@@ -123,6 +123,7 @@ vi.mock('./rate-limiter.js', () => ({
 }));
 
 import {
+  buildDashboardJson,
   startDashboardServer,
   getDashboardPidPath,
   writeDashboardServerInfo,
@@ -420,6 +421,43 @@ describe('dashboard-server', () => {
       const result = await sendRequest('GET', '/api/data');
       const data = JSON.parse(result.body);
       expect(Array.isArray(data.shelvedPRUrls)).toBe(true);
+    });
+
+    it('should derive shelvedPRUrls from digest.shelvedPRs, not config.shelvedPRUrls (#981)', () => {
+      // Dashboard card shows `stats.shelvedPRs`, which counts digest.shelvedPRs.
+      // The response's shelvedPRUrls must use the same source so the PR list
+      // filter matches. Previously it pulled from config.shelvedPRUrls, which
+      // excluded dormant-non-addressing PRs the orchestration layer had
+      // already moved into digest.shelvedPRs — leaving them visible in the
+      // active list while still counted in the shelved card.
+      const digest = makeDigest({
+        shelvedPRs: [
+          {
+            number: 1,
+            url: 'https://github.com/o/r/pull/1',
+            title: 'Explicit shelf',
+            repo: 'o/r',
+            daysSinceActivity: 10,
+            status: 'waiting_on_maintainer',
+          },
+          {
+            number: 2,
+            url: 'https://github.com/o/r/pull/2',
+            title: 'Dormant auto-shelf',
+            repo: 'o/r',
+            daysSinceActivity: 45,
+            status: 'waiting_on_maintainer',
+          },
+        ],
+      });
+      const state = makeState({
+        config: { shelvedPRUrls: ['https://github.com/o/r/pull/1'] },
+        lastDigest: digest,
+      });
+
+      const data = buildDashboardJson(digest, state, []);
+
+      expect(data.shelvedPRUrls).toEqual(['https://github.com/o/r/pull/1', 'https://github.com/o/r/pull/2']);
     });
 
     it('should include repos with metadata and exclude repos without in repoMetadata (#677)', async () => {

--- a/packages/core/src/commands/dashboard-server.ts
+++ b/packages/core/src/commands/dashboard-server.ts
@@ -119,8 +119,12 @@ function getIssueListMtimeMs(): number | null {
 
 /**
  * Build the JSON payload that the SPA expects from GET /api/data.
+ *
+ * Exported for unit testing of response-shape concerns that the full
+ * handler harness can't reach (it bakes a stale cachedDigest at server
+ * start-up, so tests that need a specific digest should call this directly).
  */
-function buildDashboardJson(
+export function buildDashboardJson(
   digest: DailyDigest,
   state: Readonly<AgentState>,
   commentedIssues: CommentedIssue[],
@@ -167,7 +171,11 @@ function buildDashboardJson(
     monthlyOpened,
     monthlyClosed,
     activePRs: applyStatusOverrides(digest.openPRs || [], state),
-    shelvedPRUrls: state.config.shelvedPRUrls || [],
+    // Source of truth is digest.shelvedPRs (union of explicitly-shelved URLs
+    // and dormant-non-addressing PRs auto-shelved for display). Returning
+    // only state.config.shelvedPRUrls would under-count and desync from
+    // stats.shelvedPRs, which is already derived from digest.shelvedPRs. (#981)
+    shelvedPRUrls: (digest.shelvedPRs || []).map((ref) => ref.url),
     recentlyMergedPRs: digest.recentlyMergedPRs || [],
     recentlyClosedPRs: digest.recentlyClosedPRs || [],
     autoUnshelvedPRs: digest.autoUnshelvedPRs || [],


### PR DESCRIPTION
## Summary
The stats card and shelved section got their shelved counts from different sources, so a repo with dormant-non-addressing PRs would show N in the card but N-k in the section.

- **Card** (`stats.shelvedPRs`): from `digest.shelvedPRs` — the reconciled union of explicitly-shelved URLs **and** dormant PRs that orchestration auto-shelves.
- **Section filter** (`shelvedPRUrls` in API response): was `state.config.shelvedPRUrls` — only the explicit list.

Dormant auto-shelved PRs fell through the gap: counted by the card, still rendered as active.

## Fix
Return `(digest.shelvedPRs || []).map((ref) => ref.url)` as `shelvedPRUrls`. Same source of truth feeds both.

Side effect (intended): dormant-non-addressing PRs now appear in the shelved section instead of the active list, matching what the card already claimed.

## Notes
- Exported `buildDashboardJson` so the fix can be unit-tested directly. The existing handler harness caches `digest` at server start and can't be re-seeded without either a GitHub token or intrusive test surgery.
- Removed `state.config.shelvedPRUrls` as the direct response source, but it's still the authoritative persisted list — orchestration reads from it and writes into `digest.shelvedPRs`.

## Test plan
- [x] New unit test: `buildDashboardJson` returns `shelvedPRUrls` from digest (explicit + dormant)
- [x] Full suite: 227 dashboard + 142 mcp-server + core all green
- [x] Typecheck, lint, format-check

Fixes #981

🤖 Generated with [Claude Code](https://claude.com/claude-code)