### PR TITLE
fix: parse skipped-issues file into scout state (#989)

### DIFF
--- a/packages/core/src/commands/scout-bridge.test.ts
+++ b/packages/core/src/commands/scout-bridge.test.ts
@@ -13,11 +13,17 @@ vi.mock('@oss-scout/core', () => ({
   createScout: vi.fn(),
 }));
 
+vi.mock('./skip-file-parser.js', () => ({
+  loadSkippedIssues: vi.fn(() => []),
+}));
+
 import { getStateManager } from '../core/index.js';
 import { buildScoutState } from './scout-bridge.js';
+import { loadSkippedIssues } from './skip-file-parser.js';
 import { makeAgentState, makeDailyDigest, makeFetchedPR, makeStateManagerMock } from '../core/test-utils.js';
 
 const mockGetStateManager = vi.mocked(getStateManager);
+const mockLoadSkippedIssues = vi.mocked(loadSkippedIssues);
 
 describe('buildScoutState', () => {
   beforeEach(() => {
@@ -209,5 +215,38 @@ describe('buildScoutState', () => {
     const result = buildScoutState();
 
     expect(result.savedResults).toEqual([]);
+  });
+
+  it('should populate skippedIssues from the parsed skip file', () => {
+    const state = makeAgentState({
+      config: { skippedIssuesPath: '/vault/open-source/skipped-issues.md' },
+    });
+    mockGetStateManager.mockReturnValue(makeStateManagerMock({ state, config: state.config }));
+
+    const skipped = [
+      {
+        url: 'https://github.com/owncast/owncast/issues/4883',
+        repo: 'owncast/owncast',
+        number: 4883,
+        title: '',
+        skippedAt: '2026-04-15T00:00:00.000Z',
+      },
+    ];
+    mockLoadSkippedIssues.mockReturnValueOnce(skipped);
+
+    const result = buildScoutState();
+
+    expect(mockLoadSkippedIssues).toHaveBeenCalledWith('/vault/open-source/skipped-issues.md');
+    expect(result.skippedIssues).toEqual(skipped);
+  });
+
+  it('should default skippedIssues to [] when parser returns empty', () => {
+    const state = makeAgentState({ config: { skippedIssuesPath: undefined } });
+    mockGetStateManager.mockReturnValue(makeStateManagerMock({ state, config: state.config }));
+    mockLoadSkippedIssues.mockReturnValueOnce([]);
+
+    const result = buildScoutState();
+
+    expect(result.skippedIssues).toEqual([]);
   });
 });

--- a/packages/core/src/commands/scout-bridge.ts
+++ b/packages/core/src/commands/scout-bridge.ts
@@ -5,6 +5,7 @@
 
 import { createScout, type OssScout, type ScoutState } from '@oss-scout/core';
 import { getStateManager, requireGitHubToken } from '../core/index.js';
+import { loadSkippedIssues } from './skip-file-parser.js';
 
 /**
  * Build a ScoutState from the current AgentState.
@@ -55,7 +56,7 @@ export function buildScoutState(): ScoutState {
       openedAt: pr.createdAt,
     })),
     savedResults: [],
-    skippedIssues: [],
+    skippedIssues: loadSkippedIssues(config.skippedIssuesPath),
     lastRunAt: state.lastRunAt,
   };
 }

--- a/packages/core/src/commands/skip-file-parser.test.ts
+++ b/packages/core/src/commands/skip-file-parser.test.ts
@@ -102,6 +102,38 @@ not-a-valid-line
     });
   });
 
+  it('should reject invalid calendar dates that JS would silently normalize', () => {
+    // Date.parse('2026-02-30T00:00:00.000Z') silently rolls over to Mar 2.
+    // Without a round-trip guard this entry would be stored under the wrong
+    // date and scout's 90-day cull would fire against a shifted value.
+    const content = `2026-02-30 https://github.com/owner/repo/issues/1
+2026-02-29 https://github.com/owner/repo/issues/2
+2026-04-15 https://github.com/good/repo/issues/99
+`;
+    const result = parseSkippedIssuesContent(content);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].url).toBe('https://github.com/good/repo/issues/99');
+    // Both invalid calendar dates must trigger a warning that includes the
+    // normalized date so the user can find and fix them.
+    const warnMessages = mockWarn.mock.calls.map((call) => call[1]);
+    expect(warnMessages.some((m: unknown) => typeof m === 'string' && m.includes('2026-02-30'))).toBe(true);
+    expect(warnMessages.some((m: unknown) => typeof m === 'string' && m.includes('2026-02-29'))).toBe(true);
+  });
+
+  it('should include 1-based line numbers in warnings', () => {
+    const content = `# header
+2026-04-15 https://github.com/good/repo/issues/1
+not-a-valid-line
+2026-04-16 https://github.com/good/repo/issues/2
+`;
+    parseSkippedIssuesContent(content);
+
+    // The malformed line is line 3 (header is 1, first valid is 2).
+    const warnMessages = mockWarn.mock.calls.map((call) => call[1]);
+    expect(warnMessages.some((m: unknown) => typeof m === 'string' && m.includes('Line 3'))).toBe(true);
+  });
+
   it('should tolerate blank lines between entries', () => {
     const content = `
 2026-04-15 https://github.com/owner/repo/issues/1

--- a/packages/core/src/commands/skip-file-parser.test.ts
+++ b/packages/core/src/commands/skip-file-parser.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Tests for skip-file-parser (#989)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    readFileSync: vi.fn(),
+  };
+});
+
+vi.mock('../core/logger.js', () => ({
+  warn: vi.fn(),
+}));
+
+import * as fs from 'fs';
+import { warn } from '../core/logger.js';
+import { parseSkippedIssuesContent, loadSkippedIssues } from './skip-file-parser.js';
+
+const mockExistsSync = vi.mocked(fs.existsSync);
+const mockReadFileSync = vi.mocked(fs.readFileSync);
+const mockWarn = vi.mocked(warn);
+
+describe('parseSkippedIssuesContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return [] for an empty file', () => {
+    expect(parseSkippedIssuesContent('')).toEqual([]);
+  });
+
+  it('should return [] for a comment-only file', () => {
+    const content = `# Skipped Issues — auto-culled after 90 days
+# Format: YYYY-MM-DD URL
+
+`;
+    expect(parseSkippedIssuesContent(content)).toEqual([]);
+  });
+
+  it('should parse valid date + URL entries into SkippedIssue[]', () => {
+    const content = `# Skipped Issues — auto-culled after 90 days
+# Format: YYYY-MM-DD URL
+
+2026-04-15 https://github.com/owncast/owncast/issues/4883
+2026-04-19 https://github.com/super-productivity/super-productivity/issues/7271
+`;
+    const result = parseSkippedIssuesContent(content);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      url: 'https://github.com/owncast/owncast/issues/4883',
+      repo: 'owncast/owncast',
+      number: 4883,
+      title: '',
+      skippedAt: '2026-04-15T00:00:00.000Z',
+    });
+    expect(result[1]).toEqual({
+      url: 'https://github.com/super-productivity/super-productivity/issues/7271',
+      repo: 'super-productivity/super-productivity',
+      number: 7271,
+      title: '',
+      skippedAt: '2026-04-19T00:00:00.000Z',
+    });
+  });
+
+  it('should skip malformed lines, warn, and preserve surrounding valid entries', () => {
+    const content = `# header
+2026-04-15 https://github.com/owncast/owncast/issues/4883
+not-a-valid-line
+2026-13-99 https://github.com/owner/repo/issues/1
+2026-04-19 not-a-url
+2026-04-20 https://github.com/good/repo/issues/99
+`;
+    const result = parseSkippedIssuesContent(content);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].url).toBe('https://github.com/owncast/owncast/issues/4883');
+    expect(result[1].url).toBe('https://github.com/good/repo/issues/99');
+    // At least one warning per malformed line
+    expect(mockWarn).toHaveBeenCalled();
+    const warnCalls = mockWarn.mock.calls.length;
+    expect(warnCalls).toBeGreaterThanOrEqual(3);
+  });
+
+  it('should handle PR URLs as well as issue URLs', () => {
+    const content = `2026-04-15 https://github.com/owner/repo/pull/42
+`;
+    const result = parseSkippedIssuesContent(content);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      url: 'https://github.com/owner/repo/pull/42',
+      repo: 'owner/repo',
+      number: 42,
+      title: '',
+      skippedAt: '2026-04-15T00:00:00.000Z',
+    });
+  });
+
+  it('should tolerate blank lines between entries', () => {
+    const content = `
+2026-04-15 https://github.com/owner/repo/issues/1
+
+2026-04-16 https://github.com/owner/repo/issues/2
+
+`;
+    const result = parseSkippedIssuesContent(content);
+    expect(result).toHaveLength(2);
+  });
+});
+
+describe('loadSkippedIssues', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should return [] when no path is configured', () => {
+    const result = loadSkippedIssues(undefined);
+    expect(result).toEqual([]);
+    expect(mockExistsSync).not.toHaveBeenCalled();
+    expect(mockReadFileSync).not.toHaveBeenCalled();
+  });
+
+  it('should return [] when the path is an empty string', () => {
+    const result = loadSkippedIssues('');
+    expect(result).toEqual([]);
+  });
+
+  it('should return [] when the file does not exist', () => {
+    mockExistsSync.mockReturnValue(false);
+    const result = loadSkippedIssues('/does/not/exist.md');
+    expect(result).toEqual([]);
+    expect(mockReadFileSync).not.toHaveBeenCalled();
+  });
+
+  it('should read and parse the file when it exists', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(`# header
+2026-04-15 https://github.com/owncast/owncast/issues/4883
+`);
+
+    const result = loadSkippedIssues('/real/path.md');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].url).toBe('https://github.com/owncast/owncast/issues/4883');
+    expect(mockReadFileSync).toHaveBeenCalledWith('/real/path.md', 'utf-8');
+  });
+
+  it('should return [] and warn if reading the file throws', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('EACCES');
+    });
+
+    const result = loadSkippedIssues('/restricted/path.md');
+    expect(result).toEqual([]);
+    expect(mockWarn).toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/commands/skip-file-parser.ts
+++ b/packages/core/src/commands/skip-file-parser.ts
@@ -1,0 +1,94 @@
+/**
+ * Parser for the skipped-issues markdown file (#989).
+ *
+ * The file format is one entry per line:
+ *   2026-04-15 https://github.com/owner/repo/issues/123
+ * Lines starting with `#` and blank lines are ignored.
+ *
+ * Produces SkippedIssue entries that plug directly into oss-scout's ScoutState
+ * so the search engine filters already-skipped URLs out of results.
+ */
+
+import * as fs from 'fs';
+import type { SkippedIssue } from '@oss-scout/core';
+import { warn } from '../core/logger.js';
+import { errorMessage } from '../core/errors.js';
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const GITHUB_URL_RE = /^https:\/\/github\.com\/([^/]+\/[^/]+)\/(?:issues|pull)\/(\d+)(?:[/?#].*)?$/;
+
+/**
+ * Parse the raw text of a skipped-issues file into SkippedIssue entries.
+ * Pure function — no I/O. Malformed lines are warned and skipped; the rest
+ * pass through unchanged.
+ */
+export function parseSkippedIssuesContent(content: string): SkippedIssue[] {
+  const results: SkippedIssue[] = [];
+
+  const lines = content.split(/\r?\n/);
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (line === '' || line.startsWith('#')) continue;
+
+    // Split on first whitespace run: "YYYY-MM-DD <url>"
+    const match = line.match(/^(\S+)\s+(\S+)\s*$/);
+    if (!match) {
+      warn('skip-file-parser', `Ignoring malformed line (expected "<date> <url>"): ${line}`);
+      continue;
+    }
+
+    const [, dateStr, url] = match;
+
+    if (!DATE_RE.test(dateStr)) {
+      warn('skip-file-parser', `Ignoring line with invalid date (expected YYYY-MM-DD): ${line}`);
+      continue;
+    }
+
+    const dateMs = Date.parse(`${dateStr}T00:00:00.000Z`);
+    if (Number.isNaN(dateMs)) {
+      warn('skip-file-parser', `Ignoring line with unparseable date: ${line}`);
+      continue;
+    }
+
+    const urlMatch = url.match(GITHUB_URL_RE);
+    if (!urlMatch) {
+      warn('skip-file-parser', `Ignoring line with non-GitHub-issue URL: ${line}`);
+      continue;
+    }
+
+    const [, repo, numberStr] = urlMatch;
+    const number = Number.parseInt(numberStr, 10);
+
+    results.push({
+      url,
+      repo,
+      number,
+      title: '',
+      skippedAt: new Date(dateMs).toISOString(),
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Read the skipped-issues file from disk and parse it.
+ * Returns `[]` when:
+ *   - `path` is undefined or empty,
+ *   - the file does not exist,
+ *   - the file cannot be read (a warning is logged).
+ */
+export function loadSkippedIssues(path: string | undefined): SkippedIssue[] {
+  if (!path) return [];
+  if (!fs.existsSync(path)) return [];
+
+  let content: string;
+  try {
+    content = fs.readFileSync(path, 'utf-8');
+  } catch (err) {
+    warn('skip-file-parser', `Failed to read skipped-issues file at ${path}: ${errorMessage(err)}`);
+    return [];
+  }
+
+  return parseSkippedIssuesContent(content);
+}

--- a/packages/core/src/commands/skip-file-parser.ts
+++ b/packages/core/src/commands/skip-file-parser.ts
@@ -26,33 +26,47 @@ export function parseSkippedIssuesContent(content: string): SkippedIssue[] {
   const results: SkippedIssue[] = [];
 
   const lines = content.split(/\r?\n/);
-  for (const rawLine of lines) {
-    const line = rawLine.trim();
+  for (let i = 0; i < lines.length; i++) {
+    const lineNumber = i + 1;
+    const line = lines[i].trim();
     if (line === '' || line.startsWith('#')) continue;
 
     // Split on first whitespace run: "YYYY-MM-DD <url>"
     const match = line.match(/^(\S+)\s+(\S+)\s*$/);
     if (!match) {
-      warn('skip-file-parser', `Ignoring malformed line (expected "<date> <url>"): ${line}`);
+      warn('skip-file-parser', `Line ${lineNumber}: malformed (expected "<date> <url>"): ${line}`);
       continue;
     }
 
     const [, dateStr, url] = match;
 
     if (!DATE_RE.test(dateStr)) {
-      warn('skip-file-parser', `Ignoring line with invalid date (expected YYYY-MM-DD): ${line}`);
+      warn('skip-file-parser', `Line ${lineNumber}: invalid date format (expected YYYY-MM-DD): ${line}`);
       continue;
     }
 
     const dateMs = Date.parse(`${dateStr}T00:00:00.000Z`);
     if (Number.isNaN(dateMs)) {
-      warn('skip-file-parser', `Ignoring line with unparseable date: ${line}`);
+      warn('skip-file-parser', `Line ${lineNumber}: unparseable date: ${line}`);
+      continue;
+    }
+
+    // Guard against JS Date normalization — Date.parse silently shifts
+    // invalid calendar dates (e.g. 2026-02-30 → 2026-03-02). Without this
+    // round-trip check the entry would be stored under the wrong date and
+    // scout's 90-day cull would run against a shifted value.
+    const roundTrip = new Date(dateMs).toISOString().slice(0, 10);
+    if (roundTrip !== dateStr) {
+      warn(
+        'skip-file-parser',
+        `Line ${lineNumber}: invalid calendar date ${dateStr} (would be normalized to ${roundTrip}): ${line}`,
+      );
       continue;
     }
 
     const urlMatch = url.match(GITHUB_URL_RE);
     if (!urlMatch) {
-      warn('skip-file-parser', `Ignoring line with non-GitHub-issue URL: ${line}`);
+      warn('skip-file-parser', `Line ${lineNumber}: non-GitHub-issue URL: ${line}`);
       continue;
     }
 


### PR DESCRIPTION
## Summary

Fixes #989.

`scout-bridge` previously hardcoded `skippedIssues: []` when building ScoutState, so scout's search filter always ran against an empty set. Any URL added to the configured `skippedIssuesPath` file would keep re-appearing in subsequent search rounds.

### Changes

- **New `skip-file-parser.ts`** exposes `parseSkippedIssuesContent(content)` (pure) and `loadSkippedIssues(path)` (disk wrapper). Parses `<YYYY-MM-DD> <url>` lines, skips blanks/comments, and warns on malformed lines.
- **`scout-bridge.ts`** now calls `loadSkippedIssues(config.skippedIssuesPath)` instead of passing `[]`.
- Dates that JS `Date.parse` silently normalizes (e.g. `2026-02-30` → `2026-03-02`) are rejected via a round-trip check. Without this, the entry would store under a shifted date and scout's 90-day cull would fire against the wrong value.
- Warnings include 1-based line numbers so malformed entries in large skip files can be located without grepping.
- Malformed URLs, non-GitHub URLs, unparseable dates, missing files, and read failures all return `[]` (with a warning where appropriate) — safe defaults for an opt-in config file.

Stays synchronous to match the existing pattern in `startup.ts`.

## Test plan

- [x] 13 new tests in `skip-file-parser.test.ts` — parse empty/comment-only/valid/malformed/PR-URL/blank-line/invalid-calendar-date cases, plus all `loadSkippedIssues` failure modes
- [x] 2 new tests in `scout-bridge.test.ts` asserting `loadSkippedIssues` is invoked with the configured path and its output flows into `skippedIssues`
- [x] Full `@oss-autopilot/core` suite: 1897 pass / 14 skipped, no regressions
- [x] `tsc --noEmit` clean
- [x] `eslint` + `prettier --check` clean
