### PR TITLE
fix: persist /oss Pick-from-list skips to skipped-issues file

### DIFF
--- a/packages/core/src/cli-registry.test.ts
+++ b/packages/core/src/cli-registry.test.ts
@@ -48,6 +48,9 @@ vi.mock('./commands/local-repos.js', () => ({ runLocalRepos: mockRunLocalRepos }
 const mockServeDashboard = vi.fn();
 vi.mock('./commands/dashboard.js', () => ({ serveDashboard: mockServeDashboard }));
 
+const mockRunSkipAdd = vi.fn();
+vi.mock('./commands/skip-add.js', () => ({ runSkipAdd: mockRunSkipAdd }));
+
 // ─── Import after mocks ────────────────────────────────────────────────────
 
 import { commands } from './cli-registry.js';
@@ -389,5 +392,103 @@ describe('--json vs display output branching', () => {
     await program.parseAsync(['node', 'cli', 'undismiss', ISSUE_URL]);
 
     expect(consoleLogSpy).toHaveBeenCalledWith('Was not dismissed.');
+  });
+});
+
+// ─── skip-add action ────────────────────────────────────────────────────────
+
+describe('skip-add action', () => {
+  const SKIP_FILE = '/tmp/test-skip.md';
+
+  it('prints "Added to skip list" on successful new append', async () => {
+    mockRunSkipAdd.mockReturnValue({
+      added: true,
+      alreadyPresent: false,
+      url: ISSUE_URL,
+      path: SKIP_FILE,
+      date: '2026-04-19',
+    });
+    const program = buildProgram('skip-add');
+
+    await program.parseAsync(['node', 'cli', 'skip-add', ISSUE_URL]);
+
+    expect(mockRunSkipAdd).toHaveBeenCalledWith({ issueUrl: ISSUE_URL, skipFilePath: undefined });
+    expect(consoleLogSpy).toHaveBeenCalledWith(`Added to skip list: ${ISSUE_URL} (2026-04-19)`);
+    expect(consoleLogSpy).toHaveBeenCalledWith(`  File: ${SKIP_FILE}`);
+    expect(mockOutputJson).not.toHaveBeenCalled();
+  });
+
+  it('prints "Already on skip list" when URL is already present', async () => {
+    mockRunSkipAdd.mockReturnValue({
+      added: false,
+      alreadyPresent: true,
+      url: ISSUE_URL,
+      path: SKIP_FILE,
+    });
+    const program = buildProgram('skip-add');
+
+    await program.parseAsync(['node', 'cli', 'skip-add', ISSUE_URL]);
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(`Already on skip list: ${ISSUE_URL}`);
+    expect(consoleLogSpy).toHaveBeenCalledWith(`  File: ${SKIP_FILE}`);
+  });
+
+  it('emits JSON and skips text output when --json is set', async () => {
+    const payload = {
+      added: true,
+      alreadyPresent: false,
+      url: ISSUE_URL,
+      path: SKIP_FILE,
+      date: '2026-04-19',
+    };
+    mockRunSkipAdd.mockReturnValue(payload);
+    const program = buildProgram('skip-add');
+
+    await program.parseAsync(['node', 'cli', 'skip-add', ISSUE_URL, '--json']);
+
+    expect(mockOutputJson).toHaveBeenCalledWith(payload);
+    expect(consoleLogSpy).not.toHaveBeenCalled();
+  });
+
+  it('passes --path through to runSkipAdd', async () => {
+    mockRunSkipAdd.mockReturnValue({
+      added: true,
+      alreadyPresent: false,
+      url: ISSUE_URL,
+      path: SKIP_FILE,
+      date: '2026-04-19',
+    });
+    const program = buildProgram('skip-add');
+
+    await program.parseAsync(['node', 'cli', 'skip-add', ISSUE_URL, '--path', SKIP_FILE]);
+
+    expect(mockRunSkipAdd).toHaveBeenCalledWith({ issueUrl: ISSUE_URL, skipFilePath: SKIP_FILE });
+  });
+
+  it('routes errors through handleCommandError (text mode)', async () => {
+    mockRunSkipAdd.mockImplementation(() => {
+      throw new Error('bad url');
+    });
+    const program = buildProgram('skip-add');
+
+    await expect(program.parseAsync(['node', 'cli', 'skip-add', 'bogus'])).rejects.toThrow('process.exit called');
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error: bad url');
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+    expect(mockOutputJsonError).not.toHaveBeenCalled();
+  });
+
+  it('routes errors through handleCommandError (JSON mode)', async () => {
+    mockRunSkipAdd.mockImplementation(() => {
+      throw new Error('bad url');
+    });
+    const program = buildProgram('skip-add');
+
+    await expect(program.parseAsync(['node', 'cli', 'skip-add', 'bogus', '--json'])).rejects.toThrow(
+      'process.exit called',
+    );
+
+    expect(mockOutputJsonError).toHaveBeenCalledWith('bad url', 'UNKNOWN');
+    expect(processExitSpy).toHaveBeenCalledWith(1);
   });
 });

--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -316,6 +316,36 @@ export const commands: CLICommandDef[] = [
     },
   },
 
+  // ── Skip Add ───────────────────────────────────────────────────────────
+  {
+    name: 'skip-add',
+    localOnly: true,
+    register(program) {
+      program
+        .command('skip-add <issue-url>')
+        .description('Append an issue URL to the skipped-issues file (idempotent)')
+        .option('--path <file>', 'Skipped-issues file path (falls back to config.skippedIssuesPath)')
+        .option('--json', 'Output as JSON')
+        .action(async (issueUrl, options) => {
+          try {
+            const { runSkipAdd } = await import('./commands/skip-add.js');
+            const data = runSkipAdd({ issueUrl, skipFilePath: options.path });
+            if (options.json) {
+              outputJson(data);
+            } else if (data.added) {
+              console.log(`Added to skip list: ${data.url} (${data.date})`);
+              console.log(`  File: ${data.path}`);
+            } else {
+              console.log(`Already on skip list: ${data.url}`);
+              console.log(`  File: ${data.path}`);
+            }
+          } catch (err) {
+            handleCommandError(err, options.json);
+          }
+        });
+    },
+  },
+
   // ── Track ──────────────────────────────────────────────────────────────
   {
     name: 'track',

--- a/packages/core/src/cli.test.ts
+++ b/packages/core/src/cli.test.ts
@@ -110,6 +110,7 @@ describe('LOCAL_ONLY_COMMANDS (derived from registry)', () => {
     'override',
     'clear-override',
     'stats',
+    'skip-add',
   ];
 
   const expectedTokenRequired = [
@@ -372,6 +373,7 @@ describe('Command registration', () => {
       'clear-override',
       'stats',
       'state',
+      'skip-add',
     ];
 
     for (const name of expectedCommands) {

--- a/packages/core/src/commands/skip-add.test.ts
+++ b/packages/core/src/commands/skip-add.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for skip-add.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+vi.mock('../core/index.js', () => ({
+  getStateManager: vi.fn(),
+}));
+
+import { getStateManager } from '../core/index.js';
+import { runSkipAdd } from './skip-add.js';
+
+const mockGetStateManager = vi.mocked(getStateManager);
+
+function stateManagerWithPath(skippedIssuesPath: string | undefined) {
+  return {
+    getState: () => ({ config: { skippedIssuesPath } }),
+  } as unknown as ReturnType<typeof getStateManager>;
+}
+
+describe('runSkipAdd', () => {
+  let tmpDir: string;
+  let skipFile: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'skip-add-'));
+    skipFile = path.join(tmpDir, 'skipped-issues.md');
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('creates the file with the standard header when it does not exist', () => {
+    const result = runSkipAdd({
+      issueUrl: 'https://github.com/foo/bar/issues/1',
+      skipFilePath: skipFile,
+      now: new Date('2026-04-19T12:00:00Z'),
+    });
+
+    const contents = fs.readFileSync(skipFile, 'utf-8');
+    expect(contents).toContain('# Skipped Issues — auto-culled after 90 days');
+    expect(contents).toContain('# Format: YYYY-MM-DD URL');
+    expect(contents).toContain('2026-04-19 https://github.com/foo/bar/issues/1');
+    expect(result).toEqual({
+      added: true,
+      alreadyPresent: false,
+      url: 'https://github.com/foo/bar/issues/1',
+      path: skipFile,
+      date: '2026-04-19',
+    });
+  });
+
+  it('appends to an existing file without duplicating the header', () => {
+    fs.writeFileSync(
+      skipFile,
+      '# Skipped Issues — auto-culled after 90 days\n# Format: YYYY-MM-DD URL\n\n2026-04-15 https://github.com/owner/repo/issues/99\n',
+    );
+
+    runSkipAdd({
+      issueUrl: 'https://github.com/foo/bar/issues/1',
+      skipFilePath: skipFile,
+      now: new Date('2026-04-19T00:00:00Z'),
+    });
+
+    const contents = fs.readFileSync(skipFile, 'utf-8');
+    const headerOccurrences = contents.split('# Skipped Issues').length - 1;
+    expect(headerOccurrences).toBe(1);
+    expect(contents).toContain('2026-04-15 https://github.com/owner/repo/issues/99');
+    expect(contents).toContain('2026-04-19 https://github.com/foo/bar/issues/1');
+  });
+
+  it('is a no-op when the URL is already present (idempotent)', () => {
+    fs.writeFileSync(
+      skipFile,
+      '# Skipped Issues — auto-culled after 90 days\n# Format: YYYY-MM-DD URL\n\n2026-04-15 https://github.com/foo/bar/issues/1\n',
+    );
+    const before = fs.readFileSync(skipFile, 'utf-8');
+
+    const result = runSkipAdd({
+      issueUrl: 'https://github.com/foo/bar/issues/1',
+      skipFilePath: skipFile,
+      now: new Date('2026-04-19T00:00:00Z'),
+    });
+
+    const after = fs.readFileSync(skipFile, 'utf-8');
+    expect(after).toBe(before);
+    expect(result).toEqual({
+      added: false,
+      alreadyPresent: true,
+      url: 'https://github.com/foo/bar/issues/1',
+      path: skipFile,
+    });
+  });
+
+  it('accepts PR URLs (matches skip-file-parser semantics)', () => {
+    const result = runSkipAdd({
+      issueUrl: 'https://github.com/foo/bar/pull/42',
+      skipFilePath: skipFile,
+      now: new Date('2026-04-19T00:00:00Z'),
+    });
+
+    expect(result.added).toBe(true);
+    const contents = fs.readFileSync(skipFile, 'utf-8');
+    expect(contents).toContain('2026-04-19 https://github.com/foo/bar/pull/42');
+  });
+
+  it('rejects non-GitHub URLs', () => {
+    expect(() =>
+      runSkipAdd({
+        issueUrl: 'https://gitlab.com/foo/bar/issues/1',
+        skipFilePath: skipFile,
+      }),
+    ).toThrow(/Invalid GitHub issue or PR URL/);
+    expect(fs.existsSync(skipFile)).toBe(false);
+  });
+
+  it('rejects malformed URLs (missing issue number)', () => {
+    expect(() =>
+      runSkipAdd({
+        issueUrl: 'https://github.com/foo/bar/issues/',
+        skipFilePath: skipFile,
+      }),
+    ).toThrow(/Invalid GitHub issue or PR URL/);
+  });
+
+  it('falls back to config.skippedIssuesPath when skipFilePath is omitted', () => {
+    mockGetStateManager.mockReturnValue(stateManagerWithPath(skipFile));
+
+    const result = runSkipAdd({
+      issueUrl: 'https://github.com/foo/bar/issues/7',
+      now: new Date('2026-04-19T00:00:00Z'),
+    });
+
+    expect(result.added).toBe(true);
+    expect(result.path).toBe(skipFile);
+    const contents = fs.readFileSync(skipFile, 'utf-8');
+    expect(contents).toContain('2026-04-19 https://github.com/foo/bar/issues/7');
+  });
+
+  it('throws when no path can be resolved', () => {
+    mockGetStateManager.mockReturnValue(stateManagerWithPath(undefined));
+
+    expect(() => runSkipAdd({ issueUrl: 'https://github.com/foo/bar/issues/1' })).toThrow(
+      /No skipped-issues path configured/,
+    );
+  });
+
+  it('uses UTC for the date (not local time)', () => {
+    runSkipAdd({
+      issueUrl: 'https://github.com/foo/bar/issues/1',
+      skipFilePath: skipFile,
+      // 23:30 UTC on Apr 19 is already Apr 19 UTC — cross-check with a
+      // TZ-sensitive moment: 01:30 UTC on Apr 20 would be Apr 19 in PDT.
+      now: new Date('2026-04-20T01:30:00Z'),
+    });
+
+    const contents = fs.readFileSync(skipFile, 'utf-8');
+    expect(contents).toContain('2026-04-20 https://github.com/foo/bar/issues/1');
+    expect(contents).not.toContain('2026-04-19 https://github.com/foo/bar/issues/1');
+  });
+});

--- a/packages/core/src/commands/skip-add.test.ts
+++ b/packages/core/src/commands/skip-add.test.ts
@@ -1,7 +1,3 @@
-/**
- * Tests for skip-add.
- */
-
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';

--- a/packages/core/src/commands/skip-add.ts
+++ b/packages/core/src/commands/skip-add.ts
@@ -1,0 +1,87 @@
+/**
+ * Skip-add command — append an issue URL to the skipped-issues file.
+ *
+ * Closes the write-side gap left open by #989: the read-side (scout-bridge
+ * parsing the file into state) is already done, but no workflow other than
+ * /oss-search had a way to append to the file. Now any flow — including
+ * /oss "Pick from list" — can invoke `oss-autopilot skip-add <url>` and the
+ * URL will be picked up by scout's search filter on the next boot.
+ */
+
+import * as fs from 'fs';
+import { loadSkippedIssues } from './skip-file-parser.js';
+import { getStateManager } from '../core/index.js';
+
+// Keep in sync with GITHUB_URL_RE in skip-file-parser.ts.
+const GITHUB_URL_RE = /^https:\/\/github\.com\/([^/]+\/[^/]+)\/(?:issues|pull)\/(\d+)(?:[/?#].*)?$/;
+
+const FILE_HEADER = '# Skipped Issues — auto-culled after 90 days\n# Format: YYYY-MM-DD URL\n\n';
+
+export interface SkipAddOptions {
+  issueUrl: string;
+  /** Override the configured `skippedIssuesPath`. */
+  skipFilePath?: string;
+  /** Injected for deterministic tests. Defaults to `new Date()`. */
+  now?: Date;
+}
+
+export interface SkipAddOutput {
+  added: boolean;
+  alreadyPresent: boolean;
+  url: string;
+  path: string;
+  /** Populated only when an entry was appended. */
+  date?: string;
+}
+
+function formatUtcDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Append an issue URL to the skipped-issues file.
+ *
+ * Creates the file with the standard header if it doesn't exist. If the URL
+ * is already present (per the skip-file-parser's view of the file), this is
+ * a no-op and returns `alreadyPresent: true`.
+ *
+ * @throws when no path can be resolved or the URL isn't a GitHub issue/PR URL.
+ */
+export function runSkipAdd(options: SkipAddOptions): SkipAddOutput {
+  const skipFilePath = options.skipFilePath ?? getStateManager().getState().config.skippedIssuesPath;
+
+  if (!skipFilePath) {
+    throw new Error(
+      'No skipped-issues path configured. Set one via `oss-autopilot config --set skippedIssuesPath=<path>` or pass --path.',
+    );
+  }
+
+  if (!GITHUB_URL_RE.test(options.issueUrl)) {
+    throw new Error(`Invalid GitHub issue or PR URL: ${options.issueUrl}`);
+  }
+
+  const existing = loadSkippedIssues(skipFilePath);
+  if (existing.some((entry) => entry.url === options.issueUrl)) {
+    return {
+      added: false,
+      alreadyPresent: true,
+      url: options.issueUrl,
+      path: skipFilePath,
+    };
+  }
+
+  if (!fs.existsSync(skipFilePath)) {
+    fs.writeFileSync(skipFilePath, FILE_HEADER);
+  }
+
+  const date = formatUtcDate(options.now ?? new Date());
+  fs.appendFileSync(skipFilePath, `${date} ${options.issueUrl}\n`);
+
+  return {
+    added: true,
+    alreadyPresent: false,
+    url: options.issueUrl,
+    path: skipFilePath,
+    date,
+  };
+}

--- a/packages/core/src/commands/skip-add.ts
+++ b/packages/core/src/commands/skip-add.ts
@@ -1,13 +1,3 @@
-/**
- * Skip-add command — append an issue URL to the skipped-issues file.
- *
- * Closes the write-side gap left open by #989: the read-side (scout-bridge
- * parsing the file into state) is already done, but no workflow other than
- * /oss-search had a way to append to the file. Now any flow — including
- * /oss "Pick from list" — can invoke `oss-autopilot skip-add <url>` and the
- * URL will be picked up by scout's search filter on the next boot.
- */
-
 import * as fs from 'fs';
 import { loadSkippedIssues } from './skip-file-parser.js';
 import { getStateManager } from '../core/index.js';

--- a/workflows/work-through-issues.md
+++ b/workflows/work-through-issues.md
@@ -394,7 +394,15 @@ Options:
 ```
 
 When user selects "Start implementing", proceed to Step 6 (implementation flow).
-When user selects "Skip this issue", return to Step 3 (display available issues).
+
+When user selects "Skip this issue":
+1. Persist the skip so scout filters it out of future searches. Use the CLI:
+   ```bash
+   GITHUB_TOKEN=$(gh auth token 2>/dev/null || echo "$GITHUB_TOKEN") node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" skip-add {issueUrl} --json
+   ```
+   - This appends `YYYY-MM-DD <url>` to the configured `skippedIssuesPath` (idempotent; a no-op if already present).
+   - On error (no path configured, invalid URL), surface the message to the user and ask whether to retry or continue without persisting.
+2. Return to Step 3 (display available issues).
 
 ### 6. After selecting issue → implementation → draft PR → review → ready
 

--- a/workflows/work-through-issues.md
+++ b/workflows/work-through-issues.md
@@ -396,12 +396,14 @@ Options:
 When user selects "Start implementing", proceed to Step 6 (implementation flow).
 
 When user selects "Skip this issue":
-1. Persist the skip so scout filters it out of future searches. Use the CLI:
+1. Persist the skip so scout filters it out of future searches. Capture the JSON result and the exit code:
    ```bash
-   GITHUB_TOKEN=$(gh auth token 2>/dev/null || echo "$GITHUB_TOKEN") node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" skip-add {issueUrl} --json
+   SKIP_OUT=$(node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" skip-add "{issue_url}" --json)
+   SKIP_RC=$?
    ```
-   - This appends `YYYY-MM-DD <url>` to the configured `skippedIssuesPath` (idempotent; a no-op if already present).
-   - On error (no path configured, invalid URL), surface the message to the user and ask whether to retry or continue without persisting.
+   - On success (`$SKIP_RC == 0`), `SKIP_OUT` is JSON with `{ added, alreadyPresent, url, path, date? }`. Briefly confirm to the user whether the URL was newly added or already present.
+   - On failure (`$SKIP_RC != 0`), do NOT silently return to Step 3. Parse the error envelope from `SKIP_OUT` (`{ success: false, error }`) or fall back to displaying the raw output. Offer: retry / skip-persistence-for-this-session / done-for-now. The user decides.
+   - `skip-add` is `localOnly` — no GitHub token required.
 2. Return to Step 3 (display available issues).
 
 ### 6. After selecting issue → implementation → draft PR → review → ready


### PR DESCRIPTION
## Summary

Follow-up to #990. That PR made scout parse `skipped-issues.md` into state on every boot, closing the read side of #989. This closes the write side: no workflow other than `/oss-search` had a way to append to the file, so skips from `/oss` "Pick from list" disappeared silently.

Adds a `skip-add <issue-url>` CLI subcommand (`localOnly`) that:
- Appends `YYYY-MM-DD <url>` to `config.skippedIssuesPath`.
- Creates the file with the standard header if missing.
- Is idempotent via `parseSkippedIssuesContent` (duplicate URL is a no-op).
- Validates against the same GitHub issue/PR URL regex as the parser.
- Exposes `--path` override and `--json` output.

Also wires `workflows/work-through-issues.md`'s "Skip this issue" branch to invoke `skip-add` with exit-code and JSON-envelope checks, so failures are surfaced to the user instead of silently returning to Step 3.

## Review panel

Ran the pr-review-toolkit convergence locally before pushing. Devil's advocate pass confirmed 6 findings, refuted 12. Applied the 6:
- Workflow captures exit code and parses the JSON envelope
- Added 6 `cli-registry.test.ts` branch tests for the action handler
- `{issueUrl}` → `{issue_url}` to match the file's snake_case convention
- Dropped the `GITHUB_TOKEN=` prefix (command is `localOnly`)
- Trimmed a rot-prone top-of-file JSDoc
- Quoted the URL placeholder in the shell invocation

## Test plan

- [x] 9 new tests in `skip-add.test.ts` — creation, append, idempotency, PR URL, invalid URL, malformed URL, config fallback, missing path, UTC date
- [x] 6 new tests in `cli-registry.test.ts` — `added`/`alreadyPresent` branches, `--json`, `--path` pass-through, `handleCommandError` (text + JSON)
- [x] Full `@oss-autopilot/core` suite: 1913 pass / 14 skipped
- [x] `tsc --noEmit` clean
- [x] `eslint packages/` clean
- [x] `prettier --check packages/` clean
