### PR TITLE
fix: audit-v2 batch 1 — daysBetween docs + three silent catches

### DIFF
--- a/packages/core/src/commands/dashboard-server.test.ts
+++ b/packages/core/src/commands/dashboard-server.test.ts
@@ -1283,5 +1283,49 @@ describe('dashboard-server', () => {
       const data = JSON.parse(result.body);
       expect(data.stats).toBeDefined();
     });
+
+    it('sets X-Dashboard-Stale: 1 and serves cached payload when rebuild fails (#994)', async () => {
+      const baseTime = Date.now();
+      writeIssueList('## Pursue\n- [#1](https://github.com/o/r/issues/1) — First\n', baseTime);
+
+      // Prime the cache with a successful GET (no stale header expected).
+      const first = await sendRequest('GET', '/api/data');
+      expect(first.statusCode).toBe(200);
+      expect(first.headers['x-dashboard-stale']).toBeUndefined();
+      const firstBody = first.body;
+
+      // Bump the issue-list mtime to force a rebuild, then swap getState to a
+      // throwing impl for the duration of the second request so buildDashboardJson
+      // fails inside the rebuild try/catch.
+      writeIssueList(
+        '## Pursue\n- [#1](https://github.com/o/r/issues/1) — First\n- [#2](https://github.com/o/r/issues/2) — Second\n',
+        baseTime + 60_000,
+      );
+      const healthyState = mockStateManager.getState.getMockImplementation();
+      mockStateManager.getState.mockImplementation(() => {
+        throw new Error('boom');
+      });
+
+      const second = await sendRequest('GET', '/api/data');
+      expect(second.statusCode).toBe(200);
+      expect(second.headers['x-dashboard-stale']).toBe('1');
+      // Stale payload matches the last successful one — degraded mode, not 500.
+      expect(second.body).toBe(firstBody);
+
+      // Restore healthy getState; the stale header should not be sticky.
+      if (healthyState) {
+        mockStateManager.getState.mockImplementation(healthyState);
+      } else {
+        mockStateManager.getState.mockReturnValue(
+          makeState({
+            lastDigest: makeDigest(),
+            config: { issueListPath, skippedIssuesPath: undefined } as any,
+          }),
+        );
+      }
+      const third = await sendRequest('GET', '/api/data');
+      expect(third.statusCode).toBe(200);
+      expect(third.headers['x-dashboard-stale']).toBeUndefined();
+    });
   });
 });

--- a/packages/core/src/commands/dashboard-server.ts
+++ b/packages/core/src/commands/dashboard-server.ts
@@ -323,20 +323,16 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
         // Also rebuild when the vetted issue list file was edited outside this server (#924)
         const currentIssueListMtimeMs = getIssueListMtimeMs();
         const issueListChanged = currentIssueListMtimeMs !== cachedIssueListMtimeMs;
-        let staleRebuild = false;
         if (stateChanged || issueListChanged) {
           try {
             cachedJsonData = buildDashboardJson(cachedDigest, stateManager.getState(), cachedCommentedIssues);
             cachedIssueListMtimeMs = currentIssueListMtimeMs;
           } catch (error) {
             warn(MODULE, `Failed to rebuild dashboard data after state reload: ${errorMessage(error)}`);
-            // Intentional: serve previous cachedJsonData rather than returning 500.
+            // Serve previous cachedJsonData rather than returning 500.
             // Signal staleness via response header so clients can detect the degraded mode (#994).
-            staleRebuild = true;
+            res.setHeader('X-Dashboard-Stale', '1');
           }
-        }
-        if (staleRebuild) {
-          res.setHeader('X-Dashboard-Stale', '1');
         }
         sendJson(res, 200, cachedJsonData);
         return;

--- a/packages/core/src/commands/dashboard-server.ts
+++ b/packages/core/src/commands/dashboard-server.ts
@@ -323,14 +323,20 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
         // Also rebuild when the vetted issue list file was edited outside this server (#924)
         const currentIssueListMtimeMs = getIssueListMtimeMs();
         const issueListChanged = currentIssueListMtimeMs !== cachedIssueListMtimeMs;
+        let staleRebuild = false;
         if (stateChanged || issueListChanged) {
           try {
             cachedJsonData = buildDashboardJson(cachedDigest, stateManager.getState(), cachedCommentedIssues);
             cachedIssueListMtimeMs = currentIssueListMtimeMs;
           } catch (error) {
             warn(MODULE, `Failed to rebuild dashboard data after state reload: ${errorMessage(error)}`);
-            // Intentional: serve previous cachedJsonData rather than returning 500
+            // Intentional: serve previous cachedJsonData rather than returning 500.
+            // Signal staleness via response header so clients can detect the degraded mode (#994).
+            staleRebuild = true;
           }
+        }
+        if (staleRebuild) {
+          res.setHeader('X-Dashboard-Stale', '1');
         }
         sendJson(res, 200, cachedJsonData);
         return;

--- a/packages/core/src/commands/startup.ts
+++ b/packages/core/src/commands/startup.ts
@@ -115,8 +115,11 @@ export function detectIssueList(): IssueListInfo | undefined {
     if (configuredSkipPath && fs.existsSync(configuredSkipPath)) {
       skippedIssuesPath = configuredSkipPath;
     }
-  } catch {
-    /* fall through */
+  } catch (err) {
+    // State access can fail on a degraded state file (corrupt JSON, EACCES).
+    // Default-path probe below still runs; warn so the underlying cause is visible (#994).
+    // Matches the sibling warn at line 64 for `issueListPath` read failures.
+    warn('startup', `Could not read skippedIssuesPath from state: ${errorMessage(err)}`);
   }
 
   // Probe default path: same directory as issue list, named skipped-issues.md

--- a/packages/core/src/core/state.ts
+++ b/packages/core/src/core/state.ts
@@ -218,8 +218,10 @@ export class StateManager {
       // The Gist is the source of truth; local cache is for fallback.
       try {
         atomicWriteFileSync(getStateCachePath(), JSON.stringify(this.state, null, 2), 0o600);
-      } catch {
-        // Best-effort cache write
+      } catch (err) {
+        // Cache write failure is non-fatal (Gist remains source of truth), but
+        // silent failure masks degraded-mode risk on next offline bootstrap (#994).
+        warn(MODULE, `Failed to write Gist local cache: ${errorMessage(err)}`);
       }
       return;
     }

--- a/packages/core/src/core/utils.ts
+++ b/packages/core/src/core/utils.ts
@@ -253,14 +253,14 @@ export function extractOwnerRepo(url: string): { owner: string; repo: string } |
 }
 
 /**
- * Calculates the number of whole days between two dates, using floor rounding.
+ * Calculates the number of whole days between two dates, clamped to zero.
  *
- * Can return negative values if `from` is after `to`. Partial days are truncated
- * (e.g., 1.9 days returns 1).
+ * Returns `0` if `from` is after `to` — reversed ranges and clock-skew do not
+ * produce negative values. Partial days are truncated (e.g., 1.9 days -> 1).
  *
  * @param from - The start date
  * @param to - The end date (defaults to the current date/time)
- * @returns Number of whole days between the two dates (may be negative)
+ * @returns Number of whole days between the two dates, minimum `0`
  *
  * @example
  * daysBetween(new Date('2024-01-01'), new Date('2024-01-10'))
@@ -268,7 +268,7 @@ export function extractOwnerRepo(url: string): { owner: string; repo: string } |
  *
  * @example
  * daysBetween(new Date('2024-01-10'), new Date('2024-01-01'))
- * // -9
+ * // 0 (clamped; reversed ranges are not signed)
  */
 export function daysBetween(from: Date, to: Date = new Date()): number {
   return Math.max(0, Math.floor((to.getTime() - from.getTime()) / (1000 * 60 * 60 * 24)));


### PR DESCRIPTION
## Summary

Audit-v2 batch 1 — closes two high-priority audit findings with five small, low-risk diffs.

Closes #993 — `daysBetween` docstring now describes the `Math.max(0, ...)` clamp instead of claiming negatives are possible.

Closes #994 — three empty catches that were silently swallowing errors after the `nonFatalCatch` rollout now have appropriate logging:

| Site | Change |
|---|---|
| `state.ts:219-223` | Empty catch → `warn` on Gist local-cache write failure |
| `startup.ts:118-120` | Empty catch → `warn` on state-access failure in `detectIssueList` (upgraded from `debug` per silent-failure-hunter review) |
| `dashboard-server.ts:326-340` | Adds `X-Dashboard-Stale: 1` response header when rebuild-after-reload fails, so clients can detect the serve-stale degraded mode. Still returns 200 with last-good body rather than 500. |

## Regression test

`dashboard-server.test.ts:1287` asserts:
1. Header is set on rebuild failure.
2. Stale payload matches the last successful body (degraded mode, not 500).
3. Header is not sticky after `getState` recovers.

## Review

Pre-commit parallel review (code-reviewer, silent-failure-hunter, pr-test-analyzer):
- Code-reviewer: no Critical/Recommended findings — header ordering safe, docstring accurate, `nonFatalCatch` opt-outs justified per site.
- Silent-failure-hunter: original `debug` in startup.ts was too quiet for degraded-state errors; upgraded to `warn` in this PR to match the sibling `warn` at line 64.
- pr-test-analyzer: flagged missing coverage for the new `X-Dashboard-Stale` header; regression test added.

## Test plan

- [x] `pnpm run lint` — clean
- [x] `pnpm test` — all 3 packages green (core 1,914 / dashboard 227 / mcp-server 142; +1 new test vs main)
- [x] Regression test run in isolation passes
- [x] Parallel review loop converged

_Part of the audit-2026-04-19-v2 follow-up. Remaining issues: #995–#1007._
