### PR TITLE
fix(ci): skip Dependabot Triage gracefully when token secret is missing

### DIFF
--- a/.github/workflows/dependabot-triage.yml
+++ b/.github/workflows/dependabot-triage.yml
@@ -13,7 +13,24 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
+      - name: Verify DEPENDABOT_TRIAGE_TOKEN is configured
+        id: check-token
+        env:
+          GH_TOKEN: ${{ secrets.DEPENDABOT_TRIAGE_TOKEN }}
+        shell: bash
+        run: |
+          # The triage script needs a PAT with cross-repo search + auto-merge scope.
+          # If the secret is missing/expired, skip with a clear signal rather than
+          # failing the workflow every day (#995).
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::warning title=Triage skipped::DEPENDABOT_TRIAGE_TOKEN secret is not set. Configure a PAT with 'repo' scope to enable auto-merge triage."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Triage dependabot PRs
+        if: steps.check-token.outputs.configured == 'true'
         env:
           GH_TOKEN: ${{ secrets.DEPENDABOT_TRIAGE_TOKEN }}
           REPORT_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

Closes #995.

The `Dependabot Triage` scheduled workflow has been failing daily since 2026-04-15. Logs show that `DEPENDABOT_TRIAGE_TOKEN` is missing/expired, so `GH_TOKEN` is empty and `gh api user` exits 4 on the very first call — producing a red job every morning.

## Change

Add a preflight step that:
1. Inspects `secrets.DEPENDABOT_TRIAGE_TOKEN` via `env:` (safe access pattern).
2. If empty/missing: emits a `::warning` annotation with rotation guidance and sets `configured=false`.
3. Gates the real triage step via `if: steps.check-token.outputs.configured == 'true'`.

Net effect: workflow completes **green with a clear skip reason** instead of failing. When the secret is rotated back in, the triage step runs normally with zero other changes needed.

## Test plan

- [x] Workflow file parses (YAML valid)
- [x] `pnpm run lint` clean
- [ ] On merge, next scheduled run (14:00 UTC) should complete green with the skip warning visible in the run summary
- [ ] After rotating the secret, the real triage step executes

_Part of audit-v2 follow-up. Companion issue #996 is the settings-side fix (enable Dependabot security updates) and requires a settings toggle, not a code change._
