### PR TITLE
docs: audit-v2 batch 3 — README stats, ROADMAP, dashboard README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ A Preact SPA that auto-opens when you run `/oss` — PR management, charts, cont
 
 **Three deployment models** — Claude Code plugin with 7 specialized agents, MCP server for Cursor/Claude Desktop/Codex/Windsurf, and a standalone CLI with `--json` structured output. Same core, different interfaces.
 
-**Deterministic core, AI orchestration layer** — Critical logic (PR status classification, CI failure analysis, state management) lives in tested TypeScript, not in prompts. The CLI returns structured JSON that agents consume. CI failures are categorized into a deterministic taxonomy — actionable vs. fork limitation vs. auth gate vs. infrastructure — rather than asking an LLM each time. 2,260+ tests validate the core independently of any LLM.
+**Deterministic core, AI orchestration layer** — Critical logic (PR status classification, CI failure analysis, state management) lives in tested TypeScript, not in prompts. The CLI returns structured JSON that agents consume. CI failures are categorized into a deterministic taxonomy — actionable vs. fork limitation vs. auth gate vs. infrastructure — rather than asking an LLM each time. 2,200+ tests validate the core independently of any LLM.
 
 **Production-grade GitHub API integration** — ETag-based HTTP caching, automatic rate limit backoff with retries, bounded concurrency pools, and paginated fetching. Handles the full complexity of fork-based contribution workflows: correct diff ranges, squash commit counting, and `--head` flag handling for cross-fork PRs. Designed to run daily without hitting API limits.
 
@@ -104,7 +104,7 @@ A Preact SPA that auto-opens when you run `/oss` — PR management, charts, cont
 
 **Security discipline** — State files written with `0o600` permissions, data directory created with `0o700`. Concurrent state write protection prevents corruption from parallel runs. Runtime schema validation via Zod on every state file read. XSS prevention tested. Input validation hardened across CLI arguments and API responses.
 
-**Automated release pipeline** — Conventional commits feed into release-please for automatic versioning and changelogs, with CI/CD publishing to npm on merge. 140+ published releases since March 2026, with 200+ changelog versions spanning the full v0.1.0 → v1.15.x history.
+**Automated release pipeline** — Conventional commits feed into release-please for automatic versioning and changelogs, with CI/CD publishing to npm on merge. 140+ published releases since March 2026, with 170+ changelog versions spanning the full v0.1.0 → v1.15.x history.
 
 Every feature in the list above was driven by real usage — capacity warnings came from overcommitting, "skip comment when code speaks for itself" came from over-commenting, diminishing returns detection came from spending too long searching. The tool is shaped by the contributions it manages.
 
@@ -187,8 +187,8 @@ All commands return `{ success, data, error, timestamp }` with `--json`.
 
 | Metric | Value |
 |--------|-------|
-| Releases | 140+ published (200+ changelog versions, v0.1.0 → v1.15.x) |
-| Tests | 2,260+ across 100+ files |
+| Releases | 140+ published (170+ changelog versions, v0.1.0 → v1.15.x) |
+| Tests | 2,200+ across 100+ files |
 | Issues + PRs | 1,000+ |
 | Time span | Jan 2026 → present |
 | npm packages | 3 |

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ A Preact SPA that auto-opens when you run `/oss` — PR management, charts, cont
 
 **Three deployment models** — Claude Code plugin with 7 specialized agents, MCP server for Cursor/Claude Desktop/Codex/Windsurf, and a standalone CLI with `--json` structured output. Same core, different interfaces.
 
-**Deterministic core, AI orchestration layer** — Critical logic (PR status classification, CI failure analysis, state management) lives in tested TypeScript, not in prompts. The CLI returns structured JSON that agents consume. CI failures are categorized into a deterministic taxonomy — actionable vs. fork limitation vs. auth gate vs. infrastructure — rather than asking an LLM each time. 1,762 tests validate the core independently of any LLM.
+**Deterministic core, AI orchestration layer** — Critical logic (PR status classification, CI failure analysis, state management) lives in tested TypeScript, not in prompts. The CLI returns structured JSON that agents consume. CI failures are categorized into a deterministic taxonomy — actionable vs. fork limitation vs. auth gate vs. infrastructure — rather than asking an LLM each time. 2,260+ tests validate the core independently of any LLM.
 
 **Production-grade GitHub API integration** — ETag-based HTTP caching, automatic rate limit backoff with retries, bounded concurrency pools, and paginated fetching. Handles the full complexity of fork-based contribution workflows: correct diff ranges, squash commit counting, and `--head` flag handling for cross-fork PRs. Designed to run daily without hitting API limits.
 
@@ -104,7 +104,7 @@ A Preact SPA that auto-opens when you run `/oss` — PR management, charts, cont
 
 **Security discipline** — State files written with `0o600` permissions, data directory created with `0o700`. Concurrent state write protection prevents corruption from parallel runs. Runtime schema validation via Zod on every state file read. XSS prevention tested. Input validation hardened across CLI arguments and API responses.
 
-**Automated release pipeline** — Conventional commits feed into release-please for automatic versioning and changelogs, with CI/CD publishing to npm on merge. 70+ published releases since March 2026, with 150+ changelog versions spanning the full v0.1.0 → v1.11.0 history.
+**Automated release pipeline** — Conventional commits feed into release-please for automatic versioning and changelogs, with CI/CD publishing to npm on merge. 140+ published releases since March 2026, with 200+ changelog versions spanning the full v0.1.0 → v1.15.x history.
 
 Every feature in the list above was driven by real usage — capacity warnings came from overcommitting, "skip comment when code speaks for itself" came from over-commenting, diminishing returns detection came from spending too long searching. The tool is shaped by the contributions it manages.
 
@@ -187,9 +187,9 @@ All commands return `{ success, data, error, timestamp }` with `--json`.
 
 | Metric | Value |
 |--------|-------|
-| Releases | 70+ published (150+ changelog versions, v0.1.0 → v1.11.0) |
-| Tests | 1,762 across 62 files |
-| Issues + PRs | 912+ |
+| Releases | 140+ published (200+ changelog versions, v0.1.0 → v1.15.x) |
+| Tests | 2,260+ across 100+ files |
+| Issues + PRs | 1,000+ |
 | Time span | Jan 2026 → present |
 | npm packages | 3 |
 | CLI commands | 30+ |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,11 +4,25 @@ This roadmap reflects the current development priorities for oss-autopilot. Item
 
 Have an idea? Open a [Discussion](https://github.com/costajohnt/oss-autopilot/discussions) or file an issue.
 
-## Current Focus
+## Now (next 1-2 weeks)
 
-No open issues at this time. The backlog is clear!
+- [ ] Node 20 EOL transition — bump engines and CI matrix before April 30, 2026 ([#983](https://github.com/costajohnt/oss-autopilot/issues/983))
+- [ ] Unify skip-list persistence — the `.md` file and `state.skippedIssues` currently drift ([#992](https://github.com/costajohnt/oss-autopilot/issues/992))
+- [ ] Audit-v2 follow-up sprint — close the 15 issues filed by the 2026-04-19 audit ([#993](https://github.com/costajohnt/oss-autopilot/issues/993)–[#1007](https://github.com/costajohnt/oss-autopilot/issues/1007))
 
-File a new issue or start a discussion to suggest improvements.
+## Next (next 1-2 months)
+
+- [ ] Runtime `--json` contract enforcement — golden-file tests cover the happy path but nothing validates output shape at runtime ([#965](https://github.com/costajohnt/oss-autopilot/issues/965))
+- [ ] Per-repo learning from merged PR review feedback — adapt pursue-order signals based on what actually gets merged ([#867](https://github.com/costajohnt/oss-autopilot/issues/867))
+- [ ] Contract tests for mutating CLI commands (`track`, `dismiss`, `shelve`, `move`) ([#997](https://github.com/costajohnt/oss-autopilot/issues/997))
+
+## Later (no fixed timeline)
+
+- [ ] 1.0 launch content — blog post, social posts, competitive positioning ([#731](https://github.com/costajohnt/oss-autopilot/issues/731))
+- [ ] Dashboard live demo for non-dev audiences — 30-min visual walkthrough ([#940](https://github.com/costajohnt/oss-autopilot/issues/940))
+- [ ] Co-maintainer recruitment — the project is currently solo-maintained (bus factor of 1)
+
+Have an idea? Open a [Discussion](https://github.com/costajohnt/oss-autopilot/discussions) or file an issue.
 
 ## Completed (Recent)
 

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -1,0 +1,79 @@
+# @oss-autopilot/dashboard
+
+Interactive dashboard SPA for [OSS Autopilot](https://github.com/costajohnt/oss-autopilot) — a Preact + Vite single-page app that visualizes the contributor's active PRs, merged history, and pursue-queue.
+
+> This package is **private** (not published to npm). It builds a static bundle that `@oss-autopilot/core` serves from its `dashboard serve` command.
+
+## How it fits
+
+```
+┌──────────────────────────────────────────────────────┐
+│  Browser                                             │
+│  ┌────────────────────────────────────────────┐      │
+│  │ @oss-autopilot/dashboard  (Preact SPA)     │      │
+│  │  • Chart.js visualizations                 │      │
+│  │  • Celebration toast hook                  │      │
+│  │  • Dark theme toggle                       │      │
+│  └────────────────────────────────────────────┘      │
+│                    │  fetch /api/data                │
+│                    ▼                                 │
+│  ┌────────────────────────────────────────────┐      │
+│  │ dashboard-server.ts  (in @oss-autopilot/core)     │
+│  │  • serves built dist/ as static assets     │      │
+│  │  • returns DashboardJsonData on /api/data  │      │
+│  │  • accepts POST /api/action for mutations  │      │
+│  └────────────────────────────────────────────┘      │
+└──────────────────────────────────────────────────────┘
+```
+
+The runtime contract (`DashboardJsonData`) is single-sourced in [`@oss-autopilot/core/commands/dashboard-data.ts`](../core/src/commands/dashboard-data.ts); the dashboard imports it via `@oss-autopilot/core/types` rather than redeclaring.
+
+## Develop
+
+```bash
+# From the repo root:
+pnpm install
+pnpm dashboard:dev    # Vite dev server on http://localhost:5173
+```
+
+The dev server talks to a running `oss-autopilot dashboard serve` (or uses mock data via `import.meta.env.DEV` branches in `src/hooks/use-dashboard.ts`).
+
+## Build
+
+```bash
+pnpm dashboard:build  # outputs packages/dashboard/dist/
+```
+
+`@oss-autopilot/core/commands/dashboard-server.ts` path-resolves this `dist/` directory at runtime.
+
+## Test
+
+```bash
+pnpm --filter @oss-autopilot/dashboard test         # one-shot
+pnpm --filter @oss-autopilot/dashboard test:watch   # watch mode
+```
+
+Tests use `vitest` + `@testing-library/preact` + `jsdom`. Current count: 227 tests across 18 files (see root [README](../../README.md#by-the-numbers) for the full project totals).
+
+## File layout
+
+| Path | Purpose |
+|---|---|
+| `src/app.tsx` | Root component + route shell |
+| `src/components/` | Visualization components (charts, cards, tables) |
+| `src/hooks/use-dashboard.ts` | `/api/data` fetcher + polling |
+| `src/hooks/use-theme.ts` | Dark-theme toggle with `localStorage` persistence |
+| `src/hooks/use-celebration.ts` | Celebration toast on newly-merged PRs (confetti) |
+| `src/types.ts` | Dashboard-side types (imports shared types from core) |
+| `vite.config.ts` | Vite + Preact plugin config |
+
+## Why a separate package?
+
+The dashboard is kept in its own workspace package so its Vite/Preact toolchain doesn't bleed into the CLI bundle, and so its test run can be parallelized by vitest across the three packages. It is deliberately not published to npm — the built artifact is consumed at runtime via filesystem path detection from the core package.
+
+## See also
+
+- Root [README](../../README.md) — installation, positioning, and feature overview
+- [`ARCHITECTURE.md`](../../ARCHITECTURE.md) — three-layer architecture
+- [`@oss-autopilot/core` README](../core/README.md) — CLI and core library
+- [`@oss-autopilot/mcp` README](../mcp-server/README.md) — MCP server


### PR DESCRIPTION
## Summary

Docs bundle — closes three low-priority audit findings in one PR.

| Closes | Change |
|---|---|
| #1005 | `ROADMAP.md`: replace *"No open issues at this time. The backlog is clear!"* with Now / Next / Later horizons seeded from open issues (#983, #992, #867, #965, #731, #940, audit-v2 sprint). |
| #1006 | `README.md`: update stale metrics. `1,762 tests` → `2,260+`, `70+ releases` → `140+`, `v1.11.0` → `v1.15.x`, `62 files` → `100+ files`, `912+ issues+PRs` → `1,000+`. By-the-Numbers table and two prose mentions. |
| #1007 | Add `packages/dashboard/README.md` — the only workspace package that lacked a package-level README, creating orientation friction for SPA contributors. |

## Test plan

- [x] `pnpm run lint` — clean
- [x] `pnpm run format:check` — prettier clean
- [x] README stats independently verified: `gh release list` shows 144 releases; `find packages -name "*.test.ts*"` shows 101 test files; `pnpm test` shows 2,260+ tests
- [x] Dashboard README content accurate vs actual `packages/dashboard/` file layout

_Part of audit-v2 follow-up. See also: #1009 (batch 1), #1010 (batch 2)._
