### PR TITLE
refactor: single-source MAX_SEARCH_RESULTS constant

### DIFF
--- a/packages/core/src/cli-registry.test.ts
+++ b/packages/core/src/cli-registry.test.ts
@@ -30,7 +30,7 @@ vi.mock('./formatters/json.js', () => ({
 // ─── Mock dynamic command-module imports ────────────────────────────────────
 
 const mockRunSearch = vi.fn();
-vi.mock('./commands/search.js', () => ({ runSearch: mockRunSearch }));
+vi.mock('./commands/search.js', () => ({ runSearch: mockRunSearch, MAX_SEARCH_RESULTS: 100 }));
 
 const mockRunDismiss = vi.fn();
 const mockRunUndismiss = vi.fn();

--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -204,7 +204,7 @@ export const commands: CLICommandDef[] = [
           executeAction(
             options,
             async () => {
-              const { runSearch } = await import('./commands/search.js');
+              const { runSearch, MAX_SEARCH_RESULTS } = await import('./commands/search.js');
               let maxResults = 5;
               if (count !== undefined) {
                 const parsed = Number(count);
@@ -213,7 +213,6 @@ export const commands: CLICommandDef[] = [
                 }
                 maxResults = parsed;
               }
-              const MAX_SEARCH_RESULTS = 100;
               if (maxResults > MAX_SEARCH_RESULTS) {
                 console.warn(`Capping search to ${MAX_SEARCH_RESULTS} results (requested: ${maxResults})`);
                 maxResults = MAX_SEARCH_RESULTS;

--- a/packages/core/src/cli.test.ts
+++ b/packages/core/src/cli.test.ts
@@ -423,15 +423,13 @@ describe('Command registration', () => {
 // ─── Search maxResults cap ────────────────────────────────────────────────────
 
 describe('Search maxResults cap', () => {
-  it('should enforce MAX_SEARCH_RESULTS = 100 in the search command definition', () => {
+  it('should enforce MAX_SEARCH_RESULTS = 100 via the shared export (#1002)', async () => {
     const searchCmd = commands.find((c) => c.name === 'search');
     expect(searchCmd).toBeDefined();
 
-    // Verify the cap constant is defined in the source (structural check)
-    const src = readFileSync(join(__dirname, 'cli-registry.ts'), 'utf-8');
-    const match = src.match(/const MAX_SEARCH_RESULTS\s*=\s*(\d+)/);
-    expect(match).not.toBeNull();
-    expect(Number(match![1])).toBe(100);
+    // Behavior check: assert the single-source-of-truth constant equals 100.
+    const { MAX_SEARCH_RESULTS } = await import('./commands/search.js');
+    expect(MAX_SEARCH_RESULTS).toBe(100);
   });
 
   it('should warn to console when capping maxResults', () => {

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -25,7 +25,7 @@ export { runStartup } from './startup.js';
 /** Return contribution statistics (merge rate, PR counts, repo breakdown) from local state. */
 export { runStatus } from './status.js';
 /** Search GitHub for contributable issues using multi-strategy discovery. */
-export { runSearch } from './search.js';
+export { runSearch, MAX_SEARCH_RESULTS } from './search.js';
 /** Vet a single GitHub issue for claimability (open, unassigned, no linked PRs, repo health). */
 export { runVet } from './vet.js';
 /** Re-vet all available issues in a curated issue list for freshness. */

--- a/packages/core/src/commands/search.ts
+++ b/packages/core/src/commands/search.ts
@@ -9,6 +9,13 @@ import { type SearchOutput } from '../formatters/json.js';
 
 export { type SearchOutput } from '../formatters/json.js';
 
+/**
+ * Hard cap on issue-search result count. Shared between CLI (`cli-registry.ts`),
+ * MCP tool (`tools.ts`), and MCP prompt (`prompts.ts`) so a future adjustment
+ * lands in one place instead of three (#1002).
+ */
+export const MAX_SEARCH_RESULTS = 100;
+
 interface SearchOptions {
   maxResults: number;
 }

--- a/packages/mcp-server/src/prompts.test.ts
+++ b/packages/mcp-server/src/prompts.test.ts
@@ -58,6 +58,7 @@ vi.mock('@oss-autopilot/core/commands', () => ({
   runDismiss: vi.fn(),
   runUndismiss: vi.fn(),
   runMove: vi.fn(),
+  MAX_SEARCH_RESULTS: 100,
 }));
 
 vi.mock('@oss-autopilot/core', () => ({

--- a/packages/mcp-server/src/prompts.ts
+++ b/packages/mcp-server/src/prompts.ts
@@ -9,7 +9,7 @@
  */
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { runDaily, runComments, runSearch } from '@oss-autopilot/core/commands';
+import { runDaily, runComments, runSearch, MAX_SEARCH_RESULTS } from '@oss-autopilot/core/commands';
 import { errorMessage } from '@oss-autopilot/core';
 
 /** Build a single-message prompt result with a user text message. */
@@ -83,7 +83,6 @@ export function registerPrompts(server: McpServer): void {
     },
     async ({ maxResults }) => {
       try {
-        const MAX_SEARCH_RESULTS = 100;
         let capped = maxResults ?? 5;
         if (!Number.isInteger(capped) || capped < 1) capped = 5;
         if (capped > MAX_SEARCH_RESULTS) capped = MAX_SEARCH_RESULTS;

--- a/packages/mcp-server/src/tools-execution.test.ts
+++ b/packages/mcp-server/src/tools-execution.test.ts
@@ -29,6 +29,7 @@ vi.mock('@oss-autopilot/core/commands', () => ({
   runDismiss: vi.fn(),
   runUndismiss: vi.fn(),
   runMove: mockRunMove,
+  MAX_SEARCH_RESULTS: 100,
 }));
 
 vi.mock('@oss-autopilot/core', () => ({

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -28,6 +28,7 @@ import {
   runDismiss,
   runUndismiss,
   runMove,
+  MAX_SEARCH_RESULTS,
 } from '@oss-autopilot/core/commands';
 import { errorMessage } from '@oss-autopilot/core';
 
@@ -128,7 +129,6 @@ export function registerTools(server: McpServer): void {
       annotations: { readOnlyHint: true },
     },
     wrapTool((args: { maxResults?: number }) => {
-      const MAX_SEARCH_RESULTS = 100;
       let maxResults = args.maxResults ?? 5;
       if (!Number.isInteger(maxResults) || maxResults < 1) {
         throw new Error(`Invalid maxResults: ${maxResults}. Must be a positive integer.`);


### PR DESCRIPTION
## Summary

Closes #1002.

The search cap `MAX_SEARCH_RESULTS = 100` was independently declared in three files. Three-site drift risk — if one caller started allowing 200 and the others stayed at 100, CLI and MCP would silently diverge.

## Change

Export from `packages/core/src/commands/search.ts` (colocated with `runSearch`, the only consumer), re-export via the commands barrel, import at all three call sites:

| Site | Before | After |
|---|---|---|
| `packages/core/src/cli-registry.ts:191` | Local `const MAX_SEARCH_RESULTS = 100` | Destructured from `await import('./commands/search.js')` |
| `packages/mcp-server/src/tools.ts:131` | Local `const` | Imported from `@oss-autopilot/core/commands` |
| `packages/mcp-server/src/prompts.ts:86` | Local `const` | Imported from `@oss-autopilot/core/commands` |

## Test changes

The `cli.test.ts` structural test (which regex-matched the source file) is replaced by a behavior assertion: `expect(MAX_SEARCH_RESULTS).toBe(100)` against the real export.

`cli-registry.test.ts`, `tools-execution.test.ts`, and `prompts.test.ts` have their `vi.mock` factories updated to provide the new export.

## Test plan

- [x] `pnpm run lint` — clean
- [x] `pnpm --filter @oss-autopilot/core run typecheck` — clean
- [x] `pnpm --filter @oss-autopilot/mcp run typecheck` — clean (after rebuilding core `dist/`)
- [x] `pnpm test` — 1,913 + 227 + 142 = 2,282 green across all three packages

_Part of audit-v2 follow-up. PRs so far: #1009 (batch 1), #1010 (batch 2), #1011 (batch 3), this one (batch 4)._
