### PR TITLE
refactor: single-source ActionRequest + DashboardStats across core/dashboard

### DIFF
--- a/packages/core/src/commands/dashboard-data.ts
+++ b/packages/core/src/commands/dashboard-data.ts
@@ -65,6 +65,17 @@ export interface DashboardJsonData {
   lastUpdated?: string;
 }
 
+/** Action types the dashboard can request via POST /api/action. */
+export type DashboardActionType = 'move' | 'dismiss_issue_response';
+
+/** Body shape for POST /api/action — single source for both server validation and SPA client (#998). */
+export interface ActionRequest {
+  action: DashboardActionType;
+  url: string;
+  /** Target state for move action. */
+  target?: 'attention' | 'waiting' | 'shelved' | 'auto';
+}
+
 export function buildDashboardStats(
   digest: DailyDigest,
   state: Readonly<AgentState>,

--- a/packages/core/src/commands/dashboard-server.ts
+++ b/packages/core/src/commands/dashboard-server.ts
@@ -23,6 +23,7 @@ import {
   storedToMergedPRs,
   storedToClosedPRs,
   type DashboardJsonData,
+  type ActionRequest,
 } from './dashboard-data.js';
 import { openInBrowser, detectIssueList } from './startup.js';
 import { parseIssueList, type ParseIssueListOutput } from './parse-list.js';
@@ -57,13 +58,6 @@ export interface DashboardServerOptions {
   assetsDir: string;
   token: string | null;
   open: boolean;
-}
-
-interface ActionRequest {
-  action: 'move' | 'dismiss_issue_response';
-  url: string;
-  /** Target state for move action. */
-  target?: 'attention' | 'waiting' | 'shelved' | 'auto';
 }
 
 // ── Constants ────────────────────────────────────────────────────────────────

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -89,6 +89,12 @@ export { runDetectFormatters } from './detect-formatters.js';
 /** Scan for locally cloned repos. */
 export { runLocalRepos } from './local-repos.js';
 
+// ── Dashboard Data Contract ─────────────────────────────────────────────────
+// Single source of truth for the types the dashboard SPA consumes.
+// Imported by @oss-autopilot/dashboard to prevent drift (#965, #998).
+
+export type { DashboardJsonData, DashboardStats, DashboardActionType, ActionRequest } from './dashboard-data.js';
+
 // ── Output Types ────────────────────────────────────────────────────────────
 // All commands return JsonOutput<T> where T is the command-specific type below.
 

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -16,7 +16,13 @@ import type {
   RepoMetadataEntry,
 } from '@oss-autopilot/core/types';
 
-import type { ParsedIssueItem, ParseIssueListOutput } from '@oss-autopilot/core/commands';
+import type {
+  ParsedIssueItem,
+  ParseIssueListOutput,
+  DashboardStats,
+  DashboardActionType,
+  ActionRequest,
+} from '@oss-autopilot/core/commands';
 
 // Re-export shared types so consumers keep using `import { X } from '../types'`
 export type {
@@ -30,18 +36,10 @@ export type {
   RepoMetadataEntry,
   ParsedIssueItem,
   ParseIssueListOutput,
+  DashboardStats,
+  DashboardActionType,
+  ActionRequest,
 };
-
-// -- Dashboard-specific types --
-
-export interface DashboardStats {
-  activePRs: number;
-  shelvedPRs: number;
-  mergedPRs: number;
-  closedPRs: number;
-  mergeRate: string;
-  availableIssues?: number;
-}
 
 /** The shape of the GET /api/data response from the dashboard server. */
 export interface DashboardData {
@@ -62,15 +60,4 @@ export interface DashboardData {
   allClosedPRs: ClosedPR[];
   repoMetadata?: Record<string, RepoMetadataEntry>;
   vettedIssues?: ParseIssueListOutput | null;
-}
-
-/** Actions a user can take from the dashboard. */
-export type ActionType = 'move' | 'dismiss_issue_response';
-
-/** Request body for POST /api/action. */
-export interface ActionRequest {
-  action: ActionType;
-  url: string;
-  /** Target state for move action. */
-  target?: 'attention' | 'waiting' | 'shelved' | 'auto';
 }


### PR DESCRIPTION
## Summary

Closes #998.

Two interfaces were declared independently on both sides of the core/dashboard package boundary, risking silent drift when one side added a field:

| Interface | Before | After |
|---|---|---|
| `ActionRequest` | `dashboard-server.ts:62` **and** `dashboard/src/types.ts:71` | Single-sourced in `dashboard-data.ts`, imported by both |
| `DashboardStats` | `dashboard-data.ts:31` **and** `dashboard/src/types.ts:37` | Single-sourced in `dashboard-data.ts`, imported by dashboard |

Follows the pattern already used for `DashboardJsonData` (#972/#965): core is the single source, dashboard imports and re-exports.

## Changes

- `packages/core/src/commands/dashboard-data.ts` — move `ActionRequest` here (colocated with the other dashboard data-contract types); add `DashboardActionType` alias for the action-name union.
- `packages/core/src/commands/index.ts` — new section re-exporting `DashboardJsonData`, `DashboardStats`, `DashboardActionType`, `ActionRequest`.
- `packages/core/src/commands/dashboard-server.ts` — import `ActionRequest` from `./dashboard-data.js` instead of redeclaring.
- `packages/dashboard/src/types.ts` — import all four dashboard types from `@oss-autopilot/core/commands` and re-export for SPA consumers. Removes the now-unused `ActionType` alias (no caller used it; every consumer uses `ActionRequest`).

## Test plan

- [x] `pnpm run lint` clean
- [x] `pnpm run format:check` clean
- [x] `pnpm -r run typecheck` clean (core, dashboard, mcp all green — dashboard now sees the single-sourced types from core `dist/`)
- [x] `pnpm test` — 1,913 / 227 / 142 = 2,282 tests pass across all three packages

_Part of audit-v2 follow-up. PRs so far: #1009, #1010, #1011, #1012, this (batch 5)._
