### PR TITLE
refactor: extract ensureGistPersistence helper (single-source for CLI + MCP)

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -60,21 +60,10 @@ program.hook('preAction', async (thisCommand, actionCommand) => {
     }
 
     // Activate Gist persistence if configured, before any command runs.
-    // Peek at the config file directly to avoid creating a local-only singleton
-    // (getStateManager() would lock in local mode before getStateManagerAsync runs).
-    let persistence: string | undefined;
-    try {
-      const { getStatePath } = await import('./core/index.js');
-      const fs = await import('fs');
-      const raw = fs.readFileSync(getStatePath(), 'utf-8');
-      persistence = JSON.parse(raw)?.config?.persistence;
-    } catch {
-      // No state file or unreadable — local mode, lazy init
-    }
-    if (persistence === 'gist' && token) {
-      const { getStateManagerAsync } = await import('./core/index.js');
-      await getStateManagerAsync(token);
-    }
+    // Shared helper peeks at the state file and only pre-sets the singleton
+    // when Gist mode is the configured persistence (#1000).
+    const { ensureGistPersistence } = await import('./core/index.js');
+    await ensureGistPersistence(token);
   }
 });
 

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -3,7 +3,14 @@
  * Re-exports all core functionality for convenient imports
  */
 
-export { StateManager, getStateManager, getStateManagerAsync, resetStateManager, type Stats } from './state.js';
+export {
+  StateManager,
+  getStateManager,
+  getStateManagerAsync,
+  ensureGistPersistence,
+  resetStateManager,
+  type Stats,
+} from './state.js';
 export { GistStateStore } from './gist-state-store.js';
 export {
   PRMonitor,

--- a/packages/core/src/core/state.ts
+++ b/packages/core/src/core/state.ts
@@ -789,6 +789,41 @@ export async function getStateManagerAsync(token?: string): Promise<StateManager
 }
 
 /**
+ * Bootstrap helper for processes that may run in Gist persistence mode.
+ *
+ * Peeks at the state file to check if Gist mode is configured. If so and a
+ * valid token is provided, pre-sets the singleton via {@link getStateManagerAsync}
+ * so subsequent synchronous {@link getStateManager} calls return the Gist-backed
+ * instance. No-op when the state file is absent, unparseable, or not in Gist mode.
+ *
+ * Consolidates identical filesystem-peek + getStateManagerAsync logic that
+ * was duplicated between the CLI bootstrap (`cli.ts`) and MCP tool bootstrap
+ * (`mcp-server/src/tools.ts`) — #1000.
+ *
+ * @param token - GitHub token with `gist` scope, or `null` to skip activation
+ *
+ * @example
+ * // CLI bootstrap
+ * await ensureGistPersistence(token);
+ */
+export async function ensureGistPersistence(token: string | null): Promise<void> {
+  if (!token) return;
+
+  let persistence: string | undefined;
+  try {
+    const raw = fs.readFileSync(getStatePath(), 'utf-8');
+    persistence = JSON.parse(raw)?.config?.persistence;
+  } catch {
+    // No state file or unreadable — stay in local mode
+    return;
+  }
+
+  if (persistence === 'gist') {
+    await getStateManagerAsync(token);
+  }
+}
+
+/**
  * Reset the singleton StateManager instance to null. Intended for test isolation.
  */
 export function resetStateManager(): void {

--- a/packages/mcp-server/src/index-main.test.ts
+++ b/packages/mcp-server/src/index-main.test.ts
@@ -30,6 +30,8 @@ vi.mock('@oss-autopilot/core', () => ({
       lastDigest: { openPRs: [], shelvedPRs: [] },
     }),
   }),
+  getGitHubTokenAsync: vi.fn().mockResolvedValue(null),
+  ensureGistPersistence: vi.fn().mockResolvedValue(undefined),
 }));
 
 // Mock StdioServerTransport — must use function() not arrow to support `new`

--- a/packages/mcp-server/src/prompts.test.ts
+++ b/packages/mcp-server/src/prompts.test.ts
@@ -68,6 +68,8 @@ vi.mock('@oss-autopilot/core', () => ({
       lastDigest: { openPRs: [], shelvedPRs: [] },
     }),
   }),
+  getGitHubTokenAsync: vi.fn().mockResolvedValue(null),
+  ensureGistPersistence: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { createServer } from './server.js';

--- a/packages/mcp-server/src/resources.test.ts
+++ b/packages/mcp-server/src/resources.test.ts
@@ -40,6 +40,8 @@ vi.mock('@oss-autopilot/core', () => ({
     const [owner, repo] = fullName.split('/');
     return { owner, repo };
   },
+  getGitHubTokenAsync: vi.fn().mockResolvedValue(null),
+  ensureGistPersistence: vi.fn().mockResolvedValue(undefined),
   getStateManager: vi.fn().mockReturnValue({
     getState: vi.fn().mockReturnValue({
       lastDigest: {

--- a/packages/mcp-server/src/tools-execution.test.ts
+++ b/packages/mcp-server/src/tools-execution.test.ts
@@ -39,6 +39,8 @@ vi.mock('@oss-autopilot/core', () => ({
       lastDigest: { openPRs: [], shelvedPRs: [] },
     }),
   }),
+  getGitHubTokenAsync: vi.fn().mockResolvedValue(null),
+  ensureGistPersistence: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { createServer } from './server.js';

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -38,23 +38,12 @@ async function ensureGistInit(): Promise<void> {
   if (gistInitDone) return;
   gistInitDone = true;
 
-  // Read config file — may legitimately fail (no state file yet)
-  let persistence: string | undefined;
-  try {
-    const { getStatePath } = await import('@oss-autopilot/core');
-    const fs = await import('fs');
-    const raw = fs.readFileSync(getStatePath(), 'utf-8');
-    persistence = JSON.parse(raw)?.config?.persistence;
-  } catch {
-    return;
-  }
-
-  if (persistence === 'gist') {
-    // Gist init errors (GistPermissionError, network) propagate to wrapTool's catch
-    const { getStateManagerAsync, getGitHubTokenAsync } = await import('@oss-autopilot/core');
-    const token = await getGitHubTokenAsync();
-    if (token) await getStateManagerAsync(token);
-  }
+  // Gist init errors (GistPermissionError, network) propagate to wrapTool's catch.
+  // Shared helper in core unifies the "peek at state file, check persistence mode,
+  // pre-set singleton" logic that was previously duplicated with cli.ts (#1000).
+  const { ensureGistPersistence, getGitHubTokenAsync } = await import('@oss-autopilot/core');
+  const token = await getGitHubTokenAsync();
+  await ensureGistPersistence(token);
 }
 
 /** Standard MCP text content result. */


### PR DESCRIPTION
## Summary

Closes #1000.

The "peek at state file, if `persistence === 'gist'` then call `getStateManagerAsync`" pattern was duplicated between `cli.ts:62-77` and `mcp-server/src/tools.ts:36-56`. Two separate copies of ~15 lines of filesystem + JSON parsing logic at the boundary between startup and core state management.

## Change

Extract `ensureGistPersistence(token)` to `packages/core/src/core/state.ts` (colocated with `getStateManagerAsync`), re-export via `core/index.ts`, and collapse both call sites.

| Site | Before | After |
|---|---|---|
| `packages/core/src/cli.ts` | 16-line peek + dynamic import + call | 4 lines (`await ensureGistPersistence(token)`) |
| `packages/mcp-server/src/tools.ts` | 22-line `ensureGistInit` body | 9 lines — still wraps with `gistInitDone` one-shot guard since MCP tool calls can be repeated in a long-lived process, unlike the CLI's single-invocation lifecycle |

The helper is a no-op when the token is `null`, when the state file doesn't exist, or when persistence is anything other than `'gist'`. Behavior-preserving for both call sites.

## Test changes

MCP test mocks in `tools-execution.test.ts`, `prompts.test.ts`, and `resources.test.ts` now stub `getGitHubTokenAsync` + `ensureGistPersistence` so `wrapTool`'s `ensureGistInit` call resolves cleanly (previously those tests avoided it by not importing the missing export — now we import it and mock it to no-op).

## Test plan

- [x] `pnpm run lint` clean
- [x] `pnpm run format:check` clean
- [x] `pnpm -r run typecheck` clean
- [x] `pnpm test` — 1,913 / 227 / 142 = 2,282 tests pass

_Part of audit-v2 follow-up. PRs so far: #1009, #1010, #1011, #1012, #1013, this (batch 6)._
