### PR TITLE
test: audit-v2 batch 8 — hermetic stateFileExists + queueMicrotask in dashboard-lifecycle

### DIFF
--- a/packages/core/src/commands/dashboard-lifecycle.test.ts
+++ b/packages/core/src/commands/dashboard-lifecycle.test.ts
@@ -250,7 +250,9 @@ describe('launchDashboardServer', () => {
       unref: vi.fn(),
       pid: 99999,
       on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
-        if (event === 'error') setTimeout(() => cb(new Error('ENOENT')), 50);
+        // queueMicrotask fires on the next microtask — deterministic, no wall-clock
+        // dependency, avoids CI-slowness flakes vs a setTimeout (#1004).
+        if (event === 'error') queueMicrotask(() => cb(new Error('ENOENT')));
       }),
     });
     mockReadDashboardServerInfo.mockReturnValue(null);
@@ -268,7 +270,7 @@ describe('launchDashboardServer', () => {
       unref: vi.fn(),
       pid: 99999,
       on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
-        if (event === 'exit') setTimeout(() => cb(1), 50);
+        if (event === 'exit') queueMicrotask(() => cb(1));
       }),
     });
     mockReadDashboardServerInfo.mockReturnValue(null);

--- a/packages/core/src/core/utils.test.ts
+++ b/packages/core/src/core/utils.test.ts
@@ -479,11 +479,47 @@ describe('getGitHubTokenAsync', () => {
 });
 
 describe('stateFileExists', () => {
-  it('should agree with direct filesystem check on the state file path', () => {
-    // Validates the function returns the correct boolean by comparing against
-    // a manual check of the same path. Covers both true (dev) and false (CI) cases.
-    const stateFile = path.join(os.homedir(), '.oss-autopilot', 'state.json');
-    expect(stateFileExists()).toBe(fs.existsSync(stateFile));
+  let tempHome: string;
+  let originalHome: string | undefined;
+  let originalUserProfile: string | undefined;
+
+  beforeEach(() => {
+    // Hermetic fixture: redirect os.homedir() (which reads HOME on Unix,
+    // USERPROFILE on Windows) so stateFileExists checks the temp dir, not
+    // the developer/CI user's real ~/.oss-autopilot (#1003).
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'oss-statefile-test-'));
+    originalHome = process.env.HOME;
+    originalUserProfile = process.env.USERPROFILE;
+    process.env.HOME = tempHome;
+    process.env.USERPROFILE = tempHome;
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originalUserProfile;
+    try {
+      fs.rmSync(tempHome, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it('returns false when the state file does not exist', () => {
+    expect(stateFileExists()).toBe(false);
+  });
+
+  it('returns true when the state file exists', () => {
+    const dir = path.join(tempHome, '.oss-autopilot');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'state.json'), '{}');
+    expect(stateFileExists()).toBe(true);
+  });
+
+  it('returns false when the directory exists but the file does not', () => {
+    fs.mkdirSync(path.join(tempHome, '.oss-autopilot'), { recursive: true });
+    expect(stateFileExists()).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Test-hygiene bundle — closes two low-priority audit findings in one PR.

## Closes #1003 — tautological stateFileExists test

`utils.test.ts:481-487` compared `stateFileExists()` to `fs.existsSync(path.join(os.homedir(), '.oss-autopilot/state.json'))` — both called the same filesystem at the same path, so the assertion could never fail while the function worked at all, and observed behavior depended on whether the developer had `~/.oss-autopilot/` on their machine.

**Fix:** Three hermetic tests that redirect `HOME`/`USERPROFILE` to a temp dir and exercise all three possible states:

- file absent → `false`
- file present → `true`
- directory exists, file does not → `false`

First attempt used `vi.spyOn(os, 'homedir')` but `os.homedir` is non-configurable in this Node build. Switched to env-var redirection which is portable and works on both Unix (`HOME`) and Windows (`USERPROFILE`).

## Closes #1004 — real setTimeouts in dashboard-lifecycle tests

`dashboard-lifecycle.test.ts:253,271` used `setTimeout(() => cb(...), 50)` inside mocked child-process event handlers. Under CI load these wall-clock timeouts can reorder with awaits and produce intermittent failures.

**Fix:** Replace both with `queueMicrotask(() => cb(...))`. The original 50ms delay was just to fire the callback asynchronously (after `launchDashboardServer` finished registering its handler) — `queueMicrotask` achieves the same without wall-clock coupling.

## Intentionally out of scope

The 50ms wait in `packages/dashboard/src/app.test.tsx:481` is kept. It verifies the *absence* of a celebration toast after initial render — you can't `queueMicrotask` your way to confidence that something did not happen. A fixed wait is the right shape there.

## Test plan

- [x] `pnpm run lint` clean
- [x] `pnpm run format:check` clean
- [x] `pnpm test` — 2,282 tests pass (1,913 / 227 / 142)
- [x] New hermetic tests do not touch the developer's real `~/.oss-autopilot/`

_Part of audit-v2 follow-up. PRs so far: #1009, #1010, #1011, #1012, #1013, #1014, this (batch 8)._
