### PR TITLE
test: add --json contract tests for 4 mutating commands (track, dismiss, shelve, move)

### DIFF
--- a/packages/core/src/commands/__golden__/dismiss.noop.json
+++ b/packages/core/src/commands/__golden__/dismiss.noop.json
@@ -1,0 +1,4 @@
+{
+  "dismissed": false,
+  "url": "https://github.com/owner/repo/issues/42"
+}

--- a/packages/core/src/commands/__golden__/dismiss.success.json
+++ b/packages/core/src/commands/__golden__/dismiss.success.json
@@ -1,0 +1,4 @@
+{
+  "dismissed": true,
+  "url": "https://github.com/owner/repo/issues/42"
+}

--- a/packages/core/src/commands/__golden__/move.attention.json
+++ b/packages/core/src/commands/__golden__/move.attention.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/owner/repo/pull/42",
+  "target": "attention",
+  "description": "Moved to Need Attention"
+}

--- a/packages/core/src/commands/__golden__/move.auto.json
+++ b/packages/core/src/commands/__golden__/move.auto.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/owner/repo/pull/42",
+  "target": "auto",
+  "description": "Reset to computed status"
+}

--- a/packages/core/src/commands/__golden__/move.shelved.json
+++ b/packages/core/src/commands/__golden__/move.shelved.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/owner/repo/pull/42",
+  "target": "shelved",
+  "description": "Shelved — excluded from capacity and actionable items"
+}

--- a/packages/core/src/commands/__golden__/move.waiting.json
+++ b/packages/core/src/commands/__golden__/move.waiting.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/owner/repo/pull/42",
+  "target": "waiting",
+  "description": "Moved to Waiting on Maintainer"
+}

--- a/packages/core/src/commands/__golden__/shelve.noop.json
+++ b/packages/core/src/commands/__golden__/shelve.noop.json
@@ -1,0 +1,4 @@
+{
+  "shelved": false,
+  "url": "https://github.com/owner/repo/pull/42"
+}

--- a/packages/core/src/commands/__golden__/shelve.success.json
+++ b/packages/core/src/commands/__golden__/shelve.success.json
@@ -1,0 +1,4 @@
+{
+  "shelved": true,
+  "url": "https://github.com/owner/repo/pull/42"
+}

--- a/packages/core/src/commands/__golden__/track.json
+++ b/packages/core/src/commands/__golden__/track.json
@@ -1,0 +1,8 @@
+{
+  "pr": {
+    "repo": "owner/repo",
+    "number": 42,
+    "title": "Improve error handling in foo()",
+    "url": "https://github.com/owner/repo/pull/42"
+  }
+}

--- a/packages/core/src/commands/__golden__/undismiss.noop.json
+++ b/packages/core/src/commands/__golden__/undismiss.noop.json
@@ -1,0 +1,4 @@
+{
+  "undismissed": false,
+  "url": "https://github.com/owner/repo/issues/42"
+}

--- a/packages/core/src/commands/__golden__/undismiss.success.json
+++ b/packages/core/src/commands/__golden__/undismiss.success.json
@@ -1,0 +1,4 @@
+{
+  "undismissed": true,
+  "url": "https://github.com/owner/repo/issues/42"
+}

--- a/packages/core/src/commands/__golden__/unshelve.noop.json
+++ b/packages/core/src/commands/__golden__/unshelve.noop.json
@@ -1,0 +1,4 @@
+{
+  "unshelved": false,
+  "url": "https://github.com/owner/repo/pull/42"
+}

--- a/packages/core/src/commands/__golden__/unshelve.success.json
+++ b/packages/core/src/commands/__golden__/unshelve.success.json
@@ -1,0 +1,4 @@
+{
+  "unshelved": true,
+  "url": "https://github.com/owner/repo/pull/42"
+}

--- a/packages/core/src/commands/dismiss.contract.test.ts
+++ b/packages/core/src/commands/dismiss.contract.test.ts
@@ -1,0 +1,60 @@
+/**
+ * --json contract test for the `dismiss`/`undismiss` commands (#965, #997).
+ *
+ * Goldens pin the DismissOutput/UndismissOutput shapes so the plugin and MCP
+ * server cannot silently drift apart from the CLI. Covers both success (newly
+ * dismissed/undismissed) and noop (already in the target state) paths.
+ *
+ * Update on intentional shape changes with:
+ *   npx vitest run -u src/commands/dismiss.contract.test.ts
+ */
+
+import { describe, it, vi, beforeEach, expect } from 'vitest';
+
+const mockDismissIssue = vi.fn();
+const mockUndismissIssue = vi.fn();
+
+vi.mock('../core/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../core/index.js')>('../core/index.js');
+  return {
+    ...actual,
+    getStateManager: () => ({
+      dismissIssue: mockDismissIssue,
+      undismissIssue: mockUndismissIssue,
+    }),
+  };
+});
+
+import { runDismiss, runUndismiss } from './dismiss.js';
+
+const TEST_ISSUE_URL = 'https://github.com/owner/repo/issues/42';
+
+describe('dismiss --json contract', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('dismiss success output matches the golden shape', async () => {
+    mockDismissIssue.mockReturnValue(true);
+    const result = await runDismiss({ url: TEST_ISSUE_URL });
+    await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/dismiss.success.json');
+  });
+
+  it('dismiss noop output matches the golden shape (already dismissed)', async () => {
+    mockDismissIssue.mockReturnValue(false);
+    const result = await runDismiss({ url: TEST_ISSUE_URL });
+    await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/dismiss.noop.json');
+  });
+
+  it('undismiss success output matches the golden shape', async () => {
+    mockUndismissIssue.mockReturnValue(true);
+    const result = await runUndismiss({ url: TEST_ISSUE_URL });
+    await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/undismiss.success.json');
+  });
+
+  it('undismiss noop output matches the golden shape (not currently dismissed)', async () => {
+    mockUndismissIssue.mockReturnValue(false);
+    const result = await runUndismiss({ url: TEST_ISSUE_URL });
+    await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/undismiss.noop.json');
+  });
+});

--- a/packages/core/src/commands/move.contract.test.ts
+++ b/packages/core/src/commands/move.contract.test.ts
@@ -1,0 +1,62 @@
+/**
+ * --json contract test for the `move` command (#965, #997).
+ *
+ * Goldens pin the MoveOutput shape for all four valid targets so the plugin
+ * and MCP server cannot silently drift apart from the CLI.
+ *
+ * Update on intentional shape changes with:
+ *   npx vitest run -u src/commands/move.contract.test.ts
+ */
+
+import { describe, it, vi, beforeEach, expect } from 'vitest';
+
+const mockSetStatusOverride = vi.fn();
+const mockClearStatusOverride = vi.fn();
+const mockShelvePR = vi.fn();
+const mockUnshelvePR = vi.fn();
+const mockBatch = vi.fn((fn: () => void) => fn());
+
+vi.mock('../core/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../core/index.js')>('../core/index.js');
+  return {
+    ...actual,
+    getStateManager: () => ({
+      setStatusOverride: mockSetStatusOverride,
+      clearStatusOverride: mockClearStatusOverride,
+      shelvePR: mockShelvePR,
+      unshelvePR: mockUnshelvePR,
+      batch: mockBatch,
+    }),
+  };
+});
+
+import { runMove } from './move.js';
+
+const TEST_PR_URL = 'https://github.com/owner/repo/pull/42';
+
+describe('move --json contract', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockBatch.mockImplementation((fn: () => void) => fn());
+  });
+
+  it('target=attention output matches the golden shape', async () => {
+    const result = await runMove({ prUrl: TEST_PR_URL, target: 'attention' });
+    await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/move.attention.json');
+  });
+
+  it('target=waiting output matches the golden shape', async () => {
+    const result = await runMove({ prUrl: TEST_PR_URL, target: 'waiting' });
+    await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/move.waiting.json');
+  });
+
+  it('target=shelved output matches the golden shape', async () => {
+    const result = await runMove({ prUrl: TEST_PR_URL, target: 'shelved' });
+    await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/move.shelved.json');
+  });
+
+  it('target=auto output matches the golden shape', async () => {
+    const result = await runMove({ prUrl: TEST_PR_URL, target: 'auto' });
+    await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/move.auto.json');
+  });
+});

--- a/packages/core/src/commands/shelve.contract.test.ts
+++ b/packages/core/src/commands/shelve.contract.test.ts
@@ -1,0 +1,66 @@
+/**
+ * --json contract test for the `shelve`/`unshelve` commands (#965, #997).
+ *
+ * Goldens pin the ShelveOutput/UnshelveOutput shapes so the plugin and MCP
+ * server cannot silently drift apart from the CLI. Covers both success (newly
+ * shelved/unshelved) and noop (already in the target state) paths.
+ *
+ * Update on intentional shape changes with:
+ *   npx vitest run -u src/commands/shelve.contract.test.ts
+ */
+
+import { describe, it, vi, beforeEach, expect } from 'vitest';
+
+const mockShelvePR = vi.fn();
+const mockUnshelvePR = vi.fn();
+const mockClearStatusOverride = vi.fn();
+const mockBatch = vi.fn((fn: () => void) => fn());
+
+vi.mock('../core/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../core/index.js')>('../core/index.js');
+  return {
+    ...actual,
+    getStateManager: () => ({
+      shelvePR: mockShelvePR,
+      unshelvePR: mockUnshelvePR,
+      clearStatusOverride: mockClearStatusOverride,
+      batch: mockBatch,
+    }),
+  };
+});
+
+import { runShelve, runUnshelve } from './shelve.js';
+
+const TEST_PR_URL = 'https://github.com/owner/repo/pull/42';
+
+describe('shelve --json contract', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    // Batch is a pass-through wrapper — default impl re-applies the mutation
+    mockBatch.mockImplementation((fn: () => void) => fn());
+  });
+
+  it('shelve success output matches the golden shape', async () => {
+    mockShelvePR.mockReturnValue(true);
+    const result = await runShelve({ prUrl: TEST_PR_URL });
+    await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/shelve.success.json');
+  });
+
+  it('shelve noop output matches the golden shape (already shelved)', async () => {
+    mockShelvePR.mockReturnValue(false);
+    const result = await runShelve({ prUrl: TEST_PR_URL });
+    await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/shelve.noop.json');
+  });
+
+  it('unshelve success output matches the golden shape', async () => {
+    mockUnshelvePR.mockReturnValue(true);
+    const result = await runUnshelve({ prUrl: TEST_PR_URL });
+    await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/unshelve.success.json');
+  });
+
+  it('unshelve noop output matches the golden shape (not currently shelved)', async () => {
+    mockUnshelvePR.mockReturnValue(false);
+    const result = await runUnshelve({ prUrl: TEST_PR_URL });
+    await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/unshelve.noop.json');
+  });
+});

--- a/packages/core/src/commands/track.contract.test.ts
+++ b/packages/core/src/commands/track.contract.test.ts
@@ -1,0 +1,42 @@
+/**
+ * --json contract test for the `track` command (#965, #997).
+ *
+ * runTrack is a v2 informational lookup that fetches PR metadata from GitHub
+ * and returns it. It does not mutate state. The golden pins the TrackOutput
+ * shape so the plugin and MCP server cannot silently drift apart from the CLI.
+ *
+ * Update on intentional shape changes with:
+ *   npx vitest run -u src/commands/track.contract.test.ts
+ */
+
+import { describe, it, vi, beforeEach, expect } from 'vitest';
+
+const mockPullsGet = vi.fn();
+
+vi.mock('../core/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../core/index.js')>('../core/index.js');
+  return {
+    ...actual,
+    getOctokit: vi.fn(() => ({ pulls: { get: mockPullsGet } })),
+    requireGitHubToken: vi.fn(() => 'ghp_fake_token'),
+  };
+});
+
+import { runTrack } from './track.js';
+
+const TEST_PR_URL = 'https://github.com/owner/repo/pull/42';
+
+describe('track --json contract', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('output matches the golden shape', async () => {
+    mockPullsGet.mockResolvedValue({
+      data: { title: 'Improve error handling in foo()' },
+    });
+
+    const result = await runTrack({ prUrl: TEST_PR_URL });
+    await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/track.json');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #997.

Adds golden-file contract tests for the four state-mutating CLI commands whose `--json` output the plugin and MCP server parse. Without contract tests, schema drift on these commands could silently break integrators.

## Coverage matrix

| Command | Tests | Goldens |
|---|---|---|
| `track` | 1 (happy path) | `track.json` |
| `dismiss` / `undismiss` | 4 (success + noop per direction) | `dismiss.success.json`, `dismiss.noop.json`, `undismiss.success.json`, `undismiss.noop.json` |
| `shelve` / `unshelve` | 4 (success + noop per direction) | `shelve.success.json`, `shelve.noop.json`, `unshelve.success.json`, `unshelve.noop.json` |
| `move` | 4 (all valid targets: `attention`, `waiting`, `shelved`, `auto`) | `move.attention.json`, `move.waiting.json`, `move.shelved.json`, `move.auto.json` |

Total: 4 new test files, 13 new tests, 13 new golden fixtures. `__golden__/README.md` guidance for updating snapshots is unchanged.

## Pattern

Mirrors `state-cmd.contract.test.ts`:
- `vi.mock('../core/index.js', async () => ({ ...await vi.importActual(...), getStateManager: () => fakes }))` — preserves all other exports while stubbing just the state access the command uses.
- `beforeEach(() => vi.resetAllMocks())` — prevents fixture bleed from earlier tests.
- `toMatchFileSnapshot('./__golden__/*.json')` — fails with a diff when the output shape drifts.

## Test plan

- [x] `pnpm run lint` clean
- [x] `pnpm run format:check` clean
- [x] `pnpm test` — 1,926 core + 227 dashboard + 142 mcp-server = 2,295 tests pass (+13 vs main)

_Part of audit-v2 follow-up. PRs so far: #1009, #1010, #1011, #1012, #1013, #1014, #1015, this (batch 7)._
