### PR TITLE
chore: clarify v2 semantics of track/untrack (deprecate, don't remove)

### DIFF
--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -352,7 +352,7 @@ export const commands: CLICommandDef[] = [
     register(program) {
       program
         .command('track <pr-url>')
-        .description('Add a PR to track')
+        .description('Fetch metadata for a PR (informational — v2 does not maintain a local tracking list)')
         .option('--json', 'Output as JSON')
         .action(async (prUrl, options) => {
           try {
@@ -362,7 +362,8 @@ export const commands: CLICommandDef[] = [
               outputJson(data);
             } else {
               console.log(`\nPR: ${data.pr.repo}#${data.pr.number} - ${data.pr.title}`);
-              console.log('Note: In v2, PRs are tracked automatically via the daily run.');
+              console.log('Note: In v2, PRs are discovered automatically on each daily run — this command only');
+              console.log('fetches metadata for inspection. Nothing is persisted locally.');
             }
           } catch (err) {
             handleCommandError(err, options.json);
@@ -378,7 +379,7 @@ export const commands: CLICommandDef[] = [
     register(program) {
       program
         .command('untrack <pr-url>')
-        .description('Stop tracking a PR')
+        .description('[DEPRECATED] No-op in v2. Use `shelve` to hide a PR from the daily digest.')
         .option('--json', 'Output as JSON')
         .action(async (prUrl, options) => {
           try {
@@ -387,10 +388,9 @@ export const commands: CLICommandDef[] = [
             if (options.json) {
               outputJson(data);
             } else {
-              console.log(
-                'Note: In v2, PRs are fetched fresh on each daily run \u2014 there is no local tracking list to remove from.',
-              );
-              console.log('Use `shelve` to temporarily hide a PR from the daily summary.');
+              // Stderr so scripts piping stdout don't see the deprecation notice.
+              console.error('[DEPRECATED] `untrack` is a no-op in v2. PRs are fetched fresh on each daily run —');
+              console.error('there is no local tracking list to remove from. Use `shelve` to hide a PR instead.');
             }
           } catch (err) {
             handleCommandError(err, options.json);

--- a/packages/core/src/commands/track.ts
+++ b/packages/core/src/commands/track.ts
@@ -1,7 +1,16 @@
 /**
- * Track/Untrack commands
- * In v2, PRs are fetched fresh from GitHub on each `daily` run.
- * These commands are preserved for backward compatibility.
+ * Track/Untrack commands (v2 semantics — see #1001)
+ *
+ * **These commands do not mutate state.** In v2, PRs are discovered and
+ * enriched automatically on every `daily` run — there is no local tracking
+ * list to add to or remove from. The commands are preserved for backwards
+ * compatibility with v1 callers, but:
+ *
+ * - `runTrack` is an **informational lookup** that fetches PR metadata from
+ *   GitHub and returns it. Useful for inspecting a specific PR's shape
+ *   without waiting for the next `daily` run. Nothing is persisted.
+ * - `runUntrack` is **deprecated** and always a no-op. Use `shelve` to hide
+ *   a PR from the daily digest.
  */
 
 import { getOctokit, requireGitHubToken } from '../core/index.js';
@@ -16,7 +25,11 @@ export interface UntrackOutput {
 }
 
 /**
- * Validate and fetch metadata for a PR URL.
+ * Fetch metadata for a PR URL (informational — does not persist).
+ *
+ * In v2 this is a read-only lookup. PRs are discovered automatically on each
+ * `daily` run; this command exists for one-off inspection of a specific PR's
+ * shape (title, repo, number).
  *
  * @param options - Track options
  * @param options.prUrl - Full GitHub PR URL
@@ -50,11 +63,14 @@ export async function runTrack(options: { prUrl: string }): Promise<TrackOutput>
 }
 
 /**
- * No-op in v2 — PRs are fetched fresh on each daily run.
+ * @deprecated No-op in v2. Use `runShelve` to hide a PR from the daily digest.
+ *
+ * Kept for backwards compatibility with v1 callers. PRs are fetched fresh
+ * on each `daily` run, so there is no local tracking list to remove from.
  *
  * @param options - Untrack options
- * @param options.prUrl - Full GitHub PR URL
- * @returns Message explaining v2 behavior
+ * @param options.prUrl - Full GitHub PR URL (validated but not used)
+ * @returns Output object with `removed: false` and a message explaining v2 behavior
  * @throws {ValidationError} If the URL is not a valid GitHub PR URL
  */
 export async function runUntrack(options: { prUrl: string }): Promise<UntrackOutput> {

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -149,12 +149,12 @@ describe('MCP tool registrations', () => {
   });
 
   describe('annotations', () => {
-    const readOnlyTools = ['status', 'search', 'vet', 'comments', 'check-setup'];
+    // track is read-only in v2: fetches metadata from GitHub, does not persist (#1001).
+    // untrack is a no-op in v2 (#1001) — deprecated, also read-only since it doesn't mutate state.
+    const readOnlyTools = ['status', 'search', 'vet', 'comments', 'check-setup', 'track', 'untrack'];
     const mutatingTools = [
       'daily',
       'startup',
-      'track',
-      'untrack',
       'read',
       'post',
       'claim',
@@ -181,11 +181,6 @@ describe('MCP tool registrations', () => {
       expect(tool).toBeDefined();
       expect(tool!.annotations).toBeDefined();
       expect((tool!.annotations as Record<string, unknown>).readOnlyHint).toBe(false);
-    });
-
-    it('untrack has destructiveHint: true', () => {
-      const tool = tools.find((t) => t.name === 'untrack')!;
-      expect((tool.annotations as Record<string, unknown>).destructiveHint).toBe(true);
     });
   });
 });

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -170,29 +170,32 @@ export function registerTools(server: McpServer): void {
     wrapTool(runVetList),
   );
 
-  // 5. track — Track a PR
+  // 5. track — Fetch PR metadata (informational; v2 does not persist a tracking list)
   server.registerTool(
     'track',
     {
       description:
-        'Start tracking a pull request. Adds the PR to your monitored list so it appears in daily checks and status reports.',
+        'Fetch metadata for a pull request (repo, number, title). Informational only — in v2, PRs are discovered automatically on each daily run and nothing is persisted locally. Use `daily` or `status` for ongoing monitoring.',
       inputSchema: {
-        prUrl: z.string().describe('Full GitHub PR URL to track (e.g. https://github.com/owner/repo/pull/123)'),
+        prUrl: z
+          .string()
+          .describe('Full GitHub PR URL to fetch metadata for (e.g. https://github.com/owner/repo/pull/123)'),
       },
-      annotations: { readOnlyHint: false, destructiveHint: false },
+      annotations: { readOnlyHint: true },
     },
     wrapTool(runTrack),
   );
 
-  // 6. untrack — Stop tracking a PR
+  // 6. untrack — Deprecated no-op (v2 has no local tracking list)
   server.registerTool(
     'untrack',
     {
-      description: 'Stop tracking a pull request. Removes the PR from your monitored list.',
+      description:
+        '[DEPRECATED] No-op in v2. PRs are fetched fresh on each daily run, so there is no local tracking list to remove from. Use `shelve` to hide a PR from the daily digest instead.',
       inputSchema: {
-        prUrl: z.string().describe('Full GitHub PR URL to untrack (e.g. https://github.com/owner/repo/pull/123)'),
+        prUrl: z.string().describe('Full GitHub PR URL (ignored — command is a no-op)'),
       },
-      annotations: { readOnlyHint: false, destructiveHint: true },
+      annotations: { readOnlyHint: true },
     },
     wrapTool(runUntrack),
   );


### PR DESCRIPTION
## Summary

Closes #1001.

`track` and `untrack` were carried forward from v1's local-tracking model, but the descriptions and MCP annotations still implied state mutation. In v2, PRs are discovered and enriched automatically on each `daily` run — there is no local tracking list. The ambiguity led to a real audit finding (and would confuse any new user or integrator).

## Choice

Rather than a breaking removal (which would need a major version bump on both `@oss-autopilot/core` and `@oss-autopilot/mcp`), **clarify the semantics everywhere a user or integrator could see them**.

| Surface | Change |
|---|---|
| CLI `track --help` | "Fetch metadata for a PR (informational — v2 does not maintain a local tracking list)" |
| CLI `untrack --help` | `[DEPRECATED] No-op in v2. Use \`shelve\` to hide a PR from the daily digest.` |
| CLI `untrack` interactive output | Deprecation notice printed to **stderr** so scripts piping stdout don't see the noise |
| MCP `track` tool | `readOnlyHint: true` (was `false`). Description now says "Informational only — nothing is persisted locally" |
| MCP `untrack` tool | `readOnlyHint: true` (was `false`, `destructiveHint: true`). Description starts with `[DEPRECATED]` so LLM clients deprioritize it |
| Source docstrings | File-level and per-function JSDoc rewritten. `runUntrack` carries `@deprecated` pointing callers at `runShelve` |

## Test plan

- [x] `pnpm run lint` clean
- [x] `pnpm run format:check` clean
- [x] `pnpm -r run typecheck` clean
- [x] `pnpm test` — 1,913 / 227 / 141 = 2,281 (the MCP annotation-matrix test that asserted `untrack destructiveHint: true` was removed, since a no-op is not destructive; `track` and `untrack` joined the read-only tool list)
- [x] Golden contract tests for `track` (#997) still pass — the output shape is unchanged, only documentation and MCP annotations moved

_Part of audit-v2 follow-up. PRs so far: #1009, #1010, #1011, #1012, #1013, #1014, #1015, #1016, this (batch 9)._
