### PR TITLE
feat(dashboard): animated stat counters and manual celebrate button

### DIFF
--- a/packages/dashboard/src/app.tsx
+++ b/packages/dashboard/src/app.tsx
@@ -27,7 +27,7 @@ interface DashboardHeaderProps {
   onRefresh: () => void;
   theme: Theme;
   onToggleTheme: () => void;
-  onCelebrate?: () => void;
+  onCelebrate: () => void;
 }
 
 function RefreshIcon() {
@@ -81,11 +81,9 @@ function DashboardHeader({
         <div class="header-right">
           {lastUpdated && <span class="last-updated">{formatRelativeTime(lastUpdated)}</span>}
           <ThemeToggle theme={theme} onToggle={onToggleTheme} />
-          {onCelebrate && (
-            <button type="button" class="celebrate-btn" onClick={onCelebrate} aria-label="Celebrate">
-              🎉
-            </button>
-          )}
+          <button type="button" class="celebrate-btn" onClick={onCelebrate} aria-label="Celebrate">
+            🎉
+          </button>
           <button class="refresh-btn" onClick={onRefresh} disabled={loading || refreshing}>
             {loading || refreshing ? <span class="spinner" /> : <RefreshIcon />}
             {refreshLabel(loading, refreshing)}
@@ -136,21 +134,23 @@ function AppContent() {
 
   if (!data) return null;
 
+  const headerProps: DashboardHeaderProps = {
+    stats: data.stats,
+    loading,
+    refreshing,
+    lastUpdated,
+    onRefresh: refresh,
+    theme,
+    onToggleTheme: toggleTheme,
+    onCelebrate: triggerCelebration,
+  };
+
   // Route: /merged — show all merged PRs
   if (path === '/merged') {
     const mergedPRs = data.allMergedPRs ?? [];
     return (
       <div class="dashboard">
-        <DashboardHeader
-          stats={data.stats}
-          loading={loading}
-          refreshing={refreshing}
-          lastUpdated={lastUpdated}
-          onRefresh={refresh}
-          theme={theme}
-          onToggleTheme={toggleTheme}
-          onCelebrate={triggerCelebration}
-        />
+        <DashboardHeader {...headerProps} />
         <MergedPRList mergedPRs={mergedPRs} repoMetadata={data.repoMetadata} onBack={() => route('/')} />
         <CelebrationToast celebration={celebration} onDismiss={dismissCelebration} />
       </div>
@@ -162,16 +162,7 @@ function AppContent() {
     const closedPRs = data.allClosedPRs ?? [];
     return (
       <div class="dashboard">
-        <DashboardHeader
-          stats={data.stats}
-          loading={loading}
-          refreshing={refreshing}
-          lastUpdated={lastUpdated}
-          onRefresh={refresh}
-          theme={theme}
-          onToggleTheme={toggleTheme}
-          onCelebrate={triggerCelebration}
-        />
+        <DashboardHeader {...headerProps} />
         <ClosedPRList closedPRs={closedPRs} onBack={() => route('/')} />
         <CelebrationToast celebration={celebration} onDismiss={dismissCelebration} />
       </div>
@@ -182,16 +173,7 @@ function AppContent() {
   if (path === '/issues') {
     return (
       <div class="dashboard">
-        <DashboardHeader
-          stats={data.stats}
-          loading={loading}
-          refreshing={refreshing}
-          lastUpdated={lastUpdated}
-          onRefresh={refresh}
-          theme={theme}
-          onToggleTheme={toggleTheme}
-          onCelebrate={triggerCelebration}
-        />
+        <DashboardHeader {...headerProps} />
         {data.vettedIssues ? (
           <VettedIssueList
             vettedIssues={data.vettedIssues}
@@ -246,16 +228,7 @@ function AppContent() {
 
   return (
     <div class="dashboard">
-      <DashboardHeader
-        stats={data.stats}
-        loading={loading}
-        refreshing={refreshing}
-        lastUpdated={lastUpdated}
-        onRefresh={refresh}
-        theme={theme}
-        onToggleTheme={toggleTheme}
-        onCelebrate={triggerCelebration}
-      />
+      <DashboardHeader {...headerProps} />
 
       {error && (
         <div class="error-banner" role="alert">

--- a/packages/dashboard/src/app.tsx
+++ b/packages/dashboard/src/app.tsx
@@ -27,6 +27,7 @@ interface DashboardHeaderProps {
   onRefresh: () => void;
   theme: Theme;
   onToggleTheme: () => void;
+  onCelebrate?: () => void;
 }
 
 function RefreshIcon() {
@@ -46,6 +47,7 @@ function DashboardHeader({
   onRefresh,
   theme,
   onToggleTheme,
+  onCelebrate,
 }: DashboardHeaderProps) {
   return (
     <header class="dashboard-header">
@@ -79,6 +81,11 @@ function DashboardHeader({
         <div class="header-right">
           {lastUpdated && <span class="last-updated">{formatRelativeTime(lastUpdated)}</span>}
           <ThemeToggle theme={theme} onToggle={onToggleTheme} />
+          {onCelebrate && (
+            <button type="button" class="celebrate-btn" onClick={onCelebrate} aria-label="Celebrate">
+              🎉
+            </button>
+          )}
           <button class="refresh-btn" onClick={onRefresh} disabled={loading || refreshing}>
             {loading || refreshing ? <span class="spinner" /> : <RefreshIcon />}
             {refreshLabel(loading, refreshing)}
@@ -92,7 +99,11 @@ function DashboardHeader({
 function AppContent() {
   const { data, loading, refreshing, error, clearError, refresh, performAction, lastUpdated } = useDashboard();
   const { theme, toggleTheme } = useTheme();
-  const { celebration, dismiss: dismissCelebration } = useCelebration(data?.stats.mergedPRs);
+  const {
+    celebration,
+    dismiss: dismissCelebration,
+    trigger: triggerCelebration,
+  } = useCelebration(data?.stats.mergedPRs);
   const [filters, setFilters] = useState<Filters>({ status: 'all', repo: 'all', search: '' });
   const [selectedUrl, setSelectedUrl] = useState<string | null>(null);
   const [shelvedOpen, setShelvedOpen] = useState(false);
@@ -138,6 +149,7 @@ function AppContent() {
           onRefresh={refresh}
           theme={theme}
           onToggleTheme={toggleTheme}
+          onCelebrate={triggerCelebration}
         />
         <MergedPRList mergedPRs={mergedPRs} repoMetadata={data.repoMetadata} onBack={() => route('/')} />
         <CelebrationToast celebration={celebration} onDismiss={dismissCelebration} />
@@ -158,6 +170,7 @@ function AppContent() {
           onRefresh={refresh}
           theme={theme}
           onToggleTheme={toggleTheme}
+          onCelebrate={triggerCelebration}
         />
         <ClosedPRList closedPRs={closedPRs} onBack={() => route('/')} />
         <CelebrationToast celebration={celebration} onDismiss={dismissCelebration} />
@@ -177,6 +190,7 @@ function AppContent() {
           onRefresh={refresh}
           theme={theme}
           onToggleTheme={toggleTheme}
+          onCelebrate={triggerCelebration}
         />
         {data.vettedIssues ? (
           <VettedIssueList
@@ -240,6 +254,7 @@ function AppContent() {
         onRefresh={refresh}
         theme={theme}
         onToggleTheme={toggleTheme}
+        onCelebrate={triggerCelebration}
       />
 
       {error && (

--- a/packages/dashboard/src/components/animated-value.test.tsx
+++ b/packages/dashboard/src/components/animated-value.test.tsx
@@ -57,4 +57,23 @@ describe('AnimatedValue', () => {
     });
     expect(container.textContent).toBe('10');
   });
+
+  it('does not crash when value transitions between number, numeric-string, and non-numeric-string', () => {
+    // Regression: useCountUp must be called unconditionally, otherwise
+    // Preact throws "Rendered fewer hooks than expected" on a shape change.
+    const { container, rerender } = render(<AnimatedValue value={5} />);
+    act(() => vi.advanceTimersByTime(1000));
+    expect(container.textContent).toBe('5');
+
+    rerender(<AnimatedValue value="42%" />);
+    act(() => vi.advanceTimersByTime(1000));
+    expect(container.textContent).toBe('42%');
+
+    rerender(<AnimatedValue value="N/A" />);
+    expect(container.textContent).toBe('N/A');
+
+    rerender(<AnimatedValue value={7} />);
+    act(() => vi.advanceTimersByTime(1000));
+    expect(container.textContent).toBe('7');
+  });
 });

--- a/packages/dashboard/src/components/animated-value.test.tsx
+++ b/packages/dashboard/src/components/animated-value.test.tsx
@@ -62,18 +62,24 @@ describe('AnimatedValue', () => {
     // Regression: useCountUp must be called unconditionally, otherwise
     // Preact throws "Rendered fewer hooks than expected" on a shape change.
     const { container, rerender } = render(<AnimatedValue value={5} />);
-    act(() => vi.advanceTimersByTime(1000));
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
     expect(container.textContent).toBe('5');
 
     rerender(<AnimatedValue value="42%" />);
-    act(() => vi.advanceTimersByTime(1000));
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
     expect(container.textContent).toBe('42%');
 
     rerender(<AnimatedValue value="N/A" />);
     expect(container.textContent).toBe('N/A');
 
     rerender(<AnimatedValue value={7} />);
-    act(() => vi.advanceTimersByTime(1000));
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
     expect(container.textContent).toBe('7');
   });
 });

--- a/packages/dashboard/src/components/animated-value.test.tsx
+++ b/packages/dashboard/src/components/animated-value.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@testing-library/preact';
+import { AnimatedValue } from './animated-value';
+
+describe('AnimatedValue', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders a numeric value and animates to it', () => {
+    const { container } = render(<AnimatedValue value={42} />);
+    expect(container.textContent).toBe('0');
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(container.textContent).toBe('42');
+  });
+
+  it('renders a string with numeric prefix and suffix', () => {
+    const { container } = render(<AnimatedValue value="75%" />);
+    expect(container.textContent).toBe('0%');
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(container.textContent).toBe('75%');
+  });
+
+  it('handles a value of 0', () => {
+    const { container } = render(<AnimatedValue value={0} />);
+    expect(container.textContent).toBe('0');
+  });
+
+  it('handles a non-numeric string by rendering it directly', () => {
+    const { container } = render(<AnimatedValue value="N/A" />);
+    expect(container.textContent).toBe('N/A');
+  });
+
+  it('animates integer values without decimals', () => {
+    const { container } = render(<AnimatedValue value={10} />);
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    const midText = container.textContent!;
+    expect(midText).toMatch(/^\d+$/);
+
+    act(() => {
+      vi.advanceTimersByTime(800);
+    });
+    expect(container.textContent).toBe('10');
+  });
+});

--- a/packages/dashboard/src/components/animated-value.test.tsx
+++ b/packages/dashboard/src/components/animated-value.test.tsx
@@ -43,6 +43,18 @@ describe('AnimatedValue', () => {
     expect(container.textContent).toBe('N/A');
   });
 
+  it('renders decimal-containing strings statically (no mangled partial animation)', () => {
+    // `"76.9%"` would partially match a naive /^(\d+)(.*)$/ as 76 + ".9%",
+    // causing the user to briefly see "0.9%", "37.9%", etc. Render statically.
+    const { container } = render(<AnimatedValue value="76.9%" />);
+    expect(container.textContent).toBe('76.9%');
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(container.textContent).toBe('76.9%');
+  });
+
   it('animates integer values without decimals', () => {
     const { container } = render(<AnimatedValue value={10} />);
 

--- a/packages/dashboard/src/components/animated-value.tsx
+++ b/packages/dashboard/src/components/animated-value.tsx
@@ -5,10 +5,14 @@ interface AnimatedValueProps {
 }
 
 export function AnimatedValue({ value }: AnimatedValueProps) {
-  // Always call useCountUp unconditionally to satisfy the Rules of Hooks:
-  // if `value` transitions between number/string/non-numeric-string across
-  // renders, a conditional hook call would throw "Rendered fewer hooks".
-  const stringMatch = typeof value === 'string' ? value.match(/^(\d+)(.*)$/) : null;
+  // Always call useCountUp unconditionally to satisfy the Rules of Hooks.
+  //
+  // Regex pattern: integer prefix (`\d+`), optionally followed by a non-digit
+  // character and the rest of the string. The `[^\d.]` guard rejects decimals
+  // like `"76.9%"` that would otherwise partially match (`76` + `.9%`) and
+  // render a broken count-up (`"0.9%"`, `"37.9%"`, `"76.9%"`). Decimal or
+  // otherwise non-matching strings fall through to static rendering.
+  const stringMatch = typeof value === 'string' ? value.match(/^(\d+)([^\d.].*)?$/) : null;
   const target = typeof value === 'number' ? value : stringMatch ? parseInt(stringMatch[1], 10) : 0;
   const animated = useCountUp(target);
 
@@ -17,7 +21,7 @@ export function AnimatedValue({ value }: AnimatedValueProps) {
   return (
     <>
       {animated}
-      {stringMatch[2]}
+      {stringMatch[2] ?? ''}
     </>
   );
 }

--- a/packages/dashboard/src/components/animated-value.tsx
+++ b/packages/dashboard/src/components/animated-value.tsx
@@ -1,0 +1,24 @@
+import { useCountUp } from '../hooks/use-count-up';
+
+interface AnimatedValueProps {
+  value: string | number;
+}
+
+export function AnimatedValue({ value }: AnimatedValueProps) {
+  if (typeof value === 'number') {
+    return <>{useCountUp(value)}</>;
+  }
+
+  const match = value.match(/^(\d+)(.*)$/);
+  if (!match) return <>{value}</>;
+
+  const num = parseInt(match[1], 10);
+  const suffix = match[2];
+
+  return (
+    <>
+      {useCountUp(num)}
+      {suffix}
+    </>
+  );
+}

--- a/packages/dashboard/src/components/animated-value.tsx
+++ b/packages/dashboard/src/components/animated-value.tsx
@@ -5,20 +5,19 @@ interface AnimatedValueProps {
 }
 
 export function AnimatedValue({ value }: AnimatedValueProps) {
-  if (typeof value === 'number') {
-    return <>{useCountUp(value)}</>;
-  }
+  // Always call useCountUp unconditionally to satisfy the Rules of Hooks:
+  // if `value` transitions between number/string/non-numeric-string across
+  // renders, a conditional hook call would throw "Rendered fewer hooks".
+  const stringMatch = typeof value === 'string' ? value.match(/^(\d+)(.*)$/) : null;
+  const target = typeof value === 'number' ? value : stringMatch ? parseInt(stringMatch[1], 10) : 0;
+  const animated = useCountUp(target);
 
-  const match = value.match(/^(\d+)(.*)$/);
-  if (!match) return <>{value}</>;
-
-  const num = parseInt(match[1], 10);
-  const suffix = match[2];
-
+  if (typeof value === 'number') return <>{animated}</>;
+  if (!stringMatch) return <>{value}</>;
   return (
     <>
-      {useCountUp(num)}
-      {suffix}
+      {animated}
+      {stringMatch[2]}
     </>
   );
 }

--- a/packages/dashboard/src/components/stats-bar.test.tsx
+++ b/packages/dashboard/src/components/stats-bar.test.tsx
@@ -1,10 +1,18 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, fireEvent } from '@testing-library/preact';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, act } from '@testing-library/preact';
 import { StatsBar } from './stats-bar';
 
 describe('StatsBar', () => {
   const stats = { activePRs: 5, shelvedPRs: 2, mergedPRs: 10, closedPRs: 3, mergeRate: '76.9%' };
   const baseProps = { stats, needAttentionCount: 3, waitingCount: 2 };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
 
   it('renders all stat cards', () => {
     const { container } = render(<StatsBar {...baseProps} />);
@@ -12,8 +20,11 @@ describe('StatsBar', () => {
     expect(cards).toHaveLength(5);
   });
 
-  it('displays correct values', () => {
+  it('displays correct values after animation', () => {
     const { container } = render(<StatsBar {...baseProps} />);
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
     const values = [...container.querySelectorAll('.stat-value')].map((el) => el.textContent);
     expect(values).toEqual(['3', '2', '2', '10', '3']);
   });

--- a/packages/dashboard/src/components/stats-bar.tsx
+++ b/packages/dashboard/src/components/stats-bar.tsx
@@ -1,4 +1,5 @@
 import type { DashboardStats } from '../types';
+import { AnimatedValue } from './animated-value';
 
 interface StatsBarProps {
   stats: DashboardStats;
@@ -52,7 +53,9 @@ export function StatsBar({
             onClick={card.onClick}
             {...(card.onClick ? { type: 'button' as const } : {})}
           >
-            <span class="stat-value">{card.value}</span>
+            <span class="stat-value">
+              <AnimatedValue value={card.value} />
+            </span>
             <span class="stat-label">{card.label}</span>
           </Tag>
         );

--- a/packages/dashboard/src/hooks/use-celebration.ts
+++ b/packages/dashboard/src/hooks/use-celebration.ts
@@ -87,6 +87,7 @@ function fireConfetti(): void {
 export function useCelebration(mergedCount: number | undefined): {
   celebration: Celebration | null;
   dismiss: () => void;
+  trigger: () => void;
 } {
   const [celebration, setCelebration] = useState<Celebration | null>(null);
 
@@ -120,5 +121,18 @@ export function useCelebration(mergedCount: number | undefined): {
 
   const dismiss = useCallback(() => setCelebration(null), []);
 
-  return { celebration, dismiss };
+  const trigger = useCallback(() => {
+    const reducedMotion =
+      typeof window !== 'undefined' && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true;
+    if (!reducedMotion) {
+      try {
+        fireConfetti();
+      } catch (err) {
+        console.warn('[useCelebration] confetti setup failed:', err);
+      }
+    }
+    setCelebration({ message: 'Party time!', shownAt: Date.now() });
+  }, []);
+
+  return { celebration, dismiss, trigger };
 }

--- a/packages/dashboard/src/hooks/use-celebration.ts
+++ b/packages/dashboard/src/hooks/use-celebration.ts
@@ -84,6 +84,17 @@ function fireConfetti(): void {
   frame();
 }
 
+/**
+ * Fire confetti unless the user has requested reduced motion. `fireConfetti`
+ * already swallows its own synchronous throws (see the try/catch in `frame()`
+ * above), so callers don't need to wrap this in their own try/catch.
+ */
+function playConfettiIfAllowed(): void {
+  const reducedMotion =
+    typeof window !== 'undefined' && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true;
+  if (!reducedMotion) fireConfetti();
+}
+
 export function useCelebration(mergedCount: number | undefined): {
   celebration: Celebration | null;
   dismiss: () => void;
@@ -107,13 +118,7 @@ export function useCelebration(mergedCount: number | undefined): {
 
     const delta = mergedCount - stored;
     writeStoredCount(mergedCount);
-
-    const reducedMotion =
-      typeof window !== 'undefined' && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true;
-
-    if (!reducedMotion) {
-      fireConfetti();
-    }
+    playConfettiIfAllowed();
 
     const message = delta === 1 ? '1 new PR merged. Great work!' : `${delta} new PRs merged. Great work!`;
     setCelebration({ message, shownAt: Date.now() });
@@ -122,15 +127,7 @@ export function useCelebration(mergedCount: number | undefined): {
   const dismiss = useCallback(() => setCelebration(null), []);
 
   const trigger = useCallback(() => {
-    const reducedMotion =
-      typeof window !== 'undefined' && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true;
-    if (!reducedMotion) {
-      try {
-        fireConfetti();
-      } catch (err) {
-        console.warn('[useCelebration] confetti setup failed:', err);
-      }
-    }
+    playConfettiIfAllowed();
     setCelebration({ message: 'Party time!', shownAt: Date.now() });
   }, []);
 

--- a/packages/dashboard/src/hooks/use-count-up.test.ts
+++ b/packages/dashboard/src/hooks/use-count-up.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/preact';
+import { useCountUp } from './use-count-up';
+
+describe('useCountUp', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns 0 initially when given a positive target', () => {
+    const { result } = renderHook(() => useCountUp(42));
+    // On the very first render, the hook starts at 0
+    expect(result.current).toBe(0);
+  });
+
+  it('reaches the target value after the animation duration', () => {
+    const { result } = renderHook(() => useCountUp(10, { duration: 500 }));
+
+    // Advance past the full duration
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+
+    expect(result.current).toBe(10);
+  });
+
+  it('returns 0 immediately when target is 0', () => {
+    const { result } = renderHook(() => useCountUp(0));
+    expect(result.current).toBe(0);
+  });
+
+  it('always returns an integer (no decimals during animation)', () => {
+    const values: number[] = [];
+    const { result } = renderHook(() => {
+      const val = useCountUp(7, { duration: 300 });
+      values.push(val);
+      return val;
+    });
+
+    // Step through in small increments
+    for (let i = 0; i < 20; i++) {
+      act(() => {
+        vi.advanceTimersByTime(20);
+      });
+    }
+
+    // Every intermediate value should be an integer
+    for (const v of values) {
+      expect(Number.isInteger(v)).toBe(true);
+    }
+  });
+
+  it('updates to new target when target changes', () => {
+    const { result, rerender } = renderHook(({ target }: { target: number }) => useCountUp(target, { duration: 500 }), {
+      initialProps: { target: 10 },
+    });
+
+    // Complete first animation
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+    expect(result.current).toBe(10);
+
+    // Change target
+    rerender({ target: 20 });
+
+    // Complete second animation
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+    expect(result.current).toBe(20);
+  });
+
+  it('produces intermediate values between 0 and the target', () => {
+    const values = new Set<number>();
+    const { result } = renderHook(() => {
+      const val = useCountUp(100, { duration: 500 });
+      values.add(val);
+      return val;
+    });
+
+    // Step through the animation
+    for (let i = 0; i < 30; i++) {
+      act(() => {
+        vi.advanceTimersByTime(20);
+      });
+    }
+
+    // Should have values between 0 and 100 (not just 0 and 100)
+    expect(values.size).toBeGreaterThan(2);
+    for (const v of values) {
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it('respects prefers-reduced-motion by skipping animation', () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn().mockImplementation((query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(() => false),
+      })),
+    );
+
+    const { result } = renderHook(() => useCountUp(42));
+    // Should immediately show the final value, no animation
+    expect(result.current).toBe(42);
+
+    vi.restoreAllMocks();
+  });
+
+  it('uses default duration when none specified', () => {
+    const { result } = renderHook(() => useCountUp(50));
+
+    // Default duration is 800ms. At 200ms we should be mid-animation.
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(result.current).toBeGreaterThan(0);
+    expect(result.current).toBeLessThanOrEqual(50);
+
+    // After full duration animation should be complete
+    act(() => {
+      vi.advanceTimersByTime(700);
+    });
+    expect(result.current).toBe(50);
+  });
+});

--- a/packages/dashboard/src/hooks/use-count-up.test.ts
+++ b/packages/dashboard/src/hooks/use-count-up.test.ts
@@ -35,7 +35,7 @@ describe('useCountUp', () => {
 
   it('always returns an integer (no decimals during animation)', () => {
     const values: number[] = [];
-    const { result } = renderHook(() => {
+    renderHook(() => {
       const val = useCountUp(7, { duration: 300 });
       values.push(val);
       return val;
@@ -77,7 +77,7 @@ describe('useCountUp', () => {
 
   it('produces intermediate values between 0 and the target', () => {
     const values = new Set<number>();
-    const { result } = renderHook(() => {
+    renderHook(() => {
       const val = useCountUp(100, { duration: 500 });
       values.add(val);
       return val;

--- a/packages/dashboard/src/hooks/use-count-up.ts
+++ b/packages/dashboard/src/hooks/use-count-up.ts
@@ -7,13 +7,18 @@ interface UseCountUpOptions {
 export function useCountUp(target: number, options?: UseCountUpOptions): number {
   const duration = options?.duration ?? 800;
   const [value, setValue] = useState(0);
+  const valueRef = useRef(0);
+  valueRef.current = value;
   const rafRef = useRef<number>(0);
   const startTimeRef = useRef<number>(0);
   const startValueRef = useRef(0);
 
   useEffect(() => {
-    // Skip animation when user prefers reduced motion
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    // Skip animation when user prefers reduced motion. Guard `matchMedia` for
+    // SSR/test environments that don't polyfill it — mirror `use-celebration.ts`.
+    const prefersReducedMotion =
+      typeof window !== 'undefined' && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true;
+    if (prefersReducedMotion) {
       setValue(target);
       return;
     }
@@ -23,7 +28,10 @@ export function useCountUp(target: number, options?: UseCountUpOptions): number 
       return;
     }
 
-    startValueRef.current = value;
+    // Read via ref so we animate from the currently-displayed value without
+    // needing `value` in the dep array (which would re-fire the effect on
+    // every frame).
+    startValueRef.current = valueRef.current;
     startTimeRef.current = 0;
 
     const step = (timestamp: number) => {

--- a/packages/dashboard/src/hooks/use-count-up.ts
+++ b/packages/dashboard/src/hooks/use-count-up.ts
@@ -1,0 +1,53 @@
+import { useState, useEffect, useRef } from 'preact/hooks';
+
+interface UseCountUpOptions {
+  duration?: number;
+}
+
+export function useCountUp(target: number, options?: UseCountUpOptions): number {
+  const duration = options?.duration ?? 800;
+  const [value, setValue] = useState(0);
+  const rafRef = useRef<number>(0);
+  const startTimeRef = useRef<number>(0);
+  const startValueRef = useRef(0);
+
+  useEffect(() => {
+    // Skip animation when user prefers reduced motion
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      setValue(target);
+      return;
+    }
+
+    if (target === 0) {
+      setValue(0);
+      return;
+    }
+
+    startValueRef.current = value;
+    startTimeRef.current = 0;
+
+    const step = (timestamp: number) => {
+      if (!startTimeRef.current) startTimeRef.current = timestamp;
+      const elapsed = timestamp - startTimeRef.current;
+      const progress = Math.min(elapsed / duration, 1);
+
+      // ease-out cubic for a natural deceleration feel
+      const eased = 1 - Math.pow(1 - progress, 3);
+
+      const current = Math.round(startValueRef.current + (target - startValueRef.current) * eased);
+      setValue(current);
+
+      if (progress < 1) {
+        rafRef.current = requestAnimationFrame(step);
+      }
+    };
+
+    rafRef.current = requestAnimationFrame(step);
+
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, [target, duration]);
+
+  return value;
+}

--- a/packages/dashboard/src/styles.css
+++ b/packages/dashboard/src/styles.css
@@ -491,6 +491,27 @@ a:hover {
   animation: spin 0.8s linear infinite;
 }
 
+.celebrate-btn {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: var(--sp-1) var(--sp-2);
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  transition: all 0.2s var(--ease);
+}
+
+.celebrate-btn:hover {
+  border-color: var(--border-hover);
+  transform: scale(1.15);
+}
+
+.celebrate-btn:focus-visible {
+  outline: 2px solid var(--blue);
+  outline-offset: 2px;
+}
+
 /* === Stats Bar === */
 
 .stats-bar {

--- a/packages/dashboard/vite.config.ts
+++ b/packages/dashboard/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   },
   server: {
     proxy: {
-      '/api': 'http://localhost:3001',
+      '/api': 'http://127.0.0.1:3001',
     },
   },
 });


### PR DESCRIPTION
## Summary
- `AnimatedValue` + `useCountUp` hook animate stat-bar values with an ease-out cubic count-up (~800ms). Respects `prefers-reduced-motion` by snapping straight to the final number.
- New 🎉 button in the dashboard header fires the confetti + toast celebration on demand — useful for demos and for when the merged-PR count hasn't ticked up yet.
- Vite dev-server API proxy target switched from `localhost` to `127.0.0.1` to avoid IPv6 resolution surprises on some systems.

## Test plan
- [ ] `pnpm --filter @oss-autopilot/dashboard run test` passes (new `animated-value` + `use-count-up` suites, updated `stats-bar` suite — 240 tests total)
- [ ] Dev server: `pnpm --filter @oss-autopilot/dashboard run dev` → numbers count up on initial load and after refresh
- [ ] Header 🎉 button fires confetti + toast
- [ ] `prefers-reduced-motion: reduce` snaps stats to final value and skips confetti