### PR TITLE
chore: gitignore Claude Code local session files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ data/
 # Local settings
 .claude/*.local.md
 .claude/settings.json
+.claude/settings.local.json
+.claude/scheduled_tasks.lock
 
 # Registry tokens
 .mcpregistry_*


### PR DESCRIPTION
## Summary
- Add `.claude/settings.local.json` and `.claude/scheduled_tasks.lock` to `.gitignore`. These are per-user session files that Claude Code writes at runtime and shouldn't be committed.

## Test plan
- [ ] `git status` no longer surfaces these files as untracked after they are created locally