### PR TITLE
fix(hooks): detect dashboard source changes in session-start rebuild check

### DIFF
--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -31,9 +31,13 @@ if [ -f "${PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" ] && [ "${PLUGIN_ROOT
 fi
 
 # --- Step 1.5: Build dashboard SPA if missing or stale ---
+# Stale check scans src/, vite.config.ts, tsconfig.json, and package.json
+# against dist/index.html. Must match the check in commands/oss-dashboard.md —
+# checking package.json alone misses the common case where only src/ changes
+# (package.json is private, pinned at 0.1.0, and rarely touched).
 DASHBOARD_INDEX="${PLUGIN_ROOT}/packages/dashboard/dist/index.html"
 DASHBOARD_PKG="${PLUGIN_ROOT}/packages/dashboard/package.json"
-if [ -f "${DASHBOARD_PKG}" ] && { [ ! -f "${DASHBOARD_INDEX}" ] || [ "${DASHBOARD_PKG}" -nt "${DASHBOARD_INDEX}" ]; }; then
+if [ -f "${DASHBOARD_PKG}" ] && { [ ! -f "${DASHBOARD_INDEX}" ] || [ -n "$(find "${PLUGIN_ROOT}/packages/dashboard/src" "${DASHBOARD_PKG}" "${PLUGIN_ROOT}/packages/dashboard/vite.config.ts" "${PLUGIN_ROOT}/packages/dashboard/tsconfig.json" -newer "${DASHBOARD_INDEX}" -print -quit 2>/dev/null)" ]; }; then
   # Dashboard depends on @oss-autopilot/core types via workspace:* protocol.
   # Use pnpm if available (required for workspace: resolution), fall back to npm.
   if command -v pnpm &>/dev/null; then


### PR DESCRIPTION
## Summary

- Session-start hook compared only `packages/dashboard/package.json` mtime against `dist/index.html`, missing source-only changes.
- `dashboard/package.json` is `private: true` with its version pinned at `0.1.0`; release-please never bumps it, so the stale check almost never fired. The feature in #1019 (celebrate button + animated counters) shipped in v1.16.0 but was invisible to users running the plugin update flow.
- Switch to the same `find -newer` pattern already used in `commands/oss-dashboard.md`, scanning `src/`, `vite.config.ts`, `tsconfig.json`, and `package.json`. The two stale checks now agree.

Closes #1022.

## Test plan

- [x] `bash -n hooks/session-start.sh` passes
- [x] Simulated the new check locally — correctly identifies `src/` as newer than the stale `dist/index.html` on my machine
- [x] `pnpm --filter @oss-autopilot/core test` (1929/1929 pass)
- [x] `pnpm --filter @oss-autopilot/dashboard test` (242/242 pass)
- [ ] CI green