### PR TITLE
fix(dashboard): allow blob: workers in CSP for canvas-confetti

### DIFF
--- a/packages/core/src/commands/dashboard-server.test.ts
+++ b/packages/core/src/commands/dashboard-server.test.ts
@@ -840,6 +840,15 @@ describe('dashboard-server', () => {
       expect(result.headers['content-security-policy']).toContain("default-src 'self'");
     });
 
+    it('should allow blob: workers in Content-Security-Policy (canvas-confetti)', async () => {
+      // Regression: canvas-confetti loads its animation worker from a blob: URL.
+      // Without an explicit worker-src directive, the browser falls back to
+      // script-src, which does not list blob:, and the celebrate button fails
+      // silently in production.
+      const result = await sendRequest('GET', '/api/data');
+      expect(result.headers['content-security-policy']).toContain("worker-src 'self' blob:");
+    });
+
     it('should set Referrer-Policy to strict-origin-when-cross-origin', async () => {
       const result = await sendRequest('GET', '/api/data');
       expect(result.headers['referrer-policy']).toBe('strict-origin-when-cross-origin');

--- a/packages/core/src/commands/dashboard-server.ts
+++ b/packages/core/src/commands/dashboard-server.ts
@@ -216,9 +216,13 @@ function readBody(req: http.IncomingMessage, maxBytes: number = MAX_BODY_BYTES):
 function setSecurityHeaders(res: http.ServerResponse): void {
   res.setHeader('X-Content-Type-Options', 'nosniff');
   res.setHeader('X-Frame-Options', 'DENY');
+  // worker-src: canvas-confetti generates its animation worker as a Blob and
+  // loads it via a blob: URL. Without this directive the browser falls back
+  // to script-src, which doesn't list blob:, and the celebrate button fails
+  // silently. Scoped to workers only — safer than widening script-src.
   res.setHeader(
     'Content-Security-Policy',
-    "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'",
+    "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; worker-src 'self' blob:",
   );
   res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
 }


### PR DESCRIPTION
## Summary

- Fix the celebrate button rendering its toast but no confetti in real browsers. canvas-confetti spawns its animation worker from a `blob:` URL, and the dashboard server's CSP had no `worker-src` directive — so the browser fell back to `script-src`, which doesn't list `blob:`, and the worker was blocked.
- Add `worker-src 'self' blob:` to the CSP (scoped to workers — safer than widening `script-src`).
- Add a regression test asserting the directive is present.

## Why this wasn't caught earlier

The feature was manually verified via Puppeteer (via the Vite dev/preview server, which doesn't emit this CSP), so the production header path was never exercised against real confetti. The existing CSP test only asserted `default-src 'self'`, not the full directive set the app actually depends on.

## Test plan

- [x] `pnpm test` — all 1930 tests pass
- [x] `pnpm run lint` — clean
- [x] `tsc --noEmit` — clean
- [x] New test `should allow blob: workers in Content-Security-Policy (canvas-confetti)` asserts the directive is present
- [ ] Manual verification in real Chrome after release: click celebrate button → confetti renders → no CSP console warnings

## Follow-up ideas (not in this PR)

Out of scope for this patch, but worth considering as separate issues:
- `packages/dashboard/src/hooks/use-celebration.ts`: the `fireConfetti` try/catch comment is misleading — canvas-confetti swallows its own worker-creation throws internally and only surfaces them via `console.warn`, so the catch can't and doesn't handle this class of failure. The comment should be tightened to say the catch covers only synchronous throws (canvas 2d context creation, missing `document.body`, etc).
- Consider promoting the `[useCelebration] confetti failed` log from `console.warn` to `console.error`, so future silent failures have a better chance of being seen without DevTools open.
- Consider checking `confetti()`'s return value for `null` (the library returns `null` when it bails out internally, e.g., no canvas available), which would have produced a loud signal for this exact bug class.