### PR TITLE
fix(hooks): preserve local edits to marketplace clone on auto-refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Run tests
         run: pnpm run test
 
+      - name: Test session-start hook helpers
+        run: bash hooks/safe-refresh-marketplace.test.sh
+
       - name: Coverage report
         if: matrix.node-version == 22
         run: pnpm run test:coverage

--- a/hooks/safe-refresh-marketplace.sh
+++ b/hooks/safe-refresh-marketplace.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Safely refresh a git clone to origin/main — preserves local changes.
+#
+# Usage: safe-refresh-marketplace.sh <clone-dir>
+#
+# Exit codes:
+#   0 — refresh succeeded (fetch + reset --hard ran)
+#   1 — skipped; clone is unsafe to reset. stdout carries a single user-visible
+#       line explaining what happened. Covers both "has local changes" and
+#       "git status itself failed" (corrupt repo, locked index, etc.).
+#   2 — skipped because fetch or reset failed (network, no origin, etc.)
+#   3 — skipped because <clone-dir> does not exist or is not a git repo
+#   4 — invalid usage
+#
+# Contract: on exit 1, stdout MUST be a single line — the caller may interpolate
+# it into a JSON field with basic escaping.
+
+set -euo pipefail
+
+CLONE_DIR="${1:-}"
+if [ -z "$CLONE_DIR" ]; then
+    echo "Usage: $(basename "$0") <clone-dir>" >&2
+    exit 4
+fi
+
+if [ ! -d "${CLONE_DIR}/.git" ]; then
+    exit 3
+fi
+
+# Capture both stdout and exit code of `git status --porcelain`. A non-zero
+# exit (corrupt repo, missing HEAD, locked .git/index.lock, interrupted
+# merge/rebase, etc.) produces empty stdout — without the explicit rc check
+# those cases would be misclassified as clean, and the reset below would
+# run on a broken clone.
+status_output=$(git -C "${CLONE_DIR}" status --porcelain 2>/dev/null) && status_rc=0 || status_rc=$?
+
+if [ "$status_rc" -ne 0 ]; then
+    echo "Marketplace clone at ${CLONE_DIR} is in an inconsistent state (git status failed); your files are untouched. Inspect it manually to resume auto-updates."
+    exit 1
+fi
+
+if [ -n "$status_output" ]; then
+    echo "Local changes detected in marketplace clone (${CLONE_DIR}); your edits are preserved and auto-refresh was skipped. Commit, stash, or revert them to resume auto-updates."
+    exit 1
+fi
+
+if git -C "${CLONE_DIR}" fetch --quiet origin main 2>/dev/null \
+    && git -C "${CLONE_DIR}" reset --hard origin/main --quiet 2>/dev/null; then
+    exit 0
+fi
+
+exit 2

--- a/hooks/safe-refresh-marketplace.test.sh
+++ b/hooks/safe-refresh-marketplace.test.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# Test harness for safe-refresh-marketplace.sh.
+#
+# Uses only bash + core git — no bats/jest. Run with:
+#   bash hooks/safe-refresh-marketplace.test.sh
+# Exits 0 if all pass, 1 on first failure. Prints a one-line result per case.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+SUBJECT="${SCRIPT_DIR}/safe-refresh-marketplace.sh"
+
+if [ ! -x "$SUBJECT" ]; then
+    echo "FAIL: subject under test is not executable: $SUBJECT"
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+CURRENT_CASE=""
+
+fail() {
+    echo "  FAIL: ${CURRENT_CASE}: $*"
+    FAIL=$((FAIL + 1))
+}
+
+pass() {
+    echo "  PASS: ${CURRENT_CASE}"
+    PASS=$((PASS + 1))
+}
+
+# Build a fake "remote" + "clone" pair in a throwaway tmpdir. The clone is
+# set up so `safe-refresh-marketplace.sh` can fast-forward it to remote main.
+setup() {
+    WORK=$(mktemp -d)
+    REMOTE="${WORK}/remote"
+    CLONE="${WORK}/clone"
+
+    git init --quiet --initial-branch=main --bare "$REMOTE"
+
+    git init --quiet --initial-branch=main "${WORK}/seed"
+    (
+        cd "${WORK}/seed"
+        git config user.email test@example.com
+        git config user.name Test
+        echo "v1" >README.md
+        git add README.md
+        git commit --quiet -m "initial"
+        git remote add origin "$REMOTE"
+        git push --quiet origin main
+    )
+
+    git clone --quiet "$REMOTE" "$CLONE"
+    # Note: no user.email/user.name config inside $CLONE — none of the test
+    # cases create commits there, so the config is unused.
+
+    # Advance the remote so a fetch sees a new commit.
+    (
+        cd "${WORK}/seed"
+        echo "v2" >README.md
+        git commit --quiet -am "bump"
+        git push --quiet origin main
+    )
+}
+
+teardown() {
+    rm -rf "$WORK"
+}
+
+run() {
+    CURRENT_CASE="$1"
+    shift
+    setup
+    "$@"
+    teardown
+}
+
+# --- Cases -----------------------------------------------------------------
+
+case_invalid_usage() {
+    # Direct call (no `if` wrapper): bash's `if cmd; then; fi` without else
+    # returns 0 when cmd fails, masking the real exit code.
+    "$SUBJECT" >/dev/null 2>&1
+    rc=$?
+    [ "$rc" = 4 ] && pass || fail "expected exit 4 for missing arg, got $rc"
+}
+
+case_not_a_repo() {
+    plain="${WORK}/not-a-repo"
+    mkdir -p "$plain"
+    "$SUBJECT" "$plain" >/dev/null 2>&1
+    rc=$?
+    [ "$rc" = 3 ] && pass || fail "expected exit 3 for non-git dir, got $rc"
+}
+
+case_clean_clone_refreshes() {
+    # Clone is one commit behind remote; expect fast-forward success.
+    "$SUBJECT" "$CLONE" >/dev/null 2>&1
+    rc=$?
+    if [ "$rc" != 0 ]; then
+        fail "expected exit 0 on clean clone, got $rc"
+        return
+    fi
+    head_msg=$(git -C "$CLONE" log -1 --format=%s)
+    [ "$head_msg" = "bump" ] && pass || fail "expected HEAD to be 'bump' after refresh, got '$head_msg'"
+}
+
+case_uncommitted_edits_preserved() {
+    # Modify a tracked file and verify it survives the call.
+    echo "local edit" >>"$CLONE/README.md"
+    out=$("$SUBJECT" "$CLONE" 2>/dev/null) && rc=0 || rc=$?
+    if [ "$rc" != 1 ]; then
+        fail "expected exit 1 on uncommitted change, got $rc"
+        return
+    fi
+    if ! echo "$out" | grep -qi "local changes detected"; then
+        fail "expected skip message to mention 'local changes', got '$out'"
+        return
+    fi
+    content=$(cat "$CLONE/README.md")
+    if ! echo "$content" | grep -q "local edit"; then
+        fail "uncommitted edit was destroyed"
+        return
+    fi
+    head_msg=$(git -C "$CLONE" log -1 --format=%s)
+    [ "$head_msg" = "initial" ] && pass || fail "expected HEAD to stay at 'initial', got '$head_msg'"
+}
+
+case_staged_changes_preserved() {
+    # Stage a change without committing. Must survive.
+    echo "staged" >"$CLONE/staged.txt"
+    git -C "$CLONE" add staged.txt
+    "$SUBJECT" "$CLONE" >/dev/null 2>&1
+    rc=$?
+    if [ "$rc" != 1 ]; then
+        fail "expected exit 1 on staged change, got $rc"
+        return
+    fi
+    if [ ! -f "$CLONE/staged.txt" ]; then
+        fail "staged file was destroyed"
+        return
+    fi
+    staged_count=$(git -C "$CLONE" diff --cached --name-only | wc -l | tr -d ' ')
+    [ "$staged_count" = "1" ] && pass || fail "expected 1 staged file, got $staged_count"
+}
+
+case_untracked_file_preserved() {
+    # Untracked files should also block the reset.
+    echo "untracked" >"$CLONE/notes.txt"
+    "$SUBJECT" "$CLONE" >/dev/null 2>&1
+    rc=$?
+    if [ "$rc" != 1 ]; then
+        fail "expected exit 1 on untracked file, got $rc"
+        return
+    fi
+    [ -f "$CLONE/notes.txt" ] && pass || fail "untracked file was destroyed"
+}
+
+case_corrupt_repo_preserved() {
+    # `git status` fails when HEAD is missing. Verify the clone is classified
+    # as "unsafe to reset" (exit 1, user-visible message) rather than silently
+    # treated as clean and reset.
+    rm -f "$CLONE/.git/HEAD"
+    out=$("$SUBJECT" "$CLONE" 2>/dev/null) && rc=0 || rc=$?
+    if [ "$rc" != 1 ]; then
+        fail "expected exit 1 for corrupt repo (missing HEAD), got $rc"
+        return
+    fi
+    if ! echo "$out" | grep -qi "inconsistent state"; then
+        fail "expected corrupt-repo message to mention 'inconsistent state', got '$out'"
+        return
+    fi
+    # The clone's working tree must be untouched — no new checkout, no reset.
+    [ ! -f "$CLONE/.git/HEAD" ] && pass || fail "HEAD reappeared — script performed an unsafe operation"
+}
+
+case_fetch_failure_returns_2() {
+    # Point origin at a nonexistent path. Clean clone so the dirty check passes;
+    # fetch must fail, and the script must exit 2 without touching the tree.
+    git -C "$CLONE" remote set-url origin "${WORK}/nonexistent-remote"
+    "$SUBJECT" "$CLONE" >/dev/null 2>&1
+    rc=$?
+    if [ "$rc" != 2 ]; then
+        fail "expected exit 2 on unreachable remote, got $rc"
+        return
+    fi
+    head_msg=$(git -C "$CLONE" log -1 --format=%s)
+    [ "$head_msg" = "initial" ] && pass || fail "expected HEAD to stay at 'initial' after failed fetch, got '$head_msg'"
+}
+
+# --- Driver ----------------------------------------------------------------
+
+echo "Running safe-refresh-marketplace.sh tests..."
+run case_invalid_usage        case_invalid_usage
+run case_not_a_repo           case_not_a_repo
+run case_clean_clone_refreshes case_clean_clone_refreshes
+run case_uncommitted_edits_preserved case_uncommitted_edits_preserved
+run case_staged_changes_preserved    case_staged_changes_preserved
+run case_untracked_file_preserved    case_untracked_file_preserved
+run case_corrupt_repo_preserved      case_corrupt_repo_preserved
+run case_fetch_failure_returns_2     case_fetch_failure_returns_2
+
+echo
+echo "Results: ${PASS} passed, ${FAIL} failed."
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -10,16 +10,8 @@ PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 messages=""
 NL=$'\n'
 
-# --- Step 0: Auto-refresh marketplace cache (non-blocking) ---
-# Claude Code caches third-party marketplace repos as git clones but never
-# auto-refreshes them, so plugin updates aren't discoverable. A background
-# fetch+reset on every session keeps the cache current without blocking startup.
-# Uses fetch+reset instead of pull to handle divergent branches gracefully
-# (e.g. if a local commit was accidentally made in the marketplace clone).
+# Marketplace clone path; refresh is handled by safe-refresh-marketplace.sh in Step 2.
 MARKETPLACE_DIR="$HOME/.claude/plugins/marketplaces/oss-autopilot"
-if [ -d "$MARKETPLACE_DIR/.git" ]; then
-  (cd "$MARKETPLACE_DIR" && git fetch --quiet origin main 2>/dev/null && git reset --hard origin/main --quiet 2>/dev/null) &
-fi
 
 # --- Step 1: Rebuild stale CLI bundle (if needed) ---
 if [ -f "${PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" ] && [ "${PLUGIN_ROOT}/packages/core/package.json" -nt "${PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" ]; then
@@ -72,27 +64,34 @@ if [ -n "$CURRENT" ]; then
       # Mark check as done only after a successful API response
       touch "$LAST_CHECK"
       if [ "$LATEST" != "$CURRENT" ]; then
-        # Pull the marketplace clone so /plugin update sees the new version
-        MARKETPLACE_DIR="${HOME}/.claude/plugins/marketplaces/oss-autopilot"
+        # Pull marketplace clone so /plugin update sees the new version.
+        # Helper preserves dirty trees (exit 1) and reports corrupt-repo state.
         marketplace_pulled=false
-        if [ -d "${MARKETPLACE_DIR}/.git" ]; then
-          if git -C "${MARKETPLACE_DIR}" fetch origin main --quiet 2>/dev/null \
-            && git -C "${MARKETPLACE_DIR}" reset --hard origin/main --quiet 2>/dev/null; then
-            marketplace_pulled=true
-          fi
-        fi
-        # Update known_marketplaces.json so Claude Code recognises the marketplace change.
+        marketplace_skip_msg=""
+        refresh_output=$("${SCRIPT_DIR}/safe-refresh-marketplace.sh" "${MARKETPLACE_DIR}") && refresh_rc=0 || refresh_rc=$?
+        case "$refresh_rc" in
+          0) marketplace_pulled=true ;;
+          1) marketplace_skip_msg="$refresh_output" ;;
+          2|3) : ;;  # fetch/reset failed or no clone — generic "Auto-pull failed" fires below
+          *) marketplace_skip_msg="Auto-refresh helper exited unexpectedly (code ${refresh_rc})." ;;
+        esac
+        # Update known_marketplaces.json only if the clone actually refreshed —
+        # bumping `lastUpdated` when we skipped the pull would lie about state.
         # Uses atomic write (tmp + mv) to prevent corruption on interruption.
-        KNOWN_MP="${HOME}/.claude/plugins/known_marketplaces.json"
-        if [ -f "$KNOWN_MP" ] && command -v jq &>/dev/null; then
-          jq --arg ts "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
-            'if has("oss-autopilot") then .["oss-autopilot"].lastUpdated = $ts else . end' \
-            "$KNOWN_MP" > "${KNOWN_MP}.tmp" \
-            && mv "${KNOWN_MP}.tmp" "$KNOWN_MP" \
-            || rm -f "${KNOWN_MP}.tmp"
+        if [ "$marketplace_pulled" = true ]; then
+          KNOWN_MP="${HOME}/.claude/plugins/known_marketplaces.json"
+          if [ -f "$KNOWN_MP" ] && command -v jq &>/dev/null; then
+            jq --arg ts "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
+              'if has("oss-autopilot") then .["oss-autopilot"].lastUpdated = $ts else . end' \
+              "$KNOWN_MP" > "${KNOWN_MP}.tmp" \
+              && mv "${KNOWN_MP}.tmp" "$KNOWN_MP" \
+              || rm -f "${KNOWN_MP}.tmp"
+          fi
         fi
         if [ "$marketplace_pulled" = true ]; then
           update_msg="OSS Autopilot v${LATEST} available (you have v${CURRENT}). Run: /plugin update oss-autopilot"
+        elif [ -n "$marketplace_skip_msg" ]; then
+          update_msg="OSS Autopilot v${LATEST} available (you have v${CURRENT}). ${marketplace_skip_msg} Then run: /plugin update oss-autopilot"
         else
           update_msg="OSS Autopilot v${LATEST} available (you have v${CURRENT}). Auto-pull failed. Run: cd ${MARKETPLACE_DIR} && git pull origin main, then /plugin update oss-autopilot"
         fi


### PR DESCRIPTION
## Summary

- Closes #1027.
- `hooks/session-start.sh` was running `git reset --hard origin/main` on the marketplace clone unconditionally, silently destroying any local edits.
- Reset logic moved into `hooks/safe-refresh-marketplace.sh`, which skips with a user-visible message when the clone has uncommitted / staged / untracked changes OR when `git status` itself exits non-zero (corrupt repo, missing HEAD, locked index, interrupted merge/rebase).
- Former backgrounded Step 0 race is removed — Step 2 is the sole caller.
- `known_marketplaces.json.lastUpdated` is now bumped only on a successful refresh, so it no longer lies about state.

## Test plan

- [x] `bash hooks/safe-refresh-marketplace.test.sh` — 8 cases pass (usage, non-git dir, clean refresh, uncommitted / staged / untracked preserved, corrupt repo preserved, fetch failure returns exit 2).
- [x] `pnpm run lint` clean.
- [x] `pnpm --filter @oss-autopilot/core test` — 1,930 pass.
- [x] Hook harness wired into `.github/workflows/ci.yml` as a new `Test session-start hook helpers` step.
- [x] Acceptance criteria from #1027:
  - `git reset --hard` no longer runs when the clone has uncommitted or untracked changes.
  - Dirty-clone users see a message explaining the skip and the remediation.
  - Step 0 / Step 2 race is eliminated (single code path).
  - Shell-based test proves a dirty tree is preserved.

## Review cycle

Ran pr-review-toolkit in parallel (code-reviewer, silent-failure-hunter, code-simplifier). First pass surfaced one Critical (corrupt-repo misclassified as clean) plus Recommended findings (timestamp-lie, unknown exit-code swallow, missing CI wiring). All addressed; second convergence pass returned "Converged — no blocking findings."
