### PR TITLE
fix(commands): remove phantom scoreThreshold/showHealthCheck config refs

### DIFF
--- a/.claude-plugin/scripts/health-check.cjs
+++ b/.claude-plugin/scripts/health-check.cjs
@@ -6,13 +6,9 @@
  *
  * Behavior:
  * - Reads ~/.oss-autopilot/state.json (cached from last /oss run)
- * - If showHealthCheck is false in config, exits silently
  * - If no state exists, shows a first-run hint to run /oss
  * - If last digest is >7 days old, nudges the user to catch up
  * - Otherwise, outputs a compact one-liner: "OSS: 15 active PRs — 3 need addressing, 12 waiting on maintainer (2h ago)"
- *
- * Configuration: Set showHealthCheck to false to disable:
- *   node packages/core/dist/cli.bundle.cjs setup --set showHealthCheck=false
  *
  * Error handling: Errors are logged to stderr (visible in debug) but never
  * disrupt session start — the hook always exits cleanly.
@@ -28,7 +24,6 @@ try {
     process.exit(0);
   }
   const state = JSON.parse(s);
-  if (state.config && state.config.showHealthCheck === false) process.exit(0);
   const lastRun = state.lastDigestAt || state.lastRunAt;
   if (!lastRun || !state.lastDigest) {
     console.log('OSS: No PR data yet. Run /oss to get started.');

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,18 @@ jobs:
       - name: Test session-start hook helpers
         run: bash hooks/safe-refresh-marketplace.test.sh
 
+      - name: Guard against phantom config field regressions
+        # These keys were deleted from the v3 state schema (see
+        # state-persistence.ts migrateV2ToV3). They must NOT reappear in
+        # plugin-facing docs or scripts — setup --set silently no-ops on
+        # deleted keys, so references become lies.
+        run: |
+          if grep -rn --include='*.md' --include='*.cjs' --include='*.sh' \
+             -E '(scoreThreshold|showHealthCheck)' commands/ .claude-plugin/; then
+            echo "::error::Found references to deleted v3 config keys. See issue #1033."
+            exit 1
+          fi
+
       - name: Coverage report
         if: matrix.node-version == 22
         run: pnpm run test:coverage

--- a/commands/oss-help.md
+++ b/commands/oss-help.md
@@ -67,5 +67,3 @@ Key settings: GitHub username, max active PRs, dormant threshold, preferred lang
 ### Session Start Health Check
 
 On every session start, the plugin shows a one-liner PR status summary (e.g., "OSS: 15 active PRs — 3 need addressing, 12 waiting on maintainer (2h ago)"). This reads cached state from your last `/oss` run — no network calls.
-
-To disable: `node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" setup --set showHealthCheck=false`

--- a/commands/oss-search.md
+++ b/commands/oss-search.md
@@ -131,18 +131,14 @@ Use AskUserQuestion:
      Return: score (1-10), recommendation (pursue/maybe/skip), red flags.")
    ```
 
-3. **Score Threshold Filter:** After all vet agents return, read `scoreThreshold` from config:
-   ```bash
-   node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" config --json
-   ```
-   Parse the `scoreThreshold` field from the returned `data.config` object. If the config command fails, log: "Could not read scoreThreshold from config. Using default threshold of 6." and use 6 as the threshold.
+3. **Score Threshold Filter:** After all vet agents return, filter on a fixed threshold of 6/10.
 
    For each vetted issue:
-   - Score **>= threshold** → proceed to tier assignment (step 4)
-   - Score **< threshold** → skip, do NOT add to any tier
+   - Score **>= 6** → proceed to tier assignment (step 4)
+   - Score **< 6** → skip, do NOT add to any tier
 
    If any filtered, display:
-   > "Filtered {count} issue(s) below score threshold ({threshold}/10)."
+   > "Filtered {count} issue(s) below score threshold (6/10)."
 
    List filtered issues briefly:
    ```

--- a/commands/setup-oss.md
+++ b/commands/setup-oss.md
@@ -191,16 +191,7 @@ node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" setup --set squas
 
 This sets the global `squashByDefault` setting.
 
-**Question 11: Score Threshold for Vetted Issues**
-- "Minimum score threshold for vetted issues? Issues below this score are auto-filtered during `/oss-search` vetting."
-- Options: "4 (lenient)", "5 (moderate)", "6 (default)", "7 (selective)", "8 (strict)"
-
-Extract the number from the selected option and apply:
-```bash
-node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" setup --set scoreThreshold=NUMBER --json
-```
-
-**Question 12: Diff Viewer Preference**
+**Question 11: Diff Viewer Preference**
 - "How would you like to review diffs before committing?"
 - Options: "Inline (default) — print diff in CLI", "SourceTree — open repo in SourceTree", "VS Code — open diff in VS Code", "Custom command"
 
@@ -426,12 +417,6 @@ If "Don't track", skip — no config change needed (the search flow handles miss
 - Options: "Yes, always squash (Recommended)", "No, keep individual commits", "Ask me each time"
 
 This sets the global `squashByDefault` setting.
-
-**Question 11: Score Threshold for Vetted Issues**
-- "Minimum score threshold for vetted issues? Issues below this score are auto-filtered during `/oss-search` vetting."
-- Options: "4 (lenient)", "5 (moderate)", "6 (default)", "7 (selective)", "8 (strict)"
-
-Store the selected number in config as `scoreThreshold`.
 
 ## Step 5: Verify GitHub Access
 


### PR DESCRIPTION
## Summary

- Closes #1033.
- Three slash commands (`setup-oss.md`, `oss-search.md`, `oss-help.md`) plus `health-check.cjs` referenced two config keys — `scoreThreshold` and `showHealthCheck` — that were explicitly deleted in the v3 state-schema migration (`state-persistence.ts:167-168`). Users configuring these via `setup --set` got a silent no-op; `oss-search`'s threshold filter read the never-written field and fell back to 6 every run.
- Applied Option A from the issue: removed all references, hardcoded the previously-configurable threshold at 6 in `oss-search.md` (matches the de-facto pre-fix behavior exactly).
- Added a CI grep guard so these keys can't reappear in plugin-facing docs or scripts.

## Behavioral notes for users

- `setup --set scoreThreshold=...` was already a silent no-op; nothing changes for users.
- `/setup-oss` no longer asks "Question 11: Score Threshold"; CLI-path questions 12 and later shift up by one.
- Session-start health check is now always-on. Users who previously ran `setup --set showHealthCheck=false` in v2 state will see the one-liner again after their state migrates to v3 — consistent with the issue's chosen resolution (no replacement opt-out knob).

## Test plan

- [x] `grep -rn 'scoreThreshold\|showHealthCheck' commands/ .claude-plugin/` — zero hits.
- [x] `pnpm run lint` clean.
- [x] `pnpm --filter @oss-autopilot/core test` — 1,930 pass, 14 skipped. V2→v3 migration test (`gist-state-store.test.ts:354-356`) intentionally retains both fields as migration inputs and still passes.
- [x] New CI step `Guard against phantom config field regressions` verified locally by dry-running the grep.

## Review cycle

Dispatched code-reviewer and silent-failure-hunter in parallel. Both converged on first pass with no blocking findings. Only actionable follow-up was the CI guard (R1 from code-reviewer), added in this commit. A pre-existing drift between CLI-path and markdown-fallback question counts was flagged as out of scope.
