### PR TITLE
fix(agents): narrow tool allowlists, drop mcp__* wildcard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,19 @@ jobs:
             exit 1
           fi
 
+      - name: Guard against mcp__* wildcard in agent tools
+        # Agents must declare specific MCP tools, never the wildcard. See
+        # agents/README.md for rationale. mcp__* would grant access to every
+        # MCP server on the user's machine (including cross-channel posting),
+        # bypassing the draft-review-post gate the global CLAUDE.md enforces.
+        # Matches only `tools:` frontmatter lines so prose in README.md that
+        # discusses the pattern (for documentation) does not false-positive.
+        run: |
+          if grep -Hn '^tools:.*mcp__\*' agents/*.md; then
+            echo "::error::Agent frontmatter contains mcp__* wildcard. Use a narrow allowlist. See agents/README.md and issue #1029."
+            exit 1
+          fi
+
       - name: Coverage report
         if: matrix.node-version == 22
         run: pnpm run test:coverage

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,0 +1,39 @@
+# Subagents — tool-list rationale
+
+Each agent here declares a narrow `tools:` allowlist rather than the `mcp__*`
+wildcard. Wildcards grant access to every MCP server the user has installed
+(LinkedIn, Gmail, Telegram, Puppeteer, Serena, etc.) in addition to this
+plugin's own MCP server — and that includes tools that post publicly on the
+user's behalf.
+
+The global CLAUDE.md rule "never post without showing a draft first" has
+two enforcement layers working together: (1) this per-agent allowlist, which
+prevents MCP-mediated posting, and (2) the `block-unauthorized-github` and
+`check-issue-mentions.sh` PreToolUse hooks, which intercept Bash-based
+`gh pr comment`, `gh issue comment`, etc. Prose in the agent body is
+advisory; both hard gates must be kept narrow.
+
+## Deliberate exclusions
+
+| Tool | Why no agent declares it |
+|---|---|
+| `mcp__plugin_oss-autopilot_oss-autopilot__post` | Writes a public GitHub comment. All posting goes through the `draft-review-post` skill so the user reviews the exact body before it ships. |
+| `mcp__plugin_oss-autopilot_oss-autopilot__claim` | Posts a claim comment on an issue. Same reason as `post`. |
+| `mcp__plugin_oss-autopilot_oss-autopilot__move`, `__track`, `__dismiss`, `__shelve` (and their inverses) | Mutate `~/.oss-autopilot/state.json`. Agents that need to influence state should produce a recommendation for the parent workflow to act on, not mutate directly. |
+| `mcp__linkedin__*`, `mcp__claude_ai_Gmail__*`, `mcp__puppeteer__*`, `mcp__plugin_serena_serena__execute_shell_command` | Out of scope — OSS Autopilot agents should never need cross-channel messaging, arbitrary web control, or sandbox escape. |
+
+## Per-agent allowlists
+
+- `contribution-strategist` — `Bash`, `Read` (read-only analyzer; emits a markdown report in chat).
+- `issue-scout` — `Bash`, `Read`, `mcp__...__search`, `mcp__...__vet`, `mcp__...__vet-list`.
+- `pr-compliance-checker` — `Bash`, `Read`, `Glob`, `Grep`, `mcp__...__read`, `mcp__...__comments`.
+- `pr-health-checker` — `Bash`, `Read`, `Grep`, `mcp__...__read`, `mcp__...__comments`.
+- `pr-responder` — `Bash`, `Read`, `Write`, `Glob`, `Grep`, `mcp__...__read`, `mcp__...__comments` (keeps `Write` for drafting response files under `/tmp`; posting still routes through `draft-review-post`).
+- `pre-commit-reviewer` — `Bash`, `Read`, `Glob`, `Grep` (local git/diff review only).
+- `repo-evaluator` — `Bash`, `Read`, `Glob`, `mcp__...__vet`.
+
+## Adding a tool
+
+When a new agent genuinely needs a tool not listed above, add it explicitly —
+never use `mcp__*`. CI enforces this via the "Guard against `mcp__*` wildcard
+in agent tools" step.

--- a/agents/contribution-strategist.md
+++ b/agents/contribution-strategist.md
@@ -40,7 +40,7 @@ User wants help with goal-setting.
 
 model: inherit
 color: magenta
-tools: ["Bash", "Read", "Write", "mcp__*"]
+tools: ["Bash", "Read"]
 ---
 
 > **Input validation:** See "AskUserQuestion Validation Protocol" in `workflows/reference.md`.

--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -22,7 +22,7 @@ User wants to evaluate a specific issue before investing time.
 
 model: inherit
 color: green
-tools: ["Bash", "Read", "Write", "mcp__*"]
+tools: ["Bash", "Read", "mcp__plugin_oss-autopilot_oss-autopilot__search", "mcp__plugin_oss-autopilot_oss-autopilot__vet", "mcp__plugin_oss-autopilot_oss-autopilot__vet-list"]
 ---
 
 > **Input validation:** See "AskUserQuestion Validation Protocol" in `workflows/reference.md`.

--- a/agents/pr-compliance-checker.md
+++ b/agents/pr-compliance-checker.md
@@ -31,7 +31,7 @@ User wants pre-submission guidance on PR quality.
 
 model: inherit
 color: orange
-tools: ["Bash", "Read", "Glob", "Grep", "WebFetch", "mcp__*"]
+tools: ["Bash", "Read", "Glob", "Grep", "mcp__plugin_oss-autopilot_oss-autopilot__read", "mcp__plugin_oss-autopilot_oss-autopilot__comments"]
 ---
 
 > **Input validation:** See "AskUserQuestion Validation Protocol" in `workflows/reference.md`.

--- a/agents/pr-health-checker.md
+++ b/agents/pr-health-checker.md
@@ -31,7 +31,7 @@ Merge conflicts are a health issue this agent handles.
 
 model: inherit
 color: yellow
-tools: ["Bash", "Read", "Write", "Grep", "mcp__*"]
+tools: ["Bash", "Read", "Grep", "mcp__plugin_oss-autopilot_oss-autopilot__read", "mcp__plugin_oss-autopilot_oss-autopilot__comments"]
 ---
 
 > **Input validation:** See "AskUserQuestion Validation Protocol" in `workflows/reference.md`.

--- a/agents/pr-responder.md
+++ b/agents/pr-responder.md
@@ -22,7 +22,7 @@ User needs help understanding and responding to a specific code review comment.
 
 model: inherit
 color: cyan
-tools: ["Bash", "Read", "Glob", "Grep", "mcp__*"]
+tools: ["Bash", "Read", "Write", "Glob", "Grep", "mcp__plugin_oss-autopilot_oss-autopilot__read", "mcp__plugin_oss-autopilot_oss-autopilot__comments"]
 ---
 
 > **Input validation:** See "AskUserQuestion Validation Protocol" in `workflows/reference.md`.

--- a/agents/pre-commit-reviewer.md
+++ b/agents/pre-commit-reviewer.md
@@ -22,7 +22,7 @@ Post-conflict resolution is a critical moment where bugs can be introduced. Revi
 
 model: inherit
 color: red
-tools: ["Bash", "Read", "Glob", "Grep", "mcp__*"]
+tools: ["Bash", "Read", "Glob", "Grep"]
 ---
 
 > **Input validation:** See "AskUserQuestion Validation Protocol" in `workflows/reference.md`.

--- a/agents/repo-evaluator.md
+++ b/agents/repo-evaluator.md
@@ -22,7 +22,7 @@ User wants to predict maintainer engagement before contributing.
 
 model: inherit
 color: blue
-tools: ["Bash", "Read", "Write", "Glob", "mcp__*"]
+tools: ["Bash", "Read", "Glob", "mcp__plugin_oss-autopilot_oss-autopilot__vet"]
 ---
 
 > **Input validation:** See "AskUserQuestion Validation Protocol" in `workflows/reference.md`.


### PR DESCRIPTION
## Summary

- Closes #1029.
- Every subagent declared `tools: [..., "mcp__*"]`. With other MCP servers installed (LinkedIn, Gmail, Puppeteer, Serena, etc.), each agent held the ability to post publicly under the user's identity — prose in the agent body said "never post without approval", but the tool list is what's actually enforced.
- Replaced wildcards with per-agent narrow allowlists; each agent declares only the MCP tools its body actually uses.
- `__post` and `__claim` are not held by any agent — posting routes through the `draft-review-post` skill.
- Added `agents/README.md` explaining the per-agent rationale and how the allowlist composes with the existing `block-unauthorized-github` and `check-issue-mentions.sh` PreToolUse hooks (two enforcement layers, both must stay narrow).
- Added a CI guard that fails if `^tools:.*mcp__\*` reappears in any `agents/*.md`.

## Allowlist summary

| Agent | Tools |
|---|---|
| contribution-strategist | `Bash`, `Read` |
| issue-scout | + `mcp__...__search`, `__vet`, `__vet-list` |
| pr-compliance-checker | `Bash`, `Read`, `Glob`, `Grep`, `__read`, `__comments` (dropped `WebFetch`) |
| pr-health-checker | `Bash`, `Read`, `Grep`, `__read`, `__comments` |
| pr-responder | + `Write`, `__read`, `__comments` (keeps `Write` for `/tmp` drafts) |
| pre-commit-reviewer | `Bash`, `Read`, `Glob`, `Grep` |
| repo-evaluator | `Bash`, `Read`, `Glob`, `__vet` |

## Test plan

- [x] `grep '^tools:.*mcp__\*' agents/*.md` — zero hits.
- [x] `pnpm run lint` clean.
- [x] `pnpm --filter @oss-autopilot/core test` — 1,930 pass, 14 skipped.
- [x] MCP tool names verified against `packages/mcp-server/src/tools.ts` registrations — all 5 resolve (`search`, `vet`, `vet-list`, `read`, `comments`).
- [x] CI guard `Guard against mcp__* wildcard in agent tools` dry-runs clean on current tree.
- [x] Per-agent prose audited: no agent has a step that uses a dropped tool (confirmed by silent-failure-hunter review).

## Review cycle

pr-review-toolkit ran in parallel (code-reviewer + silent-failure-hunter). Both converged on first pass. One Minor from silent-failure (README phrasing overstated "the allowlist is the load-bearing gate" when Bash `gh pr comment` is caught by a different PreToolUse hook) was applied in-commit.
