### PR TITLE
fix(mcp): align README and server.json with reality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,29 @@ jobs:
             exit 1
           fi
 
+      - name: Guard MCP metadata consistency
+        # Catches drift between packages/mcp-server/package.json, server.json,
+        # the registered tool count in tools.ts, and what the README claims.
+        # See issue #1034.
+        run: |
+          PKG_VERSION=$(node -p "require('./packages/mcp-server/package.json').version")
+          SERVER_JSON_VERSION=$(node -p "require('./packages/mcp-server/server.json').version")
+          PACKAGE_ENTRY_VERSION=$(node -p "require('./packages/mcp-server/server.json').packages[0].version")
+
+          if [ "$PKG_VERSION" != "$SERVER_JSON_VERSION" ] || [ "$PKG_VERSION" != "$PACKAGE_ENTRY_VERSION" ]; then
+            echo "::error::MCP server.json version ($SERVER_JSON_VERSION / $PACKAGE_ENTRY_VERSION) does not match package.json ($PKG_VERSION). Bump server.json to match."
+            exit 1
+          fi
+
+          REGISTERED=$(grep -c 'server.registerTool(' packages/mcp-server/src/tools.ts)
+          README_COUNT=$(grep -oE '\*\*Tools\*\* \| [0-9]+' packages/mcp-server/README.md | grep -oE '[0-9]+' | head -1)
+          README_ROWS=$(awk '/^## Tools Reference/,/^## Resources Reference/' packages/mcp-server/README.md | grep -c '^| `')
+
+          if [ "$REGISTERED" != "$README_COUNT" ] || [ "$REGISTERED" != "$README_ROWS" ]; then
+            echo "::error::MCP tool count drift: tools.ts registers $REGISTERED, README summary says $README_COUNT, README table rows $README_ROWS. Align all three."
+            exit 1
+          fi
+
       - name: Guard against mcp__* wildcard in agent tools
         # Agents must declare specific MCP tools, never the wildcard. See
         # agents/README.md for rationale. mcp__* would grant access to every

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -10,7 +10,7 @@ MCP server for [OSS Autopilot](https://github.com/costajohnt/oss-autopilot) — 
 
 | Feature | Count | Description |
 |---------|-------|-------------|
-| **Tools** | 20 | `daily`, `status`, `search`, `vet`, `track`, `untrack`, `read`, `comments`, `post`, `claim`, `config`, `init`, `setup`, `check-setup`, `startup`, `shelve`, `unshelve`, `dismiss`, `undismiss`, `move` |
+| **Tools** | 24 | `daily`, `status`, `search`, `vet`, `vet-list`, `track`, `untrack`, `read`, `comments`, `post`, `claim`, `config`, `init`, `setup`, `check-setup`, `startup`, `shelve`, `unshelve`, `dismiss`, `undismiss`, `move`, `state-show`, `state-sync`, `state-unlink` |
 | **Resources** | 5 | `oss://status`, `oss://config`, `oss://prs`, `oss://prs/shelved`, `oss://pr/{owner}/{repo}/{number}` |
 | **Prompts** | 3 | `triage` (PR prioritization), `respond-to-pr` (draft response), `find-issues` (discover issues) |
 
@@ -24,12 +24,12 @@ Supports **stdio** (default) and **Streamable HTTP** transports.
 ## Quick Start
 
 ```bash
-# 1. Initialize with your GitHub username
-npx @oss-autopilot/mcp@latest --init <your-github-username>
+# 1. Add the server to your MCP client (see config examples below)
 
-# 2. Add the server to your MCP client (see config examples below)
+# 2. From your MCP client, call the `init` tool once with your GitHub username
+#    (this writes ~/.oss-autopilot/state.json).
 
-# 3. Use the tools — e.g. "daily" to check your PRs, "search" to find issues
+# 3. Use the other tools — e.g. `daily` to check your PRs, `search` to find issues.
 ```
 
 ## Client Configuration
@@ -103,6 +103,7 @@ The server listens at `http://127.0.0.1:3001/mcp` and accepts POST requests.
 | `status` | Show current PR tracking status | Yes |
 | `search` | Search GitHub for contributable issues | Yes |
 | `vet` | Analyze an issue for contribution suitability | Yes |
+| `vet-list` | Re-vet all available issues in the curated issue list | No |
 | `track` | Start tracking a pull request | No |
 | `untrack` | Stop tracking a pull request | No |
 | `read` | Mark PR notifications as read | No |
@@ -119,6 +120,9 @@ The server listens at `http://127.0.0.1:3001/mcp` and accepts POST requests.
 | `dismiss` | Dismiss an issue from notifications | No |
 | `undismiss` | Re-enable notifications for a dismissed issue | No |
 | `move` | Move a PR between states (attention, waiting, shelved, auto) | No |
+| `state-show` | Show current state persistence mode (local or Gist) and sync status | Yes |
+| `state-sync` | Force push current state to the backing Gist | No |
+| `state-unlink` | Disconnect from Gist persistence and switch to local-only mode | No |
 
 ## Resources Reference
 

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -7,12 +7,12 @@
     "source": "github",
     "subfolder": "packages/mcp-server"
   },
-  "version": "2.0.2",
+  "version": "3.1.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@oss-autopilot/mcp",
-      "version": "2.0.2",
+      "version": "3.1.3",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

- Closes #1034.
- Fixed three drift issues that broke the @oss-autopilot/mcp onboarding flow for new users:

| Drift | Was | Now |
|---|---|---|
| Quick Start referenced `--init` flag | `npx ... --init <user>` (server hung on stdin) | "Add to MCP client, then call the `init` tool" |
| Summary tool count | `**Tools** \| 20` | `**Tools** \| 24` |
| Tools Reference table | 20 rows (missing `vet-list`, `state-show`, `state-sync`, `state-unlink`) | 24 rows |
| `server.json` version | `2.0.2` (both top-level and `packages[0].version`) | `3.1.3` |

- Added a CI step `Guard MCP metadata consistency` that fails on future drift between:
  - `package.json.version` ↔ `server.json.version` ↔ `server.json.packages[0].version`
  - registered tool count in `tools.ts` ↔ README summary count ↔ README Tools Reference row count

## Test plan

- [x] README: `awk '/^## Tools Reference/,/^## Resources Reference/' | grep -c '^| \`'` = 24 rows.
- [x] Tool descriptions for the 4 new rows verified against `tools.ts:150-418` (paraphrased for table-cell length).
- [x] `server.json` only has the two `version` fields changed; everything else untouched.
- [x] CI guard dry-run: `registered=24, README_count=24, README_rows=24, pkg=3.1.3, server=3.1.3, pkg_entry=3.1.3`.
- [x] `pnpm run lint` clean. `pnpm --filter @oss-autopilot/core test` — 1,930 pass.

## Review

code-reviewer converged on first pass — no Critical or Recommended findings. Two Minor observations noted as non-blocking (cosmetic Quick Start fence block, awk range could be renamed in future). Reviewer also noted a pre-existing `packages/mcp-server` test failure on main unrelated to this PR; that flake is caused by a stale `packages/core/dist/` and clears when CI runs the build step before tests.
