### PR TITLE
fix(mcp): bearer-token auth for HTTP transport

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -95,6 +95,20 @@ npx @oss-autopilot/mcp@latest --http --port 3001
 
 The server listens at `http://127.0.0.1:3001/mcp` and accepts POST requests.
 
+#### Authentication
+
+HTTP mode requires a bearer token on every request (stdio mode does not — it inherits the parent process identity). On first `--http` startup, the server generates a random 32-byte token and writes it to `~/.oss-autopilot/mcp.token` with `0600` permissions. The path and "newly generated" marker are logged to stderr at startup.
+
+Every HTTP client must send:
+
+```
+Authorization: Bearer <contents of ~/.oss-autopilot/mcp.token>
+```
+
+Requests without a valid `Authorization` header return `401`. The `Bearer` scheme is case-insensitive per RFC 7235; the token value itself is compared byte-for-byte in constant time. Requests with a non-loopback `Host` header return `403` (DNS-rebinding defense). Requests must declare a numeric `Content-Length` ≤ 1 MiB — missing, non-numeric, or oversize Content-Length values return `413`.
+
+The token persists across restarts. To rotate, delete the file and restart — a new token will be generated. To relocate the token (e.g. for multi-user or CI setups), set `OSS_AUTOPILOT_MCP_TOKEN_PATH` to the desired absolute path before starting the server.
+
 ## Tools Reference
 
 | Tool | Description | Read-only |

--- a/packages/mcp-server/src/auth.test.ts
+++ b/packages/mcp-server/src/auth.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { ensureHttpToken, validateBearerToken, isValidHost, resolveTokenPath } from './auth.js';
+
+function makeTmpTokenPath(): string {
+  return path.join(
+    os.tmpdir(),
+    `oss-autopilot-mcp-auth-test-${Date.now()}-${Math.random().toString(36).slice(2)}.token`,
+  );
+}
+
+describe('auth.resolveTokenPath', () => {
+  const originalEnv = process.env.OSS_AUTOPILOT_MCP_TOKEN_PATH;
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.OSS_AUTOPILOT_MCP_TOKEN_PATH;
+    else process.env.OSS_AUTOPILOT_MCP_TOKEN_PATH = originalEnv;
+  });
+
+  it('uses OSS_AUTOPILOT_MCP_TOKEN_PATH when set', () => {
+    process.env.OSS_AUTOPILOT_MCP_TOKEN_PATH = '/tmp/custom.token';
+    expect(resolveTokenPath()).toBe('/tmp/custom.token');
+  });
+
+  it('defaults to ~/.oss-autopilot/mcp.token', () => {
+    delete process.env.OSS_AUTOPILOT_MCP_TOKEN_PATH;
+    expect(resolveTokenPath()).toBe(path.join(os.homedir(), '.oss-autopilot', 'mcp.token'));
+  });
+
+  it('ignores an empty OSS_AUTOPILOT_MCP_TOKEN_PATH', () => {
+    process.env.OSS_AUTOPILOT_MCP_TOKEN_PATH = '';
+    expect(resolveTokenPath()).toBe(path.join(os.homedir(), '.oss-autopilot', 'mcp.token'));
+  });
+});
+
+describe('auth.ensureHttpToken', () => {
+  let tokenPath: string;
+
+  beforeEach(() => {
+    tokenPath = makeTmpTokenPath();
+  });
+
+  afterEach(() => {
+    try {
+      fs.unlinkSync(tokenPath);
+    } catch {
+      /* already gone */
+    }
+  });
+
+  it('generates a fresh 64-char hex token when no file exists', async () => {
+    const { token, path: p, freshlyGenerated } = await ensureHttpToken(tokenPath);
+    expect(p).toBe(tokenPath);
+    expect(freshlyGenerated).toBe(true);
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('persists the token between calls', async () => {
+    const first = await ensureHttpToken(tokenPath);
+    const second = await ensureHttpToken(tokenPath);
+    expect(second.freshlyGenerated).toBe(false);
+    expect(second.token).toBe(first.token);
+  });
+
+  it('writes the token file with 0600 permissions', async () => {
+    await ensureHttpToken(tokenPath);
+    const stat = fs.statSync(tokenPath);
+    // POSIX mode bits — lower 9 bits are rwx user/group/other.
+    const mode = stat.mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it('creates the containing directory when missing', async () => {
+    const nestedDir = path.join(os.tmpdir(), `oss-autopilot-mcp-auth-nested-${Date.now()}`);
+    const nestedPath = path.join(nestedDir, 'mcp.token');
+    try {
+      const result = await ensureHttpToken(nestedPath);
+      expect(fs.existsSync(nestedPath)).toBe(true);
+      expect(result.token.length).toBe(64);
+    } finally {
+      try {
+        fs.rmSync(nestedDir, { recursive: true, force: true });
+      } catch {
+        /* best-effort */
+      }
+    }
+  });
+
+  it('tightens permissions when the pre-existing token file is world-readable', async () => {
+    // Simulate a user or attacker who relaxed perms to 0644 between runs.
+    // ensureHttpToken should reload the token AND re-chmod to 0600.
+    fs.mkdirSync(path.dirname(tokenPath), { recursive: true });
+    fs.writeFileSync(tokenPath, 'a'.repeat(64) + '\n', { mode: 0o644 });
+    fs.chmodSync(tokenPath, 0o644); // Guard against umask on some systems.
+
+    const result = await ensureHttpToken(tokenPath);
+    expect(result.freshlyGenerated).toBe(false);
+    expect(result.token).toBe('a'.repeat(64));
+
+    const mode = fs.statSync(tokenPath).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+});
+
+describe('auth.validateBearerToken', () => {
+  const expected = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+  it('accepts a matching bearer header', () => {
+    expect(validateBearerToken(`Bearer ${expected}`, expected)).toBe(true);
+  });
+
+  it('rejects a missing header', () => {
+    expect(validateBearerToken(undefined, expected)).toBe(false);
+  });
+
+  it('rejects a header missing the Bearer prefix', () => {
+    expect(validateBearerToken(expected, expected)).toBe(false);
+  });
+
+  it('rejects a wrong token of the same length', () => {
+    expect(validateBearerToken(`Bearer ${'f'.repeat(64)}`, expected)).toBe(false);
+  });
+
+  it('rejects a wrong token of a different length (avoids timingSafeEqual throw)', () => {
+    expect(validateBearerToken('Bearer short', expected)).toBe(false);
+  });
+
+  it('handles surrounding whitespace', () => {
+    expect(validateBearerToken(`Bearer  ${expected}  `, expected)).toBe(true);
+  });
+
+  it('accepts case-insensitive Bearer scheme per RFC 7235', () => {
+    expect(validateBearerToken(`bearer ${expected}`, expected)).toBe(true);
+    expect(validateBearerToken(`BEARER ${expected}`, expected)).toBe(true);
+    expect(validateBearerToken(`BeArEr ${expected}`, expected)).toBe(true);
+  });
+
+  it('rejects authentication when the expected token is empty (defense in depth)', () => {
+    // crypto.timingSafeEqual('', '') returns true, which would open auth
+    // if a future caller accidentally passed an empty expected token.
+    expect(validateBearerToken('Bearer ', '')).toBe(false);
+    expect(validateBearerToken('Bearer anything', '')).toBe(false);
+    expect(validateBearerToken('', '')).toBe(false);
+  });
+});
+
+describe('auth.isValidHost', () => {
+  it('accepts 127.0.0.1:<port>', () => {
+    expect(isValidHost('127.0.0.1:3001', 3001)).toBe(true);
+  });
+
+  it('accepts localhost:<port>', () => {
+    expect(isValidHost('localhost:3001', 3001)).toBe(true);
+  });
+
+  it('rejects mismatched port', () => {
+    expect(isValidHost('127.0.0.1:9999', 3001)).toBe(false);
+  });
+
+  it('rejects a rebound attacker hostname', () => {
+    expect(isValidHost('evil.example.com:3001', 3001)).toBe(false);
+  });
+
+  it('rejects missing host header', () => {
+    expect(isValidHost(undefined, 3001)).toBe(false);
+  });
+
+  it('does NOT accept oss.localhost (stricter than dashboard server)', () => {
+    // The MCP HTTP transport is for MCP clients (Cursor, Claude Desktop,
+    // Codex) which connect via 127.0.0.1 or localhost only. `oss.localhost`
+    // is a dashboard-specific affordance and is not in the MCP allow-list.
+    expect(isValidHost('oss.localhost:3001', 3001)).toBe(false);
+  });
+});

--- a/packages/mcp-server/src/auth.ts
+++ b/packages/mcp-server/src/auth.ts
@@ -1,0 +1,133 @@
+/**
+ * HTTP transport authentication — bearer-token auth.
+ *
+ * A 32-byte random token is generated on the first `--http` startup and
+ * stored at `~/.oss-autopilot/mcp.token` (or the `OSS_AUTOPILOT_MCP_TOKEN_PATH`
+ * env-var override) with `0600` permissions. Every HTTP request must carry
+ * `Authorization: Bearer <token>` or it is rejected 401.
+ *
+ * stdio transport has no auth — it inherits the parent process identity.
+ * See issue #1028.
+ */
+
+import { promises as fs } from 'node:fs';
+import { homedir } from 'node:os';
+import * as path from 'node:path';
+import * as crypto from 'node:crypto';
+
+const TOKEN_FILE_MODE = 0o600;
+const TOKEN_DIR_MODE = 0o700;
+const TOKEN_BYTES = 32; // → 64 hex chars
+
+/**
+ * Resolve the token file path. Uses OSS_AUTOPILOT_MCP_TOKEN_PATH when set
+ * (test isolation + custom-path support); otherwise the default under the
+ * user's home directory.
+ */
+export function resolveTokenPath(): string {
+  const override = process.env.OSS_AUTOPILOT_MCP_TOKEN_PATH;
+  if (override && override.length > 0) return override;
+  return path.join(homedir(), '.oss-autopilot', 'mcp.token');
+}
+
+/**
+ * Load the token from disk. Returns null when the file does not exist so
+ * the caller can distinguish "missing → generate new" from other errors.
+ */
+async function loadToken(tokenPath: string): Promise<string | null> {
+  try {
+    const raw = await fs.readFile(tokenPath, 'utf-8');
+    const token = raw.trim();
+    if (token.length === 0) return null;
+    return token;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+/**
+ * Ensure a token file exists at `tokenPath` with 0600 perms and return its
+ * contents. If the file is missing, generates a fresh 32-byte hex token.
+ * If the file exists with laxer permissions, tightens them to 0600 and
+ * warns on stderr — prevents a world-readable token from silently
+ * persisting across restarts.
+ */
+export async function ensureHttpToken(tokenPath: string = resolveTokenPath()): Promise<{
+  token: string;
+  path: string;
+  freshlyGenerated: boolean;
+}> {
+  const existing = await loadToken(tokenPath);
+  if (existing) {
+    // Tighten permissions if the on-disk file has drifted from 0600.
+    try {
+      const stat = await fs.stat(tokenPath);
+      const mode = stat.mode & 0o777;
+      if (mode !== TOKEN_FILE_MODE) {
+        await fs.chmod(tokenPath, TOKEN_FILE_MODE);
+        console.error(`[MCP auth] Tightened permissions on ${tokenPath} from ${mode.toString(8)} to 600.`);
+      }
+    } catch {
+      // Stat / chmod failures are non-fatal; fall through with the token.
+    }
+    return { token: existing, path: tokenPath, freshlyGenerated: false };
+  }
+
+  const dir = path.dirname(tokenPath);
+  await fs.mkdir(dir, { recursive: true, mode: TOKEN_DIR_MODE });
+
+  const token = crypto.randomBytes(TOKEN_BYTES).toString('hex');
+  // `writeFile` with `mode` only sets mode on create; explicit `chmod`
+  // after write guards against `fs.open('w')` truncating a file that
+  // appeared after our earlier `loadToken` returned null (narrow race,
+  // but cheap to defend). The pre-existing-laxer-perms case is handled
+  // separately on the `loadToken` success branch above.
+  const handle = await fs.open(tokenPath, 'w', TOKEN_FILE_MODE);
+  try {
+    await handle.writeFile(token + '\n', 'utf-8');
+    await handle.chmod(TOKEN_FILE_MODE);
+  } finally {
+    await handle.close();
+  }
+  return { token, path: tokenPath, freshlyGenerated: true };
+}
+
+/**
+ * Constant-time compare of an `Authorization: Bearer <token>` header against
+ * the expected token. Returns true iff the header is present, well-formed,
+ * and matches.
+ *
+ * Per RFC 7235 the `Bearer` scheme name is case-insensitive (rejecting a
+ * spec-compliant client with lowercase `bearer` would be a silent foot-gun),
+ * so the scheme prefix check normalizes case. The token value itself is
+ * still compared byte-for-byte in constant time.
+ *
+ * Defensive guard: an empty `expected` token always fails even though
+ * `crypto.timingSafeEqual('', '')` would return true. This keeps us safe
+ * against a future caller that accidentally passes an empty token.
+ */
+export function validateBearerToken(authHeader: string | undefined, expected: string): boolean {
+  if (typeof authHeader !== 'string') return false;
+  if (expected.length === 0) return false;
+  const prefix = 'bearer ';
+  if (authHeader.slice(0, prefix.length).toLowerCase() !== prefix) return false;
+  const candidate = authHeader.slice(prefix.length).trim();
+  if (candidate.length !== expected.length) return false;
+  try {
+    return crypto.timingSafeEqual(Buffer.from(candidate), Buffer.from(expected));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Validate the `Host` header against the loopback allow-list for the given
+ * port. Blocks DNS-rebinding from a browser that has the server's IP via an
+ * attacker-controlled hostname.
+ */
+export function isValidHost(hostHeader: string | undefined, port: number): boolean {
+  if (typeof hostHeader !== 'string') return false;
+  return hostHeader === `127.0.0.1:${port}` || hostHeader === `localhost:${port}`;
+}

--- a/packages/mcp-server/src/index-main.test.ts
+++ b/packages/mcp-server/src/index-main.test.ts
@@ -67,6 +67,28 @@ vi.mock('@modelcontextprotocol/sdk/server/streamableHttp.js', () => ({
   }),
 }));
 
+// Mock auth.js so tests don't touch the real ~/.oss-autopilot/mcp.token
+// (#1028). Tests pass the stub token through the Authorization header.
+// `vi.hoisted` is required because vi.mock factories are hoisted above the
+// file; a plain `const` outside the factory would be `undefined` at mock
+// resolution time.
+const { TEST_TOKEN } = vi.hoisted(() => ({
+  TEST_TOKEN: 'test-bearer-token-0123456789abcdef0123456789abcdef012345678',
+}));
+vi.mock('./auth.js', () => ({
+  ensureHttpToken: vi.fn().mockResolvedValue({
+    token: TEST_TOKEN,
+    path: '/tmp/fake-mcp-token',
+    freshlyGenerated: false,
+  }),
+  validateBearerToken: vi.fn(
+    (header: string | undefined, expected: string) => typeof header === 'string' && header === `Bearer ${expected}`,
+  ),
+  isValidHost: vi.fn(
+    (host: string | undefined, port: number) => host === `127.0.0.1:${port}` || host === `localhost:${port}`,
+  ),
+}));
+
 import { main, ENTRY_SUFFIXES } from './index.js';
 
 // Sentinel error for mocked process.exit
@@ -181,11 +203,27 @@ describe('main() in-process', () => {
       return requestHandler;
     }
 
+    // Common request fixture: every /api/ route now requires a loopback
+    // Host header and a bearer token. Tests that exercise the post-auth
+    // code paths use this helper; Host/Auth negative tests construct their
+    // own request objects directly.
+    const withAuthHeaders = (req: Partial<{ url: string; method: string }>) => ({
+      url: req.url,
+      method: req.method,
+      headers: {
+        host: '127.0.0.1:3001',
+        authorization: `Bearer ${TEST_TOKEN}`,
+        // POSTs now require a numeric Content-Length in range (#1028 review).
+        // GETs ignore it.
+        'content-length': '100',
+      },
+    });
+
     it('returns 404 for non-/mcp paths', async () => {
       const handler = await setupHttpHandler();
 
       const res = { writeHead: vi.fn(), end: vi.fn(), headersSent: false };
-      await handler({ url: '/wrong-path', method: 'POST' }, res);
+      await handler(withAuthHeaders({ url: '/wrong-path', method: 'POST' }), res);
 
       expect(res.writeHead).toHaveBeenCalledWith(404);
       expect(res.end).toHaveBeenCalledWith('Not Found');
@@ -195,7 +233,7 @@ describe('main() in-process', () => {
       const handler = await setupHttpHandler();
 
       const res = { writeHead: vi.fn(), end: vi.fn(), headersSent: false };
-      await handler({ url: '/mcp', method: 'GET' }, res);
+      await handler(withAuthHeaders({ url: '/mcp', method: 'GET' }), res);
 
       expect(res.writeHead).toHaveBeenCalledWith(405);
       expect(res.end).toHaveBeenCalledWith('Method Not Allowed');
@@ -204,7 +242,7 @@ describe('main() in-process', () => {
     it('processes valid POST /mcp through transport', async () => {
       const handler = await setupHttpHandler();
 
-      const req = { url: '/mcp', method: 'POST' };
+      const req = withAuthHeaders({ url: '/mcp', method: 'POST' });
       const res = { writeHead: vi.fn(), end: vi.fn(), headersSent: false };
       await handler(req, res);
 
@@ -219,7 +257,7 @@ describe('main() in-process', () => {
       mockHandleRequest.mockRejectedValueOnce(new Error('Transport error'));
 
       const res = { writeHead: vi.fn(), end: vi.fn(), headersSent: false };
-      await handler({ url: '/mcp', method: 'POST' }, res);
+      await handler(withAuthHeaders({ url: '/mcp', method: 'POST' }), res);
 
       expect(res.writeHead).toHaveBeenCalledWith(500);
       expect(res.end).toHaveBeenCalledWith('Internal Server Error');
@@ -231,9 +269,69 @@ describe('main() in-process', () => {
       mockHandleRequest.mockRejectedValueOnce(new Error('Transport error'));
 
       const res = { writeHead: vi.fn(), end: vi.fn(), headersSent: true };
-      await handler({ url: '/mcp', method: 'POST' }, res);
+      await handler(withAuthHeaders({ url: '/mcp', method: 'POST' }), res);
 
       expect(res.writeHead).not.toHaveBeenCalled();
+    });
+
+    it('rejects requests with an invalid Host header (403)', async () => {
+      const handler = await setupHttpHandler();
+
+      const res = { writeHead: vi.fn(), end: vi.fn(), headersSent: false };
+      await handler(
+        {
+          url: '/mcp',
+          method: 'POST',
+          headers: { host: 'evil.example.com', authorization: `Bearer ${TEST_TOKEN}` },
+        },
+        res,
+      );
+
+      expect(res.writeHead).toHaveBeenCalledWith(403);
+      expect(res.end).toHaveBeenCalledWith('Invalid host');
+    });
+
+    it('rejects requests with a missing Authorization header (401)', async () => {
+      const handler = await setupHttpHandler();
+
+      const res = { writeHead: vi.fn(), end: vi.fn(), headersSent: false };
+      await handler(
+        {
+          url: '/mcp',
+          method: 'POST',
+          headers: { host: '127.0.0.1:3001', 'content-length': '100' },
+        },
+        res,
+      );
+
+      expect(res.writeHead).toHaveBeenCalledWith(
+        401,
+        expect.objectContaining({
+          'WWW-Authenticate': expect.stringMatching(/Bearer/),
+        }),
+      );
+      expect(res.end).toHaveBeenCalledWith('Unauthorized');
+    });
+
+    it('rejects requests whose Content-Length exceeds 1 MiB (413)', async () => {
+      const handler = await setupHttpHandler();
+
+      const res = { writeHead: vi.fn(), end: vi.fn(), headersSent: false };
+      await handler(
+        {
+          url: '/mcp',
+          method: 'POST',
+          headers: {
+            host: '127.0.0.1:3001',
+            authorization: `Bearer ${TEST_TOKEN}`,
+            'content-length': String(1_048_577),
+          },
+        },
+        res,
+      );
+
+      expect(res.writeHead).toHaveBeenCalledWith(413);
+      expect(res.end).toHaveBeenCalledWith('Payload Too Large');
     });
   });
 });

--- a/packages/mcp-server/src/index.test.ts
+++ b/packages/mcp-server/src/index.test.ts
@@ -3,6 +3,9 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { request } from 'node:http';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 const MCP_SERVER_CWD = new URL('..', import.meta.url).pathname;
 
@@ -34,12 +37,28 @@ function randomPort(): number {
   return 10000 + Math.floor(Math.random() * 50000);
 }
 
-/** Spawn an HTTP MCP server and wait for it to be listening. */
-function spawnHttpServer(args: string[]): Promise<{ port: number; proc: ChildProcess; close: () => void }> {
+/** Spawn an HTTP MCP server and wait for it to be listening. Returns the
+ * resolved bearer token from the test-isolated token file alongside the
+ * server handle. */
+interface HttpServerHandle {
+  port: number;
+  proc: ChildProcess;
+  close: () => void;
+  token: string;
+  tokenPath: string;
+}
+
+function spawnHttpServer(args: string[], env: Record<string, string> = {}): Promise<HttpServerHandle> {
   return new Promise((resolve, reject) => {
+    // Per-server token path so concurrent tests don't collide with each
+    // other or with the user's real ~/.oss-autopilot/mcp.token.
+    const tokenPath =
+      env.OSS_AUTOPILOT_MCP_TOKEN_PATH ??
+      path.join(os.tmpdir(), `oss-autopilot-mcp-test-${Date.now()}-${Math.random().toString(36).slice(2)}.token`);
     const proc = spawn('npx', ['tsx', 'src/index.ts', ...args], {
       cwd: MCP_SERVER_CWD,
       stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, OSS_AUTOPILOT_MCP_TOKEN_PATH: tokenPath, ...env },
     });
 
     const timeout = setTimeout(() => {
@@ -48,20 +67,31 @@ function spawnHttpServer(args: string[]): Promise<{ port: number; proc: ChildPro
     }, 10_000);
 
     let stderrData = '';
-    proc.stderr!.on('data', (chunk: Buffer) => {
+    let resolved = false;
+    const onData = (chunk: Buffer) => {
       stderrData += chunk.toString();
+      if (resolved) return;
       // Server prints "listening on http://127.0.0.1:<port>/mcp" when ready
       const match = stderrData.match(/listening on http:\/\/127\.0\.0\.1:(\d+)\/mcp/);
-      if (match) {
-        clearTimeout(timeout);
-        const port = parseInt(match[1], 10);
-        resolve({
-          port,
-          proc,
-          close: () => proc.kill('SIGTERM'),
-        });
-      }
-    });
+      if (!match) return;
+      resolved = true;
+      clearTimeout(timeout);
+      proc.stderr!.off('data', onData);
+      const port = parseInt(match[1], 10);
+      // Token file was written synchronously by ensureHttpToken before
+      // httpServer.listen, so it must exist by the time the banner prints.
+      const token = fs.readFileSync(tokenPath, 'utf-8').trim();
+      resolve({
+        port,
+        proc,
+        token,
+        tokenPath,
+        close: () => {
+          proc.kill('SIGTERM');
+        },
+      });
+    };
+    proc.stderr!.on('data', onData);
 
     proc.on('error', (err) => {
       clearTimeout(timeout);
@@ -83,26 +113,34 @@ function httpRequest(
   method: string,
   path: string,
   body?: string,
-): Promise<{ status: number; body: string }> {
+  extraHeaders: Record<string, string> = {},
+): Promise<{ status: number; body: string; headers: Record<string, string | string[] | undefined> }> {
   return new Promise((resolve, reject) => {
+    const baseHeaders: Record<string, string | number> = body
+      ? {
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream',
+          'Content-Length': Buffer.byteLength(body),
+        }
+      : {};
     const req = request(
       {
         hostname: '127.0.0.1',
         port,
         path,
         method,
-        headers: body
-          ? {
-              'Content-Type': 'application/json',
-              Accept: 'application/json, text/event-stream',
-              'Content-Length': Buffer.byteLength(body),
-            }
-          : {},
+        headers: { ...baseHeaders, ...extraHeaders },
       },
       (res) => {
         let data = '';
         res.on('data', (chunk: Buffer) => (data += chunk.toString()));
-        res.on('end', () => resolve({ status: res.statusCode!, body: data }));
+        res.on('end', () =>
+          resolve({
+            status: res.statusCode!,
+            body: data,
+            headers: res.headers as Record<string, string | string[] | undefined>,
+          }),
+        );
       },
     );
     req.on('error', reject);
@@ -141,7 +179,7 @@ describe('MCP server stdio transport', { timeout: 30_000 }, () => {
 });
 
 describe('MCP server HTTP transport', { timeout: 30_000 }, () => {
-  let serverHandle: { port: number; proc: ChildProcess; close: () => void } | undefined;
+  let serverHandle: HttpServerHandle | undefined;
 
   afterEach(() => {
     if (serverHandle) {
@@ -150,11 +188,16 @@ describe('MCP server HTTP transport', { timeout: 30_000 }, () => {
     }
   });
 
+  function authHeader(): Record<string, string> {
+    if (!serverHandle) throw new Error('serverHandle not initialized');
+    return { Authorization: `Bearer ${serverHandle.token}` };
+  }
+
   it('POST /mcp with JSON-RPC initialize returns valid response', async () => {
     const port = randomPort();
     serverHandle = await spawnHttpServer(['--http', `--port=${port}`]);
 
-    const res = await httpRequest(serverHandle.port, 'POST', '/mcp', INITIALIZE_BODY);
+    const res = await httpRequest(serverHandle.port, 'POST', '/mcp', INITIALIZE_BODY, authHeader());
 
     expect(res.status).toBe(200);
     // Streamable HTTP transport returns SSE — extract JSON from "data:" lines
@@ -194,9 +237,92 @@ describe('MCP server HTTP transport', { timeout: 30_000 }, () => {
     const port = randomPort();
     serverHandle = await spawnHttpServer(['--http', '--port', String(port)]);
 
-    const res = await httpRequest(serverHandle.port, 'POST', '/mcp', INITIALIZE_BODY);
+    const res = await httpRequest(serverHandle.port, 'POST', '/mcp', INITIALIZE_BODY, authHeader());
 
     expect(res.status).toBe(200);
+  });
+
+  // ── Bearer-token auth (#1028) ───────────────────────────────────
+
+  it('rejects POST /mcp with no Authorization header (401)', async () => {
+    const port = randomPort();
+    serverHandle = await spawnHttpServer(['--http', `--port=${port}`]);
+
+    const res = await httpRequest(serverHandle.port, 'POST', '/mcp', INITIALIZE_BODY);
+
+    expect(res.status).toBe(401);
+    expect(res.body).toBe('Unauthorized');
+    expect(res.headers['www-authenticate']).toMatch(/Bearer/);
+  });
+
+  it('rejects POST /mcp with a malformed Authorization header (401)', async () => {
+    const port = randomPort();
+    serverHandle = await spawnHttpServer(['--http', `--port=${port}`]);
+
+    const res = await httpRequest(serverHandle.port, 'POST', '/mcp', INITIALIZE_BODY, {
+      Authorization: 'Basic user:pass',
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects POST /mcp with a wrong bearer token (401)', async () => {
+    const port = randomPort();
+    serverHandle = await spawnHttpServer(['--http', `--port=${port}`]);
+
+    const res = await httpRequest(serverHandle.port, 'POST', '/mcp', INITIALIZE_BODY, {
+      Authorization: `Bearer ${'0'.repeat(64)}`,
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('persists the token across server restarts', async () => {
+    const tokenPath = path.join(os.tmpdir(), `oss-autopilot-mcp-test-persist-${Date.now()}.token`);
+    const port1 = randomPort();
+    const first = await spawnHttpServer(['--http', `--port=${port1}`], {
+      OSS_AUTOPILOT_MCP_TOKEN_PATH: tokenPath,
+    });
+    const firstToken = first.token;
+    first.proc.kill('SIGTERM');
+    await new Promise((r) => setTimeout(r, 300));
+
+    const port2 = randomPort();
+    serverHandle = await spawnHttpServer(['--http', `--port=${port2}`], {
+      OSS_AUTOPILOT_MCP_TOKEN_PATH: tokenPath,
+    });
+    expect(serverHandle.token).toBe(firstToken);
+  });
+
+  // ── Host-header validation ──────────────────────────────────────
+
+  it('rejects requests with a non-loopback Host header (403)', async () => {
+    const port = randomPort();
+    serverHandle = await spawnHttpServer(['--http', `--port=${port}`]);
+
+    const res = await httpRequest(serverHandle.port, 'POST', '/mcp', INITIALIZE_BODY, {
+      ...authHeader(),
+      Host: 'evil.example.com',
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toBe('Invalid host');
+  });
+
+  // ── Body-size cap ───────────────────────────────────────────────
+
+  it('rejects requests whose Content-Length exceeds 1 MiB (413)', async () => {
+    const port = randomPort();
+    serverHandle = await spawnHttpServer(['--http', `--port=${port}`]);
+
+    // Lie about Content-Length — server should reject before reading the body.
+    const res = await httpRequest(serverHandle.port, 'POST', '/mcp', INITIALIZE_BODY, {
+      ...authHeader(),
+      'Content-Length': String(1_048_577),
+    });
+
+    expect(res.status).toBe(413);
+    expect(res.body).toBe('Payload Too Large');
   });
 });
 

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -4,11 +4,14 @@
  * Entry point supporting stdio (default) and Streamable HTTP transports.
  */
 import { createServer } from './server.js';
+import { ensureHttpToken, validateBearerToken, isValidHost } from './auth.js';
 
 export { createServer } from './server.js';
 export { registerTools } from './tools.js';
 export { registerResources } from './resources.js';
 export { registerPrompts } from './prompts.js';
+
+const MAX_BODY_BYTES = 1_048_576; // 1 MiB
 
 export async function main() {
   const args = process.argv.slice(2);
@@ -30,10 +33,21 @@ export async function main() {
       process.exit(1);
     }
 
+    // Ensure a bearer token exists before accepting any requests (#1028).
+    const tokenInfo = await ensureHttpToken();
+
     const { createServer: createHttpServer } = await import('node:http');
     const { StreamableHTTPServerTransport } = await import('@modelcontextprotocol/sdk/server/streamableHttp.js');
 
     const httpServer = createHttpServer(async (req, res) => {
+      // DNS-rebinding defense: reject Host headers outside the loopback
+      // allow-list BEFORE doing any other work (#1028).
+      if (!isValidHost(req.headers['host'], port)) {
+        res.writeHead(403);
+        res.end('Invalid host');
+        return;
+      }
+
       if (req.url !== '/mcp') {
         res.writeHead(404);
         res.end('Not Found');
@@ -44,6 +58,27 @@ export async function main() {
         res.end('Method Not Allowed');
         return;
       }
+
+      // Require every request to declare a numeric Content-Length within the
+      // cap. Rejecting missing / non-numeric / chunked up-front avoids
+      // relying on the MCP SDK's transport-internal limits (which are not
+      // documented to exist for the streamable HTTP POST reader) and closes
+      // the "send chunked to skip the cap" bypass noted in #1028 review.
+      const contentLengthHeader = req.headers['content-length'];
+      const contentLength = typeof contentLengthHeader === 'string' ? parseInt(contentLengthHeader, 10) : NaN;
+      if (!Number.isFinite(contentLength) || contentLength < 0 || contentLength > MAX_BODY_BYTES) {
+        res.writeHead(413);
+        res.end('Payload Too Large');
+        return;
+      }
+
+      // Bearer-token auth: every /mcp request must carry Authorization.
+      if (!validateBearerToken(req.headers['authorization'], tokenInfo.token)) {
+        res.writeHead(401, { 'WWW-Authenticate': 'Bearer realm="oss-autopilot-mcp"' });
+        res.end('Unauthorized');
+        return;
+      }
+
       // Stateless mode: fresh server + transport per request to avoid
       // race conditions from concurrent connect() calls on a shared instance.
       const server = createServer();
@@ -65,14 +100,20 @@ export async function main() {
     });
 
     const shutdown = () => {
-      httpServer.close();
-      process.exit(0);
+      // Drain in-flight requests before exiting. Hard-exit after 5s so a
+      // hung client cannot prevent shutdown.
+      httpServer.close(() => process.exit(0));
+      setTimeout(() => process.exit(0), 5000).unref();
     };
     process.on('SIGINT', shutdown);
     process.on('SIGTERM', shutdown);
 
     httpServer.listen(port, '127.0.0.1', () => {
       console.error(`OSS Autopilot MCP server listening on http://127.0.0.1:${port}/mcp`);
+      console.error(
+        `Authentication: Bearer token${tokenInfo.freshlyGenerated ? ' (newly generated)' : ''} at ${tokenInfo.path}`,
+      );
+      console.error('Clients must send: Authorization: Bearer <token-file-contents>');
     });
   } else {
     // Default: stdio transport


### PR DESCRIPTION
## Summary

- Closes #1028.
- HTTP-mode MCP server previously accepted any local POST to `/mcp` with **no authentication** — any process on the loopback interface (editor extensions, sandbox escapes, other users on a shared dev box) could invoke `post`/`claim` and write public GitHub comments under the user's identity.
- New layered defense:
  1. **Bearer-token auth.** Fresh 32-byte hex token generated at `~/.oss-autopilot/mcp.token` (mode `0600`) on first `--http` start. Required on every `/mcp` request via `Authorization: Bearer <token>`. Constant-time compare with `crypto.timingSafeEqual`. Case-insensitive scheme per RFC 7235.
  2. **Host-header allow-list.** Loopback only (`127.0.0.1:port`, `localhost:port`). Blocks DNS-rebinding.
  3. **Body-size cap.** Requires numeric `Content-Length` ≤ 1 MiB — missing / chunked / non-numeric values return 413 up-front.
- Defensive polish: pre-existing token file with laxer perms is auto-tightened to 0600 + warned on stderr; empty-expected-token always fails validation; shutdown drains in-flight requests with a 5s hard-exit fallback.
- New `OSS_AUTOPILOT_MCP_TOKEN_PATH` env-var for custom deployments and test isolation.
- README documents the auth flow and rotation procedure.

stdio transport is unchanged — it already inherits the parent-process identity.

## Test plan

- [x] `packages/mcp-server/src/auth.test.ts` — 20 new unit tests (token gen / persistence / 0600 perms / auto-tightening / RFC 7235 case-insensitive Bearer / empty-token defense / Host allow-list).
- [x] `packages/mcp-server/src/index.test.ts` — new end-to-end spawn tests covering 401 (no auth / malformed / wrong token), token persistence across restarts, 403 (rebound Host), 413 (oversized Content-Length).
- [x] `packages/mcp-server/src/index-main.test.ts` — mocked-handler tests for each status code path.
- [x] `pnpm run lint` clean. `pnpm run format:check` clean. `pnpm -C packages/mcp-server test` — 172 pass.
- [x] `pnpm -C packages/core test` — 1,938 pass (unaffected).
- [x] `pnpm -C packages/dashboard test` — 244 pass (unaffected).

## Review cycle

Ran code-reviewer + silent-failure-hunter in parallel.

- **code-reviewer:** Converged — no blocking findings. Flagged a misleading comment on `auth.ts:68-70`; fixed in-commit.
- **silent-failure-hunter:** 1 HIGH + 3 MEDIUM + 3 LOW. HIGH (Content-Length chunked bypass) + all 3 MEDIUMs (pre-existing laxer perms, case-sensitive Bearer, empty-expected defense) + 2 LOWs (shutdown drain, README accuracy) addressed in-commit. Remaining LOWs (persistence race if two servers start simultaneously; RFC 6750 `error="invalid_token"` enrichment) deferred as future work.

## Upgrade path

Existing HTTP users will see 401 on their next request unless they update their MCP client configuration to send `Authorization: Bearer <contents of ~/.oss-autopilot/mcp.token>`. No migration needed for stdio users.
