### PR TITLE
fix(state): optimistic compare-and-swap for state.json writes

### DIFF
--- a/packages/core/src/core/errors.ts
+++ b/packages/core/src/core/errors.ts
@@ -59,6 +59,29 @@ export class GistPermissionError extends ConfigurationError {
 }
 
 /**
+ * Thrown when an optimistic compare-and-swap on state.json detects that
+ * another process wrote the file between load and save. See issue #1030.
+ *
+ * Library consumers should call `stateManager.reloadIfChanged()` and
+ * re-apply their mutation. The runtime `message` is phrased for CLI
+ * end-users; the structured `expectedMtimeMs` / `actualMtimeMs` fields
+ * are for programmatic handling.
+ */
+export class ConcurrencyError extends OssAutopilotError {
+  constructor(
+    public readonly expectedMtimeMs: number,
+    public readonly actualMtimeMs: number,
+  ) {
+    super(
+      'Another oss-autopilot process wrote state.json concurrently. ' +
+        'Re-run the command to retry — the last write wins and no data was lost from the other process.',
+      'CONCURRENCY_ERROR',
+    );
+    this.name = 'ConcurrencyError';
+  }
+}
+
+/**
  * Extract a human-readable message from an unknown error value.
  */
 export function errorMessage(e: unknown): string {
@@ -135,6 +158,7 @@ export function resolveErrorCode(err: unknown): import('../formatters/json.js').
   // Check our custom error classes first
   if (err instanceof ConfigurationError) return 'CONFIGURATION';
   if (err instanceof ValidationError) return 'VALIDATION';
+  if (err instanceof ConcurrencyError) return 'CONCURRENCY';
 
   // Check HTTP status codes (Octokit errors)
   const status = getHttpStatusCode(err);

--- a/packages/core/src/core/state-persistence.test.ts
+++ b/packages/core/src/core/state-persistence.test.ts
@@ -5,6 +5,8 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { StateManager, acquireLock, releaseLock, atomicWriteFileSync, resetStateManager } from './state.js';
+import { saveState, createFreshState } from './state-persistence.js';
+import { ConcurrencyError } from './errors.js';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -822,5 +824,129 @@ describe('reloadStateIfChanged additional edge cases', () => {
     expect(sm.reloadIfChanged()).toBe(false);
 
     fs.chmodSync(statePath, 0o600);
+  });
+});
+
+// ── Cross-process optimistic concurrency (#1030) ────────────────────────────
+//
+// The advisory lock in saveState() blocks concurrent *writers*, but before
+// this fix there was no guard against the classic lost-update race:
+// process A and process B both load at time T1, both mutate in memory, both
+// queue behind the lock, and whichever writes last silently clobbers the
+// other's changes. saveState now compares the caller-supplied expected mtime
+// against the on-disk mtime inside the lock and throws ConcurrencyError on
+// mismatch. StateManager.save() propagates that error up.
+describe('saveState optimistic compare-and-swap (#1030)', () => {
+  beforeEach(() => {
+    mockTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oss-state-cas-'));
+  });
+
+  afterEach(() => {
+    resetStateManager();
+    fs.rmSync(mockTmpDir, { recursive: true, force: true });
+    mockTmpDir = '';
+  });
+
+  it('saves normally when no external write happened between load and save', () => {
+    const sm = new StateManager(false);
+    sm.updateConfig({ githubUsername: 'alice' });
+    sm.save(); // seeds the file + lastLoadedMtimeMs
+
+    // In-process mutate + save again — mtime still matches because we
+    // were the last writer.
+    sm.updateConfig({ githubUsername: 'bob' });
+    expect(() => sm.save()).not.toThrow();
+
+    const statePath = path.join(mockTmpDir, 'state.json');
+    const written = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    expect(written.config.githubUsername).toBe('bob');
+  });
+
+  it('throws ConcurrencyError when another process wrote between load and save', async () => {
+    // Seed state + capture loaded mtime.
+    const sm = new StateManager(false);
+    sm.updateConfig({ githubUsername: 'alice' });
+    sm.save();
+
+    // Simulate another process writing the file.
+    const statePath = path.join(mockTmpDir, 'state.json');
+    const raw = fs.readFileSync(statePath, 'utf-8');
+    const otherProcState = JSON.parse(raw);
+    otherProcState.config.githubUsername = 'bob-wrote-this-from-another-process';
+    // Sleep briefly so the new mtime is meaningfully different from the
+    // last write. macOS tmpfs has low mtime resolution; a short sleep +
+    // utimesSync forces a detectable new mtime.
+    await new Promise((r) => setTimeout(r, 50));
+    fs.writeFileSync(statePath, JSON.stringify(otherProcState, null, 2), { mode: 0o600 });
+    const future = new Date(Date.now() + 1000);
+    fs.utimesSync(statePath, future, future);
+
+    // updateConfig calls autoSave → save → saveState, which throws.
+    // Wrap the mutation itself since that's where the throw originates.
+    expect(() => sm.updateConfig({ githubUsername: 'alice-would-clobber-bob' })).toThrow(ConcurrencyError);
+
+    // The on-disk file still has bob's write — alice did NOT clobber it.
+    const final = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    expect(final.config.githubUsername).toBe('bob-wrote-this-from-another-process');
+  });
+
+  it('saveState bypasses the check when expectedMtimeMs is null (first write path)', () => {
+    const fresh = createFreshState();
+    // No file on disk; passing null means "skip CAS" — should succeed.
+    expect(() => saveState(fresh, null)).not.toThrow();
+    const statePath = path.join(mockTmpDir, 'state.json');
+    expect(fs.existsSync(statePath)).toBe(true);
+  });
+
+  it('saveState with matching expectedMtimeMs succeeds, with mismatching throws', async () => {
+    const fresh = createFreshState();
+    const firstMtime = saveState(fresh, null);
+    expect(firstMtime).toBeGreaterThan(0);
+
+    // Matching mtime — writes fine.
+    const secondMtime = saveState(fresh, firstMtime);
+    expect(secondMtime).toBeGreaterThan(0);
+
+    // Force the on-disk mtime forward without going through saveState.
+    const statePath = path.join(mockTmpDir, 'state.json');
+    await new Promise((r) => setTimeout(r, 50));
+    const future = new Date(Date.now() + 2000);
+    fs.utimesSync(statePath, future, future);
+
+    // Now saveState with the stale mtime must throw.
+    expect(() => saveState(fresh, secondMtime)).toThrow(ConcurrencyError);
+  });
+
+  it('allowReloadAndLoseMutation downgrades ConcurrencyError to a reload warning', async () => {
+    const sm = new StateManager(false);
+    sm.updateConfig({ githubUsername: 'alice' });
+    sm.save();
+
+    // External writer races in.
+    const statePath = path.join(mockTmpDir, 'state.json');
+    const other = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    other.config.githubUsername = 'carol';
+    await new Promise((r) => setTimeout(r, 50));
+    fs.writeFileSync(statePath, JSON.stringify(other, null, 2), { mode: 0o600 });
+    const future = new Date(Date.now() + 1000);
+    fs.utimesSync(statePath, future, future);
+
+    // Directly mutate state without going through autoSave so the
+    // mutation survives long enough to call save() explicitly with the
+    // bypass flag. This simulates a caller that has set the flag up-front
+    // for idempotent / observer-only mutations.
+    const st = sm.getState() as typeof sm.getState extends () => infer S ? S : never;
+    // Typing gymnastics — getState returns Readonly<AgentState>, but we
+    // need to mutate for the test. Cast through any.
+    (sm.getState() as unknown as { config: { githubUsername: string } }).config.githubUsername =
+      'alice-overwrite-attempt';
+    void st;
+
+    expect(() => sm.save({ allowReloadAndLoseMutation: true })).not.toThrow();
+
+    // In-memory state now reflects the external write, NOT our stale mutation.
+    expect(sm.getState().config.githubUsername).toBe('carol');
+    const onDisk = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    expect(onDisk.config.githubUsername).toBe('carol');
   });
 });

--- a/packages/core/src/core/state-persistence.ts
+++ b/packages/core/src/core/state-persistence.ts
@@ -9,7 +9,7 @@ import * as path from 'path';
 import { AgentState } from './types.js';
 import { AgentStateSchema } from './state-schema.js';
 import { getStatePath, getBackupDir, getDataDir } from './utils.js';
-import { errorMessage } from './errors.js';
+import { errorMessage, ConcurrencyError } from './errors.js';
 import { debug, warn } from './logger.js';
 
 const MODULE = 'state';
@@ -490,9 +490,22 @@ function cleanupBackups(): void {
 /**
  * Persist state to disk, creating a timestamped backup of the previous
  * state file first. Retains at most 10 backup files.
+ *
+ * When `expectedMtimeMs` is provided (non-null, non-zero), implements
+ * optimistic compare-and-swap: if the on-disk file has been modified since
+ * the caller last loaded it, throws `ConcurrencyError` instead of
+ * overwriting. This prevents the classic read-modify-write lost-update
+ * race across processes (see issue #1030). Pass `null` / `0` to disable
+ * the check (first write, or when the caller has already reloaded).
+ *
+ * The check runs *inside* the advisory lock so the compare-and-swap is
+ * atomic with respect to the write.
+ *
  * @returns The file's mtime after writing (for change detection).
+ * @throws ConcurrencyError when `expectedMtimeMs` is provided and the
+ *   on-disk mtime no longer matches.
  */
-export function saveState(state: Readonly<AgentState>): number {
+export function saveState(state: Readonly<AgentState>, expectedMtimeMs: number | null = null): number {
   const statePath = getStatePath();
   const lockPath = statePath + '.lock';
   const backupDir = getBackupDir();
@@ -501,6 +514,16 @@ export function saveState(state: Readonly<AgentState>): number {
   acquireLock(lockPath);
 
   try {
+    // Compare-and-swap: reject the write if the file changed externally
+    // between the caller's last load and now. Zero/null bypasses the
+    // check for first writes and Gist-mode local-cache paths.
+    if (expectedMtimeMs !== null && expectedMtimeMs > 0 && fs.existsSync(statePath)) {
+      const currentMtimeMs = safeGetMtimeMs(statePath);
+      if (currentMtimeMs !== expectedMtimeMs) {
+        throw new ConcurrencyError(expectedMtimeMs, currentMtimeMs);
+      }
+    }
+
     // Create backup of existing state (best-effort, non-fatal)
     try {
       if (fs.existsSync(statePath)) {

--- a/packages/core/src/core/state.ts
+++ b/packages/core/src/core/state.ts
@@ -28,7 +28,7 @@ import {
 import * as repoScoring from './repo-score-manager.js';
 import type { Stats } from './repo-score-manager.js';
 import { debug, warn } from './logger.js';
-import { errorMessage, ConfigurationError } from './errors.js';
+import { errorMessage, ConfigurationError, ConcurrencyError } from './errors.js';
 import { GistStateStore, type OctokitLike } from './gist-state-store.js';
 import { getStatePath, getStateCachePath } from './utils.js';
 
@@ -205,8 +205,19 @@ export class StateManager {
    *
    * In Gist mode, writes to a local cache file (not the main state file) so the Gist
    * remains the source of truth. Use `checkpoint()` to push state to the Gist.
+   *
+   * Local-file mode uses optimistic compare-and-swap: if another process has
+   * written `state.json` since we last loaded/saved, `saveState` throws
+   * `ConcurrencyError`. See issue #1030.
+   *
+   * @throws ConcurrencyError (local file mode only) when the on-disk state
+   *   was modified externally between this StateManager's last load/save
+   *   and now. Callers that tolerate silent merge can set
+   *   `{ allowReloadAndLoseMutation: true }` to downgrade the error into a
+   *   warning — but note that doing so abandons any in-memory mutation
+   *   made since the last load. Fail-loud (the default) is preferred.
    */
-  save(): void {
+  save(options: { allowReloadAndLoseMutation?: boolean } = {}): void {
     this.state.lastRunAt = new Date().toISOString();
 
     if (this.inMemoryOnly) {
@@ -216,6 +227,10 @@ export class StateManager {
     if (this.gistStore) {
       // In Gist mode, write to local cache (not main state file).
       // The Gist is the source of truth; local cache is for fallback.
+      // Intentionally NO compare-and-swap on this cache path — two processes
+      // racing on state-cache.json can clobber each other, but the next
+      // `refreshFromGist()` or `checkpoint()` re-syncs from the authoritative
+      // Gist. The trade-off is a transiently-stale offline bootstrap (#1030).
       try {
         atomicWriteFileSync(getStateCachePath(), JSON.stringify(this.state, null, 2), 0o600);
       } catch (err) {
@@ -226,8 +241,17 @@ export class StateManager {
       return;
     }
 
-    // Local file mode (existing behavior)
-    this.lastLoadedMtimeMs = saveState(this.state);
+    // Local file mode with optimistic compare-and-swap.
+    try {
+      this.lastLoadedMtimeMs = saveState(this.state, this.lastLoadedMtimeMs);
+    } catch (err) {
+      if (err instanceof ConcurrencyError && options.allowReloadAndLoseMutation) {
+        warn(MODULE, `Concurrent external write detected; reloading and discarding in-memory mutation. ${err.message}`);
+        this.reloadIfChanged();
+        return;
+      }
+      throw err;
+    }
   }
 
   /** Push current state to Gist (async). Call at well-defined moments (end of daily, after claim). */

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -17,6 +17,7 @@ export type ErrorCode =
   | 'NETWORK'
   | 'NOT_FOUND'
   | 'STATE_CORRUPTED'
+  | 'CONCURRENCY'
   | 'UNKNOWN';
 
 export interface JsonOutput<T = unknown> {


### PR DESCRIPTION
## Summary

- Closes #1030.
- `StateManager.save()` previously serialized writers via an advisory lock but did NOT detect that another process had written `state.json` between the caller's load and save. Classic lost-update race: A loads at T1, B loads at T1, A saves (T2), B saves (T3) silently clobbering A's changes. `daily`, the MCP server, and the dashboard-server action handler all mutate state concurrently, so blast radius was high.
- `saveState(state, expectedMtimeMs?)` now does optimistic compare-and-swap *inside* the existing advisory lock. Null / 0 bypasses (first-write path); a positive expected mtime is compared against the on-disk mtime and throws `ConcurrencyError` on mismatch instead of overwriting.
- New `ConcurrencyError` class resolves to `errorCode: 'CONCURRENCY'` in the JSON envelope (new union member). Message is end-user friendly ("Another oss-autopilot process wrote state.json concurrently. Re-run the command to retry.").
- `StateManager.save()` default is fail-loud (propagates the error to the caller). Opt-in `save({ allowReloadAndLoseMutation: true })` catches + reloads + discards in-memory mutation — reserved for idempotent/observer-only writers; no production caller uses it yet but tests lock the contract.
- Gist-mode local cache path is deliberately NOT CAS-guarded: the Gist is authoritative, cache staleness is self-healed by `refreshFromGist()` / `checkpoint()`. Documented inline.

## Test plan

- [x] `pnpm -C packages/core test state-persistence` — 50 passed (5 new CAS cases).
- [x] `pnpm -C packages/core test` — 1,943 pass, 14 skipped.
- [x] `pnpm run lint` clean. `pnpm run format:check` clean.
- [x] Acceptance criteria from #1030 verified:
  - No silent lost update: the CAS throws a typed error or the write succeeds.
  - New test exercises two-writer scenario end-to-end.
  - `lastLoadedMtimeMs` consulted inside `save()` (not just external callers).
  - Auto-backups + atomic-write paths unchanged.
  - Gist-mode checkpoint behavior unchanged.

## Review cycle

- **code-reviewer:** Converged — no blocking findings. Three Minor polish items (errorCode union, CLI-facing message wording, `allowReloadAndLoseMutation` documentation). First two addressed in-commit; third is speculative and kept as documented contract for future callers.
- **silent-failure-hunter:** identified one systemic concern — the CAS fires at the state layer, but the *orchestrator* layer (try/catch around `batch()` in `daily.ts` and `dashboard-data.ts`) currently turns `ConcurrencyError` into a `warn()` + discarded mutation. This is meaningfully better than the pre-fix silent clobber (user now sees a warning) but not ideal. Per-command retry-on-ConcurrencyError is intentionally **out of scope for this PR** — tracked as follow-up under the UM2 umbrella ("Hook ordering and CLI PR-flow hygiene"). The hunter's other findings (nested-autoSave cascade, Gist cache, test mtime portability) either don't apply in practice or are addressed in-commit (Gist documentation, bypass flag semantics).

## Out-of-scope (follow-up)

- Plumb `ConcurrencyError` recognition through `daily.ts` / `dashboard-data.ts` outer catches so user-visible messaging distinguishes "external write" from "generic save failure".
- Per-CLI-command retry-on-ConcurrencyError for `shelve` / `dismiss` / `move` mutators.
- Migrate Gist sync to ETag-based optimistic concurrency (audit M29).
