### PR TITLE
fix(dashboard): surface partial-fetch failures + stop silent monthly-count decay

### DIFF
--- a/packages/core/src/commands/dashboard-data.test.ts
+++ b/packages/core/src/commands/dashboard-data.test.ts
@@ -510,6 +510,23 @@ describe('mergeMonthlyCounts', () => {
     expect(existing).toEqual({ '2026-01': 5 });
     expect(fresh).toEqual({ '2026-02': 10 });
   });
+
+  it('does not shrink an existing month when fresh count is lower (#1035)', () => {
+    // Scenario: fresh fetch was capped at 3 pages and only covered a partial
+    // window of an older month. Without anti-regression, the smaller partial
+    // count would silently overwrite the authoritative historical count.
+    const existing = { '2025-11': 42, '2026-01': 9 };
+    const fresh = { '2025-11': 8, '2026-01': 11 };
+    const result = mergeMonthlyCounts(existing, fresh);
+    expect(result).toEqual({ '2025-11': 42, '2026-01': 11 });
+  });
+
+  it('takes the maximum when fresh equals existing (identity)', () => {
+    const existing = { '2025-11': 42 };
+    const fresh = { '2025-11': 42 };
+    const result = mergeMonthlyCounts(existing, fresh);
+    expect(result).toEqual({ '2025-11': 42 });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1119,5 +1136,36 @@ describe('fetchDashboardData', () => {
     expect(mockAddClosedPRs).toHaveBeenCalled();
     expect(mockWarn).toHaveBeenCalledWith('dashboard-data', expect.stringContaining('Failed to store closed PRs'));
     expect(result.digest).toBeDefined();
+  });
+
+  // ── partialFailures surfacing (#1035) ────────────────────────────────
+
+  it('returns empty partialFailures when all sub-fetches succeed', async () => {
+    const result = await fetchDashboardData('test-token');
+    expect(result.partialFailures).toEqual([]);
+  });
+
+  it('records the failing label in partialFailures when a sub-fetch degrades', async () => {
+    mockFetchRecentlyMergedPRs.mockRejectedValue(new Error('network timeout'));
+    const result = await fetchDashboardData('test-token');
+    expect(result.partialFailures).toContain('fetch recently merged PRs');
+  });
+
+  it('accumulates multiple labels when several sub-fetches fail', async () => {
+    mockFetchRecentlyMergedPRs.mockRejectedValue(new Error('network error'));
+    mockFetchRecentlyClosedPRs.mockRejectedValue(new Error('network error'));
+    mockFetchUserMergedPRCounts.mockRejectedValue(new Error('search API error'));
+    const result = await fetchDashboardData('test-token');
+    expect(result.partialFailures).toEqual(
+      expect.arrayContaining(['fetch recently merged PRs', 'fetch recently closed PRs', 'fetch merged PR counts']),
+    );
+    expect(result.partialFailures.length).toBe(3);
+  });
+
+  it('does not record a rate-limit-or-auth rejection in partialFailures (re-throws instead)', async () => {
+    const rateLimitError = new Error('API rate limit exceeded');
+    mockFetchRecentlyMergedPRs.mockRejectedValue(rateLimitError);
+    mockIsRateLimitOrAuthError.mockImplementation((err: unknown) => err === rateLimitError);
+    await expect(fetchDashboardData('test-token')).rejects.toThrow('API rate limit exceeded');
   });
 });

--- a/packages/core/src/commands/dashboard-data.ts
+++ b/packages/core/src/commands/dashboard-data.ts
@@ -5,7 +5,7 @@
  */
 
 import { getStateManager, PRMonitor, IssueConversationMonitor, getOctokit } from '../core/index.js';
-import { errorMessage, isRateLimitOrAuthError, nonFatalCatch } from '../core/errors.js';
+import { errorMessage, isRateLimitOrAuthError } from '../core/errors.js';
 import { warn } from '../core/logger.js';
 import { emptyPRCountsResult, fetchMergedPRsSince, fetchClosedPRsSince } from '../core/github-stats.js';
 import { parseGitHubUrl } from '../core/utils.js';
@@ -63,6 +63,14 @@ export interface DashboardJsonData {
   vettedIssues?: ParseIssueListOutput | null;
   offline?: boolean;
   lastUpdated?: string;
+  /**
+   * Labels of sub-fetches that degraded to empty fallbacks during this data
+   * build. Non-empty means one or more background calls failed and the
+   * corresponding sections of the response are approximations (stale or
+   * zero'd) rather than authoritative. The SPA surfaces this as a banner
+   * so users know the dashboard is showing partial data. See #1035.
+   */
+  partialFailures?: string[];
 }
 
 /** Action types the dashboard can request via POST /api/action. */
@@ -114,8 +122,15 @@ export function buildDashboardStats(
 /**
  * Merge fresh API counts into existing stored counts.
  * Months present in the fresh data are updated; months only in the existing data are preserved.
- * This prevents historical data loss when the API returns incomplete results
- * (e.g. due to pagination limits or transient failures).
+ *
+ * Anti-regression guard (#1035): when the fresh count for a given month is
+ * smaller than the already-stored count for that month, we keep the larger
+ * value. This matters when the fresh fetch was capped (pagination limits,
+ * 1000-result Search API ceiling, or partial failures) and would otherwise
+ * silently overwrite authoritative historical data with a partial window.
+ * The trade-off: a month that genuinely shrinks (e.g., user deleted a merged
+ * PR reference remotely) cannot be decremented via this path — but that is
+ * a rare case, and the alternative is silent decay of historical analytics.
  */
 export function mergeMonthlyCounts(
   existing: Record<string, number>,
@@ -123,7 +138,8 @@ export function mergeMonthlyCounts(
 ): Record<string, number> {
   const merged = { ...existing };
   for (const [month, count] of Object.entries(fresh)) {
-    merged[month] = count;
+    const current = merged[month];
+    merged[month] = current === undefined ? count : Math.max(current, count);
   }
   return merged;
 }
@@ -182,6 +198,15 @@ export interface DashboardFetchResult {
   commentedIssues: CommentedIssue[];
   allMergedPRs: MergedPR[];
   allClosedPRs: ClosedPR[];
+  /**
+   * Labels of non-critical sub-fetches that degraded to empty fallbacks
+   * during this run. Empty array means every fetch succeeded. Non-empty
+   * means one or more slices of the returned data are approximations —
+   * callers surface this to the user so "0 recently merged" does not look
+   * authoritative when it is actually "fetch failed, fell back to empty".
+   * See #1035.
+   */
+  partialFailures: string[];
 }
 
 /**
@@ -203,6 +228,20 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
   const watermark = stateManager.getMergedPRWatermark();
   const closedWatermark = stateManager.getClosedPRWatermark();
 
+  // Track which non-critical sub-fetches degraded to fallbacks so the SPA
+  // can surface a "partial data" banner instead of silently showing zeros.
+  // Rate-limit / auth errors still rethrow via isRateLimitOrAuthError —
+  // those abort the whole run, not a partial surface.
+  const partialFailures: string[] = [];
+  const trackingCatch = <T>(label: string, fallback: T) => {
+    return (err: unknown): T => {
+      if (isRateLimitOrAuthError(err)) throw err;
+      partialFailures.push(label);
+      warn(MODULE, `Failed to ${label}: ${errorMessage(err)}`);
+      return fallback;
+    };
+  };
+
   const [
     { prs, failures },
     recentlyClosedPRs,
@@ -214,24 +253,14 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
     newClosedPRs,
   ] = await Promise.all([
     prMonitor.fetchUserOpenPRs(),
+    prMonitor.fetchRecentlyClosedPRs().catch(trackingCatch('fetch recently closed PRs', [] as ClosedPR[])),
+    prMonitor.fetchRecentlyMergedPRs().catch(trackingCatch('fetch recently merged PRs', [] as MergedPR[])),
     prMonitor
-      .fetchRecentlyClosedPRs()
-      .catch(nonFatalCatch({ module: MODULE, label: 'fetch recently closed PRs', fallback: [] as ClosedPR[] })),
-    prMonitor
-      .fetchRecentlyMergedPRs()
-      .catch(nonFatalCatch({ module: MODULE, label: 'fetch recently merged PRs', fallback: [] as MergedPR[] })),
-    prMonitor.fetchUserMergedPRCounts(starFilter).catch(
-      nonFatalCatch({
-        module: MODULE,
-        label: 'fetch merged PR counts',
-        fallback: emptyPRCountsResult<{ count: number; lastMergedAt: string }>(),
-      }),
-    ),
+      .fetchUserMergedPRCounts(starFilter)
+      .catch(trackingCatch('fetch merged PR counts', emptyPRCountsResult<{ count: number; lastMergedAt: string }>())),
     prMonitor
       .fetchUserClosedPRCounts(starFilter)
-      .catch(
-        nonFatalCatch({ module: MODULE, label: 'fetch closed PR counts', fallback: emptyPRCountsResult<number>() }),
-      ),
+      .catch(trackingCatch('fetch closed PR counts', emptyPRCountsResult<number>())),
     // Issue conversation fetch has custom messaging based on the error content, so it keeps its bespoke catch.
     issueMonitor.fetchCommentedIssues().catch((error) => {
       if (isRateLimitOrAuthError(error)) throw error;
@@ -240,6 +269,7 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
         warn(MODULE, `Issue conversation tracking requires setup: ${msg}`);
       } else {
         warn(MODULE, `Issue conversation fetch failed: ${msg}`);
+        partialFailures.push('fetch issue conversations');
       }
       return {
         issues: [] as CommentedIssue[],
@@ -247,10 +277,10 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
       };
     }),
     fetchMergedPRsSince(octokit, config, watermark).catch(
-      nonFatalCatch({ module: MODULE, label: 'fetch merged PRs for storage', fallback: [] as StoredMergedPR[] }),
+      trackingCatch('fetch merged PRs for storage', [] as StoredMergedPR[]),
     ),
     fetchClosedPRsSince(octokit, config, closedWatermark).catch(
-      nonFatalCatch({ module: MODULE, label: 'fetch closed PRs for storage', fallback: [] as StoredClosedPR[] }),
+      trackingCatch('fetch closed PRs for storage', [] as StoredClosedPR[]),
     ),
   ]);
 
@@ -313,7 +343,7 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
     throw new Error('Dashboard data fetch failed: digest was not generated');
   }
 
-  return { digest, commentedIssues, allMergedPRs, allClosedPRs };
+  return { digest, commentedIssues, allMergedPRs, allClosedPRs, partialFailures };
 }
 
 /**

--- a/packages/core/src/commands/dashboard-server.test.ts
+++ b/packages/core/src/commands/dashboard-server.test.ts
@@ -447,6 +447,23 @@ describe('dashboard-server', () => {
       expect(Array.isArray(data.shelvedPRUrls)).toBe(true);
     });
 
+    it('buildDashboardJson sets partialFailures only when non-empty (#1035)', () => {
+      // Omitted/undefined → no field on the response. Empty array → no field.
+      // Non-empty → field present. This keeps the wire format minimal and
+      // lets the SPA guard via `data.partialFailures?.length > 0`.
+      const digest = makeDigest();
+      const state = makeState({ lastDigest: digest });
+
+      const none = buildDashboardJson(digest, state, []);
+      expect(none.partialFailures).toBeUndefined();
+
+      const empty = buildDashboardJson(digest, state, [], undefined, undefined, []);
+      expect(empty.partialFailures).toBeUndefined();
+
+      const some = buildDashboardJson(digest, state, [], undefined, undefined, ['fetch recently merged PRs']);
+      expect(some.partialFailures).toEqual(['fetch recently merged PRs']);
+    });
+
     it('should derive shelvedPRUrls from digest.shelvedPRs, not config.shelvedPRUrls (#981)', () => {
       // Dashboard card shows `stats.shelvedPRs`, which counts digest.shelvedPRs.
       // The response's shelvedPRUrls must use the same source so the PR list
@@ -1069,6 +1086,7 @@ describe('dashboard-server', () => {
         commentedIssues: [],
         allMergedPRs: [],
         allClosedPRs: [],
+        partialFailures: [],
       });
 
       const result = await sendRequest('POST', '/api/refresh');

--- a/packages/core/src/commands/dashboard-server.ts
+++ b/packages/core/src/commands/dashboard-server.ts
@@ -125,6 +125,7 @@ export function buildDashboardJson(
   commentedIssues: CommentedIssue[],
   allMergedPRs?: MergedPR[],
   allClosedPRs?: ClosedPR[],
+  partialFailures?: string[],
 ): DashboardJsonData {
   const prsByRepo = computePRsByRepo(digest, state);
   const topRepos = computeTopRepos(prsByRepo);
@@ -180,6 +181,7 @@ export function buildDashboardJson(
     allClosedPRs: filteredClosedPRs,
     repoMetadata,
     vettedIssues,
+    partialFailures: partialFailures && partialFailures.length > 0 ? partialFailures : undefined,
   };
 }
 
@@ -324,6 +326,12 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
   // cache after the port is bound, so the startup poller sees us in time.
   let cachedDigest: DailyDigest = stateManager.getState().lastDigest!;
   let cachedCommentedIssues: CommentedIssue[] = [];
+  // Persist the last-known partialFailures across rebuild requests (#1035).
+  // Cleared only when a fresh fetchDashboardData returns zero failures;
+  // re-threaded into every buildDashboardJson call so the SPA banner does
+  // not disappear when /api/data rebuilds after a state change or after a
+  // POST /api/action completes.
+  let cachedPartialFailures: string[] | undefined = undefined;
 
   if (!cachedDigest) {
     throw new Error(
@@ -335,7 +343,14 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
   let cachedJsonData: DashboardJsonData;
   let cachedIssueListMtimeMs = getIssueListMtimeMs();
   try {
-    cachedJsonData = buildDashboardJson(cachedDigest, stateManager.getState(), cachedCommentedIssues);
+    cachedJsonData = buildDashboardJson(
+      cachedDigest,
+      stateManager.getState(),
+      cachedCommentedIssues,
+      undefined,
+      undefined,
+      cachedPartialFailures,
+    );
   } catch (error) {
     throw new Error(
       `Failed to build dashboard data: ${errorMessage(error)}. State data may be corrupted — try running: daily --json`,
@@ -385,7 +400,14 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
         const issueListChanged = currentIssueListMtimeMs !== cachedIssueListMtimeMs;
         if (stateChanged || issueListChanged) {
           try {
-            cachedJsonData = buildDashboardJson(cachedDigest, stateManager.getState(), cachedCommentedIssues);
+            cachedJsonData = buildDashboardJson(
+              cachedDigest,
+              stateManager.getState(),
+              cachedCommentedIssues,
+              undefined,
+              undefined,
+              cachedPartialFailures,
+            );
             cachedIssueListMtimeMs = currentIssueListMtimeMs;
           } catch (error) {
             warn(MODULE, `Failed to rebuild dashboard data after state reload: ${errorMessage(error)}`);
@@ -518,8 +540,18 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
       return;
     }
 
-    // Rebuild dashboard data from cached digest + updated state
-    cachedJsonData = buildDashboardJson(cachedDigest, stateManager.getState(), cachedCommentedIssues);
+    // Rebuild dashboard data from cached digest + updated state. Persist
+    // the last-known partialFailures across action rebuilds (#1035) so the
+    // SPA banner survives user interactions until the next successful
+    // refresh clears it.
+    cachedJsonData = buildDashboardJson(
+      cachedDigest,
+      stateManager.getState(),
+      cachedCommentedIssues,
+      undefined,
+      undefined,
+      cachedPartialFailures,
+    );
     cachedIssueListMtimeMs = getIssueListMtimeMs();
 
     sendJson(res, 200, cachedJsonData);
@@ -543,12 +575,16 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
       const result = await fetchDashboardData(currentToken);
       cachedDigest = result.digest;
       cachedCommentedIssues = result.commentedIssues;
+      // Update the persistent banner signal — clear on a clean refresh,
+      // set when one or more sub-fetches degraded. See #1035.
+      cachedPartialFailures = result.partialFailures.length > 0 ? result.partialFailures : undefined;
       cachedJsonData = buildDashboardJson(
         cachedDigest,
         stateManager.getState(),
         cachedCommentedIssues,
         result.allMergedPRs,
         result.allClosedPRs,
+        cachedPartialFailures,
       );
       cachedIssueListMtimeMs = getIssueListMtimeMs();
       sendJson(res, 200, cachedJsonData);
@@ -673,12 +709,14 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
         }
         cachedDigest = result.digest;
         cachedCommentedIssues = result.commentedIssues;
+        cachedPartialFailures = result.partialFailures.length > 0 ? result.partialFailures : undefined;
         cachedJsonData = buildDashboardJson(
           cachedDigest,
           stateManager.getState(),
           cachedCommentedIssues,
           result.allMergedPRs,
           result.allClosedPRs,
+          cachedPartialFailures,
         );
         cachedIssueListMtimeMs = getIssueListMtimeMs();
         warn(MODULE, 'Background data refresh complete');

--- a/packages/dashboard/src/app.tsx
+++ b/packages/dashboard/src/app.tsx
@@ -145,12 +145,28 @@ function AppContent() {
     onCelebrate: triggerCelebration,
   };
 
+  // Shared partial-data banner — rendered on every route so users don't
+  // lose the "showing partial data" signal when navigating to /merged
+  // etc., where the affected arrays (allMergedPRs, allClosedPRs) are the
+  // primary content. See #1035.
+  const partialBanner =
+    data.partialFailures && data.partialFailures.length > 0 ? (
+      <div class="partial-banner" role="status" aria-live="polite">
+        <span>
+          Showing partial data — {data.partialFailures.length} background fetch
+          {data.partialFailures.length === 1 ? '' : 'es'} failed ({data.partialFailures.join(', ')}). Some sections may
+          be incomplete; try refreshing.
+        </span>
+      </div>
+    ) : null;
+
   // Route: /merged — show all merged PRs
   if (path === '/merged') {
     const mergedPRs = data.allMergedPRs ?? [];
     return (
       <div class="dashboard">
         <DashboardHeader {...headerProps} />
+        {partialBanner}
         <MergedPRList mergedPRs={mergedPRs} repoMetadata={data.repoMetadata} onBack={() => route('/')} />
         <CelebrationToast celebration={celebration} onDismiss={dismissCelebration} />
       </div>
@@ -163,6 +179,7 @@ function AppContent() {
     return (
       <div class="dashboard">
         <DashboardHeader {...headerProps} />
+        {partialBanner}
         <ClosedPRList closedPRs={closedPRs} onBack={() => route('/')} />
         <CelebrationToast celebration={celebration} onDismiss={dismissCelebration} />
       </div>
@@ -174,6 +191,7 @@ function AppContent() {
     return (
       <div class="dashboard">
         <DashboardHeader {...headerProps} />
+        {partialBanner}
         {data.vettedIssues ? (
           <VettedIssueList
             vettedIssues={data.vettedIssues}
@@ -238,6 +256,8 @@ function AppContent() {
           </button>
         </div>
       )}
+
+      {partialBanner}
 
       <main id="main-content" class="dashboard-main">
         <div class="animate-in delay-1">

--- a/packages/dashboard/src/styles.css
+++ b/packages/dashboard/src/styles.css
@@ -1157,6 +1157,22 @@ a:hover {
   color: var(--base);
 }
 
+/* Non-fatal "showing partial data" notice — uses amber/warning palette rather
+ * than red, so users can distinguish it from hard errors that block actions.
+ * See #1035.
+ */
+.partial-banner {
+  display: flex;
+  align-items: center;
+  padding: var(--sp-3) var(--sp-4);
+  margin: 0 0 var(--sp-3);
+  border-radius: var(--radius);
+  background: var(--amber-dim);
+  color: var(--text-primary);
+  border-left: 3px solid var(--amber);
+  font-size: 0.85rem;
+}
+
 .action-error {
   width: 100%;
   margin: 0 0 var(--sp-2);

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -60,4 +60,10 @@ export interface DashboardData {
   allClosedPRs: ClosedPR[];
   repoMetadata?: Record<string, RepoMetadataEntry>;
   vettedIssues?: ParseIssueListOutput | null;
+  /**
+   * Labels of non-critical sub-fetches that degraded to empty fallbacks
+   * on the last refresh. Non-empty → UI should warn the user that slices
+   * of the response are stale/zero'd rather than authoritative (#1035).
+   */
+  partialFailures?: string[];
 }


### PR DESCRIPTION
## Summary

- Closes #1035 — the final Critical from the audit.
- Two silent-failure modes in the dashboard data path:
  1. `fetchDashboardData` wrapped every non-critical sub-fetch in `nonFatalCatch` with empty-value fallbacks. A partial outage rendered "0 recently merged" with no signal to the user.
  2. `mergeMonthlyCounts` was right-wins — a capped or partial fresh fetch could silently overwrite a month's stored count with a smaller value, letting historical analytics decay on disk.

## Changes

### Core (`packages/core/src/commands/dashboard-data.ts`)
- `mergeMonthlyCounts` now takes `Math.max(current, fresh)` per month — fresh can raise but never shrink. Documented trade-off.
- Local `trackingCatch<T>(label, fallback)` replaces inline `nonFatalCatch`; on non-fatal error it appends the label to a scoped `partialFailures: string[]` accumulator, preserving the rate-limit-rethrow invariant. Bespoke issue-conversation catch also records labels (except for "No GitHub username configured", which is a setup state, not a failure).
- `DashboardFetchResult` gains required `partialFailures: string[]`; `DashboardJsonData` gains optional `partialFailures?: string[]` (undefined when empty so the SPA banner renders only when needed).

### Server (`packages/core/src/commands/dashboard-server.ts`)
- `buildDashboardJson` accepts a new optional `partialFailures?` parameter.
- `cachedPartialFailures` persists at server-closure level and is re-threaded into every `buildDashboardJson` call (previous commit only plumbed it through `handleRefresh`; review flagged that rebuilds from `/api/data` stateChanged and `/api/action` silently dropped the signal — the banner would vanish on the next innocuous request). Only a successful `fetchDashboardData` with zero failures clears it.

### SPA (`packages/dashboard/src/`)
- `types.ts`: `partialFailures?: string[]` on `DashboardData`.
- `app.tsx`: shared `partialBanner` JSX rendered on every route (`/`, `/merged`, `/closed`, `/issues`). Review flagged that the original placement only rendered on the default route — users navigating to `/merged` to see the data that was itself affected by a partial fetch would lose the warning.
- `styles.css`: `.partial-banner` uses the project's existing tokens (`--amber`, `--amber-dim`, `--text-primary`). The initial CSS referenced undefined `--accent` / `--fg` tokens which would have rendered the banner invisible — review flagged as Critical.

## Test plan

- [x] `pnpm --filter @oss-autopilot/core run build` clean.
- [x] `pnpm run lint` clean. `pnpm run format:check` clean.
- [x] `pnpm -C packages/core test` — 1,949 pass, 14 skipped.
- [x] `pnpm -C packages/dashboard test` — 244 pass.
- [x] `pnpm -C packages/mcp-server test` — 172 pass.
- [x] New tests: +2 `mergeMonthlyCounts` (anti-shrink + identity); +4 `fetchDashboardData` (empty happy path, single-label append, multi-label accumulation, rate-limit rethrow does not pollute); +1 `dashboard-server.test` asserting `buildDashboardJson` omits `partialFailures` when empty and sets it when non-empty.

## Acceptance criteria

- [x] `DashboardJsonData` includes a `partialFailures: string[]` field populated whenever a non-fatal sub-fetch fires.
- [x] The SPA renders a visible warning when `partialFailures.length > 0`, on every route.
- [x] `mergeMonthlyCounts` never shrinks an existing month's count when merging an empty or smaller fresh map.
- [x] New unit tests cover: (a) partial fetch failures append to `partialFailures`, (b) merge does not shrink existing months, (c) happy path preserves existing behavior when everything succeeds.

## Review cycle

- **code-reviewer:** 2 Critical findings — CSS references undefined tokens, partialFailures dropped on non-refresh rebuilds. Both fixed in-commit.
- **silent-failure-hunter:** 3 Critical findings — the same two as code-reviewer, plus banner-scoped-to-default-route. All three fixed in-commit. Lower-severity items (anti-regression over-counting a rare case, in-memory-only lifetime, bespoke issue-conversation branch handling) documented in code comments or left as accepted trade-offs.

## Out-of-scope

- Symmetric `warnings: string[]` for `DailyOutput` (audit H7 — tracked separately).
- A "rebuild monthly analytics" CLI affordance for the rare case where a month genuinely shrinks and the anti-regression prevents decrement (noted as code comment).
- Gist-mode cache also has no CAS — documented as acceptable in #1030 and out of scope here.
