### PR TITLE
fix(cli): shelve/unshelve emit ShelveOutput (not MoveOutput)

### DIFF
--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -870,6 +870,11 @@ export const commands: CLICommandDef[] = [
   },
 
   // ── Shelve ─────────────────────────────────────────────────────────────
+  // Delegates to runShelve so the CLI emits the same `ShelveOutput`
+  // ({shelved, url}) as the library export + MCP tool. Previously it called
+  // runMove and emitted `MoveOutput` ({url, target, description}), which
+  // drifted from the pinned contract test and broke plugin consumers
+  // reading `data.shelved`. See issue #1037.
   {
     name: 'shelve',
     localOnly: true,
@@ -881,9 +886,9 @@ export const commands: CLICommandDef[] = [
         .action((prUrl, options) =>
           executeAction(
             options,
-            async () => (await import('./commands/move.js')).runMove({ prUrl, target: 'shelved' }),
+            async () => (await import('./commands/shelve.js')).runShelve({ prUrl }),
             (data) => {
-              console.log(data.description);
+              console.log(data.shelved ? `Shelved ${data.url}` : `Already shelved: ${data.url}`);
             },
           ),
         );
@@ -902,9 +907,9 @@ export const commands: CLICommandDef[] = [
         .action((prUrl, options) =>
           executeAction(
             options,
-            async () => (await import('./commands/move.js')).runMove({ prUrl, target: 'auto' }),
+            async () => (await import('./commands/shelve.js')).runUnshelve({ prUrl }),
             (data) => {
-              console.log(data.description);
+              console.log(data.unshelved ? `Unshelved ${data.url}` : `Not currently shelved: ${data.url}`);
             },
           ),
         );


### PR DESCRIPTION
## Summary

- Closes #1037.
- The \`shelve\` / \`unshelve\` CLI handlers delegated to \`runMove\` and emitted \`MoveOutput\` (\`{url, target, description}\`), while the library exports and MCP tool emitted \`ShelveOutput\` (\`{shelved, url}\`). Plugin consumers reading \`data.shelved\` from the CLI got undefined.
- Chose Option A from the issue — CLI now calls \`runShelve\` / \`runUnshelve\` directly. Preserves the semantic \"did this become shelved?\" shape and leaves the generic multi-target API on \`move\`.
- Text-output branches updated to read the new fields.

## Test plan

- [x] \`pnpm --filter @oss-autopilot/core run build\` clean.
- [x] \`pnpm run lint\` / \`pnpm run format:check\` clean.
- [x] \`pnpm -C packages/core test\` — 1,952 pass, 14 skipped.
- [x] \`shelve.contract.test.ts\` already pins \`ShelveOutput\` / \`UnshelveOutput\` on \`runShelve\` / \`runUnshelve\`. Since the CLI now routes through those functions, the CLI output shape is guaranteed to match the pinned contract — the existing contract tests cover both library and CLI paths transitively.