### PR TITLE
feat(cli): add doctor command, rename check-integration → orphan-files (#1039)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 
 env:
   # Bundle size thresholds (bytes). Update via PR when increases are justified.
-  BUNDLE_MAX_CORE: 730000 # ~713 KB (increased for config-key registry + did-you-mean helpers, #1038)
+  BUNDLE_MAX_CORE: 740000 # ~722 KB (increased for doctor command + config-key registry, #1038/#1039)
   BUNDLE_MAX_MCP: 2000000 # ~1953 KB
   STARTUP_WARN_MS: 500 # Warn if CLI startup exceeds 500ms
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -117,7 +117,8 @@ Debug and warning output goes to stderr via the logger, so it never contaminates
 | `comments` / `post` / `claim` | `comments.ts` | Track issue conversations, post comments, claim issues |
 | `local-repos` | `local-repos.ts` | Scan for locally cloned repos |
 | `parse-list` | `parse-list.ts` | Parse a curated issue list file |
-| `check-integration` | `check-integration.ts` | Check if new files are referenced |
+| `orphan-files` (alias: `check-integration`) | `check-integration.ts` | Audit new files on this branch for cross-references |
+| `doctor` | `doctor.ts` | System-health diagnostic — token, bundle, state, scout, rate limit |
 | `read` | `read.ts` | Mark PR comments as read |
 | `stats` | `stats.ts` | Show contribution statistics (merge rate, PR counts) |
 | `detect-formatters` | `detect-formatters.ts` | Detect formatters and linters configured in a repository |

--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -775,12 +775,13 @@ export const commands: CLICommandDef[] = [
 
   // ── Check Integration ──────────────────────────────────────────────────
   {
-    name: 'check-integration',
+    name: 'orphan-files',
     localOnly: true,
     register(program) {
       program
-        .command('check-integration')
-        .description('Detect new files not referenced by the codebase')
+        .command('orphan-files')
+        .alias('check-integration')
+        .description('Detect new files on this branch that no other file references')
         .option('--base <branch>', 'Base branch to compare against', 'main')
         .option('--json', 'Output as JSON')
         .action((options) =>
@@ -806,6 +807,37 @@ export const commands: CLICommandDef[] = [
                   }
                 }
               }
+            },
+          ),
+        );
+    },
+  },
+
+  // ── Doctor ─────────────────────────────────────────────────────────────
+  {
+    name: 'doctor',
+    localOnly: true,
+    register(program) {
+      program
+        .command('doctor')
+        .description('Run a system-health diagnostic (token, bundle, state, scout, rate limit)')
+        .option('--json', 'Output as JSON')
+        .action((options) =>
+          executeAction(
+            options,
+            async () => (await import('./commands/doctor.js')).runDoctor(),
+            (data) => {
+              console.log('\nSystem health\n');
+              for (const check of data.checks) {
+                const icon = check.status === 'ok' ? '[OK]   ' : check.status === 'warning' ? '[WARN] ' : '[ERR]  ';
+                console.log(`${icon}${check.name}: ${check.message}`);
+                if (check.remediation) {
+                  console.log(`       ↳ ${check.remediation}`);
+                }
+              }
+              console.log(
+                `\n${data.summary.ok} ok / ${data.summary.warnings} warning / ${data.summary.errors} error\n`,
+              );
             },
           ),
         );

--- a/packages/core/src/cli.test.ts
+++ b/packages/core/src/cli.test.ts
@@ -98,7 +98,8 @@ describe('LOCAL_ONLY_COMMANDS (derived from registry)', () => {
     'checkSetup',
     'serve',
     'parse-issue-list',
-    'check-integration',
+    'orphan-files',
+    'doctor',
     'detect-formatters',
     'local-repos',
     'startup',
@@ -359,7 +360,8 @@ describe('Command registration', () => {
       'checkSetup',
       'serve',
       'parse-issue-list',
-      'check-integration',
+      'orphan-files',
+      'doctor',
       'detect-formatters',
       'local-repos',
       'startup',
@@ -609,8 +611,8 @@ describe('CLI argument parsing', () => {
     expect(portOpt!.defaultValue).toBe('3000');
   });
 
-  it('check-integration has --base option defaulting to "main"', () => {
-    const cmd = findCmd('check-integration');
+  it('orphan-files has --base option defaulting to "main"', () => {
+    const cmd = findCmd('orphan-files');
     expect(cmd).toBeDefined();
     const baseOpt = cmd!.options.find((o) => o.long === '--base');
     expect(baseOpt).toBeDefined();

--- a/packages/core/src/commands/doctor.test.ts
+++ b/packages/core/src/commands/doctor.test.ts
@@ -1,0 +1,386 @@
+/**
+ * Tests for the doctor command (#1039).
+ *
+ * Each check is covered with an ok-path + at least one warning/error path.
+ * External side effects (child_process, fs, Octokit, token resolution) are
+ * mocked at module level so every path is deterministic.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// ── Module-level mocks ──────────────────────────────────────────────────
+
+vi.mock('child_process', () => ({
+  execFile: vi.fn(),
+}));
+
+vi.mock('../core/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../core/index.js')>('../core/index.js');
+  return {
+    ...actual,
+    getGitHubTokenAsync: vi.fn(),
+    getOctokit: vi.fn(),
+    getStatePath: vi.fn(),
+  };
+});
+
+import { execFile } from 'child_process';
+import { getGitHubTokenAsync, getOctokit, getStatePath } from '../core/index.js';
+import {
+  checkBundleUpToDate,
+  checkGhAuth,
+  checkGhCli,
+  checkGitHubRateLimit,
+  checkGitHubToken,
+  checkScoutResolvable,
+  checkStateFile,
+  runDoctor,
+} from './doctor.js';
+
+const mockExecFile = vi.mocked(execFile);
+const mockGetGitHubTokenAsync = vi.mocked(getGitHubTokenAsync);
+const mockGetOctokit = vi.mocked(getOctokit);
+const mockGetStatePath = vi.mocked(getStatePath);
+
+/**
+ * Configure `mockExecFile` to return distinct (stdout/err/code) results per
+ * invocation. Each entry represents one `execFile(...)` call in order.
+ *
+ * Shape note: `util.promisify(execFile)` resolves to the **first non-error
+ * argument** passed to the callback — so we invoke the callback with a
+ * single `{stdout, stderr}` object, matching what the real Node child
+ * process helper yields when promisified.
+ */
+function stubExecFile(responses: Array<{ stdout?: string; stderr?: string; error?: Error & { code?: number } }>): void {
+  let i = 0;
+  mockExecFile.mockImplementation(((_cmd: string, _args: string[], _opts: unknown, cb: unknown) => {
+    const callback = cb as (err: Error | null, value?: { stdout: string; stderr: string }) => void;
+    const r = responses[i++] ?? responses[responses.length - 1];
+    if (r.error) {
+      callback(r.error);
+    } else {
+      callback(null, { stdout: r.stdout ?? '', stderr: r.stderr ?? '' });
+    }
+    return {} as unknown as ReturnType<typeof execFile>;
+  }) as unknown as typeof execFile);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── checkGhCli ──────────────────────────────────────────────────────────
+
+describe('checkGhCli', () => {
+  it('reports ok when `gh --version` succeeds', async () => {
+    stubExecFile([{ stdout: 'gh version 2.50.0 (2024-06-01)\nhttps://github.com/cli/cli/releases/tag/v2.50.0\n' }]);
+    const result = await checkGhCli();
+    expect(result.status).toBe('ok');
+    expect(result.message).toContain('gh version 2.50.0');
+  });
+
+  it('reports "not on PATH" when spawn fails with ENOENT', async () => {
+    stubExecFile([{ error: Object.assign(new Error('ENOENT'), { code: 'ENOENT' }) }]);
+    const result = await checkGhCli();
+    expect(result.status).toBe('warning');
+    expect(result.message).toMatch(/not found on PATH/);
+    expect(result.remediation).toMatch(/cli\.github\.com/);
+  });
+
+  it('distinguishes "present but broken" from "not installed"', async () => {
+    // A timeout or non-ENOENT spawn error means gh *is* installed but isn't
+    // usable — telling the user to install gh would be actively misleading.
+    stubExecFile([{ error: Object.assign(new Error('command timed out'), { code: 'ETIMEDOUT' }) }]);
+    const result = await checkGhCli();
+    expect(result.status).toBe('warning');
+    expect(result.message).toMatch(/present but failed to run/);
+    expect(result.message).toMatch(/timed out/);
+    expect(result.remediation).not.toMatch(/cli\.github\.com/);
+  });
+});
+
+// ── checkGhAuth ─────────────────────────────────────────────────────────
+
+describe('checkGhAuth', () => {
+  it('reports ok when gh is authenticated', async () => {
+    stubExecFile([{ stdout: 'Logged in to github.com as user (oauth_token)' }]);
+    const result = await checkGhAuth();
+    expect(result.status).toBe('ok');
+  });
+
+  it('reports warning when gh auth status fails, mentioning both auth and network as possible causes', async () => {
+    stubExecFile([
+      { error: Object.assign(new Error('not authenticated'), { code: 1 as never }), stderr: 'not logged in' },
+    ]);
+    const result = await checkGhAuth();
+    expect(result.status).toBe('warning');
+    // Remediation should cover both the "not logged in" case AND the network/proxy case.
+    expect(result.remediation).toMatch(/gh auth login/);
+    expect(result.remediation).toMatch(/network|proxy/i);
+  });
+});
+
+// ── checkGitHubToken ────────────────────────────────────────────────────
+
+describe('checkGitHubToken', () => {
+  it('warns when no token is available', async () => {
+    mockGetGitHubTokenAsync.mockResolvedValue(null);
+    const result = await checkGitHubToken();
+    expect(result.status).toBe('warning');
+    expect(result.remediation).toMatch(/GITHUB_TOKEN|gh auth login/);
+  });
+
+  it('reports ok when token authenticates successfully', async () => {
+    mockGetGitHubTokenAsync.mockResolvedValue('ghp_abc123');
+    const mockOctokit = {
+      users: { getAuthenticated: vi.fn().mockResolvedValue({ data: { login: 'octocat' } }) },
+    };
+    mockGetOctokit.mockReturnValue(mockOctokit as any);
+    const result = await checkGitHubToken();
+    expect(result.status).toBe('ok');
+    expect(result.message).toContain('@octocat');
+  });
+
+  it('reports error when token is present but API auth fails', async () => {
+    mockGetGitHubTokenAsync.mockResolvedValue('ghp_expired');
+    const mockOctokit = {
+      users: { getAuthenticated: vi.fn().mockRejectedValue(new Error('Bad credentials')) },
+    };
+    mockGetOctokit.mockReturnValue(mockOctokit as any);
+    const result = await checkGitHubToken();
+    expect(result.status).toBe('error');
+    expect(result.message).toContain('Bad credentials');
+    expect(result.remediation).toMatch(/refresh|fresh/);
+  });
+});
+
+// ── checkBundleUpToDate ─────────────────────────────────────────────────
+
+describe('checkBundleUpToDate', () => {
+  const tmpBase = path.join(os.tmpdir(), `oss-autopilot-doctor-${process.pid}`);
+
+  beforeEach(() => {
+    fs.mkdirSync(tmpBase, { recursive: true });
+  });
+
+  it('reports ok when bundle is newer than source', () => {
+    const bundlePath = path.join(tmpBase, 'fresh-bundle.cjs');
+    const sourcePath = path.join(tmpBase, 'fresh-source.ts');
+    fs.writeFileSync(sourcePath, '// src');
+    fs.writeFileSync(bundlePath, '// bundle');
+    // Bump bundle mtime forward so it's strictly newer than source.
+    const newer = new Date(Date.now() + 10_000);
+    fs.utimesSync(bundlePath, newer, newer);
+
+    const result = checkBundleUpToDate({ bundlePath, sourcePath });
+    expect(result.status).toBe('ok');
+  });
+
+  it('reports warning when source is newer than bundle', () => {
+    const bundlePath = path.join(tmpBase, 'stale-bundle.cjs');
+    const sourcePath = path.join(tmpBase, 'stale-source.ts');
+    fs.writeFileSync(bundlePath, '// bundle');
+    fs.writeFileSync(sourcePath, '// src');
+    const newer = new Date(Date.now() + 10_000);
+    fs.utimesSync(sourcePath, newer, newer);
+
+    const result = checkBundleUpToDate({ bundlePath, sourcePath });
+    expect(result.status).toBe('warning');
+    expect(result.remediation).toMatch(/pnpm run bundle/);
+  });
+
+  it('reports warning when bundle is missing but source exists', () => {
+    const bundlePath = path.join(tmpBase, 'nope-bundle.cjs');
+    const sourcePath = path.join(tmpBase, 'only-source.ts');
+    fs.writeFileSync(sourcePath, '// src');
+    const result = checkBundleUpToDate({ bundlePath, sourcePath });
+    expect(result.status).toBe('warning');
+    expect(result.message).toMatch(/not built yet/);
+  });
+
+  it('reports ok when bundle exists and source does not (npm install scenario)', () => {
+    const bundlePath = path.join(tmpBase, 'installed-bundle.cjs');
+    const sourcePath = path.join(tmpBase, 'never-shipped-source.ts');
+    fs.writeFileSync(bundlePath, '// bundle');
+    const result = checkBundleUpToDate({ bundlePath, sourcePath });
+    expect(result.status).toBe('ok');
+  });
+
+  it('reports warning when neither bundle nor source exist', () => {
+    const result = checkBundleUpToDate({
+      bundlePath: path.join(tmpBase, 'absent-bundle'),
+      sourcePath: path.join(tmpBase, 'absent-source'),
+    });
+    expect(result.status).toBe('warning');
+  });
+});
+
+// ── checkStateFile ──────────────────────────────────────────────────────
+
+describe('checkStateFile', () => {
+  const tmpBase = path.join(os.tmpdir(), `oss-autopilot-doctor-state-${process.pid}`);
+
+  beforeEach(() => {
+    fs.mkdirSync(tmpBase, { recursive: true });
+  });
+
+  it('reports ok when state file does not exist', () => {
+    const statePath = path.join(tmpBase, 'missing.json');
+    mockGetStatePath.mockReturnValue(statePath);
+    const result = checkStateFile();
+    expect(result.status).toBe('ok');
+    expect(result.message).toMatch(/first run/i);
+  });
+
+  it('reports ok when state file parses and validates', () => {
+    const statePath = path.join(tmpBase, 'valid.json');
+    fs.writeFileSync(
+      statePath,
+      JSON.stringify({
+        version: 3,
+        repoScores: {},
+        config: { githubUsername: 'u' },
+        lastRunAt: new Date().toISOString(),
+        activeIssues: [],
+      }),
+    );
+    const result = checkStateFile({ statePathOverride: statePath });
+    expect(result.status).toBe('ok');
+    expect(result.message).toMatch(/v3/);
+  });
+
+  it('reports error when state file has invalid JSON', () => {
+    const statePath = path.join(tmpBase, 'garbage.json');
+    fs.writeFileSync(statePath, '{ this is not json');
+    const result = checkStateFile({ statePathOverride: statePath });
+    expect(result.status).toBe('error');
+    expect(result.remediation).toMatch(/backup/i);
+  });
+
+  it('reports error when state file fails schema validation', () => {
+    const statePath = path.join(tmpBase, 'badschema.json');
+    fs.writeFileSync(statePath, JSON.stringify({ version: 99 /* unsupported */ }));
+    const result = checkStateFile({ statePathOverride: statePath });
+    expect(result.status).toBe('error');
+    expect(result.message).toMatch(/schema validation/i);
+  });
+});
+
+// ── checkScoutResolvable ────────────────────────────────────────────────
+
+describe('checkScoutResolvable', () => {
+  // @oss-scout/core is a real workspace dependency, so this check should pass
+  // in the test environment. `import()` goes through Node's ESM resolver,
+  // which honors the `exports` map that require.resolve cannot.
+  it('reports ok when @oss-scout/core resolves', async () => {
+    const result = await checkScoutResolvable();
+    expect(result.status).toBe('ok');
+  });
+
+  it('reports error with reinstall remediation when the package is not found', async () => {
+    const notFound = Object.assign(new Error("Cannot find package '@oss-scout/core'"), {
+      code: 'ERR_MODULE_NOT_FOUND',
+    });
+    const result = await checkScoutResolvable(() => Promise.reject(notFound));
+    expect(result.status).toBe('error');
+    expect(result.message).toMatch(/install issue/i);
+    expect(result.remediation).toMatch(/reinstall/i);
+  });
+
+  it('reports error with reinstall remediation on a corrupt install (ERR_PACKAGE_PATH_NOT_EXPORTED)', async () => {
+    const corrupt = Object.assign(new Error('No "exports" main defined'), {
+      code: 'ERR_PACKAGE_PATH_NOT_EXPORTED',
+    });
+    const result = await checkScoutResolvable(() => Promise.reject(corrupt));
+    expect(result.status).toBe('error');
+    expect(result.remediation).toMatch(/reinstall/i);
+  });
+
+  it('reports error with bug-report remediation when the package throws during init', async () => {
+    const initErr = new TypeError('Cannot read properties of undefined (reading ...)');
+    const result = await checkScoutResolvable(() => Promise.reject(initErr));
+    expect(result.status).toBe('error');
+    expect(result.message).toMatch(/failed to load/i);
+    expect(result.remediation).toMatch(/report this as a bug/i);
+  });
+});
+
+// ── checkGitHubRateLimit ────────────────────────────────────────────────
+
+describe('checkGitHubRateLimit', () => {
+  it('warns when no token is available', async () => {
+    mockGetGitHubTokenAsync.mockResolvedValue(null);
+    const result = await checkGitHubRateLimit();
+    expect(result.status).toBe('warning');
+  });
+
+  it('reports ok when remaining requests are plentiful', async () => {
+    mockGetGitHubTokenAsync.mockResolvedValue('ghp_ok');
+    mockGetOctokit.mockReturnValue({
+      rateLimit: {
+        get: vi
+          .fn()
+          .mockResolvedValue({ data: { resources: { core: { remaining: 4500, limit: 5000, reset: 1_700_000_000 } } } }),
+      },
+    } as any);
+    const result = await checkGitHubRateLimit();
+    expect(result.status).toBe('ok');
+    expect(result.message).toContain('4500/5000');
+  });
+
+  it('warns when remaining requests are below 100', async () => {
+    mockGetGitHubTokenAsync.mockResolvedValue('ghp_low');
+    mockGetOctokit.mockReturnValue({
+      rateLimit: {
+        get: vi
+          .fn()
+          .mockResolvedValue({ data: { resources: { core: { remaining: 42, limit: 5000, reset: 1_700_000_000 } } } }),
+      },
+    } as any);
+    const result = await checkGitHubRateLimit();
+    expect(result.status).toBe('warning');
+    expect(result.message).toContain('42/5000');
+  });
+
+  it('reports error when rate-limit API fails', async () => {
+    mockGetGitHubTokenAsync.mockResolvedValue('ghp_dead');
+    mockGetOctokit.mockReturnValue({
+      rateLimit: { get: vi.fn().mockRejectedValue(new Error('network down')) },
+    } as any);
+    const result = await checkGitHubRateLimit();
+    expect(result.status).toBe('error');
+    expect(result.message).toContain('network down');
+  });
+});
+
+// ── runDoctor orchestrator ──────────────────────────────────────────────
+
+describe('runDoctor', () => {
+  it('returns a summary reflecting every check status', async () => {
+    // Token check fails quickly (no token) → warnings drive summary.
+    mockGetGitHubTokenAsync.mockResolvedValue(null);
+    mockGetStatePath.mockReturnValue(path.join(os.tmpdir(), 'oss-autopilot-doctor-nofile.json'));
+    stubExecFile([{ error: Object.assign(new Error('no gh'), { code: 'ENOENT' as never }) }]);
+
+    const result = await runDoctor();
+    expect(result.checks.length).toBeGreaterThanOrEqual(6);
+    expect(result.summary.ok + result.summary.warnings + result.summary.errors).toBe(result.checks.length);
+  });
+
+  it('never aborts — a crashing check is converted to a synthetic error entry', async () => {
+    // Doctor is the tool users run when things are already broken. A single
+    // crashing check must not swallow the whole report.
+    mockGetGitHubTokenAsync.mockImplementation(() => {
+      throw new Error('unexpected sync crash from token fetch');
+    });
+    mockGetStatePath.mockReturnValue(path.join(os.tmpdir(), 'oss-autopilot-doctor-nofile.json'));
+    stubExecFile([{ error: Object.assign(new Error('no gh'), { code: 'ENOENT' as never }) }]);
+
+    // Should resolve, not reject, even with the synchronous throw above.
+    const result = await runDoctor();
+    expect(result.checks.length).toBeGreaterThanOrEqual(6);
+  });
+});

--- a/packages/core/src/commands/doctor.ts
+++ b/packages/core/src/commands/doctor.ts
@@ -1,0 +1,394 @@
+/**
+ * Doctor command — a real system-health audit.
+ *
+ * Runs independent checks against the local environment and reports an
+ * aggregate `DoctorOutput` so users can diagnose common failure modes
+ * (missing token, unauthenticated gh CLI, stale bundle, corrupted state,
+ * unresolvable scout dependency, low rate-limit budget) in one go.
+ *
+ * Each `check*` function is exported individually so tests can mock its
+ * external dependencies in isolation.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+import { getGitHubTokenAsync, getOctokit, getStatePath } from '../core/index.js';
+import { AgentStateSchema } from '../core/state-schema.js';
+import { errorMessage } from '../core/errors.js';
+
+const execFileAsync = promisify(execFile);
+
+export type DoctorCheckStatus = 'ok' | 'warning' | 'error';
+
+export interface DoctorCheck {
+  name: string;
+  status: DoctorCheckStatus;
+  message: string;
+  remediation?: string;
+}
+
+export interface DoctorOutput {
+  checks: DoctorCheck[];
+  summary: { ok: number; warnings: number; errors: number };
+}
+
+const GH_CMD_TIMEOUT_MS = 3000;
+
+// ── Individual checks ───────────────────────────────────────────────────
+
+/** Extract a Node errno-style code from an unknown thrown value. */
+function errCode(err: unknown): string | undefined {
+  if (err && typeof err === 'object' && 'code' in err) {
+    const code = (err as { code?: unknown }).code;
+    if (typeof code === 'string') return code;
+  }
+  return undefined;
+}
+
+export async function checkGhCli(): Promise<DoctorCheck> {
+  try {
+    const { stdout } = await execFileAsync('gh', ['--version'], { timeout: GH_CMD_TIMEOUT_MS });
+    const versionLine = stdout.split('\n')[0]?.trim() || 'gh present';
+    return { name: 'gh CLI installed', status: 'ok', message: versionLine };
+  } catch (err) {
+    // Distinguish "not on PATH" (ENOENT) from "present but broken" (anything
+    // else — spawn errors, timeouts, permission denied, non-zero exit). Telling
+    // users to "install gh" when gh is already installed is actively misleading.
+    const code = errCode(err);
+    if (code === 'ENOENT') {
+      return {
+        name: 'gh CLI installed',
+        status: 'warning',
+        message: 'gh CLI not found on PATH',
+        remediation: 'Install the GitHub CLI from https://cli.github.com/',
+      };
+    }
+    return {
+      name: 'gh CLI installed',
+      status: 'warning',
+      message: `gh CLI present but failed to run: ${errorMessage(err)}`,
+      remediation:
+        'Check that `gh --version` works in your shell; a timeout or permission error may indicate a broken install',
+    };
+  }
+}
+
+export async function checkGhAuth(): Promise<DoctorCheck> {
+  try {
+    await execFileAsync('gh', ['auth', 'status'], { timeout: GH_CMD_TIMEOUT_MS });
+    return { name: 'gh CLI authenticated', status: 'ok', message: 'Signed in to github.com' };
+  } catch (err) {
+    // `gh auth status` also exits non-zero on network/proxy failures and TLS
+    // issues reaching github.com — not only when the user isn't logged in.
+    // Mentioning both paths in the remediation avoids misleading users whose
+    // problem is connectivity, not auth.
+    return {
+      name: 'gh CLI authenticated',
+      status: 'warning',
+      message: `gh auth status failed: ${errorMessage(err)}`,
+      remediation:
+        'Run `gh auth login` to authenticate, or check network/proxy connectivity if the error looks network-related',
+    };
+  }
+}
+
+export async function checkGitHubToken(preloadedToken?: string | null): Promise<DoctorCheck> {
+  const token = preloadedToken !== undefined ? preloadedToken : await getGitHubTokenAsync();
+  if (!token) {
+    return {
+      name: 'GitHub token resolvable',
+      status: 'warning',
+      message: 'No GitHub token available via $GITHUB_TOKEN or `gh auth token`',
+      remediation: 'Set $GITHUB_TOKEN or run `gh auth login`',
+    };
+  }
+  try {
+    const octokit = getOctokit(token);
+    const { data } = await octokit.users.getAuthenticated();
+    return {
+      name: 'GitHub token resolvable',
+      status: 'ok',
+      message: `Authenticated as @${data.login}`,
+    };
+  } catch (err) {
+    return {
+      name: 'GitHub token resolvable',
+      status: 'error',
+      message: `Token present but API auth failed: ${errorMessage(err)}`,
+      remediation: 'Token may be expired or revoked — run `gh auth refresh` or set a fresh $GITHUB_TOKEN',
+    };
+  }
+}
+
+/**
+ * Locate `packages/core/dist/cli.bundle.cjs` across the two runtime contexts
+ * this code can run in:
+ *
+ *   - Dev (tsx): `__dirname` = `.../packages/core/src/commands`, bundle sits
+ *     two levels up in `../../dist/cli.bundle.cjs`.
+ *   - Bundled (cjs): `__dirname` = `.../packages/core/dist`, bundle sits at
+ *     `./cli.bundle.cjs` in that same directory.
+ */
+function resolveBundlePaths(): { bundlePath: string; sourcePath: string } {
+  const devBundle = path.resolve(__dirname, '../../dist/cli.bundle.cjs');
+  const coDirBundle = path.resolve(__dirname, 'cli.bundle.cjs');
+  const devSource = path.resolve(__dirname, '../cli.ts');
+  const coDirSource = path.resolve(__dirname, '../src/cli.ts');
+
+  // Prefer whichever resolves an existing file; fall back to dev paths so the
+  // "missing" branches in checkBundleUpToDate still have a sensible path to
+  // report.
+  const bundlePath = fs.existsSync(devBundle) ? devBundle : fs.existsSync(coDirBundle) ? coDirBundle : devBundle;
+  const sourcePath = fs.existsSync(devSource) ? devSource : fs.existsSync(coDirSource) ? coDirSource : devSource;
+  return { bundlePath, sourcePath };
+}
+
+/**
+ * Try `fs.statSync`; if the file is merely missing (ENOENT), return null.
+ * For other fs errors (EACCES, ELOOP, ENOTDIR, …) surface the error so the
+ * caller can report it instead of misdiagnosing it as "file missing."
+ */
+function tryStat(p: string): { stat: fs.Stats | null; error?: NodeJS.ErrnoException } {
+  try {
+    return { stat: fs.statSync(p) };
+  } catch (err) {
+    if (errCode(err) === 'ENOENT') return { stat: null };
+    return { stat: null, error: err as NodeJS.ErrnoException };
+  }
+}
+
+/**
+ * Bundle-freshness check only fires when the *source* file is present — that's
+ * the dev-repo workflow. npm consumers install the pre-built bundle with no
+ * source, so we just confirm the bundle exists.
+ */
+export function checkBundleUpToDate(options?: { bundlePath?: string; sourcePath?: string }): DoctorCheck {
+  const resolved = resolveBundlePaths();
+  const bundlePath = options?.bundlePath ?? resolved.bundlePath;
+  const sourcePath = options?.sourcePath ?? resolved.sourcePath;
+
+  const bundleResult = tryStat(bundlePath);
+  const sourceResult = tryStat(sourcePath);
+
+  if (bundleResult.error || sourceResult.error) {
+    const err = bundleResult.error ?? sourceResult.error!;
+    return {
+      name: 'CLI bundle',
+      status: 'error',
+      message: `Bundle freshness check failed: ${errorMessage(err)}`,
+      remediation: 'Check filesystem permissions on packages/core/dist/',
+    };
+  }
+  const bundleStat = bundleResult.stat;
+  const sourceStat = sourceResult.stat;
+
+  if (!bundleStat && !sourceStat) {
+    return {
+      name: 'CLI bundle',
+      status: 'warning',
+      message: 'Neither cli.ts nor cli.bundle.cjs could be located',
+      remediation: 'Reinstall the package or check your install location',
+    };
+  }
+  if (!bundleStat) {
+    return {
+      name: 'CLI bundle',
+      status: 'warning',
+      message: 'dist/cli.bundle.cjs not built yet',
+      remediation: 'Run `pnpm run bundle` to build the CLI bundle',
+    };
+  }
+  if (sourceStat && sourceStat.mtimeMs > bundleStat.mtimeMs) {
+    return {
+      name: 'CLI bundle',
+      status: 'warning',
+      message: 'Source files are newer than dist/cli.bundle.cjs',
+      remediation: 'Run `pnpm run bundle` to rebuild',
+    };
+  }
+  return { name: 'CLI bundle', status: 'ok', message: 'Bundle present and up-to-date' };
+}
+
+export function checkStateFile(options?: { statePathOverride?: string }): DoctorCheck {
+  const statePath = options?.statePathOverride ?? getStatePath();
+  if (!fs.existsSync(statePath)) {
+    return {
+      name: 'state.json valid',
+      status: 'ok',
+      message: 'No state.json yet (first run — nothing to validate)',
+    };
+  }
+  try {
+    const raw = fs.readFileSync(statePath, 'utf-8');
+    const parsed = JSON.parse(raw);
+    const result = AgentStateSchema.safeParse(parsed);
+    if (!result.success) {
+      const snippet = result.error.issues
+        .slice(0, 3)
+        .map((i) => `${i.path.join('.') || '<root>'}: ${i.message}`)
+        .join('; ');
+      return {
+        name: 'state.json valid',
+        status: 'error',
+        message: `state.json failed schema validation — ${snippet}`,
+        remediation: 'Restore from a backup in `~/.oss-autopilot/backups/` or re-run `oss-autopilot init`',
+      };
+    }
+    const version = typeof parsed?.version === 'number' ? parsed.version : '?';
+    return { name: 'state.json valid', status: 'ok', message: `state v${version} parses and validates` };
+  } catch (err) {
+    return {
+      name: 'state.json valid',
+      status: 'error',
+      message: `Failed to read/parse state.json: ${errorMessage(err)}`,
+      remediation: 'Restore from a backup in `~/.oss-autopilot/backups/`',
+    };
+  }
+}
+
+/**
+ * Dynamic import of `@oss-scout/core`. Extracted so tests can inject a throwing
+ * stub without mocking the module registry.
+ */
+export type ScoutImporter = () => Promise<unknown>;
+const defaultScoutImporter: ScoutImporter = () => import('@oss-scout/core');
+
+export async function checkScoutResolvable(importer: ScoutImporter = defaultScoutImporter): Promise<DoctorCheck> {
+  // The scout package is ESM-exports-only, so `require.resolve` fails even
+  // when it's installed. `import()` goes through the ESM resolver, which
+  // honors `exports` maps correctly. Dynamic import only loads the package
+  // on demand (not at doctor module load) and is cheap — no auth side effects.
+  try {
+    await importer();
+    return { name: '@oss-scout/core resolvable', status: 'ok', message: 'Found on module path' };
+  } catch (err) {
+    // Three outcomes we want to distinguish:
+    //   - "Package simply isn't installed" (missing from node_modules)
+    //   - "Package is present but the install is corrupt" (bad exports map,
+    //     unparseable source, missing internal file) — reinstall is the fix
+    //   - "Package loaded but threw during init" — this is a scout bug
+    const code = errCode(err);
+    const isNotFound = code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND';
+    const isCorruptInstall =
+      code === 'ERR_PACKAGE_PATH_NOT_EXPORTED' ||
+      code === 'ERR_PACKAGE_IMPORT_NOT_DEFINED' ||
+      code === 'ERR_INVALID_PACKAGE_CONFIG' ||
+      err instanceof SyntaxError;
+    const reinstallRequired = isNotFound || isCorruptInstall;
+    return {
+      name: '@oss-scout/core resolvable',
+      status: 'error',
+      message: reinstallRequired
+        ? `@oss-scout/core cannot be loaded (install issue): ${errorMessage(err)}`
+        : `@oss-scout/core failed to load: ${errorMessage(err)}`,
+      remediation: reinstallRequired
+        ? 'Reinstall dependencies (`pnpm install` or `npm install`)'
+        : 'Scout loaded but threw during initialization — report this as a bug in oss-scout with the error above',
+    };
+  }
+}
+
+export async function checkGitHubRateLimit(preloadedToken?: string | null): Promise<DoctorCheck> {
+  const token = preloadedToken !== undefined ? preloadedToken : await getGitHubTokenAsync();
+  if (!token) {
+    return {
+      name: 'GitHub rate limit',
+      status: 'warning',
+      message: 'Cannot check — no token available',
+      remediation: 'Set $GITHUB_TOKEN or run `gh auth login` to enable API-backed checks',
+    };
+  }
+  try {
+    const octokit = getOctokit(token);
+    const { data } = await octokit.rateLimit.get();
+    const core = data.resources.core;
+    const resetAt = new Date(core.reset * 1000).toISOString();
+    if (core.remaining < 100) {
+      return {
+        name: 'GitHub rate limit',
+        status: 'warning',
+        message: `Only ${core.remaining}/${core.limit} core requests remaining (resets at ${resetAt})`,
+        remediation: 'Wait for the window to reset or use a token with a higher limit',
+      };
+    }
+    return {
+      name: 'GitHub rate limit',
+      status: 'ok',
+      message: `${core.remaining}/${core.limit} core requests remaining`,
+    };
+  } catch (err) {
+    return {
+      name: 'GitHub rate limit',
+      status: 'error',
+      message: `Failed to check rate limit: ${errorMessage(err)}`,
+    };
+  }
+}
+
+// ── Orchestrator ────────────────────────────────────────────────────────
+
+/**
+ * Run all diagnostic checks and return a structured report.
+ *
+ * Checks are run concurrently where possible. None of the checks throw — each
+ * returns a `DoctorCheck` with its own status so a single failing check does
+ * not abort the rest of the audit.
+ */
+/**
+ * Run a check defensively. If it rejects or the run itself throws, convert the
+ * failure into a synthetic `DoctorCheck` with status 'error' — `doctor` is the
+ * tool users reach for when things are already broken, so it must never abort
+ * itself because one individual check crashed.
+ */
+async function runCheckSafely(name: string, runner: () => Promise<DoctorCheck> | DoctorCheck): Promise<DoctorCheck> {
+  try {
+    return await runner();
+  } catch (err) {
+    return {
+      name,
+      status: 'error',
+      message: `Check crashed unexpectedly: ${errorMessage(err)}`,
+      remediation: 'This is a bug in the doctor command — please report it with the error above',
+    };
+  }
+}
+
+export async function runDoctor(): Promise<DoctorOutput> {
+  // Pre-resolve the token once and pass it to the token-dependent checks.
+  // Without this, the first call enters the async `gh auth token` branch
+  // (setting `tokenFetchAttempted = true` synchronously, then yielding at the
+  // `execFile` await). A second concurrent caller sees the flag set and the
+  // cache still empty, and returns `null` immediately — producing a spurious
+  // "no token available" warning while the first caller later resolves a valid
+  // token. Empirically reproduced before this fix.
+  // Best-effort token fetch — if it throws (sync or async), downstream
+  // token-dependent checks still run and will report "no token available" on
+  // their own. `try/catch` covers the sync-throw case; `.catch` alone would
+  // not.
+  let token: string | null = null;
+  try {
+    token = await getGitHubTokenAsync();
+  } catch {
+    token = null;
+  }
+
+  const checks: DoctorCheck[] = await Promise.all([
+    runCheckSafely('gh CLI installed', () => checkGhCli()),
+    runCheckSafely('gh CLI authenticated', () => checkGhAuth()),
+    runCheckSafely('GitHub token resolvable', () => checkGitHubToken(token)),
+    runCheckSafely('GitHub rate limit', () => checkGitHubRateLimit(token)),
+    runCheckSafely('@oss-scout/core resolvable', () => checkScoutResolvable()),
+    runCheckSafely('CLI bundle', () => checkBundleUpToDate()),
+    runCheckSafely('state.json valid', () => checkStateFile()),
+  ]);
+
+  const summary = {
+    ok: checks.filter((c) => c.status === 'ok').length,
+    warnings: checks.filter((c) => c.status === 'warning').length,
+    errors: checks.filter((c) => c.status === 'error').length,
+  };
+  return { checks, summary };
+}

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -84,6 +84,8 @@ export { runStateUnlink } from './state-cmd.js';
 export { runParseList, pruneIssueList } from './parse-list.js';
 /** Check if new files are properly referenced/integrated. */
 export { runCheckIntegration } from './check-integration.js';
+/** System-health diagnostic — verifies tokens, bundle, state, scout, rate limit. */
+export { runDoctor, type DoctorCheck, type DoctorCheckStatus, type DoctorOutput } from './doctor.js';
 /** Detect formatters/linters configured in a local repository (#703). */
 export { runDetectFormatters } from './detect-formatters.js';
 /** Scan for locally cloned repos. */

--- a/workflows/reference.md
+++ b/workflows/reference.md
@@ -106,8 +106,11 @@ rejected with a did-you-mean suggestion.
 # Scan for local git repos
 <prefix> local-repos --json [--scan] [--clear-cache]
 
-# Check GitHub integration
-<prefix> check-integration --json
+# System-health diagnostic (token, bundle, state, scout, rate limit)
+<prefix> doctor --json
+
+# Audit new files on this branch for cross-references (old name: check-integration)
+<prefix> orphan-files --json [--base <branch>]
 ```
 
 ---


### PR DESCRIPTION
## Summary

- **Rename**: `check-integration` → `orphan-files`. Commander alias keeps the old name working for existing scripts. Internal `runCheckIntegration` export unchanged (published API).
- **New `doctor` command**: runs 7 health checks — gh CLI presence, gh auth, GitHub token API ping, rate-limit budget, `@oss-scout/core` resolvable, CLI bundle freshness, state.json schema validity. Each check reports `ok` / `warning` / `error` with an actionable remediation. `doctor` never aborts — a crashing check is converted to a synthetic error entry (via \`runCheckSafely\`) so the tool that exists to diagnose breakage never breaks itself.

Closes #1039.

## Test plan

- [x] \`pnpm run lint\` clean
- [x] \`pnpm test\` — 2005 pass, 14 skipped (27 new doctor tests, +2 cli-registry updates; was 2000 on main)
- [x] Smoke test vs real bundle: \`doctor --json\` returns 7/0/0 ok/warn/err on my dev env
- [x] \`orphan-files --json\` and \`check-integration --json\` (alias) both work
- [x] Every error branch is tested (ENOENT vs non-ENOENT for gh CLI, auth failure, token API failure, JSON parse + schema failures, fs permission errors, scout module-not-found vs init failure)
- [x] \`runDoctor\` safety net test — synchronous throw from a dependency does not abort the report
- [x] Two passes of \`pr-review-toolkit:code-reviewer\` plus one \`silent-failure-hunter\` — all in-scope findings addressed