### PR TITLE
fix(agents): declare explicit model tier instead of inherit (#1040)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
             exit 1
           fi
 
-      - name: Guard against `model: inherit` in agent frontmatter
+      - name: "Guard against `model: inherit` in agent frontmatter"
         # Every agent must declare an explicit tier (haiku/sonnet/opus) so
         # cheap bounded tasks and heavy reasoning tasks don't silently inherit
         # whatever model the parent session uses. See agents/README.md for the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,20 @@ jobs:
             exit 1
           fi
 
+      - name: Guard against `model: inherit` in agent frontmatter
+        # Every agent must declare an explicit tier (haiku/sonnet/opus) so
+        # cheap bounded tasks and heavy reasoning tasks don't silently inherit
+        # whatever model the parent session uses. See agents/README.md for the
+        # workload→tier rationale and issue #1040 for the original audit.
+        # Matches only top-of-file frontmatter `model:` keys on `*.md` files
+        # inside agents/ so prose discussing the pattern does not
+        # false-positive.
+        run: |
+          if grep -Hn '^model:[[:space:]]*inherit' agents/*.md; then
+            echo "::error::Agent frontmatter contains 'model: inherit'. Pick an explicit tier — see agents/README.md and issue #1040."
+            exit 1
+          fi
+
       - name: Coverage report
         if: matrix.node-version == 22
         run: pnpm run test:coverage

--- a/agents/README.md
+++ b/agents/README.md
@@ -37,3 +37,38 @@ advisory; both hard gates must be kept narrow.
 When a new agent genuinely needs a tool not listed above, add it explicitly —
 never use `mcp__*`. CI enforces this via the "Guard against `mcp__*` wildcard
 in agent tools" step.
+
+---
+
+# Subagents — model tiering
+
+Each agent declares an explicit `model:` value (never `inherit`). The goal is
+to pair workload with the right model class: cheap bounded tasks on `haiku`,
+judgment-heavy procedures on `sonnet`. A user running `/oss` with Haiku should
+not silently degrade `pr-responder`'s claim verification; a user running with
+Opus should not burn tokens on `pr-compliance-checker`'s deterministic rubric.
+
+## Current tiering
+
+| Agent | Tier | Workload |
+|-------|------|---------|
+| `contribution-strategist` | `haiku` | Aggregates `status --json` into a markdown summary. Bounded scope, no judgment calls. |
+| `issue-scout` | `sonnet` | Judgment on issue viability + anti-AI policy detection; reads scout-bridge output and filters. |
+| `pr-compliance-checker` | `haiku` | Deterministic 6-weight rubric emission against a PR. Structured output, minimal ambiguity. |
+| `pr-health-checker` | `sonnet` | Git rebase flow + CI log diagnosis; needs to reason about error messages and suggest fixes. |
+| `pr-responder` | `sonnet` | Claim verification + tone calibration + multi-step draft-accuracy procedure. Heavy reasoning. |
+| `pre-commit-reviewer` | `sonnet` | Five-phase diff review including security scan. Heavy reasoning. |
+| `repo-evaluator` | `haiku` | Aggregates cached repo scores into a verdict. Bounded scope. |
+
+Policy: **no agent uses `model: inherit`.** CI enforces this via the "Guard
+against `model: inherit` in agent frontmatter" step. If a future agent
+genuinely needs to inherit, add an inline frontmatter comment explaining why
+and update the CI check to allow that specific file.
+
+## Tuning
+
+These defaults are placeholders informed by workload shape, not benchmarked
+quality-per-dollar numbers. If a downstream regression surfaces (e.g., a
+`haiku`-tier agent consistently produces low-quality output, or a `sonnet`
+agent's cost makes the `/oss` flow unaffordable), bump the tier and document
+the rationale in the commit.

--- a/agents/contribution-strategist.md
+++ b/agents/contribution-strategist.md
@@ -38,7 +38,7 @@ User wants help with goal-setting.
 </commentary>
 </example>
 
-model: inherit
+model: haiku
 color: magenta
 tools: ["Bash", "Read"]
 ---

--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -20,7 +20,7 @@ User wants to evaluate a specific issue before investing time.
 </commentary>
 </example>
 
-model: inherit
+model: sonnet
 color: green
 tools: ["Bash", "Read", "mcp__plugin_oss-autopilot_oss-autopilot__search", "mcp__plugin_oss-autopilot_oss-autopilot__vet", "mcp__plugin_oss-autopilot_oss-autopilot__vet-list"]
 ---

--- a/agents/pr-compliance-checker.md
+++ b/agents/pr-compliance-checker.md
@@ -29,7 +29,7 @@ User wants pre-submission guidance on PR quality.
 </commentary>
 </example>
 
-model: inherit
+model: haiku
 color: orange
 tools: ["Bash", "Read", "Glob", "Grep", "mcp__plugin_oss-autopilot_oss-autopilot__read", "mcp__plugin_oss-autopilot_oss-autopilot__comments"]
 ---

--- a/agents/pr-health-checker.md
+++ b/agents/pr-health-checker.md
@@ -29,7 +29,7 @@ Merge conflicts are a health issue this agent handles.
 </commentary>
 </example>
 
-model: inherit
+model: sonnet
 color: yellow
 tools: ["Bash", "Read", "Grep", "mcp__plugin_oss-autopilot_oss-autopilot__read", "mcp__plugin_oss-autopilot_oss-autopilot__comments"]
 ---

--- a/agents/pr-responder.md
+++ b/agents/pr-responder.md
@@ -20,7 +20,7 @@ User needs help understanding and responding to a specific code review comment.
 </commentary>
 </example>
 
-model: inherit
+model: sonnet
 color: cyan
 tools: ["Bash", "Read", "Write", "Glob", "Grep", "mcp__plugin_oss-autopilot_oss-autopilot__read", "mcp__plugin_oss-autopilot_oss-autopilot__comments"]
 ---

--- a/agents/pre-commit-reviewer.md
+++ b/agents/pre-commit-reviewer.md
@@ -20,7 +20,7 @@ Post-conflict resolution is a critical moment where bugs can be introduced. Revi
 </commentary>
 </example>
 
-model: inherit
+model: sonnet
 color: red
 tools: ["Bash", "Read", "Glob", "Grep"]
 ---

--- a/agents/repo-evaluator.md
+++ b/agents/repo-evaluator.md
@@ -20,7 +20,7 @@ User wants to predict maintainer engagement before contributing.
 </commentary>
 </example>
 
-model: inherit
+model: haiku
 color: blue
 tools: ["Bash", "Read", "Glob", "mcp__plugin_oss-autopilot_oss-autopilot__vet"]
 ---


### PR DESCRIPTION
## Summary

- Every agent previously used \`model: inherit\`, meaning cheap bounded tasks and heavy reasoning tasks silently picked up whatever model the parent /oss session had selected.
- Assigned each agent an explicit tier informed by its workload:
  - **haiku**: \`contribution-strategist\`, \`pr-compliance-checker\`, \`repo-evaluator\` (bounded aggregation + deterministic rubric emission)
  - **sonnet**: \`issue-scout\`, \`pr-health-checker\`, \`pr-responder\`, \`pre-commit-reviewer\` (judgment calls + multi-phase reasoning)
- Extended \`agents/README.md\` with a tiering table, rationale, and a tuning note (these defaults are placeholders — bump on regression).
- Added a CI guard that fails the build if any agent reintroduces \`model: inherit\`. Dry-run verified the guard fires on a synthetic breakage and is restored clean.

Closes #1040.

## Test plan

- [x] \`pnpm run lint\` clean, \`pnpm test\` — 2005 pass
- [x] \`grep -Hn '^model:' agents/*.md\` returns 7 lines, none say \`inherit\`
- [x] CI-guard dry-run: injected \`model: inherit\` into one file → guard fires with expected error; restored the file; guard passes
- [x] \`pr-review-toolkit:code-reviewer\` — no high-confidence findings