### PR TITLE
fix(startup): use async token resolver so gh CLI fallback fires (#1041)

### DIFF
--- a/packages/core/src/commands/startup.contract.test.ts
+++ b/packages/core/src/commands/startup.contract.test.ts
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
   },
   getCLIVersion: vi.fn().mockReturnValue('99.99.99-test'),
   getGitHubToken: vi.fn(),
+  getGitHubTokenAsync: vi.fn(),
   detectGitHubUsername: vi.fn(),
 }));
 
@@ -32,6 +33,7 @@ vi.mock('../core/index.js', async () => {
     getStateManager: () => mocks.stateManager,
     getCLIVersion: mocks.getCLIVersion,
     getGitHubToken: mocks.getGitHubToken,
+    getGitHubTokenAsync: mocks.getGitHubTokenAsync,
     detectGitHubUsername: mocks.detectGitHubUsername,
   };
 });
@@ -71,7 +73,10 @@ describe('startup --json contract', () => {
 
   it('auth-error output matches the golden shape', async () => {
     mocks.stateManager.isSetupComplete.mockReturnValue(true);
+    // Both token sources must be empty for the authError branch to fire —
+    // runStartup uses the async variant (env → `gh auth token` fallback).
     mocks.getGitHubToken.mockReturnValue(null);
+    mocks.getGitHubTokenAsync.mockResolvedValue(null);
 
     const result = await runStartup();
     await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/startup.auth-error.json');

--- a/packages/core/src/commands/startup.test.ts
+++ b/packages/core/src/commands/startup.test.ts
@@ -12,6 +12,7 @@ vi.mock('../core/index.js', () => ({
     isSetupComplete: vi.fn(() => true),
   })),
   getGitHubToken: vi.fn(() => 'fake-token'),
+  getGitHubTokenAsync: vi.fn(() => Promise.resolve('fake-token')),
   getCLIVersion: vi.fn(() => '0.0.0-test'),
   getStatePath: vi.fn(() => '/tmp/state.json'),
   detectGitHubUsername: vi.fn(() => Promise.resolve(null)),
@@ -473,14 +474,14 @@ describe('runStartup behavior', () => {
     expect(result.setupComplete).toBe(false);
   });
 
-  it('should return auth error when no token', async () => {
-    const { getStateManager, getGitHubToken } = await import('../core/index.js');
+  it('should return auth error when no token is available from either source', async () => {
+    const { getStateManager, getGitHubTokenAsync } = await import('../core/index.js');
     const mockGetStateManager = getStateManager as ReturnType<typeof vi.fn>;
-    const mockGetGitHubToken = getGitHubToken as ReturnType<typeof vi.fn>;
+    const mockGetGitHubTokenAsync = getGitHubTokenAsync as ReturnType<typeof vi.fn>;
     mockGetStateManager.mockReturnValue({
       isSetupComplete: vi.fn(() => true),
     });
-    mockGetGitHubToken.mockReturnValue(null);
+    mockGetGitHubTokenAsync.mockResolvedValue(null);
 
     const result = await runStartup();
 
@@ -488,11 +489,31 @@ describe('runStartup behavior', () => {
     expect(result.authError).toContain('authentication required');
   });
 
+  it('proceeds when only the `gh auth token` fallback returns a token (#1041)', async () => {
+    // Regression: `startup` used the sync `getGitHubToken()` which reads env
+    // only. A user authenticated via `gh auth login` but without
+    // $GITHUB_TOKEN was wrongly routed to `authError`. The async fallback
+    // must now drive the decision.
+    const { getStateManager, getGitHubToken, getGitHubTokenAsync } = await import('../core/index.js');
+    (getStateManager as ReturnType<typeof vi.fn>).mockReturnValue({
+      isSetupComplete: vi.fn(() => true),
+    });
+    (getGitHubToken as ReturnType<typeof vi.fn>).mockReturnValue(null); // env var unset
+    (getGitHubTokenAsync as ReturnType<typeof vi.fn>).mockResolvedValue('token-from-gh-cli');
+    executeDailyCheck.mockResolvedValue(makeDailyOutput(0));
+
+    const result = await runStartup();
+
+    expect(result.setupComplete).toBe(true);
+    expect(result.authError).toBeUndefined();
+    expect(executeDailyCheck).toHaveBeenCalledWith('token-from-gh-cli');
+  });
+
   it('should propagate daily check failure to caller', async () => {
     // Reset mocks to ensure auth passes
-    const { getStateManager: gsm, getGitHubToken: ght } = await import('../core/index.js');
+    const { getStateManager: gsm, getGitHubTokenAsync: ghtAsync } = await import('../core/index.js');
     (gsm as ReturnType<typeof vi.fn>).mockReturnValue({ isSetupComplete: vi.fn(() => true) });
-    (ght as ReturnType<typeof vi.fn>).mockReturnValue('fake-token');
+    (ghtAsync as ReturnType<typeof vi.fn>).mockResolvedValue('fake-token');
 
     executeDailyCheck.mockRejectedValue(new Error('Network error'));
 

--- a/packages/core/src/commands/startup.ts
+++ b/packages/core/src/commands/startup.ts
@@ -10,7 +10,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { execFile } from 'child_process';
-import { getStateManager, getGitHubToken, getCLIVersion, detectGitHubUsername } from '../core/index.js';
+import { getStateManager, getGitHubTokenAsync, getCLIVersion, detectGitHubUsername } from '../core/index.js';
 import { errorMessage } from '../core/errors.js';
 import { warn } from '../core/logger.js';
 import { type StartupOutput, type IssueListInfo } from '../formatters/json.js';
@@ -220,8 +220,12 @@ export async function runStartup(): Promise<StartupOutput> {
     }
   }
 
-  // 2. Check auth
-  const token = getGitHubToken();
+  // 2. Check auth — use the async variant so the `gh auth token` CLI fallback
+  // fires for users who ran `gh auth login` but never exported $GITHUB_TOKEN.
+  // The sync `getGitHubToken()` reads only the env var, matching the `preAction`
+  // token check that the CLI's `localOnly: true` flag on `startup` deliberately
+  // skips — the mismatch produced a spurious `authError` for valid users.
+  const token = await getGitHubTokenAsync();
   if (!token) {
     return {
       version,


### PR DESCRIPTION
## Summary

\`startup.ts\` called the sync \`getGitHubToken()\` (env-only), bypassing the \`gh auth token\` fallback that the main CLI \`preAction\` check uses. Because \`startup\` is registered \`localOnly: true\`, the \`preAction\` validator is skipped — so users who \`gh auth login\`-ed but never exported \`$GITHUB_TOKEN\` saw a spurious \`authError\`.

- One-line swap: \`const token = getGitHubToken()\` → \`const token = await getGitHubTokenAsync()\`.
- Added a regression test that mocks sync source null + async source populated and asserts \`executeDailyCheck\` receives the async-sourced token rather than hitting the authError branch.
- Updated the existing authError unit test and the --json contract test to null both sources for the failure path.

Closes #1041.

## Test plan

- [x] \`pnpm test\` — 2006 core + 244 dashboard + 172 MCP tests all pass
- [x] Smoke test: \`GITHUB_TOKEN= node dist/cli.bundle.cjs startup --json\` resolves via \`gh auth token\` and runs daily (pre-fix: authError)
- [x] \`pr-review-toolkit:code-reviewer\` — no high-confidence findings; scope confirmed faithful