### PR TITLE
fix(search,vet-list): defend against scout data-contract drift (#1043)

### DIFF
--- a/packages/core/src/commands/__golden__/search.json
+++ b/packages/core/src/commands/__golden__/search.json
@@ -19,6 +19,10 @@
       "reasonsToSkip": [],
       "searchPriority": "merged_pr",
       "viabilityScore": 88,
+      "grade": {
+        "letter": "B",
+        "reason": "~2-day avg response, unknown activity"
+      },
       "repoScore": {
         "score": 8,
         "mergedPRCount": 4,
@@ -46,7 +50,11 @@
         "No prior relationship"
       ],
       "searchPriority": "normal",
-      "viabilityScore": 60
+      "viabilityScore": 60,
+      "grade": {
+        "letter": "F",
+        "reason": "unknown maintainer responsiveness, merge rate, activity"
+      }
     },
     {
       "issue": {
@@ -63,7 +71,11 @@
         "Maintainer unresponsive for 120 days"
       ],
       "searchPriority": "normal",
-      "viabilityScore": 12
+      "viabilityScore": 12,
+      "grade": {
+        "letter": "F",
+        "reason": "unknown maintainer responsiveness, merge rate, activity"
+      }
     }
   ],
   "excludedRepos": [

--- a/packages/core/src/commands/search.contract.test.ts
+++ b/packages/core/src/commands/search.contract.test.ts
@@ -105,6 +105,20 @@ describe('search --json contract', () => {
     });
 
     const result = await runSearch({ maxResults: 10 });
+
+    // #1043 boundary defenses: every candidate must hold a finite score in
+    // range, a valid GitHub issue URL, and a letter grade — regardless of
+    // what scout emits. Asserted alongside the golden so a scout regression
+    // to `null` / `NaN` / reshaped fields breaks autopilot CI here, not in
+    // production.
+    for (const candidate of result.candidates) {
+      expect(Number.isFinite(candidate.viabilityScore)).toBe(true);
+      expect(candidate.viabilityScore).toBeGreaterThanOrEqual(0);
+      expect(candidate.viabilityScore).toBeLessThanOrEqual(100);
+      expect(candidate.issue.url).toMatch(/^https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/\d+$/);
+      expect(candidate.grade.letter).toMatch(/^[ABCF]$/);
+    }
+
     await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/search.json');
   });
 

--- a/packages/core/src/commands/search.test.ts
+++ b/packages/core/src/commands/search.test.ts
@@ -188,4 +188,108 @@ describe('runSearch', () => {
 
     await expect(runSearch({ maxResults: 5 })).rejects.toThrow('API rate limit exceeded');
   });
+
+  // ── #1043 data-contract defenses ─────────────────────────────────────
+
+  it('assigns a grade letter to every candidate (#1043)', async () => {
+    mockSearch.mockResolvedValue({
+      candidates: [
+        {
+          issue: {
+            repo: 'unknown/repo',
+            number: 1,
+            title: 'Issue',
+            url: 'https://github.com/unknown/repo/issues/1',
+            labels: [],
+          },
+          recommendation: 'approve',
+          reasonsToApprove: [],
+          reasonsToSkip: [],
+          searchPriority: 'medium',
+          viabilityScore: 70,
+        },
+      ],
+      excludedRepos: [],
+      aiPolicyBlocklist: [],
+      strategiesUsed: ['broad'],
+    });
+
+    const result = await runSearch({ maxResults: 5 });
+
+    // Repo has no autopilot-tracked score, scout-side signals are treated as
+    // unknown — every signal missing degrades to F per issue-grading policy.
+    expect(result.candidates[0].grade.letter).toBe('F');
+    expect(result.candidates[0].grade.reason).toMatch(/unknown/i);
+  });
+
+  it('computes a higher grade when a healthy repoScore is known (#1043)', async () => {
+    mockSearch.mockResolvedValue({
+      candidates: [
+        {
+          issue: {
+            repo: 'healthy/repo',
+            number: 1,
+            title: 'Issue',
+            url: 'https://github.com/healthy/repo/issues/1',
+            labels: [],
+          },
+          recommendation: 'approve',
+          reasonsToApprove: [],
+          reasonsToSkip: [],
+          searchPriority: 'high',
+          viabilityScore: 88,
+        },
+      ],
+      excludedRepos: [],
+      aiPolicyBlocklist: [],
+      strategiesUsed: ['merged'],
+    });
+    mockGetStateManager.mockReturnValue({
+      getState: vi.fn().mockReturnValue({ config: { excludeRepos: [], aiPolicyBlocklist: [] } }),
+      getRepoScore: vi.fn().mockReturnValue({
+        score: 9,
+        mergedPRCount: 20,
+        closedWithoutMergeCount: 3,
+        avgResponseDays: 2,
+        signals: { isResponsive: true },
+      }),
+    } as any);
+
+    const result = await runSearch({ maxResults: 5 });
+
+    // High merge rate (20/23 ≈ 87%) + fast response → at worst C after the
+    // one-step degrade for unknown commit activity. Assert it beat F.
+    expect(result.candidates[0].grade.letter).not.toBe('F');
+  });
+
+  it('sanitizes an out-of-contract viabilityScore from scout (#1043)', async () => {
+    mockSearch.mockResolvedValue({
+      candidates: [
+        {
+          issue: {
+            repo: 'sketchy/repo',
+            number: 1,
+            title: 'Issue',
+            url: 'https://github.com/sketchy/repo/issues/1',
+            labels: [],
+          },
+          recommendation: 'approve',
+          reasonsToApprove: [],
+          reasonsToSkip: [],
+          searchPriority: 'medium',
+          viabilityScore: 999, // out-of-contract (should be 0-100)
+        },
+      ],
+      excludedRepos: [],
+      aiPolicyBlocklist: [],
+      strategiesUsed: ['broad'],
+    });
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await runSearch({ maxResults: 5 });
+
+    expect(result.candidates[0].viabilityScore).toBe(0);
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('out-of-contract viabilityScore'));
+    errSpy.mockRestore();
+  });
 });

--- a/packages/core/src/commands/search.ts
+++ b/packages/core/src/commands/search.ts
@@ -6,8 +6,12 @@
 import { createAutopilotScout } from './scout-bridge.js';
 import { getStateManager } from '../core/index.js';
 import { type SearchOutput } from '../formatters/json.js';
+import { gradeFromCandidate } from '../core/issue-grading.js';
+import { warn } from '../core/logger.js';
 
 export { type SearchOutput } from '../formatters/json.js';
+
+const MODULE = 'search';
 
 /**
  * Hard cap on issue-search result count. Shared between CLI (`cli-registry.ts`),
@@ -38,6 +42,20 @@ interface SearchOptions {
  * }
  * ```
  */
+/**
+ * Coerce scout's raw `viabilityScore` into a trustworthy 0–100 number.
+ * Scout is supposed to emit a finite integer in range, but out-of-contract
+ * values (NaN, Infinity, negative, >100, non-number) would otherwise flow
+ * straight through to consumers. Defend at the boundary — see #1043.
+ */
+function sanitizeViabilityScore(raw: unknown): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw) || raw < 0 || raw > 100) {
+    warn(MODULE, `Ignoring out-of-contract viabilityScore from scout: ${JSON.stringify(raw)}`);
+    return 0;
+  }
+  return raw;
+}
+
 export async function runSearch(options: SearchOptions): Promise<SearchOutput> {
   const scout = await createAutopilotScout();
   const result = await scout.search({ maxResults: options.maxResults });
@@ -47,6 +65,26 @@ export async function runSearch(options: SearchOptions): Promise<SearchOutput> {
   const searchOutput: SearchOutput = {
     candidates: result.candidates.map((c) => {
       const repoScoreRecord = stateManager.getRepoScore(c.issue.repo);
+      // Scout's `search` does not emit per-candidate projectHealth (only
+      // `vetIssue` does). Pass a sentinel `checkFailed: true` so the grader
+      // correctly treats scout-side signals as unknown and grades purely from
+      // the autopilot-tracked repoScore. Candidates without a repoScore
+      // receive 'F' — that's an honest signal for "we haven't seen this repo
+      // before" rather than a fabricated score.
+      const grade = gradeFromCandidate({
+        repo: c.issue.repo,
+        projectHealth: { avgIssueResponseDays: null, daysSinceLastCommit: null, checkFailed: true },
+        getRepoScore: (repo) => {
+          const score = stateManager.getRepoScore(repo);
+          return score
+            ? {
+                mergedPRCount: score.mergedPRCount,
+                closedWithoutMergeCount: score.closedWithoutMergeCount,
+                avgResponseDays: score.avgResponseDays ?? null,
+              }
+            : undefined;
+        },
+      });
       return {
         issue: {
           repo: c.issue.repo,
@@ -60,7 +98,8 @@ export async function runSearch(options: SearchOptions): Promise<SearchOutput> {
         reasonsToApprove: c.reasonsToApprove,
         reasonsToSkip: c.reasonsToSkip,
         searchPriority: c.searchPriority,
-        viabilityScore: c.viabilityScore,
+        viabilityScore: sanitizeViabilityScore(c.viabilityScore),
+        grade,
         repoScore: repoScoreRecord
           ? {
               score: repoScoreRecord.score,

--- a/packages/core/src/commands/vet-list.test.ts
+++ b/packages/core/src/commands/vet-list.test.ts
@@ -42,6 +42,7 @@ function makeVetOutput(overrides: Partial<VetOutput> = {}): VetOutput {
     reasonsToSkip: [],
     projectHealth: { stars: 500 },
     vettingResult: { isViable: true },
+    grade: { letter: 'B', reason: 'test fixture' },
     ...overrides,
   };
 }
@@ -135,6 +136,60 @@ describe('classifyListStatus', () => {
       }),
     );
     expect(result).toBe('closed');
+  });
+
+  // ── #1043 structured skipReason preference ───────────────────────────
+
+  it('prefers scout-emitted skipReason enum over substring match (#1043)', () => {
+    // Scout could reword the free-text ("Issue was resolved") so the
+    // substring match against 'closed' no longer fires. The enum takes
+    // precedence and routes correctly.
+    const result = classifyListStatus(
+      makeVetOutput({
+        recommendation: 'skip',
+        reasonsToSkip: ['Issue was resolved'],
+      }),
+      'issue_closed',
+    );
+    expect(result).toBe('closed');
+  });
+
+  it('routes via enum to claimed/has_pr when scout emits the enum (#1043)', () => {
+    expect(classifyListStatus(makeVetOutput({ recommendation: 'skip', reasonsToSkip: [] }), 'claimed')).toBe('claimed');
+    expect(classifyListStatus(makeVetOutput({ recommendation: 'skip', reasonsToSkip: [] }), 'has_linked_pr')).toBe(
+      'has_pr',
+    );
+  });
+
+  it('falls through to recommendation-based branches for non-routing enum values (#1043)', () => {
+    // score_too_low and anti_llm_policy are skip reasons that shouldn't
+    // change the list status — let the recommendation drive it.
+    expect(classifyListStatus(makeVetOutput({ recommendation: 'approve' }), 'score_too_low')).toBe('still_available');
+    expect(classifyListStatus(makeVetOutput({ recommendation: 'skip' }), 'anti_llm_policy')).toBe('still_available');
+  });
+});
+
+describe('extractSkipReason', () => {
+  it('returns the scout-emitted enum value', async () => {
+    const { extractSkipReason } = await import('./vet-list.js');
+    expect(extractSkipReason({ skipReason: 'issue_closed' })).toBe('issue_closed');
+  });
+
+  it('returns undefined when skipReason is missing', async () => {
+    const { extractSkipReason } = await import('./vet-list.js');
+    expect(extractSkipReason({ other: 'field' })).toBeUndefined();
+  });
+
+  it('ignores unknown enum values (forward-compat poison guard)', async () => {
+    const { extractSkipReason } = await import('./vet-list.js');
+    expect(extractSkipReason({ skipReason: 'future_value_not_in_enum' })).toBeUndefined();
+  });
+
+  it('ignores non-string values', async () => {
+    const { extractSkipReason } = await import('./vet-list.js');
+    expect(extractSkipReason({ skipReason: 42 })).toBeUndefined();
+    expect(extractSkipReason(null)).toBeUndefined();
+    expect(extractSkipReason('not an object')).toBeUndefined();
   });
 });
 

--- a/packages/core/src/commands/vet-list.ts
+++ b/packages/core/src/commands/vet-list.ts
@@ -20,16 +20,81 @@ interface VetListOptions {
 }
 
 /**
- * Determine the list status from vetting results.
- * Maps vetting recommendation + reasons to a list-level status.
+ * Scout-side enumerated skip reasons (#1043). If scout emits a `skipReason`
+ * field on its vet candidate, we route on that directly rather than doing
+ * fragile substring matches against free-text. The strings scout uses today
+ * (e.g. "Issue is closed", "Issue is already claimed") would silently stop
+ * matching on a rewording — the enum makes the data contract explicit.
+ *
+ * Scout has not yet landed the enum emitter; this PR lands the reader so the
+ * switchover is drop-in when scout ships it. The substring fallback below
+ * covers the transition period.
  */
-export function classifyListStatus(vetResult: VetOutput): VetListItemStatus {
-  const skipReasons = vetResult.reasonsToSkip.map((r) => r.toLowerCase());
+export type ScoutSkipReason =
+  | 'issue_closed'
+  | 'has_linked_pr'
+  | 'claimed'
+  | 'score_too_low'
+  | 'anti_llm_policy'
+  | 'other';
 
-  if (skipReasons.some((r) => r.includes('closed'))) return 'closed';
-  if (skipReasons.some((r) => r.includes('claimed') || r.includes('assigned'))) return 'claimed';
-  if (skipReasons.some((r) => r.includes('existing pr') || r.includes('linked pr') || r.includes('pull request')))
-    return 'has_pr';
+const KNOWN_SKIP_REASONS: ReadonlySet<ScoutSkipReason> = new Set([
+  'issue_closed',
+  'has_linked_pr',
+  'claimed',
+  'score_too_low',
+  'anti_llm_policy',
+  'other',
+]);
+
+function mapSkipReasonToStatus(reason: ScoutSkipReason): VetListItemStatus | null {
+  switch (reason) {
+    case 'issue_closed':
+      return 'closed';
+    case 'claimed':
+      return 'claimed';
+    case 'has_linked_pr':
+      return 'has_pr';
+    case 'score_too_low':
+    case 'anti_llm_policy':
+    case 'other':
+      return null; // fall through to recommendation / default
+  }
+}
+
+/**
+ * Defensively extract a `skipReason` from a scout candidate. Scout's types
+ * don't expose it yet, and we want to ignore any value scout emits that
+ * isn't one of the expected enum members (forward-compat + poison guard).
+ */
+export function extractSkipReason(candidate: unknown): ScoutSkipReason | undefined {
+  if (typeof candidate !== 'object' || candidate === null) return undefined;
+  const raw = (candidate as { skipReason?: unknown }).skipReason;
+  if (typeof raw !== 'string') return undefined;
+  return KNOWN_SKIP_REASONS.has(raw as ScoutSkipReason) ? (raw as ScoutSkipReason) : undefined;
+}
+
+/**
+ * Determine the list status from vetting results.
+ *
+ * Prefers scout's structured `skipReason` enum when present; falls back to
+ * substring matching on the free-text `reasonsToSkip` for the transition
+ * period before scout emits the enum. See #1043.
+ */
+export function classifyListStatus(vetResult: VetOutput, skipReason?: ScoutSkipReason): VetListItemStatus {
+  if (skipReason) {
+    const fromEnum = mapSkipReasonToStatus(skipReason);
+    if (fromEnum) return fromEnum;
+    // skipReason was set but maps to 'other' / low-score / policy — let the
+    // recommendation-based branches below decide final status.
+  } else {
+    const skipReasons = vetResult.reasonsToSkip.map((r) => r.toLowerCase());
+
+    if (skipReasons.some((r) => r.includes('closed'))) return 'closed';
+    if (skipReasons.some((r) => r.includes('claimed') || r.includes('assigned'))) return 'claimed';
+    if (skipReasons.some((r) => r.includes('existing pr') || r.includes('linked pr') || r.includes('pull request')))
+      return 'has_pr';
+  }
 
   if (vetResult.recommendation === 'approve' || vetResult.recommendation === 'needs_review') {
     return 'still_available';
@@ -106,7 +171,7 @@ export async function runVetList(options: VetListOptions = {}): Promise<VetListO
 
         results.push({
           ...vetResult,
-          listStatus: classifyListStatus(vetResult),
+          listStatus: classifyListStatus(vetResult, extractSkipReason(candidate)),
         });
       } catch (error) {
         // Per-issue errors don't fail the batch

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -296,8 +296,17 @@ export interface SearchOutput {
     reasonsToApprove: string[];
     reasonsToSkip: string[];
     searchPriority: SearchPriority;
-    /** 0-100 scale composite viability score */
+    /** 0-100 scale composite viability score. Sanitized on the boundary (#1043): out-of-contract values are coerced to 0 and logged. */
     viabilityScore: number;
+    /**
+     * Letter grade (A/B/C/F) computed from the autopilot-tracked repoScore.
+     * Scout's `search` does not emit per-candidate projectHealth, so scout-side
+     * signals are treated as unknown; unscored repos grade 'F'. See #1043.
+     */
+    grade: {
+      letter: 'A' | 'B' | 'C' | 'F';
+      reason: string;
+    };
     repoScore?: {
       /** 1-10 scale repository quality score */
       score: number;


### PR DESCRIPTION
## Summary

Scout's outputs included unsanitized values flowing straight through to consumers. A \`checkFailed: true\` from scout could silently inflate scores; a free-text reason rewording could silently misroute vet-list items.

### Changes

- **\`search.ts\`** — sanitize \`viabilityScore\` at the boundary (non-finite / out-of-contract → 0 + log). Compute per-candidate \`grade: GradeResult\` via \`gradeFromCandidate\`. Scout's \`search\` doesn't emit per-candidate \`projectHealth\`, so a synthetic \`{ checkFailed: true }\` is passed, forcing the grader to rely only on the autopilot-tracked repoScore. Unscored repos grade 'F' — honest for search (mostly un-seen repos).
- **\`vet-list.ts\`** — new \`ScoutSkipReason\` enum + \`extractSkipReason\` defensive reader. \`classifyListStatus\` prefers the enum when present; falls back to substring matching for the transition period before scout ships the enum. Poison guard ignores unknown enum values.
- **\`SearchOutput.candidates[].grade\`** is now required.
- **Contract tests** — \`search.contract.test.ts\` asserts every candidate has a finite 0–100 viabilityScore, a valid GitHub issue URL, and \`grade.letter\` ∈ {A,B,C,F}. A scout regression emitting \`null\`/\`NaN\`/reshaped fields now breaks autopilot CI instead of shipping to users.

Closes #1043.

## Test plan

- [x] \`pnpm test\` — core 2017 + dashboard + MCP all pass
- [x] Unit tests cover: grade-from-repoScore, out-of-contract viability sanitization, enum preference, substring fallback, enum poison guard, forward-compat "other" fall-through
- [x] Contract test goldens regenerated with \`grade\` field and boundary assertions
- [x] \`pr-review-toolkit:code-reviewer\` — no high-confidence findings
- [x] Bundle 732605 bytes under 740000 threshold