### PR TITLE
fix(status): parse dates numerically instead of lex-comparing strings (#1044)

### DIFF
--- a/packages/core/src/core/status-determination.test.ts
+++ b/packages/core/src/core/status-determination.test.ts
@@ -6,7 +6,12 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { determineStatus, STALE_CI_DEMOTION_DAYS } from './status-determination.js';
+import {
+  determineStatus,
+  isCommitAfterComment,
+  normalizeToEpochMs,
+  STALE_CI_DEMOTION_DAYS,
+} from './status-determination.js';
 import type { DetermineStatusInput } from './types.js';
 
 /** Shared helper — call determineStatus with sensible defaults, overriding only the fields under test. */
@@ -769,5 +774,105 @@ describe('determineStatus multiple action reasons (#675)', () => {
     // Primary is needs_response (highest priority)
     expect(result.actionReason).toBe('needs_response');
     expect(result.actionReasons).toEqual(['needs_response', 'failing_ci', 'merge_conflict']);
+  });
+});
+
+// ── #1044 date-parsing hardening ─────────────────────────────────────
+
+describe('normalizeToEpochMs', () => {
+  it('parses well-formed UTC ISO-8601 strings', () => {
+    expect(normalizeToEpochMs('2026-02-08T12:00:00Z')).toBe(Date.UTC(2026, 1, 8, 12, 0, 0));
+  });
+
+  it('parses ISO strings with timezone offsets into the correct UTC epoch', () => {
+    // Non-UTC ISO strings are the exact case the old lex-order comparison
+    // would get wrong. Numeric parsing must reconcile them.
+    const utc = normalizeToEpochMs('2026-02-08T12:00:00Z');
+    const plusOne = normalizeToEpochMs('2026-02-08T13:00:00+01:00');
+    expect(plusOne).toBe(utc);
+  });
+
+  it('returns NaN for unparseable / empty / nullish inputs', () => {
+    expect(Number.isNaN(normalizeToEpochMs(undefined))).toBe(true);
+    expect(Number.isNaN(normalizeToEpochMs(null))).toBe(true);
+    expect(Number.isNaN(normalizeToEpochMs(''))).toBe(true);
+    expect(Number.isNaN(normalizeToEpochMs('not a date'))).toBe(true);
+  });
+});
+
+describe('isCommitAfterComment fail-closed semantics (#1044)', () => {
+  it('returns false when commitDate is unparseable', () => {
+    expect(isCommitAfterComment('not-a-date', '2026-02-07T10:00:00Z')).toBe(false);
+  });
+
+  it('returns false when commentDate is unparseable', () => {
+    expect(isCommitAfterComment('2026-02-08T12:00:00Z', 'garbage')).toBe(false);
+  });
+});
+
+describe('determineStatus fails closed on malformed dates (#1044)', () => {
+  function callDetermineStatus(overrides: Partial<DetermineStatusInput> = {}) {
+    const defaults: DetermineStatusInput = {
+      ciStatus: 'passing',
+      hasMergeConflict: false,
+      hasUnrespondedComment: false,
+      hasIncompleteChecklist: false,
+      reviewDecision: 'review_required',
+      daysSinceActivity: 2,
+      dormantThreshold: 30,
+      approachingThreshold: 25,
+      latestCommitDate: undefined,
+      lastMaintainerCommentDate: undefined,
+      latestChangesRequestedDate: undefined,
+    };
+    return determineStatus({ ...defaults, ...overrides });
+  }
+
+  it('treats an unparseable latestCommitDate as "not addressed" — status stays needs_response', () => {
+    const result = callDetermineStatus({
+      hasUnrespondedComment: true,
+      reviewDecision: 'changes_requested',
+      latestCommitDate: 'garbage-timestamp',
+      lastMaintainerCommentDate: '2026-02-07T10:00:00Z',
+      latestChangesRequestedDate: '2026-02-06T10:00:00Z',
+    });
+    expect(result.status).toBe('needs_addressing');
+    expect(result.actionReason).toBe('needs_response');
+  });
+
+  it('treats an unparseable latestChangesRequestedDate as "not addressed"', () => {
+    const result = callDetermineStatus({
+      hasUnrespondedComment: true,
+      reviewDecision: 'changes_requested',
+      latestCommitDate: '2026-02-08T12:00:00Z',
+      lastMaintainerCommentDate: '2026-02-07T10:00:00Z',
+      latestChangesRequestedDate: 'not-an-iso-string',
+    });
+    // Commit is after comment, but we can't verify it's after the malformed
+    // changesRequested date — fail closed: treat as not addressed.
+    expect(result.actionReason).toBe('needs_response');
+  });
+
+  it('handles mixed-format ISO strings where lex order disagrees with chronological order', () => {
+    // Regression demonstrator for the old `commitDate >= changesRequestedDate`
+    // string compare in `isChangesAddressedByCommit`:
+    //
+    //   commit (UTC)            = 2026-02-08T12:00:00Z (via +01:00 offset)
+    //   changesRequested (UTC)  = 2026-02-08T12:30:00Z
+    //
+    // Chronologically: commit < changesRequested → NOT addressed (correct).
+    // Lexicographically: '2026-02-08T13:00:00+01:00' > '2026-02-08T12:30:00Z'
+    // because '3' > '2' at position 12 → OLD code said "addressed" (wrong).
+    //
+    // After #1044 this is parsed numerically, so the comparison reflects
+    // chronological order: status stays needs_changes / needs_response.
+    const result = callDetermineStatus({
+      hasUnrespondedComment: false,
+      reviewDecision: 'changes_requested',
+      latestCommitDate: '2026-02-08T13:00:00+01:00', // = 12:00 UTC
+      latestChangesRequestedDate: '2026-02-08T12:30:00Z', // 30 min AFTER commit
+    });
+    expect(result.status).toBe('needs_addressing');
+    expect(result.actionReason).toBe('needs_changes');
   });
 });

--- a/packages/core/src/core/status-determination.ts
+++ b/packages/core/src/core/status-determination.ts
@@ -38,16 +38,33 @@ export function isContributorCommit(commitAuthor?: string, contributorUsername?:
 }
 
 /**
+ * Parse an ISO-8601-ish date string into epoch milliseconds.
+ *
+ * Central helper so the whole module compares dates numerically via `getTime()`
+ * rather than relying on the lexicographic property of UTC ISO strings — the
+ * latter happens to sort correctly today but silently breaks on any other date
+ * format (local-time ISO, `Date.toString()`, non-standard). See #1044.
+ *
+ * Returns `NaN` for `undefined`, empty, or unparseable inputs so callers can
+ * make an explicit fail-closed decision; never throws.
+ */
+export function normalizeToEpochMs(date: string | undefined | null): number {
+  if (!date) return Number.NaN;
+  return new Date(date).getTime();
+}
+
+/**
  * Check whether the contributor's commit is meaningfully after the maintainer's
  * comment — i.e. the commit timestamp is at least MIN_RESPONSE_GAP_MS later (#547).
+ *
+ * Fails closed (returns `false`) if either date is unparseable, avoiding the
+ * silent lexicographic fallback that would produce wrong results for non-UTC
+ * ISO inputs. See #1044.
  */
 export function isCommitAfterComment(commitDate: string, commentDate: string): boolean {
-  const commitMs = new Date(commitDate).getTime();
-  const commentMs = new Date(commentDate).getTime();
-  if (Number.isNaN(commitMs) || Number.isNaN(commentMs)) {
-    // Fall back to simple string comparison (pre-#547 behavior)
-    return commitDate > commentDate;
-  }
+  const commitMs = normalizeToEpochMs(commitDate);
+  const commentMs = normalizeToEpochMs(commentDate);
+  if (!Number.isFinite(commitMs) || !Number.isFinite(commentMs)) return false;
   return commitMs - commentMs >= MIN_RESPONSE_GAP_MS;
 }
 
@@ -69,15 +86,28 @@ function isCommentAddressedByCommit(
 ): boolean {
   if (!commitDate || !commentDate) return false;
   if (!isCommitAfterComment(commitDate, commentDate)) return false;
-  // Safety net (#431): if a CHANGES_REQUESTED review came after the commit, it's not addressed
-  if (changesRequestedDate && commitDate < changesRequestedDate) return false;
+  // Safety net (#431): if a CHANGES_REQUESTED review came after the commit, it's not addressed.
+  // Fail-closed on unparseable `changesRequestedDate` (#1044): treat unknown ordering as "not addressed".
+  if (changesRequestedDate) {
+    const commitMs = normalizeToEpochMs(commitDate);
+    const changesRequestedMs = normalizeToEpochMs(changesRequestedDate);
+    if (!Number.isFinite(commitMs) || !Number.isFinite(changesRequestedMs)) return false;
+    if (commitMs < changesRequestedMs) return false;
+  }
   return true;
 }
 
-/** Check whether a changes_requested review has been addressed by a subsequent contributor commit. */
+/**
+ * Check whether a changes_requested review has been addressed by a subsequent contributor commit.
+ *
+ * Fails closed (returns `false`) on unparseable inputs (#1044).
+ */
 function isChangesAddressedByCommit(commitDate: string | undefined, changesRequestedDate: string | undefined): boolean {
   if (!commitDate || !changesRequestedDate) return false;
-  return commitDate >= changesRequestedDate;
+  const commitMs = normalizeToEpochMs(commitDate);
+  const changesRequestedMs = normalizeToEpochMs(changesRequestedDate);
+  if (!Number.isFinite(commitMs) || !Number.isFinite(changesRequestedMs)) return false;
+  return commitMs >= changesRequestedMs;
 }
 
 /**


### PR DESCRIPTION
## Summary

\`status-determination.ts\` compared date strings directly (\`<\`, \`>=\`). This works for UTC ISO-8601 strings by lex-coincidence but silently produces wrong chronological ordering for any other format (timezone offsets, \`Date.toString()\`, etc.) — with no type error to catch the drift.

- New \`normalizeToEpochMs(date)\` — returns \`NaN\` for nullish/empty/unparseable inputs, \`Date.getTime()\` otherwise. Never throws.
- \`isCommentAddressedByCommit\`, \`isChangesAddressedByCommit\`, and \`isCommitAfterComment\` all compare numerically now.
- Fail-closed on unparseable dates: previously \`isCommitAfterComment\` silently lex-fell-back. "Not addressed" is a strictly safer default — worst case is a re-prompt, not a dropped maintainer comment.

## Regression demonstrator

The key test uses dates where **lex order disagrees with chronological order**:
- \`commit = '2026-02-08T13:00:00+01:00'\` → 12:00 UTC
- \`changesRequested = '2026-02-08T12:30:00Z'\` → 30 min AFTER commit

Lex says \`'13:00+01:00' > '12:30Z'\` → **old code: "addressed" (wrong)**.
Numeric says \`12:00 UTC < 12:30 UTC\` → **new code: "not addressed" (correct)**.

Closes #1044.

## Test plan

- [x] \`pnpm test\` — 2025 pass (previously 2017, +8 new tests covering \`normalizeToEpochMs\`, fail-closed, mixed-format ISO regression)
- [x] Every existing test still passes unchanged (well-formed ISO behavior preserved)
- [x] \`pr-review-toolkit:code-reviewer\` — flagged the original mixed-format test as weak; rewrote it to actually exercise the \`isChangesAddressedByCommit\` bug