### PR TITLE
fix(hooks): gate auto-format-before-push behind opt-in config (#1045)

### DIFF
--- a/hooks/auto-format-before-push.sh
+++ b/hooks/auto-format-before-push.sh
@@ -1,13 +1,22 @@
 #!/usr/bin/env bash
 # PreToolUse hook: auto-format changed files before git push.
 #
-# Detects the project's formatter, runs it on files in the current diff,
-# and commits any formatting changes before the push proceeds.
-# Passes through silently if no formatter is detected or nothing changes.
-# Never blocks a push — all errors fall through with a warning message.
+# Opt-in via `~/.oss-autopilot/state.json`'s `config.autoFormatBeforePush`.
+# When enabled, detects the project's formatter, runs it once over the full
+# list of changed files, and commits any formatting changes before the push
+# proceeds. Passes through silently if disabled, if no formatter is detected,
+# or if nothing changes. Never blocks a push — all errors fall through with a
+# warning message.
+#
+# Why opt-in (#1045): appending a `style: auto-format before push` commit to
+# an OSS contribution branch can surprise maintainers who prefer minimal-diff
+# PRs, and conflicts with the global "never reformat unrelated code" rule.
 
 # No set -e: this hook must never abort mid-execution and leave a dirty tree.
 set -uo pipefail
+
+STATE_FILE="${HOME}/.oss-autopilot/state.json"
+FORMAT_ERROR_LOG="${HOME}/.oss-autopilot/last-format-error.log"
 
 warn_and_exit() {
   local msg="$1"
@@ -23,6 +32,23 @@ WARN_EOF
   exit 0
 }
 
+# Read a config value from state.json via jq; fall back to default on any
+# failure (missing file, malformed JSON, missing key). Never throws.
+read_config() {
+  local key="$1"
+  local default="$2"
+  if [ ! -f "$STATE_FILE" ]; then
+    echo "$default"
+    return
+  fi
+  jq -r --arg default "$default" ".config.${key} // \$default" "$STATE_FILE" 2>/dev/null || echo "$default"
+}
+
+# Lowercase helper — portable to bash 3.2 (macOS) where ${var,,} is unavailable.
+to_lower() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
 input=$(cat)
 command=$(echo "$input" | jq -r '.tool_input.command // empty')
 
@@ -35,6 +61,14 @@ if ! echo "$command" | grep -qE 'git\s+push\b'; then
   exit 0
 fi
 if echo "$command" | grep -qE '(\s--force\b|\s-f\b|\s--force-with-lease)'; then
+  exit 0
+fi
+
+# ── Opt-in gate (#1045) ──────────────────────────────────────────────
+# Silent no-op unless the user has explicitly enabled the hook via
+# `oss-autopilot setup --set autoFormatBeforePush=true`.
+auto_format_enabled=$(read_config autoFormatBeforePush false)
+if [ "$auto_format_enabled" != "true" ]; then
   exit 0
 fi
 
@@ -54,10 +88,68 @@ if [ -z "$tracking_branch" ]; then
   exit 0
 fi
 
-changed_files=$(git diff --diff-filter=d --name-only "$tracking_branch"..HEAD 2>/dev/null || echo "")
-if [ -z "$changed_files" ]; then
+# ── OSS-contribution branch skip (#1045) ─────────────────────────────
+# If the branch tracks a remote whose URL owner doesn't match the user's
+# configured GitHub username, we're pushing to a fork's upstream — don't
+# append a style commit to that PR.
+current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+github_user=$(read_config githubUsername "")
+if [ -n "$current_branch" ] && [ -n "$github_user" ]; then
+  remote_name=$(git config "branch.${current_branch}.remote" 2>/dev/null || echo "")
+  if [ -n "$remote_name" ]; then
+    remote_url=$(git remote get-url "$remote_name" 2>/dev/null || echo "")
+    # Match both https://github.com/OWNER/ and git@github.com:OWNER/
+    remote_owner=$(printf '%s' "$remote_url" | sed -nE 's#.*github\.com[:/]+([^/]+)/.*#\1#p')
+    if [ -n "$remote_owner" ]; then
+      if [ "$(to_lower "$remote_owner")" != "$(to_lower "$github_user")" ]; then
+        warn_and_exit "Skipped: branch '${current_branch}' tracks remote owner '${remote_owner}' (not '${github_user}'). Auto-format is disabled on OSS contribution branches."
+      fi
+    fi
+  fi
+fi
+
+# Collect changed files null-delimited so filenames with spaces/quotes survive.
+changed_files_tmp=$(mktemp)
+trap 'rm -f "$changed_files_tmp"' EXIT
+if ! git diff -z --name-only --diff-filter=d "$tracking_branch"..HEAD >"$changed_files_tmp" 2>/dev/null; then
   exit 0
 fi
+if [ ! -s "$changed_files_tmp" ]; then
+  exit 0
+fi
+
+# Ensure the data directory exists for the error log.
+mkdir -p "$(dirname "$FORMAT_ERROR_LOG")" 2>/dev/null || true
+
+# Batched formatter helpers (#1045): run the formatter once (or at most a few
+# times if xargs splits the command line) rather than once per file. A 50-file
+# diff used to spawn 50 `npx` processes, each resolving `.bin/` — easily past
+# the 30s hook timeout. `-r` skips the call entirely if the list is empty.
+run_formatter() {
+  local name="$1"
+  shift
+  if xargs -0 -r "$@" 2>>"$FORMAT_ERROR_LOG" >/dev/null <"$changed_files_tmp"; then
+    format_result="$name"
+  else
+    format_error="$name exited non-zero; see ${FORMAT_ERROR_LOG}"
+  fi
+}
+
+run_python_formatter() {
+  local name="$1"
+  shift
+  local py_files_tmp
+  py_files_tmp=$(mktemp)
+  tr '\0' '\n' <"$changed_files_tmp" | grep '\.py$' | tr '\n' '\0' >"$py_files_tmp" 2>/dev/null || true
+  if [ -s "$py_files_tmp" ]; then
+    if xargs -0 -r "$@" 2>>"$FORMAT_ERROR_LOG" >/dev/null <"$py_files_tmp"; then
+      format_result="$name"
+    else
+      format_error="$name exited non-zero; see ${FORMAT_ERROR_LOG}"
+    fi
+  fi
+  rm -f "$py_files_tmp"
+}
 
 # Detect and run project formatter
 format_result=""
@@ -75,11 +167,17 @@ if [ -f "package.json" ]; then
 
   if [ -n "$format_script" ]; then
     if [ -f "pnpm-lock.yaml" ]; then
-      format_error=$(pnpm run "$format_script" 2>&1 >/dev/null) && format_result="pnpm run $format_script" || true
+      if pnpm run "$format_script" >/dev/null 2>>"$FORMAT_ERROR_LOG"; then
+        format_result="pnpm run $format_script"
+      fi
     elif [ -f "yarn.lock" ]; then
-      format_error=$(yarn run "$format_script" 2>&1 >/dev/null) && format_result="yarn run $format_script" || true
+      if yarn run "$format_script" >/dev/null 2>>"$FORMAT_ERROR_LOG"; then
+        format_result="yarn run $format_script"
+      fi
     else
-      format_error=$(npm run "$format_script" 2>&1 >/dev/null) && format_result="npm run $format_script" || true
+      if npm run "$format_script" >/dev/null 2>>"$FORMAT_ERROR_LOG"; then
+        format_result="npm run $format_script"
+      fi
     fi
   fi
 fi
@@ -87,24 +185,21 @@ fi
 # Fallback: check for standalone formatter config files
 if [ -z "$format_result" ] && [ -z "$format_error" ]; then
   if [ -f ".prettierrc" ] || [ -f ".prettierrc.json" ] || [ -f "prettier.config.js" ] || [ -f "prettier.config.mjs" ] || [ -f ".prettierrc.yaml" ]; then
-    format_error=$(printf '%s\n' "$changed_files" | xargs -I {} npx prettier --write {} 2>&1 >/dev/null) && format_result="prettier" || true
+    run_formatter "prettier" npx prettier --write
   elif [ -f "biome.json" ] || [ -f "biome.jsonc" ]; then
-    format_error=$(printf '%s\n' "$changed_files" | xargs -I {} npx @biomejs/biome format --write {} 2>&1 >/dev/null) && format_result="biome" || true
+    run_formatter "biome" npx @biomejs/biome format --write
   elif [ -f "pyproject.toml" ] && grep -qE '\[tool\.(black|ruff)\]' pyproject.toml 2>/dev/null; then
-    py_files=$(printf '%s\n' "$changed_files" | grep '\.py$' || true)
-    if [ -n "$py_files" ]; then
-      if command -v ruff &>/dev/null; then
-        format_error=$(printf '%s\n' "$py_files" | xargs -I {} ruff format {} 2>&1 >/dev/null) && format_result="ruff format" || true
-      elif command -v black &>/dev/null; then
-        format_error=$(printf '%s\n' "$py_files" | xargs -I {} black {} 2>&1 >/dev/null) && format_result="black" || true
-      fi
+    if command -v ruff >/dev/null 2>&1; then
+      run_python_formatter "ruff format" ruff format
+    elif command -v black >/dev/null 2>&1; then
+      run_python_formatter "black" black
     fi
   fi
 fi
 
 # If formatter was detected but failed, warn and allow push
 if [ -z "$format_result" ] && [ -n "$format_error" ]; then
-  warn_and_exit "Formatter failed. Push continuing without formatting. Error: ${format_error:0:200}"
+  warn_and_exit "Formatter failed. Push continuing without formatting. ${format_error}"
 fi
 
 if [ -z "$format_result" ]; then
@@ -116,13 +211,9 @@ if git diff --quiet 2>/dev/null; then
   exit 0
 fi
 
-# Stage ONLY files that the formatter actually modified
-formatted_files=$(git diff --name-only 2>/dev/null || echo "")
-if [ -z "$formatted_files" ]; then
-  exit 0
-fi
-
-if ! printf '%s\n' "$formatted_files" | xargs -I {} git add {} >/dev/null 2>&1; then
+# Stage ONLY files that the formatter actually modified. Null-delimited names
+# survive spaces and other special characters.
+if ! git diff --name-only -z 2>/dev/null | xargs -0 -r git add >/dev/null 2>&1; then
   warn_and_exit "Failed to stage formatting changes (git add failed). Push continuing without formatting commit."
 fi
 

--- a/packages/core/src/commands/setup.test.ts
+++ b/packages/core/src/commands/setup.test.ts
@@ -247,6 +247,24 @@ describe('runSetup', () => {
     expect(result.settings).toMatchObject({ skippedIssuesPath: '(cleared)' });
   });
 
+  it('should set autoFormatBeforePush to true', async () => {
+    const result = (await runSetup({ set: ['autoFormatBeforePush=true'] })) as SetupSetOutput;
+
+    expect(mockUpdateConfig).toHaveBeenCalledWith({ autoFormatBeforePush: true });
+    expect(result.settings).toMatchObject({ autoFormatBeforePush: 'true' });
+  });
+
+  it('should set autoFormatBeforePush to false', async () => {
+    const result = (await runSetup({ set: ['autoFormatBeforePush=false'] })) as SetupSetOutput;
+
+    expect(mockUpdateConfig).toHaveBeenCalledWith({ autoFormatBeforePush: false });
+    expect(result.settings).toMatchObject({ autoFormatBeforePush: 'false' });
+  });
+
+  it('should reject non-boolean autoFormatBeforePush values', async () => {
+    await expect(runSetup({ set: ['autoFormatBeforePush=yes'] })).rejects.toThrow(/must be "true" or "false"/i);
+  });
+
   it('should not complete=true when value is not true', async () => {
     await runSetup({ set: ['complete=false'] });
     expect(mockMarkSetupComplete).not.toHaveBeenCalled();

--- a/packages/core/src/commands/setup.ts
+++ b/packages/core/src/commands/setup.ts
@@ -183,6 +183,17 @@ export async function runSetup(options: SetupOptions): Promise<SetupOutput> {
             stateManager.updateConfig({ skippedIssuesPath: value || undefined });
             results[key] = value || '(cleared)';
             break;
+          case 'autoFormatBeforePush': {
+            if (value !== 'true' && value !== 'false') {
+              throw new ValidationError(
+                `Invalid value for autoFormatBeforePush: "${value}". Must be "true" or "false".`,
+              );
+            }
+            const enabled = value === 'true';
+            stateManager.updateConfig({ autoFormatBeforePush: enabled });
+            results[key] = String(enabled);
+            break;
+          }
           case 'includeDocIssues':
             stateManager.updateConfig({ includeDocIssues: value === 'true' });
             results[key] = value === 'true' ? 'true' : 'false';

--- a/packages/core/src/core/config-registry.ts
+++ b/packages/core/src/core/config-registry.ts
@@ -204,6 +204,13 @@ export const CONFIG_KEY_REGISTRY: readonly ConfigKeyDef[] = [
     settableVia: 'setup',
     valueHint: 'one of: local,gist',
   },
+  {
+    key: 'autoFormatBeforePush',
+    description:
+      'Opt-in: run the project formatter and append a `style:` commit before every `git push`. Off by default because formatting commits surprise OSS maintainers; the hook also skips automatically when the branch tracks a fork upstream.',
+    settableVia: 'setup',
+    valueHint: 'true|false',
+  },
 
   // ── Setup-only completion flag ──────────────────────────────────────
   {

--- a/packages/core/src/core/state-schema.ts
+++ b/packages/core/src/core/state-schema.ts
@@ -194,6 +194,12 @@ export const AgentConfigSchema = z.object({
 
   diffTool: DiffToolSchema.default('inline'),
   diffToolCustomCommand: z.string().optional(),
+
+  /**
+   * Opt-in gate for the auto-format-before-push hook (#1045). Default false:
+   * the hook does nothing on every push unless the user explicitly enables it.
+   */
+  autoFormatBeforePush: z.boolean().default(false),
 });
 
 // ── 6. Cache schemas ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The auto-format-before-push hook used to auto-append a \`style: auto-format before push\` commit on **every** non-force push and spawn **one npx subprocess per changed file**, which surprises OSS maintainers (who prefer minimal-diff PRs) and regularly timed out on 30+ file diffs.

- **Opt-in gate** — new config key \`autoFormatBeforePush\` (default \`false\`) in state-schema + config-registry + setup handler. The hook is a **silent no-op** until the user explicitly enables it.
- **Batched xargs** — one formatter invocation over all files using null-delimited \`git diff -z | xargs -0 -r\`. A 50-file diff now runs 1 \`npx\` process instead of 50.
- **OSS-contribution skip** — if the branch tracks a remote whose URL owner differs from \`config.githubUsername\`, the hook logs a skip message and exits without committing. Handles https, git@, git://, ssh:// forms case-insensitively.
- **Stderr to log** — formatter stderr captured to \`~/.oss-autopilot/last-format-error.log\` instead of swallowed.
- **Portable to bash 3.2** (macOS default) — no \`\${var,,}\` or other bash 4 idioms.

Closes #1045.

## Test plan

- [x] \`pnpm test\` — 2028 pass (+3 new tests for the setup handler)
- [x] \`bash -n\` syntax check: OK
- [x] Smoke tests: disabled-default push exits 0 silently; jq read returns "false" default when key absent
- [x] \`pr-review-toolkit:code-reviewer\` — no high-confidence findings. Empirically verified: silent no-op emits 0 bytes; fork regex handles https/ssh/git@/git:// forms case-insensitively and rejects aliased hostnames (conservative); xargs batching at 10k files splits safely; \`set -uo pipefail\` + guarded-ifs leave no leaked tempfiles