### PR TITLE
docs(workflows): extract shared review-dispatch template (#1047)

### DIFF
--- a/workflows/dispatch-review.md
+++ b/workflows/dispatch-review.md
@@ -1,0 +1,245 @@
+# Dispatch Review Agents — Shared Template
+
+**Canonical reference for the multi-agent review dispatch.** Both
+`draft-first-workflow.md` (Step 3) and `pre-commit-review.md` (sub-step 3)
+delegate to this file. Any change to the agent roster, prompt templates,
+convergence loop, or fallback goes here — not in the calling workflows.
+
+## Preconditions
+
+Before dispatching agents, the caller must provide:
+
+- `mergeBase` — the merge base commit for the full branch diff.
+  (Callers typically compute `mergeBase=$(git merge-base "$remote/$baseBranch" HEAD)` and use `git diff $mergeBase..HEAD`.)
+- `reviewDiff` — the full diff string (for inclusion in every agent prompt).
+- `changedFiles` — list of changed file paths.
+- `workingDir` — absolute path of the local repository.
+- `issueContext` — `{ title, url }` when this review is scoped to a specific issue. Used for the SCOPE block. Omit when running a generic pre-commit review.
+- `reviewPass` — integer, initialized to 1 by the caller.
+- `agentsWithFindings` — empty array, initialized by the caller. Used for targeted re-dispatch on pass 2+.
+
+## SCOPE Block
+
+**Include this SCOPE block at the top of every agent prompt when `issueContext` is provided** (new contribution flow in draft-first-workflow Step 3):
+
+```
+SCOPE: This PR addresses issue '{issueContext.title}' ({issueContext.url}).
+Focus findings on changes related to this issue. Flag pre-existing issues only
+if they are Critical severity. Do NOT suggest improvements outside the scope of this PR.
+FORMATTING RULE: Flag any diff hunks that are formatting-only (whitespace, quote style,
+trailing commas, import reordering) and unrelated to the issue fix. These must be reverted
+before the PR is submitted. Do not flag formatting that is part of the functional fix.
+```
+
+Omit the SCOPE block for generic pre-commit reviews (`pre-commit-review.md` sub-step 3 when no issue context is present). In that case, the caller's sub-step 4b runs a Scope Discipline Check after consolidation to catch unrelated changes.
+
+## Dispatch Rule
+
+**CRITICAL: Dispatch ALL agents in a SINGLE message for true parallelism.** Always dispatch the full base agent suite — do not scale down based on diff size; the convergence loop depends on comprehensive coverage.
+
+**Always include `Working directory: {workingDir}` in every agent prompt.** Without it, agents inherit the parent session's working directory and file lookups fail.
+
+## Base Agents (always dispatched)
+
+`code-reviewer`, `silent-failure-hunter`, `code-simplifier`, `pr-test-analyzer`, `comment-analyzer`.
+
+```
+Task(pr-review-toolkit:code-reviewer,
+  "[SCOPE block if applicable]
+
+   Review the following code changes for bugs, logic errors, security vulnerabilities,
+   and adherence to project conventions.
+   Repository: {repo name}
+   Working directory: {workingDir}
+   Convention notes: {any CONTRIBUTING.md or lint config findings}
+   Changed files: {changedFiles}
+
+   Additional checks:
+   - API naming conventions: If new public API surface is added, flag double-negative
+     booleans (e.g., nonInteractive when the codebase uses positive booleans).
+   - JS/TS truthiness: flag !obj.prop when the intent is strictly false, and === false
+     vs !prop inconsistencies. Flag boolean coercion of values that could be 0, '', or null.
+   - Formatting hygiene: flag diff hunks that are formatting-only (whitespace, quotes,
+     trailing commas, import reordering). Do not flag formatting that is part of the
+     functional fix.
+   - Documentation accuracy: cross-reference doc/README/JSDoc claims against code; check
+     option descriptions match defaults; flag stale docs when code behavior changed.
+
+   Diff:
+   {reviewDiff}")
+
+Task(pr-review-toolkit:silent-failure-hunter,
+  "[SCOPE block if applicable]
+
+   Review the following code changes for silent failures, inadequate error handling,
+   and inappropriate fallback behavior.
+   Working directory: {workingDir}
+   Changed files: {changedFiles}
+
+   Diff:
+   {reviewDiff}")
+
+Task(pr-review-toolkit:code-simplifier,
+  "[SCOPE block if applicable]
+
+   Review the following code changes for dead code, unnecessary complexity, and
+   simplification opportunities. Do NOT modify files — report findings only.
+   Do NOT suggest cosmetic changes (import reordering, quote style, trailing commas,
+   whitespace) as improvements — only flag them for reversion per the FORMATTING RULE.
+   Working directory: {workingDir}
+   Changed files: {changedFiles}
+
+   Diff:
+   {reviewDiff}")
+
+Task(pr-review-toolkit:pr-test-analyzer,
+  "[SCOPE block if applicable]
+
+   Analyze test coverage and assertion quality for the following code changes.
+   Working directory: {workingDir}
+   Test directory: {test dir path}
+   Changed files: {changedFiles}
+
+   Coverage: check if modified code paths have tests; identify gaps.
+
+   Assertion strength: for each new/modified test, ask 'if I broke the feature under
+   test, would this test actually catch it?' Flag:
+   - Assertions too broad (only checking final output, not intermediate states)
+   - Test names claiming comprehensive coverage but only checking a subset
+   - Tests that would still pass if the feature regressed (e.g., .toBeDefined() when a
+     specific value is expected)
+   - Override/disable tests that don't prove the override works, only that the code runs
+
+   Diff:
+   {reviewDiff}")
+
+Task(pr-review-toolkit:comment-analyzer,
+  "[SCOPE block if applicable]
+
+   Review comments in the following code changes for accuracy, completeness, and
+   long-term maintainability.
+   Working directory: {workingDir}
+   Changed files: {changedFiles}
+
+   Diff:
+   {reviewDiff}")
+```
+
+## Conditional Agents (dispatch in the SAME message)
+
+- **`pr-review-toolkit:type-design-analyzer`** — dispatch when changed files include TypeScript (`.ts`, `.tsx`) or other typed languages.
+
+  ```
+  Task(pr-review-toolkit:type-design-analyzer,
+    "[SCOPE block if applicable]
+
+     Review type design in the following TypeScript changes. Check for proper
+     encapsulation, invariant expression, and type safety.
+     Working directory: {workingDir}
+     Changed files: {changed .ts/.tsx files}
+
+     Diff:
+     {reviewDiff filtered to .ts/.tsx files}")
+  ```
+
+## Fallback
+
+If the PR review toolkit agents are unavailable (Task tool returns an error for those agent types), inform the user and dispatch the local `pre-commit-reviewer` agent instead:
+
+> "PR review toolkit agents are not available. Falling back to the built-in pre-commit reviewer. This provides a general code review but does not include specialized checks for silent failures, type design, or test coverage."
+
+```
+Task(pre-commit-reviewer,
+  "Review my pending code changes before committing.
+   Repository: {repo name}
+   Working directory: {workingDir}")
+```
+
+**Partial failure:** if some toolkit agents succeed and others fail, consolidate the successful results and note which reviews were skipped:
+> "Note: The following specialized reviews could not be completed: {list}."
+
+**Total failure:** if all agents fail, offer "Proceed (skip review)" / "Retry" / "Done for now".
+
+## Consolidated Report
+
+After all agents complete, merge outputs into a unified report. Deduplicate findings that multiple agents flagged.
+
+**Track which agents found issues:** for each agent that reported Critical or Recommended findings, add its name to `agentsWithFindings`. This enables targeted re-dispatch on subsequent passes.
+
+If any agent failed to complete, note it in the report:
+> "Warning: {agent-name} did not complete. Its findings are not included."
+
+```
+## Review Summary — Pass {reviewPass}
+
+### Critical ({count}) — Must fix before committing
+- **{file}:{line}** — {description} (found by: {agent})
+  Suggestion: {fix}
+
+### Recommended ({count}) — Should fix
+- **{file}:{line}** — {description} (found by: {agent})
+  Suggestion: {fix}
+
+### Minor ({count}) — Nice to have
+- **{file}:{line}** — {description}
+
+### Test Coverage & Quality
+- {assessment from pr-test-analyzer, including assertion strength concerns}
+
+### Documentation Accuracy
+- {any doc/README claims that don't match the code, or stale docs}
+
+### Convention Alignment
+- {any style/convention/naming mismatches}
+```
+
+**In-scope vs out-of-scope split** (when `issueContext` is provided):
+- Separate findings into **In-Scope** (Critical/Recommended/Minor) and **Out-of-Scope** (pre-existing issues flagged as Critical-severity only).
+
+If NO issues:
+```
+## Review Summary
+
+All agents passed. No issues found — changes are clean and ready to commit.
+```
+
+## Automatic Convergence Loop
+
+After consolidating findings, automatically fix and re-review until convergence. **Do not prompt the user during this loop** — it runs fully autonomously.
+
+**Loop bound:** maximum 5 passes total (including the initial pass). If convergence is not reached after 5, present remaining findings and proceed to the caller's user-decision step.
+
+**Convergence criteria:** zero Critical AND zero Recommended findings in the latest pass. Minor findings do not block convergence.
+
+**Procedure:**
+
+1. **Check convergence.** If zero Critical and zero Recommended: report
+   > "Review converged on pass {reviewPass}. {minor_count} minor finding(s) noted — changes are clean."
+   Proceed to the caller's decision step.
+
+2. **If Critical or Recommended exist:** report
+   > "Pass {reviewPass}: {critical} Critical, {recommended} Recommended, {minor} Minor. Fixing actionable findings..."
+
+3. **Fix all Critical and Recommended findings.** Minor findings are noted but not auto-fixed.
+
+4. **Increment `reviewPass`.** Re-gather the updated diff (caller's context-gather step).
+
+5. **Targeted re-dispatch (pass 2+):** re-run only agents in `agentsWithFindings` from the previous pass plus `code-reviewer` as a baseline quality gate. Reset `agentsWithFindings` before collecting new results. Report:
+   > "Re-review pass {reviewPass}: re-dispatching {agent list} (targeted) + code-reviewer (baseline). Agents that passed cleanly are skipped."
+
+6. **Re-consolidate** and return to step 1.
+
+**Cross-pass deduplication:** findings referencing the same file, line range (±5 lines), and substantially similar description are duplicates — do not re-report. Only new or materially changed findings count toward convergence.
+
+**If max passes reached without convergence:**
+> "Review did not converge after 5 passes. {remaining_count} finding(s) remain — presenting for manual review."
+
+## After the Loop
+
+Return control to the caller with:
+- final consolidated report
+- convergence status (`converged` or `max_passes_reached`)
+- `reviewPass` count
+- `agentsWithFindings` from the final pass
+
+The caller decides the next user-facing action (commit / show diff / done for now).

--- a/workflows/draft-first-workflow.md
+++ b/workflows/draft-first-workflow.md
@@ -219,161 +219,29 @@ Use `git diff $mergeBase..HEAD` for the full branch diff. If `$mergeBase` is emp
 
 ### 2. Dispatch Scope-Aware Review Agents
 
-**Dispatch ALL agents in a SINGLE message.** Always use the full Large tier (code-reviewer, silent-failure-hunter, code-simplifier, pr-test-analyzer + conditional agents) regardless of diff size. Include `Working directory: {local repo path}` in every prompt.
+**See `workflows/dispatch-review.md`** — the canonical multi-agent dispatch template (agent roster, SCOPE block, convergence loop, fallback, report format).
 
-**Prepend this SCOPE block to each agent prompt:**
-```
-SCOPE: This PR addresses issue '{issueContext.title}' ({issueContext.url}).
-Focus findings on changes related to this issue. Flag pre-existing issues only
-if they are Critical severity. Do NOT suggest improvements outside the scope of this PR.
-FORMATTING RULE: Flag any diff hunks that are formatting-only (whitespace, quote style,
-trailing commas, import reordering) and unrelated to the issue fix. These must be reverted
-before the PR is submitted. Do not flag formatting that is part of the functional fix.
-```
+Caller-specific inputs for this workflow:
+- `issueContext = { title: issueContext.title, url: issueContext.url }` — the SCOPE block is required for new contributions.
+- `reviewDiff = git diff $mergeBase..HEAD` (full branch diff from sub-step 1).
+- `workingDir` = local repo path.
+- `reviewPass = 1`, `agentsWithFindings = []`.
 
-**Agent prompts** (include the full `git diff $mergeBase..HEAD` output in each):
-
-```
-Task(pr-review-toolkit:code-reviewer,
-  "SCOPE: This PR addresses issue '{issueContext.title}' ({issueContext.url}).
-   Focus findings on changes related to this issue. Flag pre-existing issues only
-   if they are Critical severity. Do NOT suggest improvements outside the scope of this PR.
-   FORMATTING RULE: Flag any diff hunks that are formatting-only (whitespace, quote style,
-   trailing commas, import reordering) and unrelated to the issue fix. These must be reverted
-   before the PR is submitted. Do not flag formatting that is part of the functional fix.
-
-   Review the following code changes for bugs, logic errors, security vulnerabilities,
-   and adherence to project conventions. Focus on issue-related changes.
-   Repository: {repo name}
-   Working directory: {local repo path}
-   Convention notes: {any CONTRIBUTING.md or lint config findings}
-   Changed files: {changed files list}
-
-   Diff:
-   {git diff $mergeBase..HEAD output}")
-
-Task(pr-review-toolkit:silent-failure-hunter,
-  "SCOPE: This PR addresses issue '{issueContext.title}' ({issueContext.url}).
-   Focus findings on changes related to this issue. Flag pre-existing issues only
-   if they are Critical severity. Do NOT suggest improvements outside the scope of this PR.
-   FORMATTING RULE: Flag any diff hunks that are formatting-only (whitespace, quote style,
-   trailing commas, import reordering) and unrelated to the issue fix. These must be reverted
-   before the PR is submitted. Do not flag formatting that is part of the functional fix.
-
-   Review the following code changes for silent failures, inadequate error handling,
-   and inappropriate fallback behavior. Focus on changed code paths only.
-   Working directory: {local repo path}
-   Changed files: {changed files list}
-
-   Diff:
-   {git diff $mergeBase..HEAD output}")
-
-Task(pr-review-toolkit:code-simplifier,
-  "SCOPE: This PR addresses issue '{issueContext.title}' ({issueContext.url}).
-   Focus findings on changes related to this issue. Flag pre-existing issues only
-   if they are Critical severity. Do NOT suggest improvements outside the scope of this PR.
-   FORMATTING RULE: Flag any diff hunks that are formatting-only (whitespace, quote style,
-   trailing commas, import reordering) and unrelated to the issue fix. These must be reverted
-   before the PR is submitted. Do not flag formatting that is part of the functional fix.
-
-   Review the following code changes for dead code, unnecessary complexity, and
-   simplification opportunities. Focus on new/modified code only. Do NOT modify files — report findings only.
-   Do NOT suggest cosmetic changes (import reordering, quote style, trailing commas,
-   whitespace) as improvements — only flag them for reversion per the FORMATTING RULE above.
-   Working directory: {local repo path}
-   Changed files: {changed files list}
-
-   Diff:
-   {git diff $mergeBase..HEAD output}")
-
-Task(pr-review-toolkit:pr-test-analyzer,
-  "SCOPE: This PR addresses issue '{issueContext.title}' ({issueContext.url}).
-   Focus findings on changes related to this issue. Flag pre-existing issues only
-   if they are Critical severity. Do NOT suggest improvements outside the scope of this PR.
-   FORMATTING RULE: Flag any diff hunks that are formatting-only (whitespace, quote style,
-   trailing commas, import reordering) and unrelated to the issue fix. These must be reverted
-   before the PR is submitted. Do not flag formatting that is part of the functional fix.
-
-   Analyze test coverage for the following code changes. Focus on new functionality only.
-   Check if modified code paths have tests, identify gaps, and recommend what tests should be added.
-   Working directory: {local repo path}
-   Test directory: {test dir path}
-   Changed files: {changed files list}
-
-   Diff:
-   {git diff $mergeBase..HEAD output}")
-```
-
-**Conditional agents (dispatch in the SAME message if applicable):**
-
-- **`pr-review-toolkit:type-design-analyzer`** — dispatch only if changed files include TypeScript (`.ts`, `.tsx`) or other typed languages
-  ```
-  Task(pr-review-toolkit:type-design-analyzer,
-    "SCOPE: This PR addresses issue '{issueContext.title}' ({issueContext.url}).
-     Focus on issue-related type changes only.
-     FORMATTING RULE: Flag any diff hunks that are formatting-only (whitespace, quote style,
-     trailing commas, import reordering) and unrelated to the issue fix. These must be reverted
-     before the PR is submitted. Do not flag formatting that is part of the functional fix.
-
-     Review type design in the following TypeScript changes. Check for proper
-     encapsulation, invariant expression, and type safety.
-     Working directory: {local repo path}
-     Changed files: {changed .ts/.tsx files}
-
-     Diff:
-     {git diff $mergeBase..HEAD output for .ts/.tsx files}")
-  ```
-
-- **`pr-review-toolkit:comment-analyzer`** — dispatch only if 5+ files were changed
-  ```
-  Task(pr-review-toolkit:comment-analyzer,
-    "SCOPE: This PR addresses issue '{issueContext.title}' ({issueContext.url}).
-     Focus on comments in new/modified code only.
-     FORMATTING RULE: Flag any diff hunks that are formatting-only (whitespace, quote style,
-     trailing commas, import reordering) and unrelated to the issue fix. These must be reverted
-     before the PR is submitted. Do not flag formatting that is part of the functional fix.
-
-     Review comments in the following code changes for accuracy, completeness,
-     and long-term maintainability.
-     Working directory: {local repo path}
-     Changed files: {changed files list}
-
-     Diff:
-     {git diff $mergeBase..HEAD output}")
-  ```
-
-**Fallback:** If the PR review toolkit agents are unavailable, dispatch the local `pre-commit-reviewer` agent instead:
-
-> "PR review toolkit agents are not available. Falling back to the built-in pre-commit reviewer."
-
-```
-Task(pre-commit-reviewer,
-  "Review my pending code changes before committing.
-   Repository: {repo name}
-   Working directory: {path}")
-```
-
-If ALL agents fail: offer "Proceed to integration check (skip review)" / "Retry" / "Done for now".
+Initialize `roundNumber = 1` for the outer loop, then run the dispatch-review template. The convergence loop in that template handles re-dispatch automatically.
 
 ### 3. Consolidate and Present
 
-Same as the pre-commit review consolidation format, but separate findings into **In-Scope** (Critical/Recommended/Minor) and **Out-of-Scope** (pre-existing issues). Include test coverage assessment.
+Use the "In-Scope vs Out-of-Scope" split described in `dispatch-review.md` — since `issueContext` is provided, split findings into:
+- **In-Scope** (Critical / Recommended / Minor) — changes related to the issue.
+- **Out-of-Scope (pre-existing)** — Critical-severity findings only.
+
+Include the test-coverage assessment from `pr-test-analyzer`.
 
 ```
 ## Local Review — Round {roundNumber}
 
 ### In-Scope Findings
-
-#### Critical ({count}) — Must fix before publishing
-- **{file}:{line}** — {description} (found by: {agent})
-  Suggestion: {fix}
-
-#### Recommended ({count}) — Should fix
-- **{file}:{line}** — {description} (found by: {agent})
-  Suggestion: {fix}
-
-#### Minor ({count}) — Nice to have
-- **{file}:{line}** — {description}
+[Critical / Recommended / Minor — per dispatch-review.md format]
 
 ### Out-of-Scope (pre-existing)
 - {list, if any Critical-severity pre-existing issues were flagged}

--- a/workflows/pre-commit-review.md
+++ b/workflows/pre-commit-review.md
@@ -105,167 +105,19 @@ Before dispatching review agents, run the repo's lint and test commands to catch
 
 ### 3. Dispatch Review Agents in Parallel
 
-**CRITICAL: Dispatch ALL selected agents in a SINGLE message for true parallelism.**
+**See `workflows/dispatch-review.md`** — the canonical multi-agent dispatch template (agent roster, prompt content, convergence loop, fallback, consolidated report format).
 
-Pass `reviewDiff` (from sub-step 2) as context to each agent.
+Caller-specific inputs for this workflow:
+- **No `issueContext`** — this is a generic pre-commit review, not tied to a specific upstream issue. The SCOPE block is therefore omitted. Sub-step 4b (Scope Discipline Check) handles the maintainer-feedback case where requested-vs-implemented discipline matters.
+- `reviewDiff` comes from sub-step 2.
+- `workingDir` is the local repo path.
+- `reviewPass = 1`, `agentsWithFindings = []`.
 
-**Initialize tracking:** Set `reviewPass = 1` and `agentsWithFindings = []` (empty list). These are used in the convergence loop (sub-step 5) to enable targeted re-dispatch.
-
-**IMPORTANT: Always include `Working directory: {local repo path}` in every agent prompt so agents can find and read files in the correct location. Without this, agents inherit the parent session's working directory and file lookups will fail.**
-
-**Always dispatch the full base agent suite** regardless of change size. The convergence loop (sub-step 5) depends on comprehensive coverage — scaling down agents undermines the guarantee that fixes don't introduce new problems.
-
-**Base agents (always dispatched):** `code-reviewer`, `silent-failure-hunter`, `code-simplifier`, `pr-test-analyzer`, `comment-analyzer`
-
-**Agent prompts** (dispatch ALL base agents plus any conditional agents in a SINGLE message; include the full `git diff` output in each):
-
-```
-Task(pr-review-toolkit:code-reviewer,
-  "Review the following code changes for bugs, logic errors, security vulnerabilities,
-   and adherence to project conventions.
-   Repository: {repo name}
-   Working directory: {local repo path}
-   Convention notes: {any CONTRIBUTING.md or lint config findings}
-   Changed files: {changed files list}
-
-   Additional checks:
-   - API naming conventions: If new public API surface is added (exports, options, CLI flags),
-     scan existing APIs in the same module for naming patterns. Flag double-negative boolean
-     names (e.g., nonInteractive when the codebase uses positive booleans like interactive).
-   - JS/TS truthiness: Flag !obj.prop when the intent is to check for false specifically
-     but undefined would also match. Flag === false vs !prop inconsistencies. Flag boolean
-     coercion of values that could be 0, "", or null where the intent is only to check
-     for undefined.
-   - Formatting hygiene: Scan the diff for hunks that contain only formatting changes
-     (whitespace, quote style, trailing commas, import reordering, line breaks) with no
-     functional change. Flag each as Recommended: 'Formatting-only hunk at {file}:{line}
-     — revert to keep diff minimal.' Do not flag formatting that is part of the functional
-     fix (e.g., a new import that triggers automatic reordering).
-   - Documentation accuracy: If docs/README/JSDoc are changed, cross-reference factual claims
-     against the actual code. Check that option descriptions match defaults (don't say
-     "Enable X" for a feature that's on by default). If code behavior changed but docs
-     were NOT changed, flag any docs/JSDoc/comments on the changed functions that describe
-     the old behavior.
-
-   Diff:
-   {git diff output}")
-
-Task(pr-review-toolkit:silent-failure-hunter,
-  "Review the following code changes for silent failures, inadequate error handling,
-   and inappropriate fallback behavior.
-   Working directory: {local repo path}
-   Changed files: {changed files list}
-
-   Diff:
-   {git diff output}")
-
-Task(pr-review-toolkit:code-simplifier,
-  "Review the following code changes for dead code, unnecessary complexity, and
-   simplification opportunities. Do NOT modify files — report findings only.
-   Do NOT suggest cosmetic changes (import reordering, quote style, trailing commas,
-   whitespace) as improvements — those expand the diff without functional benefit.
-   Working directory: {local repo path}
-   Changed files: {changed files list}
-
-   Diff:
-   {git diff output}")
-
-Task(pr-review-toolkit:pr-test-analyzer,
-  "Analyze test coverage and assertion quality for the following code changes.
-   Working directory: {local repo path}
-   Test directory: {test dir path}
-   Changed files: {changed files list}
-
-   Coverage: Check if modified code paths have tests, identify gaps.
-
-   Assertion strength: For each new or modified test, ask 'If I broke the feature under
-   test, would this test actually catch it?' Flag:
-   - Assertions too broad (only checking final output, not intermediate states)
-   - Test names claiming comprehensive coverage but only checking a subset
-   - Tests that would still pass if the feature regressed (e.g., only .toBeDefined()
-     when a specific value is expected)
-   - Override/disable tests that don't prove the override is working, just that code runs
-
-   Diff:
-   {git diff output}")
-
-Task(pr-review-toolkit:comment-analyzer,
-  "Review comments in the following code changes for accuracy, completeness,
-   and long-term maintainability.
-   Working directory: {local repo path}
-   Changed files: {changed files list}
-
-   Diff:
-   {git diff output}")
-```
-
-**Conditional agents (dispatch in the SAME message if applicable):**
-
-- **`pr-review-toolkit:type-design-analyzer`** — dispatch only if changed files include TypeScript (`.ts`, `.tsx`) or other typed languages
-  ```
-  Task(pr-review-toolkit:type-design-analyzer,
-    "Review type design in the following TypeScript changes. Check for proper
-     encapsulation, invariant expression, and type safety.
-     Working directory: {local repo path}
-     Changed files: {changed .ts/.tsx files}
-
-     Diff:
-     {git diff output for .ts/.tsx files}")
-  ```
-
-**Fallback:** If the PR review toolkit agents are unavailable (Task tool returns an error for those agent types), inform the user and dispatch the local `pre-commit-reviewer` agent instead:
-
-> "PR review toolkit agents are not available. Falling back to the built-in pre-commit reviewer. This provides a general code review but does not include specialized checks for silent failures, type design, or test coverage."
-
-```
-Task(pre-commit-reviewer,
-  "Review my pending code changes before committing.
-   Repository: {repo name}
-   Working directory: {path}")
-```
-
-**Partial failure:** If some toolkit agents succeed and others fail, consolidate the successful results and note which reviews were skipped:
-> "Note: The following specialized reviews could not be completed: {list}."
+The template handles the full dispatch + convergence flow. Return here when the loop exits (either converged or max passes reached) with a consolidated report, then proceed to sub-step 4b (scope discipline check when responding to maintainer feedback) and sub-step 6 (user decision point).
 
 ### 4. Consolidate Findings
 
-After all agents complete, merge their outputs into a unified report. Deduplicate findings that multiple agents flagged.
-
-**Track which agents found issues:** For each agent that reported Critical or Recommended findings, add its name to `agentsWithFindings`. This list is used in the convergence loop (sub-step 5) to enable targeted re-dispatch on subsequent passes.
-
-**If any agent did not complete or returned an error**, note it in the report:
-> "Warning: {agent-name} did not complete. Its findings are not included."
-
-```
-## Pre-Commit Review Summary
-
-### Critical ({count}) — Must fix before pushing
-- **{file}:{line}** — {description} (found by: {agent})
-  Suggestion: {fix}
-
-### Recommended ({count}) — Should fix
-- **{file}:{line}** — {description} (found by: {agent})
-  Suggestion: {fix}
-
-### Minor ({count}) — Nice to have
-- **{file}:{line}** — {description}
-
-### Test Coverage & Quality
-- {assessment from pr-test-analyzer, including assertion strength concerns}
-
-### Documentation Accuracy
-- {any doc/README claims that don't match the code, or stale docs not updated after code changes}
-
-### Convention Alignment
-- {any style/convention/naming mismatches}
-```
-
-If NO issues found across all agents:
-```
-## Pre-Commit Review Summary
-
-All agents passed. No issues found — changes are clean and ready to commit.
-```
+Consolidation format is covered in `dispatch-review.md`. A generic pre-commit review does NOT split findings into in-scope vs out-of-scope (there is no issue context to scope against) — all findings are treated as actionable. The maintainer-feedback-response flow adds a scope-discipline check in sub-step 4b below.
 
 ### 4b. Scope Discipline Check
 


### PR DESCRIPTION
## Summary

Step 3 of \`draft-first-workflow.md\` and sub-step 3 of \`pre-commit-review.md\` duplicated ~260 lines of review-agent dispatch prose — SCOPE block, 5 base agents + conditional \`type-design-analyzer\` / \`comment-analyzer\`, \`pre-commit-reviewer\` fallback, and convergence loop. Any policy change required parallel edits; no test caught drift.

- New \`workflows/dispatch-review.md\` — canonical template (agent roster, SCOPE block guidance, convergence loop, fallback, report format).
- \`draft-first-workflow.md\` Step 3 → short header + reference, with the draft-first-specific SCOPE block and in-scope-vs-out-of-scope split called out.
- \`pre-commit-review.md\` sub-step 3 → similar reference, with a note that the generic flow omits the SCOPE block (sub-step 4b handles scope-discipline for maintainer-feedback responses).

### Sizes

| File | Before | After |
|---|---:|---:|
| \`draft-first-workflow.md\` | 795 | 663 |
| \`pre-commit-review.md\` | 533 | 385 |
| \`dispatch-review.md\` | 0 | 245 (new) |

Combined calling workflows: **1328 → 1048 lines (−280)**, exceeds the ≥200 target. No behavior changes — same agents, same conditions, same convergence semantics.

Closes #1047.

## Test plan

- [x] \`workflows/dispatch-review.md\` exists with the shared template.
- [x] No inline agent-prompt prose remains in the calling workflows.
- [x] All external references to Step 3 in draft-first-workflow.md and sub-step 3 in pre-commit-review.md still resolve (step numbers unchanged; references grep'd via \`grep -rn\` in \`commands/\`, \`agents/\`, \`workflows/\`).