### PR TITLE
docs(workflows): sync reference.md with cli-registry, add drift test (#1048)

### DIFF
--- a/packages/core/src/cli-registry.docs.test.ts
+++ b/packages/core/src/cli-registry.docs.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Drift-detection test: every command registered in `cli-registry.ts` must be
+ * documented in `workflows/reference.md`.
+ *
+ * Prevents the recurrence of #1048, where actively-used commands like
+ * `skip-add`, `pr-template`, `state`, and `vet-list` silently disappeared from
+ * the supposedly-authoritative reference file.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { commands } from './cli-registry.js';
+
+describe('cli-registry ↔ workflows/reference.md parity (#1048)', () => {
+  const referencePath = path.resolve(__dirname, '../../../workflows/reference.md');
+
+  it('workflows/reference.md exists', () => {
+    expect(fs.existsSync(referencePath)).toBe(true);
+  });
+
+  it('every registered CLI command appears in workflows/reference.md', () => {
+    const doc = fs.readFileSync(referencePath, 'utf-8');
+    const missing: string[] = [];
+    for (const cmd of commands) {
+      // Use word-boundaries so `state` does not match `statement` or `state-sync`,
+      // and `setup` does not match `setupComplete`. Hyphens break \b, so build a
+      // pattern that tolerates both hyphen and non-hyphen boundaries.
+      const pattern = new RegExp(
+        `(^|[^A-Za-z0-9-])${cmd.name.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')}([^A-Za-z0-9-]|$)`,
+      );
+      if (!pattern.test(doc)) {
+        missing.push(cmd.name);
+      }
+    }
+    expect(missing, `Add these commands to workflows/reference.md: ${missing.join(', ')}`).toEqual([]);
+  });
+});

--- a/workflows/reference.md
+++ b/workflows/reference.md
@@ -32,11 +32,17 @@ Local-only commands (no GitHub token needed): `status`, `setup`, `checkSetup`, `
 # Deep-vet a specific issue
 <prefix> vet <issue-url> --json
 
+# Re-vet every available issue in the curated list (use --prune to drop unavailable items)
+<prefix> vet-list --json [--prune]
+
 # Claim an issue with optional message
 <prefix> claim <issue-url> [message...] --json
 
 # Parse an issue list from a file
 <prefix> parse-issue-list <path> --json
+
+# Append an issue URL to the skipped-issues file (auto-culled after 90 days)
+<prefix> skip-add <issue-url> --json [--path <file>]
 ```
 
 ### PR Management
@@ -67,6 +73,13 @@ Local-only commands (no GitHub token needed): `status`, `setup`, `checkSetup`, `
 # Dismiss/undismiss an issue
 <prefix> dismiss <issue-url> --json
 <prefix> undismiss <issue-url> --json
+
+# Override a PR's computed status until cleared
+<prefix> override <pr-url> <attention|waiting> --json
+<prefix> clear-override <pr-url> --json
+
+# Fetch the target repo's PR description template (used by the draft-first workflow)
+<prefix> pr-template <pr-url> --json
 ```
 
 ### Dashboard
@@ -93,6 +106,11 @@ Local-only commands (no GitHub token needed): `status`, `setup`, `checkSetup`, `
 
 # Quick init with username (local-only)
 <prefix> init <username> --json
+
+# State persistence management (local-only)
+<prefix> state --show --json          # Display current persistence mode and Gist ID
+<prefix> state --sync --json          # Force push state to Gist (no-op if local mode)
+<prefix> state --unlink --json        # Switch from Gist back to local persistence
 ```
 
 The canonical list of config keys lives in
@@ -111,7 +129,29 @@ rejected with a did-you-mean suggestion.
 
 # Audit new files on this branch for cross-references (old name: check-integration)
 <prefix> orphan-files --json [--base <branch>]
+
+# Detect formatters/linters configured in a repository
+<prefix> detect-formatters [<repo-path>] --json
+
+# Contribution statistics (merged/closed counts, merge rate)
+<prefix> stats --json
 ```
+
+### Common Flags
+
+| Flag | Commands | Purpose |
+|---|---|---|
+| `--json` | all | Emit a structured `{success, data?, error?, timestamp}` envelope. Preferred for agent / programmatic consumption. |
+| `--compact` | `daily` | Reduce payload size by omitting `summary`, `repoGroups`, and full `failures` details. Retains `failureCount` + `warnings`. |
+| `--port <n>` | `dashboard serve` | TCP port for the interactive SPA (default 3000). |
+| `--open` | `dashboard serve` | Auto-open the dashboard in the default browser after starting. |
+| `--show-bots` | `comments` | Include bot authors in the comment listing (default filters them out). |
+| `--base <branch>` | `orphan-files` | Base branch to diff against for new-file detection (default `main`). |
+| `--reset` | `setup` | Re-run the setup wizard even if already complete. |
+| `--set key=value` | `setup` | Apply settings non-interactively. Repeatable. Unknown keys are rejected with a did-you-mean suggestion. |
+| `--list-keys` | `config` | Dump every known config key with descriptions (alternative to `--json`). |
+| `--prune` | `vet-list` | Remove unavailable items from the curated list file after re-vetting. |
+| `--path <file>` | `skip-add` | Override the configured `skippedIssuesPath` for a single invocation. |
 
 ---
 


### PR DESCRIPTION
## Summary

\`workflows/reference.md\` was supposed to be the authoritative list of CLI commands, but **eight registered commands were missing** — including \`skip-add\` and \`pr-template\`, both actively invoked by other workflow files. A reader consulting the reference for a command they see used elsewhere would not find it.

### Commands added
- \`skip-add\` — used by work-through-issues.md
- \`pr-template\` — used by draft-first-workflow.md Step 8
- \`state\` (show / sync / unlink) — cross-machine state persistence
- \`vet-list\` [--prune] — re-vet the curated issue list
- \`override\` / \`clear-override\` — manual PR status override
- \`detect-formatters\`
- \`stats\`

Also added a **Common Flags** table (\`--json\`, \`--compact\`, \`--port\`, \`--open\`, \`--show-bots\`, \`--base\`, \`--reset\`, \`--set\`, \`--list-keys\`, \`--prune\`, \`--path\`).

### Drift-detection guard
New \`packages/core/src/cli-registry.docs.test.ts\` reads every registered command name and asserts it appears in \`workflows/reference.md\`. Future additions that forget the reference update will fail CI — prevents recurrence of #1048.

Closes #1048.

## Test plan

- [x] Drift test passes: \`npx vitest run src/cli-registry.docs.test.ts\`
- [x] Full suite still passes (2030 tests, +2 new)
- [x] Dry-run grep confirms all 33 registered commands now appear in reference.md
- [x] Word-boundary regex avoids false positives (\`state\` doesn't match \`statement\`, \`setup\` doesn't match \`setupComplete\`)