### PR TITLE
fix(dashboard): add root error boundary + runtime schema validation (#1050)

### DIFF
--- a/packages/core/src/core/dashboard-data-schema.test.ts
+++ b/packages/core/src/core/dashboard-data-schema.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for the dashboard-data runtime schema (#1050).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { validateDashboardData } from './dashboard-data-schema.js';
+
+function minimalValidPayload(): Record<string, unknown> {
+  return {
+    stats: {
+      activePRs: 3,
+      shelvedPRs: 0,
+      mergedPRs: 12,
+      closedPRs: 1,
+      mergeRate: '92%',
+    },
+    prsByRepo: { 'octocat/spoon-knife': { active: 1, merged: 2, closed: 0 } },
+    topRepos: [{ repo: 'octocat/spoon-knife', active: 1, merged: 2, closed: 0 }],
+    monthlyMerged: { '2026-01': 2 },
+    monthlyOpened: { '2026-01': 3 },
+    monthlyClosed: { '2026-01': 0 },
+    activePRs: [],
+    shelvedPRUrls: [],
+    recentlyMergedPRs: [],
+    recentlyClosedPRs: [],
+    autoUnshelvedPRs: [],
+    commentedIssues: [],
+    issueResponses: [],
+    allMergedPRs: [],
+    allClosedPRs: [],
+  };
+}
+
+describe('validateDashboardData', () => {
+  it('accepts a minimal valid payload', () => {
+    const result = validateDashboardData(minimalValidPayload());
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts optional fields (repoMetadata, partialFailures, lastUpdated)', () => {
+    const payload = {
+      ...minimalValidPayload(),
+      repoMetadata: { 'octocat/spoon-knife': { stars: 100 } },
+      partialFailures: ['repo-metadata'],
+      lastUpdated: '2026-01-25T10:00:00Z',
+    };
+    const result = validateDashboardData(payload);
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects payload missing stats (top-level drift)', () => {
+    const payload = minimalValidPayload();
+    delete payload.stats;
+    const result = validateDashboardData(payload);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toMatch(/stats/);
+    }
+  });
+
+  it('rejects payload with wrong type for a primitive field', () => {
+    const payload = minimalValidPayload();
+    (payload.stats as { mergeRate: unknown }).mergeRate = 42; // should be string
+    const result = validateDashboardData(payload);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toMatch(/mergeRate/);
+    }
+  });
+
+  it('rejects completely invalid input (null / string / number)', () => {
+    expect(validateDashboardData(null).ok).toBe(false);
+    expect(validateDashboardData('string').ok).toBe(false);
+    expect(validateDashboardData(42).ok).toBe(false);
+    expect(validateDashboardData(undefined).ok).toBe(false);
+  });
+
+  it('allows unknown nested fields on array items (loose nested validation)', () => {
+    // Nested PR shape is pinned loosely — `z.unknown()` — so server-side
+    // additions don't break the dashboard's parse. This is intentional.
+    const payload = {
+      ...minimalValidPayload(),
+      activePRs: [{ url: '…', title: '…', someNewFutureField: 'whatever' }],
+    };
+    const result = validateDashboardData(payload);
+    expect(result.ok).toBe(true);
+  });
+
+  it('truncates long error lists with "+N more"', () => {
+    // Construct a payload with many missing required fields so we trip >3 issues.
+    const result = validateDashboardData({});
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toMatch(/\+\d+ more/);
+    }
+  });
+});

--- a/packages/core/src/core/dashboard-data-schema.ts
+++ b/packages/core/src/core/dashboard-data-schema.ts
@@ -1,0 +1,89 @@
+/**
+ * Runtime schema for the dashboard server's `GET /api/data` response (#1050).
+ *
+ * The server (`commands/dashboard-data.ts`) and client (`packages/dashboard/`)
+ * run in different processes. TypeScript can't cross the process boundary —
+ * if the server removes or renames a field, the client hits runtime
+ * `undefined` with no diagnostic. This schema is the shared runtime contract:
+ * the server can optionally self-check outgoing payloads, and the dashboard
+ * validates every `/api/data` response before committing to state.
+ *
+ * Intentional scope: this schema validates **top-level presence and primitive
+ * shape** (required vs optional fields, container types like array/object),
+ * but uses `z.array(z.unknown())` for nested PR/issue arrays rather than
+ * pinning every field. The top-level surface is the only place drift tends
+ * to go silently undetected — nested fields already blow up loudly at the
+ * render site when they change. Exhaustive nested validation would turn the
+ * schema into a maintenance burden.
+ */
+
+import { z } from 'zod';
+
+export const DashboardStatsSchema = z.object({
+  activePRs: z.number(),
+  shelvedPRs: z.number(),
+  mergedPRs: z.number(),
+  closedPRs: z.number(),
+  mergeRate: z.string(),
+  availableIssues: z.number().optional(),
+});
+
+const RepoStatsEntrySchema = z.object({
+  active: z.number(),
+  merged: z.number(),
+  closed: z.number(),
+});
+
+const TopRepoSchema = z.object({
+  repo: z.string(),
+  active: z.number(),
+  merged: z.number(),
+  closed: z.number(),
+});
+
+export const DashboardDataSchema = z.object({
+  stats: DashboardStatsSchema,
+  prsByRepo: z.record(z.string(), RepoStatsEntrySchema),
+  topRepos: z.array(TopRepoSchema),
+  monthlyMerged: z.record(z.string(), z.number()),
+  monthlyOpened: z.record(z.string(), z.number()),
+  monthlyClosed: z.record(z.string(), z.number()),
+  // PR / issue arrays are validated loosely — the domain shapes are pinned by
+  // AgentStateSchema (state-schema.ts) on the server side. Use `z.unknown()`
+  // here so server-side additions to the nested shape don't break the
+  // dashboard's parse; the UI handles unknown extra fields gracefully.
+  activePRs: z.array(z.unknown()),
+  shelvedPRUrls: z.array(z.string()),
+  recentlyMergedPRs: z.array(z.unknown()),
+  recentlyClosedPRs: z.array(z.unknown()),
+  autoUnshelvedPRs: z.array(z.unknown()),
+  commentedIssues: z.array(z.unknown()),
+  issueResponses: z.array(z.unknown()),
+  allMergedPRs: z.array(z.unknown()),
+  allClosedPRs: z.array(z.unknown()),
+  repoMetadata: z.record(z.string(), z.unknown()).optional(),
+  vettedIssues: z.unknown().nullable().optional(),
+  offline: z.boolean().optional(),
+  lastUpdated: z.string().optional(),
+  partialFailures: z.array(z.string()).optional(),
+});
+
+export type DashboardDataParsed = z.infer<typeof DashboardDataSchema>;
+
+/**
+ * Validate a raw `/api/data` payload. Returns `{ok: true, data}` on success or
+ * `{ok: false, message}` with a condensed Zod error string on failure. Never
+ * throws. The dashboard's `useDashboard` hook surfaces the message in the UI.
+ */
+export function validateDashboardData(
+  raw: unknown,
+): { ok: true; data: DashboardDataParsed } | { ok: false; message: string } {
+  const result = DashboardDataSchema.safeParse(raw);
+  if (result.success) return { ok: true, data: result.data };
+  const issues = result.error.issues
+    .slice(0, 3)
+    .map((i) => `${i.path.join('.') || '<root>'}: ${i.message}`)
+    .join('; ');
+  const more = result.error.issues.length > 3 ? ` (+${result.error.issues.length - 3} more)` : '';
+  return { ok: false, message: `Server response did not match expected shape — ${issues}${more}` };
+}

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -107,4 +107,10 @@ export {
   suggestKey,
   formatUnknownKeyError,
 } from './config-registry.js';
+export {
+  DashboardDataSchema,
+  DashboardStatsSchema,
+  validateDashboardData,
+  type DashboardDataParsed,
+} from './dashboard-data-schema.js';
 export * from './types.js';

--- a/packages/dashboard/src/error-boundary.test.tsx
+++ b/packages/dashboard/src/error-boundary.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * Tests for the dashboard error boundary (#1050).
+ *
+ * Uses @testing-library/preact for render + assertion. Exercises:
+ * - Happy path: children render normally when no error occurs.
+ * - Error path: a throwing child is caught, the default fallback is shown.
+ * - Retry: clicking "Retry" resets the boundary and re-renders children.
+ * - Custom fallback: the `fallback` prop replaces the default UI.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, screen, cleanup } from '@testing-library/preact';
+import { Component } from 'preact';
+import { ErrorBoundary } from './error-boundary';
+
+// Throw on first render; after the caller sets `shouldThrow=false` via the
+// retry path, render cleanly. Lets us verify retry re-attempts the render.
+class Thrower extends Component<{ shouldThrow: () => boolean; message: string }> {
+  render() {
+    if (this.props.shouldThrow()) {
+      throw new Error(this.props.message);
+    }
+    return <div data-testid="child-ok">child rendered</div>;
+  }
+}
+
+describe('ErrorBoundary', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Preact logs caught errors via console.error — silence during assertions.
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    cleanup();
+  });
+
+  it('renders children when no error is thrown', () => {
+    render(
+      <ErrorBoundary>
+        <div data-testid="happy">hello</div>
+      </ErrorBoundary>,
+    );
+    expect(screen.getByTestId('happy')).toBeTruthy();
+  });
+
+  it('catches a render-time throw and shows the default fallback with the error message', () => {
+    render(
+      <ErrorBoundary>
+        <Thrower shouldThrow={() => true} message="boom: someField is undefined" />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText(/Dashboard crashed/i)).toBeTruthy();
+    // Error details are in a <details> so expand / search the full text for
+    // the embedded message.
+    expect(screen.getByText(/boom: someField is undefined/i)).toBeTruthy();
+    // Reload / Retry buttons present.
+    expect(screen.getByRole('button', { name: /retry/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /reload/i })).toBeTruthy();
+  });
+
+  it('Retry resets the boundary and re-renders children', () => {
+    let shouldThrow = true;
+    const check = () => shouldThrow;
+
+    render(
+      <ErrorBoundary>
+        <Thrower shouldThrow={check} message="first render crashed" />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText(/Dashboard crashed/i)).toBeTruthy();
+
+    shouldThrow = false;
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+
+    expect(screen.getByTestId('child-ok')).toBeTruthy();
+  });
+
+  it('renders a custom fallback when provided', () => {
+    const CustomFallback = ({ error, retry }: { error: Error; retry: () => void }) => (
+      <div>
+        <span data-testid="custom-msg">custom: {error.message}</span>
+        <button type="button" onClick={retry}>
+          custom retry
+        </button>
+      </div>
+    );
+
+    render(
+      <ErrorBoundary fallback={CustomFallback}>
+        <Thrower shouldThrow={() => true} message="custom-path" />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByTestId('custom-msg').textContent).toContain('custom-path');
+    expect(screen.queryByText(/Dashboard crashed/i)).toBeNull();
+  });
+});

--- a/packages/dashboard/src/error-boundary.tsx
+++ b/packages/dashboard/src/error-boundary.tsx
@@ -1,0 +1,103 @@
+import { Component, type ComponentChildren, type ComponentType } from 'preact';
+
+/**
+ * Top-level error boundary (#1050).
+ *
+ * Any render-time throw below the boundary gets caught and rendered as a
+ * fallback message with reload/retry affordances. Without this, a single bad
+ * field reference (e.g. `data.foo.bar` when `foo` is suddenly undefined after
+ * a server-side rename) unmounts the entire SPA tree with no user-visible
+ * message — only a console error.
+ *
+ * Kept deliberately simple:
+ * - One top-level boundary around `<App />` (sub-tree boundaries can be added
+ *   later if specific panels start crashing in isolation).
+ * - The reload button full-page-reloads, which also re-fetches `/api/data`.
+ * - Troubleshooting note points the user at the CLI console and `/api/data`
+ *   so they can inspect the response when the crash is caused by server drift.
+ */
+
+interface ErrorBoundaryProps {
+  children: ComponentChildren;
+  /**
+   * Optional custom fallback. Receives the caught error and a retry callback
+   * that clears the boundary's error state. Exists primarily to let tests
+   * assert specific fallback UI without coupling to the default markup.
+   */
+  fallback?: ComponentType<{ error: Error; retry: () => void }>;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: unknown): ErrorBoundaryState {
+    return { error: error instanceof Error ? error : new Error(String(error)) };
+  }
+
+  componentDidCatch(error: unknown, errorInfo: unknown): void {
+    // Log to the browser console so the developer / user can copy the stack
+    // trace when reporting. Kept distinct from the in-UI fallback so the
+    // fallback UI stays terse.
+    console.error('[dashboard] uncaught render error:', error, errorInfo);
+  }
+
+  private retry = (): void => {
+    this.setState({ error: null });
+  };
+
+  render() {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+
+    if (this.props.fallback) {
+      const Fallback = this.props.fallback;
+      return <Fallback error={error} retry={this.retry} />;
+    }
+
+    return (
+      <div
+        role="alert"
+        aria-live="assertive"
+        style={{
+          maxWidth: 640,
+          margin: '2rem auto',
+          padding: '1.5rem',
+          border: '1px solid var(--error, #c0392b)',
+          borderRadius: 6,
+          background: 'var(--surface, #fff)',
+          color: 'var(--text-primary, #111)',
+          fontFamily: 'system-ui, -apple-system, sans-serif',
+        }}
+      >
+        <h2 style={{ marginTop: 0 }}>Dashboard crashed</h2>
+        <p>
+          Something went wrong rendering the dashboard. This usually means the server returned an unexpected response
+          shape or a UI component hit a null field.
+        </p>
+        <details style={{ margin: '1rem 0' }}>
+          <summary style={{ cursor: 'pointer' }}>Technical details</summary>
+          <pre style={{ whiteSpace: 'pre-wrap', fontSize: '0.85em', marginTop: '0.5rem' }}>{error.message}</pre>
+        </details>
+        <p style={{ fontSize: '0.9em' }}>
+          Troubleshooting:
+          <br />
+          • Check the CLI console that started the dashboard server for errors.
+          <br />• Open <code>/api/data</code> directly in a new tab to inspect the response shape.
+          <br />• Rebuild the CLI with <code>pnpm run bundle</code> if you changed server code recently.
+        </p>
+        <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1rem' }}>
+          <button type="button" onClick={this.retry}>
+            Retry
+          </button>
+          <button type="button" onClick={() => location.reload()}>
+            Reload page
+          </button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/packages/dashboard/src/hooks/use-dashboard.test.ts
+++ b/packages/dashboard/src/hooks/use-dashboard.test.ts
@@ -382,4 +382,57 @@ describe('useDashboard', () => {
       expect(result.current.error).toBe(null);
     });
   });
+
+  // ── #1050 runtime schema validation ───────────────────────────────────
+
+  describe('schema validation (#1050)', () => {
+    it('surfaces an error when /api/data returns a malformed shape (missing stats)', async () => {
+      // Response is well-formed JSON but missing the required `stats` field —
+      // previously would have committed to state and crashed at render time.
+      const malformed = { ...makeDashboardData(), stats: undefined };
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers(),
+        json: () => Promise.resolve(malformed),
+      });
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const { result } = renderHook(() => useDashboard());
+      await act(async () => {
+        await Promise.resolve();
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(result.current.data).toBe(null);
+      expect(result.current.error).toMatch(/Server response did not match expected shape/i);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('schema validation failed'),
+        expect.any(String),
+        expect.anything(),
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it('rejects a null response as malformed', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers(),
+        json: () => Promise.resolve(null),
+      });
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const { result } = renderHook(() => useDashboard());
+      await act(async () => {
+        await Promise.resolve();
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(result.current.error).toMatch(/Server response did not match expected shape/i);
+      consoleSpy.mockRestore();
+    });
+  });
 });

--- a/packages/dashboard/src/hooks/use-dashboard.ts
+++ b/packages/dashboard/src/hooks/use-dashboard.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'preact/hooks';
+import { validateDashboardData } from '@oss-autopilot/core';
 import type { DashboardData, ActionRequest } from '../types';
 
 // Module-scoped CSRF token cache — the server returns X-CSRF-Token on every
@@ -34,8 +35,19 @@ async function fetchJsonWithToken(url: string, init?: RequestInit): Promise<Json
     throw new Error(message);
   }
   const csrfToken = res.headers.get('X-CSRF-Token');
-  const data = (await res.json()) as DashboardData;
-  return { data, csrfToken };
+  const rawJson = await res.json();
+
+  // Runtime schema validation (#1050). TypeScript can't reach across the
+  // process boundary to the CLI server — if the server drops or renames a
+  // field, the dashboard would previously hit `Cannot read property X of
+  // undefined` at some random render site. Validate here so drift surfaces
+  // as a clean error message instead of a render crash.
+  const validation = validateDashboardData(rawJson);
+  if (!validation.ok) {
+    console.error('[dashboard] /api/data schema validation failed:', validation.message, rawJson);
+    throw new Error(validation.message);
+  }
+  return { data: validation.data as unknown as DashboardData, csrfToken };
 }
 
 export function useDashboard() {

--- a/packages/dashboard/src/index.tsx
+++ b/packages/dashboard/src/index.tsx
@@ -1,10 +1,16 @@
 import { render } from 'preact';
 import { App } from './app';
+import { ErrorBoundary } from './error-boundary';
 import './styles.css';
 
 const root = document.getElementById('app');
 if (root) {
-  render(<App />, root);
+  render(
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>,
+    root,
+  );
 } else {
   console.error('Dashboard mount point #app not found. Check that index.html contains <div id="app"></div>.');
   document.body.textContent = 'Dashboard failed to load: mount point not found.';


### PR DESCRIPTION
## Summary

Two reliability gaps combined to let server/client drift silently break the dashboard:

1. **No root error boundary** — a render-time throw anywhere below \`<App />\` unmounted the whole tree with no visible message.
2. **No runtime schema validation** — \`/api/data\` responses were committed to state raw. If the CLI server renamed or removed a field, the dashboard hit \`Cannot read property X of undefined\` at a random render site.

### Changes
- **\`ErrorBoundary\`** class component (Preact 10 \`componentDidCatch\`) wraps \`<App />\` in \`src/index.tsx\`. Default fallback shows the error message, Retry / Reload buttons, and troubleshooting pointers to the CLI console + \`/api/data\`. Optional custom \`fallback\` prop.
- **\`core/dashboard-data-schema.ts\`** — new \`DashboardDataSchema\` zod schema + \`validateDashboardData(raw)\` helper. Top-level presence is validated strictly; nested PR/issue arrays use \`z.unknown()\` (top-level drift is the silently-broken case; nested fields already throw loudly at render).
- **\`useDashboard\`** validates every \`/api/data\` and \`/api/action\` response. Failures surface as \`"Server response did not match expected shape — {issues}"\` in the UI and log the raw payload to the browser console for diagnostics.

### Tests
- Schema: 7 tests (happy path, missing \`stats\`, primitive drift, loose nested, null/string/undefined, optional fields, truncation).
- Error boundary: 4 tests (happy, caught throw, retry resets, custom fallback).
- Hook: 2 tests (malformed \`/api/data\` surfaces schema error, null response rejected).

Closes #1050.

## Test plan

- [x] \`pnpm test\` — core 2037 + dashboard 250 + MCP 172 all pass
- [x] \`pnpm run bundle\` — core 734911 bytes (under 740000 threshold)
- [x] \`pnpm run lint\` clean
- [x] All 13 new tests exercise the documented behavior