### PR TITLE
fix(dashboard): 404 + focus + skip-link on every route (#1052)

### DIFF
--- a/packages/dashboard/src/app.test.tsx
+++ b/packages/dashboard/src/app.test.tsx
@@ -574,5 +574,73 @@ describe('App', () => {
         expect(container.textContent).toContain('Closed X');
       });
     });
+
+    // ── #1052 routing hardening ──────────────────────────────────────
+
+    it('renders a 404 view for unknown paths instead of silently falling through to home', async () => {
+      const data = makeDashboardData();
+      mockFetchOk(data);
+
+      // Start at an unregistered path before mounting.
+      window.history.replaceState(null, '', '/foo');
+
+      const { container } = render(<App />);
+      await waitFor(() => expect(container.querySelector('.dashboard')).toBeTruthy());
+
+      expect(container.textContent).toContain('Page not found');
+      expect(container.textContent).toContain('/foo');
+      // Home-only UI (StatsBar action pills) should NOT be rendered on 404.
+      expect(Array.from(container.querySelectorAll('button')).some((b) => b.textContent?.includes('Merged PRs'))).toBe(
+        false,
+      );
+    });
+
+    it('exposes #main-content on every route so the skip link always resolves', async () => {
+      const data = makeDashboardData({ allMergedPRs: [] });
+      mockFetchOk(data);
+
+      for (const path of ['/', '/merged', '/closed', '/issues', '/unknown']) {
+        window.history.replaceState(null, '', path);
+        const { container, unmount } = render(<App />);
+        await waitFor(() => expect(container.querySelector('.dashboard')).toBeTruthy());
+        expect(container.querySelector('#main-content'), `route ${path} should have #main-content`).toBeTruthy();
+        unmount();
+      }
+    });
+
+    it('moves keyboard focus to the route heading when the path changes', async () => {
+      const data = makeDashboardData({
+        stats: { activePRs: 0, shelvedPRs: 0, mergedPRs: 1, closedPRs: 0, mergeRate: '100%' },
+        allMergedPRs: [
+          {
+            url: 'https://github.com/o/r/pull/1',
+            repo: 'o/r',
+            number: 1,
+            title: 'Merged A',
+            mergedAt: '2026-01-01T00:00:00Z',
+          },
+        ],
+      });
+      mockFetchOk(data);
+
+      const { container } = render(<App />);
+      await waitFor(() => expect(container.querySelector('.dashboard')).toBeTruthy());
+
+      const mergedButton = Array.from(container.querySelectorAll('button')).find((b) =>
+        b.textContent?.includes('Merged PRs'),
+      );
+      fireEvent.click(mergedButton!);
+
+      // Wait for the /merged view to mount, then confirm the route-change
+      // effect moved focus to the route heading. jsdom preserves the
+      // programmatic focus call, so activeElement should be the h2.
+      await waitFor(() => {
+        const heading = container.querySelector('h2[tabindex="-1"]');
+        expect(heading?.textContent).toContain('Merged pull requests');
+      });
+      const activeH2 = document.activeElement as HTMLElement | null;
+      expect(activeH2?.tagName.toLowerCase()).toBe('h2');
+      expect(activeH2?.textContent).toContain('Merged pull requests');
+    });
   });
 });

--- a/packages/dashboard/src/app.tsx
+++ b/packages/dashboard/src/app.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'preact/hooks';
+import { useState, useMemo, useEffect, useRef } from 'preact/hooks';
 import { LocationProvider, useLocation } from 'preact-iso';
 import { useDashboard } from './hooks/use-dashboard';
 import { useTheme, type Theme } from './hooks/use-theme';
@@ -94,6 +94,10 @@ function DashboardHeader({
   );
 }
 
+// Explicit route table (#1052). Any path outside this set renders a 404 view
+// rather than silently falling through to the dashboard home.
+const KNOWN_ROUTES = new Set(['/', '/merged', '/closed', '/issues']);
+
 function AppContent() {
   const { data, loading, refreshing, error, clearError, refresh, performAction, lastUpdated } = useDashboard();
   const { theme, toggleTheme } = useTheme();
@@ -106,6 +110,15 @@ function AppContent() {
   const [selectedUrl, setSelectedUrl] = useState<string | null>(null);
   const [shelvedOpen, setShelvedOpen] = useState(false);
   const { path, route } = useLocation();
+  const routeHeadingRef = useRef<HTMLHeadingElement | null>(null);
+
+  // Route-change focus management (#1052). When the path changes, move
+  // keyboard focus to the active view's primary heading so screen readers
+  // announce the new view. Using tabIndex=-1 on the h2 lets programmatic
+  // focus succeed without placing the heading in the normal tab order.
+  useEffect(() => {
+    routeHeadingRef.current?.focus({ preventScroll: false });
+  }, [path]);
 
   const shelvedUrls = useMemo(() => new Set(data?.shelvedPRUrls ?? []), [data?.shelvedPRUrls]);
 
@@ -167,7 +180,12 @@ function AppContent() {
       <div class="dashboard">
         <DashboardHeader {...headerProps} />
         {partialBanner}
-        <MergedPRList mergedPRs={mergedPRs} repoMetadata={data.repoMetadata} onBack={() => route('/')} />
+        <main id="main-content" class="dashboard-main">
+          <h2 ref={routeHeadingRef} tabIndex={-1} class="visually-hidden">
+            Merged pull requests
+          </h2>
+          <MergedPRList mergedPRs={mergedPRs} repoMetadata={data.repoMetadata} onBack={() => route('/')} />
+        </main>
         <CelebrationToast celebration={celebration} onDismiss={dismissCelebration} />
       </div>
     );
@@ -180,7 +198,12 @@ function AppContent() {
       <div class="dashboard">
         <DashboardHeader {...headerProps} />
         {partialBanner}
-        <ClosedPRList closedPRs={closedPRs} onBack={() => route('/')} />
+        <main id="main-content" class="dashboard-main">
+          <h2 ref={routeHeadingRef} tabIndex={-1} class="visually-hidden">
+            Closed pull requests
+          </h2>
+          <ClosedPRList closedPRs={closedPRs} onBack={() => route('/')} />
+        </main>
         <CelebrationToast celebration={celebration} onDismiss={dismissCelebration} />
       </div>
     );
@@ -192,27 +215,64 @@ function AppContent() {
       <div class="dashboard">
         <DashboardHeader {...headerProps} />
         {partialBanner}
-        {data.vettedIssues ? (
-          <VettedIssueList
-            vettedIssues={data.vettedIssues}
-            repoMetadata={data.repoMetadata}
-            onBack={() => route('/')}
-          />
-        ) : (
+        <main id="main-content" class="dashboard-main">
+          <h2 ref={routeHeadingRef} tabIndex={-1} class="visually-hidden">
+            Vetted issues
+          </h2>
+          {data.vettedIssues ? (
+            <VettedIssueList
+              vettedIssues={data.vettedIssues}
+              repoMetadata={data.repoMetadata}
+              onBack={() => route('/')}
+            />
+          ) : (
+            <div class="merged-view merged-view--full-width">
+              <div class="merged-view-header">
+                <button class="merged-view-back" onClick={() => route('/')} type="button">
+                  &larr; Back
+                </button>
+                <div>
+                  <h2 class="merged-view-title">Vetted Issues</h2>
+                </div>
+              </div>
+              <div class="merged-view-empty">
+                No vetted issue list found. Configure one via /setup-oss or create a potential-issue-list.md file.
+              </div>
+            </div>
+          )}
+        </main>
+        <CelebrationToast celebration={celebration} onDismiss={dismissCelebration} />
+      </div>
+    );
+  }
+
+  // Route: 404 — unknown path (#1052). Explicit view instead of silently
+  // falling through to the dashboard home.
+  if (!KNOWN_ROUTES.has(path)) {
+    return (
+      <div class="dashboard">
+        <DashboardHeader {...headerProps} />
+        {partialBanner}
+        <main id="main-content" class="dashboard-main" role="alert">
           <div class="merged-view merged-view--full-width">
             <div class="merged-view-header">
               <button class="merged-view-back" onClick={() => route('/')} type="button">
-                &larr; Back
+                &larr; Back to dashboard
               </button>
               <div>
-                <h2 class="merged-view-title">Vetted Issues</h2>
+                <h2 ref={routeHeadingRef} tabIndex={-1} class="merged-view-title">
+                  Page not found
+                </h2>
               </div>
             </div>
             <div class="merged-view-empty">
-              No vetted issue list found. Configure one via /setup-oss or create a potential-issue-list.md file.
+              <p>
+                The path <code>{path}</code> doesn&apos;t match any known route. Try the dashboard home, or one of the
+                stat pills to navigate to merged / closed / issue views.
+              </p>
             </div>
           </div>
-        )}
+        </main>
         <CelebrationToast celebration={celebration} onDismiss={dismissCelebration} />
       </div>
     );
@@ -260,6 +320,9 @@ function AppContent() {
       {partialBanner}
 
       <main id="main-content" class="dashboard-main">
+        <h2 ref={routeHeadingRef} tabIndex={-1} class="visually-hidden">
+          Dashboard
+        </h2>
         <div class="animate-in delay-1">
           <StatsBar
             stats={data.stats}

--- a/packages/dashboard/src/styles.css
+++ b/packages/dashboard/src/styles.css
@@ -1944,3 +1944,19 @@ a:hover {
     transition-duration: 0.01ms !important;
   }
 }
+
+/* Screen-reader-only utility for route-change announcements (#1052).
+   Kept focusable (width/height 1px rather than display:none) so the
+   programmatic `element.focus()` call in App's route-change effect
+   moves focus to the heading for AT users. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}


### PR DESCRIPTION
## Summary

Three accessibility / correctness gaps around the dashboard's string-switch router:
1. **Unknown paths** (e.g., \`/foo\`) silently fell through to the dashboard home.
2. **Keyboard focus** stayed on the clicked stat pill after route change — screen readers never announced the new view.
3. **Skip link** (\`.skip-link → #main-content\`) only had a landing target on the home route; \`/merged\`, \`/closed\`, \`/issues\` rendered \`<main>\`-less markup, so the link jumped to nothing.

### Changes
- \`KNOWN_ROUTES\` set. Paths outside the set render a dedicated **404 view** with the offending path + a back-to-dashboard button, instead of falling through.
- \`useEffect\` on \`path\` calls \`focus()\` on the active view's primary heading (visually-hidden \`<h2 tabIndex={-1}>\` on every route, plus the existing home h2). Screen readers now announce the new view on transition.
- Every route's body lives inside \`<main id="main-content">\`, so the skip-link always resolves.
- New \`.visually-hidden\` utility in \`styles.css\` (clip-rect pattern so the heading stays focusable programmatically).

### Scope decision
I kept the string-switch pattern (gated by \`KNOWN_ROUTES\`) rather than doing a full \`preact-iso <Router>\` rewrite. The issue proposed the Router refactor, but acceptance criteria only require 404, focus, and skip-link target — all hit by the minimal-diff approach. The Router rewrite is separable and can follow in a dedicated PR.

Closes #1052.

## Test plan

- [x] \`pnpm test\` — core 2037 + dashboard 253 + MCP 172 all pass (+3 new dashboard tests)
- [x] New tests: (a) \`/foo\` renders 404, (b) \`#main-content\` exists on \`/\`, \`/merged\`, \`/closed\`, \`/issues\`, \`/unknown\`, (c) clicking Merged PRs stat pill moves focus to the \`<h2>Merged pull requests</h2>\` heading
- [x] \`pnpm run lint\` clean
- [x] Existing route-navigation tests still pass (no regression from the #main-content wrapper or the KNOWN_ROUTES check)