### PR TITLE
fix(mcp): destructive hints + URL validation + config-key enum (#1053)

### DIFF
--- a/packages/mcp-server/src/index-main.test.ts
+++ b/packages/mcp-server/src/index-main.test.ts
@@ -32,6 +32,8 @@ vi.mock('@oss-autopilot/core', () => ({
   }),
   getGitHubTokenAsync: vi.fn().mockResolvedValue(null),
   ensureGistPersistence: vi.fn().mockResolvedValue(undefined),
+  getSetupKeys: () => ['username', 'languages', 'minStars'],
+  getConfigKeys: () => ['username', 'add-label', 'remove-label'],
 }));
 
 // Mock StdioServerTransport — must use function() not arrow to support `new`

--- a/packages/mcp-server/src/prompts.test.ts
+++ b/packages/mcp-server/src/prompts.test.ts
@@ -70,6 +70,8 @@ vi.mock('@oss-autopilot/core', () => ({
   }),
   getGitHubTokenAsync: vi.fn().mockResolvedValue(null),
   ensureGistPersistence: vi.fn().mockResolvedValue(undefined),
+  getSetupKeys: () => ['username', 'languages', 'minStars'],
+  getConfigKeys: () => ['username', 'add-label', 'remove-label'],
 }));
 
 import { createServer } from './server.js';

--- a/packages/mcp-server/src/resources.test.ts
+++ b/packages/mcp-server/src/resources.test.ts
@@ -42,6 +42,8 @@ vi.mock('@oss-autopilot/core', () => ({
   },
   getGitHubTokenAsync: vi.fn().mockResolvedValue(null),
   ensureGistPersistence: vi.fn().mockResolvedValue(undefined),
+  getSetupKeys: () => ['username', 'languages', 'minStars'],
+  getConfigKeys: () => ['username', 'add-label', 'remove-label'],
   getStateManager: vi.fn().mockReturnValue({
     getState: vi.fn().mockReturnValue({
       lastDigest: {

--- a/packages/mcp-server/src/tools-execution.test.ts
+++ b/packages/mcp-server/src/tools-execution.test.ts
@@ -41,6 +41,10 @@ vi.mock('@oss-autopilot/core', () => ({
   }),
   getGitHubTokenAsync: vi.fn().mockResolvedValue(null),
   ensureGistPersistence: vi.fn().mockResolvedValue(undefined),
+  // Config-key registry access for the config tool's key enum (#1053).
+  // Return a small known-set so the MCP schema validates against real keys.
+  getSetupKeys: () => ['username', 'languages', 'minStars'],
+  getConfigKeys: () => ['username', 'add-label', 'remove-label'],
 }));
 
 import { createServer } from './server.js';

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -182,5 +182,75 @@ describe('MCP tool registrations', () => {
       expect(tool!.annotations).toBeDefined();
       expect((tool!.annotations as Record<string, unknown>).readOnlyHint).toBe(false);
     });
+
+    // #1053 — tools that post public content under the user's identity must
+    // carry destructiveHint: true so MCP clients flag them for confirmation,
+    // and the description must warn the LLM that the action is irreversible.
+    it.each(['post', 'claim'])('destructive tool "%s" has destructiveHint: true', (name) => {
+      const tool = tools.find((t) => t.name === name);
+      expect(tool).toBeDefined();
+      expect((tool!.annotations as Record<string, unknown>).destructiveHint).toBe(true);
+    });
+
+    it.each(['post', 'claim'])('destructive tool "%s" description warns about irreversibility', (name) => {
+      const tool = tools.find((t) => t.name === name);
+      expect(tool!.description).toMatch(/irreversible/i);
+    });
+  });
+
+  // ── #1053 input-schema validation at the tool boundary ────────────────
+
+  describe('URL input validation', () => {
+    it('rejects a non-GitHub URL on `post` at the schema layer', async () => {
+      // Zod validation failures surface as isError:true results via the MCP
+      // SDK's callTool path — not as thrown rejections.
+      const result = await client.callTool({
+        name: 'post',
+        arguments: { url: 'https://example.com/comment', message: 'hi' },
+      });
+      expect(result.isError).toBe(true);
+      const text = (result.content as Array<{ text: string }>)[0]?.text ?? '';
+      expect(text).toMatch(/github/i);
+    });
+
+    it('rejects a malformed PR URL on `track` at the schema layer', async () => {
+      const result = await client.callTool({
+        name: 'track',
+        arguments: { prUrl: 'not-a-url' },
+      });
+      expect(result.isError).toBe(true);
+    });
+
+    it('rejects an issue URL where the tool expects a PR URL', async () => {
+      // `shelve` requires a PR URL; passing an issue URL should fail schema
+      // validation before the tool handler runs.
+      const result = await client.callTool({
+        name: 'shelve',
+        arguments: { prUrl: 'https://github.com/owner/repo/issues/1' },
+      });
+      expect(result.isError).toBe(true);
+      const text = (result.content as Array<{ text: string }>)[0]?.text ?? '';
+      expect(text).toMatch(/pr/i);
+    });
+  });
+
+  describe('config key enum', () => {
+    it('rejects an unknown config key at the schema layer', async () => {
+      const result = await client.callTool({
+        name: 'config',
+        arguments: { key: 'totallyMadeUpKey', value: 'x' },
+      });
+      expect(result.isError).toBe(true);
+    });
+
+    it('accepts a known config key (via registry)', async () => {
+      // We don't actually care about the result — just that the schema
+      // doesn't reject. The mocked runConfig is fine with anything.
+      const result = await client.callTool({
+        name: 'config',
+        arguments: { key: 'username', value: 'example-user' },
+      });
+      expect(result.isError).not.toBe(true);
+    });
   });
 });

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -30,7 +30,40 @@ import {
   runMove,
   MAX_SEARCH_RESULTS,
 } from '@oss-autopilot/core/commands';
-import { errorMessage } from '@oss-autopilot/core';
+import { errorMessage, getSetupKeys, getConfigKeys } from '@oss-autopilot/core';
+
+// ── GitHub URL validation (#1053) ─────────────────────────────────────
+// Previously every `url` / `prUrl` / `issueUrl` was `z.string()` with no
+// validation — an LLM could pass nonsense and the error surfaced only at
+// `runPost` / `runClaim`. These schemas put the constraint at the MCP
+// boundary so invalid URLs fail with `InvalidParams` before any network or
+// state mutation runs.
+
+const GITHUB_ISSUE_URL_REGEX = /^https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/\d+$/;
+const GITHUB_PR_URL_REGEX = /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+$/;
+const GITHUB_ISSUE_OR_PR_URL_REGEX = /^https:\/\/github\.com\/[^/]+\/[^/]+\/(?:issues|pull)\/\d+$/;
+
+const githubIssueUrlSchema = z
+  .string()
+  .url()
+  .regex(GITHUB_ISSUE_URL_REGEX, 'Must be a GitHub issue URL like https://github.com/owner/repo/issues/123');
+const githubPrUrlSchema = z
+  .string()
+  .url()
+  .regex(GITHUB_PR_URL_REGEX, 'Must be a GitHub PR URL like https://github.com/owner/repo/pull/123');
+const githubIssueOrPrUrlSchema = z
+  .string()
+  .url()
+  .regex(
+    GITHUB_ISSUE_OR_PR_URL_REGEX,
+    'Must be a GitHub issue or PR URL like https://github.com/owner/repo/issues/123 or /pull/123',
+  );
+
+// Known config-key enum (#1053) sourced from @oss-autopilot/core so it stays
+// in sync with the CLI surface. Union of setup + config keys — the config
+// tool delegates to both `runConfig` and `runSetup` internally.
+const KNOWN_CONFIG_KEYS = Array.from(new Set([...getSetupKeys(), ...getConfigKeys()]));
+const configKeySchema = KNOWN_CONFIG_KEYS.length > 0 ? z.enum(KNOWN_CONFIG_KEYS as [string, ...string[]]) : z.string(); // defensive: if the registry is empty, fall back to the old shape
 
 /** One-shot Gist persistence activation (checked once per process). */
 let gistInitDone = false;
@@ -136,7 +169,9 @@ export function registerTools(server: McpServer): void {
       description:
         'Analyze a GitHub issue to determine if it is a good candidate for contribution. Checks for clarity, scope, existing assignees, and staleness.',
       inputSchema: {
-        issueUrl: z.string().describe('Full GitHub issue URL to vet (e.g. https://github.com/owner/repo/issues/123)'),
+        issueUrl: githubIssueUrlSchema.describe(
+          'Full GitHub issue URL to vet (e.g. https://github.com/owner/repo/issues/123)',
+        ),
       },
       annotations: { readOnlyHint: true },
     },
@@ -166,9 +201,9 @@ export function registerTools(server: McpServer): void {
       description:
         'Fetch metadata for a pull request (repo, number, title). Informational only — in v2, PRs are discovered automatically on each daily run and nothing is persisted locally. Use `daily` or `status` for ongoing monitoring.',
       inputSchema: {
-        prUrl: z
-          .string()
-          .describe('Full GitHub PR URL to fetch metadata for (e.g. https://github.com/owner/repo/pull/123)'),
+        prUrl: githubPrUrlSchema.describe(
+          'Full GitHub PR URL to fetch metadata for (e.g. https://github.com/owner/repo/pull/123)',
+        ),
       },
       annotations: { readOnlyHint: true },
     },
@@ -182,7 +217,7 @@ export function registerTools(server: McpServer): void {
       description:
         '[DEPRECATED] No-op in v2. PRs are fetched fresh on each daily run, so there is no local tracking list to remove from. Use `shelve` to hide a PR from the daily digest instead.',
       inputSchema: {
-        prUrl: z.string().describe('Full GitHub PR URL (ignored — command is a no-op)'),
+        prUrl: githubPrUrlSchema.describe('Full GitHub PR URL (ignored — command is a no-op)'),
       },
       annotations: { readOnlyHint: true },
     },
@@ -195,7 +230,7 @@ export function registerTools(server: McpServer): void {
     {
       description: 'Mark PR notifications as read. Requires either prUrl or all to be specified.',
       inputSchema: {
-        prUrl: z.string().optional().describe('Full GitHub PR URL to mark as read. Omit to use --all instead.'),
+        prUrl: githubPrUrlSchema.optional().describe('Full GitHub PR URL to mark as read. Omit to use --all instead.'),
         all: z.boolean().optional().describe('If true, mark all PRs as read'),
       },
       annotations: { readOnlyHint: false, destructiveHint: false },
@@ -209,7 +244,7 @@ export function registerTools(server: McpServer): void {
     {
       description: 'Fetch and display comments on a pull request, including review comments and issue comments.',
       inputSchema: {
-        prUrl: z.string().describe('Full GitHub PR URL to fetch comments for'),
+        prUrl: githubPrUrlSchema.describe('Full GitHub PR URL to fetch comments for'),
         showBots: z.boolean().optional().describe('If true, include bot comments in the output'),
       },
       annotations: { readOnlyHint: true },
@@ -217,30 +252,32 @@ export function registerTools(server: McpServer): void {
     wrapTool(runComments),
   );
 
-  // 9. post — Post a comment
+  // 9. post — Post a comment (#1053: destructive; posts under user's identity)
   server.registerTool(
     'post',
     {
-      description: 'Post a comment on a GitHub issue or pull request.',
+      description:
+        "Post a comment on a GitHub issue or pull request. WARNING: posts a public comment under the authenticated user's identity. Irreversible (the comment can only be edited or deleted, not un-posted). Do not call without explicit user confirmation.",
       inputSchema: {
-        url: z.string().describe('Full GitHub issue or PR URL to comment on'),
-        message: z.string().describe('The comment text to post'),
+        url: githubIssueOrPrUrlSchema.describe('Full GitHub issue or PR URL to comment on'),
+        message: z.string().min(1).describe('The comment text to post'),
       },
-      annotations: { readOnlyHint: false, destructiveHint: false },
+      annotations: { readOnlyHint: false, destructiveHint: true },
     },
     wrapTool(runPost),
   );
 
-  // 10. claim — Claim an issue
+  // 10. claim — Claim an issue (#1053: destructive; posts under user's identity)
   server.registerTool(
     'claim',
     {
-      description: 'Claim a GitHub issue by posting a comment expressing intent to work on it.',
+      description:
+        "Claim a GitHub issue by posting a comment expressing intent to work on it. WARNING: posts a public comment under the authenticated user's identity. Irreversible. Do not call without explicit user confirmation.",
       inputSchema: {
-        issueUrl: z.string().describe('Full GitHub issue URL to claim'),
+        issueUrl: githubIssueUrlSchema.describe('Full GitHub issue URL to claim'),
         message: z.string().optional().describe('Custom claim message. If omitted, a default message is used.'),
       },
-      annotations: { readOnlyHint: false, destructiveHint: false },
+      annotations: { readOnlyHint: false, destructiveHint: true },
     },
     wrapTool(runClaim),
   );
@@ -252,7 +289,11 @@ export function registerTools(server: McpServer): void {
       description:
         'Get or set OSS Autopilot configuration values. With no args, shows all config. With key and value, sets the value.',
       inputSchema: {
-        key: z.string().optional().describe('Configuration key to get or set (e.g. "languages", "username")'),
+        key: configKeySchema
+          .optional()
+          .describe(
+            `Configuration key to get or set. Must be one of the known keys (derived from @oss-autopilot/core config-registry). Examples: "username", "languages", "minStars". Run the tool with no args to see all current config.`,
+          ),
         value: z.string().optional().describe('Value to set for the given key. Omit to read the current value.'),
       },
       annotations: { readOnlyHint: false, idempotentHint: true },
@@ -322,7 +363,7 @@ export function registerTools(server: McpServer): void {
     {
       description: 'Shelve a PR to temporarily hide it from daily checks and status reports without untracking it.',
       inputSchema: {
-        prUrl: z.string().describe('Full GitHub PR URL to shelve'),
+        prUrl: githubPrUrlSchema.describe('Full GitHub PR URL to shelve'),
       },
       annotations: { readOnlyHint: false, destructiveHint: false },
     },
@@ -335,7 +376,7 @@ export function registerTools(server: McpServer): void {
     {
       description: 'Unshelve a previously shelved PR, returning it to active monitoring.',
       inputSchema: {
-        prUrl: z.string().describe('Full GitHub PR URL to unshelve'),
+        prUrl: githubPrUrlSchema.describe('Full GitHub PR URL to unshelve'),
       },
       annotations: { readOnlyHint: false, destructiveHint: false },
     },
@@ -348,7 +389,7 @@ export function registerTools(server: McpServer): void {
     {
       description: 'Dismiss a GitHub issue so it no longer appears in notifications.',
       inputSchema: {
-        url: z.string().describe('Full GitHub issue URL to dismiss'),
+        url: githubIssueUrlSchema.describe('Full GitHub issue URL to dismiss'),
       },
       annotations: { readOnlyHint: false, destructiveHint: false },
     },
@@ -361,7 +402,7 @@ export function registerTools(server: McpServer): void {
     {
       description: 'Undismiss a previously dismissed issue, re-enabling notifications.',
       inputSchema: {
-        url: z.string().describe('Full GitHub issue URL to undismiss'),
+        url: githubIssueUrlSchema.describe('Full GitHub issue URL to undismiss'),
       },
       annotations: { readOnlyHint: false, destructiveHint: false },
     },
@@ -375,7 +416,7 @@ export function registerTools(server: McpServer): void {
       description:
         'Move a PR between states: attention (need attention), waiting (waiting on maintainer), shelved (hidden), or auto (reset to computed status).',
       inputSchema: {
-        prUrl: z.string().describe('Full GitHub PR URL'),
+        prUrl: githubPrUrlSchema.describe('Full GitHub PR URL'),
         target: z.enum(['attention', 'waiting', 'shelved', 'auto']).describe('Target state for the PR'),
       },
       annotations: { readOnlyHint: false, destructiveHint: false },


### PR DESCRIPTION
## Summary

Three safety gaps on the MCP tool surface:

1. \`post\` and \`claim\` posted public GitHub comments under the user's identity but carried \`destructiveHint: false\` and no warning in their descriptions — MCP clients read them as non-destructive.
2. Every URL-typed input was \`z.string()\` with no validation — an LLM could pass nonsense and the error surfaced only at \`runPost\` / \`runClaim\`, after a potential network round-trip.
3. \`config.key\` was \`z.string().optional()\` with no enum — LLMs had to guess at valid keys by trial and error; silent typos became "did nothing" with no schema failure.

### Changes
- **\`post\` / \`claim\`**: \`destructiveHint: true\` + explicit WARNING in each description ("irreversible", "under the authenticated user's identity", "do not call without explicit user confirmation").
- **GitHub URL validators** (\`githubIssueUrlSchema\`, \`githubPrUrlSchema\`, \`githubIssueOrPrUrlSchema\`) applied to every URL-typed input across \`vet\`, \`track\`, \`untrack\`, \`read\`, \`comments\`, \`post\`, \`claim\`, \`shelve\`, \`unshelve\`, \`dismiss\`, \`undismiss\`, \`move\`.
- **\`config.key\` enum** sourced from \`@oss-autopilot/core\`'s \`getSetupKeys()\` + \`getConfigKeys()\` (single source of truth in core's config-registry).
- Schema validation failures now surface as \`isError: true\` tool results from the MCP SDK (not raw rejections).

### Tests (9 new, 181 total MCP)
- \`destructiveHint: true\` on \`post\` / \`claim\`.
- Descriptions contain "irreversible".
- Non-GitHub URL on \`post\` → schema error mentioning "github".
- Malformed URL on \`track\` → schema error.
- Issue URL on \`shelve\` (expects PR URL) → schema error mentioning "pr".
- Unknown \`config.key\` → schema error.
- Known \`config.key\` → accepted.

Closes #1053.

## Test plan

- [x] \`pnpm test\` — core 2037 + dashboard 253 + MCP 181 all pass
- [x] \`pnpm run lint\` clean