### PR TITLE
docs(core): document repo-scoring formula and anti-LLM policy (#1054)

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,15 @@ Without pr-review-toolkit, the built-in pre-commit-reviewer handles all review p
 - **1,000 PR cap** — GitHub's Search API returns at most 1,000 results per query. If you have more than 1,000 open, merged, or closed PRs, the oldest results may be truncated.
 - **Individual contributor focus** — Designed for solo contributors managing their own PRs. No team dashboards, shared state, or multi-user workflows.
 
+## How It Decides
+
+Two heuristics directly shape which repos surface in discovery:
+
+- **[Repo scoring](docs/repo-scoring.md)** — 1–10 score per repo, factoring merged/closed PR history, recency, maintainer responsiveness, and hostility signals. The default `minRepoScoreThreshold` (4) excludes repos below the cutoff from search results.
+- **[Anti-LLM policy detection](docs/anti-llm-policy.md)** — scans CONTRIBUTING / CODE_OF_CONDUCT / README for language indicating the project doesn't accept AI-assisted contributions. Hard skip when matched.
+
+Both docs explain the exact rules so you can understand why a given repo did or didn't surface.
+
 ## API Documentation
 
 Full API documentation for `@oss-autopilot/core` is available at [jcosta.tech/oss-autopilot](https://jcosta.tech/oss-autopilot/).

--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -64,7 +64,7 @@ GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli
 
 ### Anti-LLM / AI Policy
 
-The CLI auto-filters repos in `aiPolicyBlocklist`. During every vetting, scan CONTRIBUTING.md, CODE_OF_CONDUCT.md, and README for anti-LLM policy language — this is a **hard skip** regardless of score (the whole workflow is AI-assisted). The matcher lives in `packages/core/src/core/anti-llm-policy.ts`; `vet --json` surfaces matches in reasons-to-skip. Categories: `explicit_ban` ("no AI-generated"), `tool_ban` ("no Copilot"), `reject_framing` ("we do not accept AI").
+The CLI auto-filters repos in `aiPolicyBlocklist`. During every vetting, scan CONTRIBUTING.md, CODE_OF_CONDUCT.md, and README for anti-LLM policy language — this is a **hard skip** regardless of score (the whole workflow is AI-assisted). The matcher lives in `packages/core/src/core/anti-llm-policy.ts`; `vet --json` surfaces matches in reasons-to-skip. Categories: `explicit_ban` ("no AI-generated"), `tool_ban` ("no Copilot"), `reject_framing` ("we do not accept AI"). See `docs/anti-llm-policy.md` for the full category definitions and appeal process.
 
 **If matched:** (1) recommendation → `skip` with reason `"anti-LLM policy"`; (2) auto-exclude the repo (concatenate, don't replace — `--set aiPolicyBlocklist=…` replaces the whole value):
 

--- a/docs/anti-llm-policy.md
+++ b/docs/anti-llm-policy.md
@@ -1,0 +1,96 @@
+# Anti-LLM Policy Detection
+
+OSS Autopilot scans a repository's `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and `README.md` before recommending any of its issues. If the scan detects language indicating the project does not accept AI- or LLM-generated contributions, the repo is auto-excluded from discovery with a clear message citing the matched phrase.
+
+This is a **hard skip** — the entire workflow is AI-assisted, so a project with an anti-LLM policy is fundamentally incompatible regardless of how healthy its score otherwise looks.
+
+The rules live in [`packages/core/src/core/anti-llm-policy.ts`](../packages/core/src/core/anti-llm-policy.ts). Changing them affects every user, so this doc is kept in sync with the regex set.
+
+## Design: precision over recall
+
+False positives silently shrink your contribution surface without recourse. The rules only match phrases that combine **a rejection keyword** (no / reject / will be closed / don't accept) with **an AI/LLM noun** (copilot, chatgpt, "AI-generated", etc.).
+
+Examples that do **not** match (and shouldn't):
+
+- *"AI division will be closed at the end of Q4"* — "closed" refers to the division, not contributions.
+- *"AI suggestions from your IDE are welcome"* — "suggestions" ≠ rejection.
+- *"No Copilot-style autocomplete in our editor"* — describes a feature, not a policy (the regex uses a negative lookahead to skip this).
+- *"We don't recommend using ChatGPT for code review"* — not a hard ban.
+
+If you see a false positive in the wild, file an issue with the exact phrase so we can tighten the regex.
+
+## Categories
+
+The scan returns zero or more matches, each tagged with one of three categories:
+
+### `explicit_ban`
+
+The repo directly forbids AI- or LLM-generated contributions.
+
+**Triggering examples:**
+
+- *"No AI-generated code."*
+- *"No LLM-authored PRs."*
+- *"Banned: AI-assisted contributions."*
+
+Regex (conceptual): `\bno\s+(ai|llm)[-\s](generated|authored|written|assisted|contributions?)` plus explicit `ban(ned|ning)` on `ai|llm`.
+
+### `tool_ban`
+
+The repo bans contributions from specific named tools.
+
+**Triggering examples:**
+
+- *"No Copilot-generated PRs."*
+- *"No ChatGPT, no Claude, no Cursor."*
+- *"No AI coding tools."*
+
+Regex (conceptual): `\bno\s+(copilot|chatgpt|claude|cursor)(-(generated|authored|assisted|written))?` with a negative lookahead so *"no copilot-style autocomplete"* (a feature description) does **not** match. Plus `\bno\s+ai\s+coding\s+tools?\b`.
+
+### `reject_framing`
+
+The repo explicitly states that AI contributions will be closed, rejected, or not accepted — requires both an AI/LLM qualifier AND a contribution noun AND a rejection verb phrase, all in the same sentence window.
+
+**Triggering examples:**
+
+- *"AI-generated code will be closed without review."*
+- *"We do not accept LLM-authored pull requests."*
+- *"AI contributions will be rejected."*
+
+## What you see when a repo is flagged
+
+The CLI / agent output includes the category and the exact matching excerpt so you can verify:
+
+```
+Skipped: owner/repo
+  Category: explicit_ban
+  Phrase: "No AI-generated code"
+  Excerpt: "…we welcome contributions. No AI-generated code, please…"
+  See docs/anti-llm-policy.md for details.
+```
+
+The excerpt is a ~80-character window around the match, chosen so you can read the surrounding sentence and judge whether the ban is really about contributions (vs. describing an unrelated feature).
+
+## Appeals / overrides
+
+If the scan flagged a repo that actually welcomes AI help:
+
+1. Verify the phrase in-context by reading the source file the excerpt cites.
+2. If it's a false positive, file an issue in this repo with the exact matching text.
+3. As a temporary workaround, remove the repo from `aiPolicyBlocklist`:
+
+   ```bash
+   oss-autopilot setup --set aiPolicyBlocklist="matplotlib/matplotlib"
+   ```
+
+   (Pass the full comma-separated list minus the entry you're removing — `--set` replaces the whole value.)
+
+## Hidden / out-of-band signals
+
+Not every anti-LLM stance is scannable from document text. Maintainers sometimes hide AI-submitted PRs as spam, add comments on closed policy issues, or voice opposition in external channels. The scan cannot see any of that. If you observe such signals during vetting, manually add the repo to `aiPolicyBlocklist` to auto-exclude future searches.
+
+## See also
+
+- [`packages/core/src/core/anti-llm-policy.ts`](../packages/core/src/core/anti-llm-policy.ts) — implementation with inline regex comments.
+- [`packages/core/src/core/anti-llm-policy.test.ts`](../packages/core/src/core/anti-llm-policy.test.ts) — pinned-behavior tests for each category.
+- [`docs/repo-scoring.md`](./repo-scoring.md) — the other user-visible heuristic that shapes discovery outcomes.

--- a/docs/repo-scoring.md
+++ b/docs/repo-scoring.md
@@ -1,0 +1,87 @@
+# Repo Scoring
+
+Every repository OSS Autopilot has seen receives a **1–10 score** that shapes which repos surface in discovery, which get recommended for new contributions, and which get quietly deprioritized. This page documents how the score is computed so a user whose favorite repo never appears in `search` results can understand why.
+
+The formula lives in [`packages/core/src/core/repo-score-manager.ts`](../packages/core/src/core/repo-score-manager.ts). Changing any weight requires updating this doc and the unit tests in lockstep.
+
+## Formula
+
+```
+BASE_SCORE
+  + min(round(log2(merged + 1) × 2), 5)      merge bonus
+  − min(closedWithoutMergeCount, 3)          closed penalty
+  + (lastMergedAt within 90 days ? 1 : 0)    recency bonus
+  + (isResponsive ? 1 : 0)                   responsiveness bonus
+  − (hasHostileComments ? 2 : 0)             hostility penalty
+clamped to [1, 10].
+```
+
+**Base score: 5.** First-time repos start neutral — the tool is deliberately optimistic so a new repo isn't punished before any signal exists.
+
+## Factors
+
+### Merge history (up to +5)
+
+Each merged PR increases the score logarithmically. The first merge is worth the most; the 20th is worth almost nothing new.
+
+| Merged PRs | Bonus |
+|---:|---:|
+| 0 | +0 |
+| 1 | +2 |
+| 2 | +3 |
+| 3 | +4 |
+| 4+ | +5 |
+
+Log scaling instead of linear means a friendly repo with 4 merges and a behemoth repo with 400 both get the maximum +5 — we care about "has merge relationship" more than "has lots of merges."
+
+### Closed-without-merge (up to −3)
+
+Each PR the user closed without merging deducts 1 from the score, capped at −3. A few rejections don't zero out an otherwise-healthy repo.
+
+### Recency (+1)
+
+If the most recent merge landed within the last **90 days**, add +1. Keeps stale "I merged one PR 5 years ago" relationships from dominating recent ones.
+
+### Responsiveness (+1)
+
+If maintainer-health signals mark the repo as responsive (see `computeRepoSignals` in `daily-logic.ts`), add +1. Currently driven by per-PR response times aggregated across the user's open PRs.
+
+### Hostility (−2)
+
+If OSS Autopilot has detected hostile maintainer comments on the user's PRs here (see `markRepoHostile`), subtract 2. This is a strong negative signal — combined with a few closed PRs, a repo can drop below the default `minRepoScoreThreshold` (4) and stop surfacing in `search` results entirely.
+
+### Clamp [1, 10]
+
+Final result is clamped so the UI and agents can rely on a fixed range.
+
+## What the number means
+
+| Score | Rough interpretation |
+|---|---|
+| 9–10 | Healthy relationship — multiple merges, recent activity, responsive maintainers. Top priority for discovery. |
+| 7–8 | Good fit — at least one merge or strong signals, no red flags. |
+| 5–6 | Unknown/neutral — first-time or balanced-with-closures. |
+| 3–4 | Below default `minRepoScoreThreshold`. Excluded from `search` unless the threshold is lowered. |
+| 1–2 | Hostile and/or consistently closes PRs. Actively avoided. |
+
+## Threshold interaction
+
+`config.minRepoScoreThreshold` (default `4`) controls the cutoff for `search` / `scout` inclusion. Lowering it lets borderline repos surface; raising it filters more aggressively.
+
+Run:
+
+```bash
+oss-autopilot setup --set minRepoScoreThreshold=3
+```
+
+…to see more repos in discovery, at the cost of occasional lower-quality matches.
+
+## Staleness
+
+Scores older than 30 days (`SCORE_TTL_MS`) are considered stale and excluded from the low-scoring-repo list. This prevents a one-time bad experience years ago from permanently blocking a repo that may have recovered — the score stays on disk but no longer filters.
+
+## See also
+
+- [`packages/core/src/core/repo-score-manager.ts`](../packages/core/src/core/repo-score-manager.ts) — named constants with rationale comments.
+- [`packages/core/src/core/repo-score-manager.test.ts`](../packages/core/src/core/repo-score-manager.test.ts) — tests that pin every factor independently.
+- [`docs/anti-llm-policy.md`](./anti-llm-policy.md) — the other user-visible heuristic that shapes discovery outcomes.

--- a/packages/core/src/core/anti-llm-policy.ts
+++ b/packages/core/src/core/anti-llm-policy.ts
@@ -16,6 +16,11 @@
  * contribution surface without recourse. We only match on phrases
  * that combine a rejection keyword (no / reject / will be closed /
  * don't accept) with an AI/LLM noun.
+ *
+ * **User-facing reference:** `docs/anti-llm-policy.md` — explains the
+ * three categories, example phrases per category, and the false-positive-
+ * resistance design (why "AI division will be closed at end of Q4"
+ * does NOT match).
  */
 
 export type AntiLLMCategory = 'explicit_ban' | 'tool_ban' | 'reject_framing';

--- a/packages/core/src/core/repo-score-manager.ts
+++ b/packages/core/src/core/repo-score-manager.ts
@@ -3,6 +3,9 @@
  * Functions that operate on AgentState for scoring, querying,
  * and computing aggregate statistics. Mutation functions modify
  * the passed state object in place; query functions are pure.
+ *
+ * **User-facing reference:** `docs/repo-scoring.md` — plain-language
+ * explanation of the formula and what a given score means.
  */
 
 import { AgentState, RepoScore, RepoScoreUpdate, StoredMergedPR, StoredClosedPR, isBelowMinStars } from './types.js';
@@ -10,6 +13,36 @@ import { debug, warn } from './logger.js';
 import { parseGitHubUrl } from './utils.js';
 
 const MODULE = 'scoring';
+
+// ── Scoring constants (#1054) ─────────────────────────────────────────
+// Previously inlined as magic numbers in `calculateScore`. Extracted with
+// rationale comments so the formula is auditable without source spelunking.
+// Changing any of these is a behavior change — update docs/repo-scoring.md
+// and the tests below in lockstep.
+
+/** Starting point before any signals are applied. Deliberately optimistic so first-time repos aren't punished. */
+const BASE_SCORE = 5;
+
+/** Logarithmic merge bonus: 1 merge→+2, 2→+3, 3→+4, 4+→+5. Log instead of linear so a 20th merge doesn't dominate. */
+const MERGE_BONUS_COEFFICIENT = 2;
+const MERGE_BONUS_CAP = 5;
+
+/** −1 per closed-without-merge PR, capped so a few rejections don't zero out an otherwise-healthy repo. */
+const CLOSED_PENALTY_CAP = 3;
+
+/** Repos whose most-recent merge is within this window get a +1 freshness bonus. */
+const RECENCY_WINDOW_DAYS = 90;
+const RECENCY_BONUS = 1;
+
+/** +1 when the repo's signals say maintainers respond to PRs (per-PR computed; see issue-grading.ts). */
+const RESPONSIVENESS_BONUS = 1;
+
+/** −2 when hostile maintainer comments have been detected (e.g., explicit rejection of PRs without review). */
+const HOSTILITY_PENALTY = 2;
+
+/** Final clamp — scores always land in this inclusive range. */
+const SCORE_MIN = 1;
+const SCORE_MAX = 10;
 
 /** Repo scores older than this are considered stale and excluded from low-scoring lists. */
 const SCORE_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
@@ -20,7 +53,7 @@ const SCORE_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 function createDefaultRepoScore(repo: string): RepoScore {
   return {
     repo,
-    score: 5, // Base score
+    score: BASE_SCORE,
     mergedPRCount: 0,
     closedWithoutMergeCount: 0,
     avgResponseDays: null,
@@ -34,24 +67,34 @@ function createDefaultRepoScore(repo: string): RepoScore {
 }
 
 /**
- * Calculate the score based on the repo's metrics.
- * Base 5, logarithmic merge bonus (max +5), -1 per closed without merge (max -3),
- * +1 if recently merged (within 90 days), +1 if responsive, -2 if hostile. Clamp 1-10.
+ * Calculate a 1–10 score for a repo based on the user's PR history and the
+ * repo's maintainer-health signals.
+ *
+ * Formula (all constants named above with rationale):
+ *   BASE_SCORE
+ *     + min(round(log2(merged + 1) * MERGE_BONUS_COEFFICIENT), MERGE_BONUS_CAP)
+ *     − min(closedWithoutMergeCount, CLOSED_PENALTY_CAP)
+ *     + (lastMergedAt within RECENCY_WINDOW_DAYS ? RECENCY_BONUS : 0)
+ *     + (isResponsive ? RESPONSIVENESS_BONUS : 0)
+ *     − (hasHostileComments ? HOSTILITY_PENALTY : 0)
+ *   clamped to [SCORE_MIN, SCORE_MAX].
+ *
+ * See `docs/repo-scoring.md` for user-facing intent and what a given
+ * score means in practice.
  */
 export function calculateScore(repoScore: RepoScore): number {
-  let score = 5; // Base score
+  let score = BASE_SCORE;
 
-  // Logarithmic merge bonus (max +5): 1→+2, 2→+3, 3→+4, 4+→+5
   if (repoScore.mergedPRCount > 0) {
-    const mergedBonus = Math.min(Math.round(Math.log2(repoScore.mergedPRCount + 1) * 2), 5);
+    const mergedBonus = Math.min(
+      Math.round(Math.log2(repoScore.mergedPRCount + 1) * MERGE_BONUS_COEFFICIENT),
+      MERGE_BONUS_CAP,
+    );
     score += mergedBonus;
   }
 
-  // -1 per closed without merge (max -3)
-  const closedPenalty = Math.min(repoScore.closedWithoutMergeCount, 3);
-  score -= closedPenalty;
+  score -= Math.min(repoScore.closedWithoutMergeCount, CLOSED_PENALTY_CAP);
 
-  // +1 if lastMergedAt is set and within 90 days (recency)
   if (repoScore.lastMergedAt) {
     const lastMergedDate = new Date(repoScore.lastMergedAt);
     if (isNaN(lastMergedDate.getTime())) {
@@ -62,24 +105,21 @@ export function calculateScore(repoScore: RepoScore): number {
     } else {
       const msPerDay = 1000 * 60 * 60 * 24;
       const daysSince = Math.floor((Date.now() - lastMergedDate.getTime()) / msPerDay);
-      if (daysSince <= 90) {
-        score += 1;
+      if (daysSince <= RECENCY_WINDOW_DAYS) {
+        score += RECENCY_BONUS;
       }
     }
   }
 
-  // +1 if responsive
   if (repoScore.signals.isResponsive) {
-    score += 1;
+    score += RESPONSIVENESS_BONUS;
   }
 
-  // -2 if hostile
   if (repoScore.signals.hasHostileComments) {
-    score -= 2;
+    score -= HOSTILITY_PENALTY;
   }
 
-  // Clamp to 1-10
-  return Math.max(1, Math.min(10, score));
+  return Math.max(SCORE_MIN, Math.min(SCORE_MAX, score));
 }
 
 /**


### PR DESCRIPTION
## Summary

Two outcome-shaping heuristics in core were undocumented — users affected by either had no user-facing explanation; the rules were discoverable only by reading source.

### Changes
- **Extracted scoring constants** in \`repo-score-manager.ts\`: \`BASE_SCORE\`, \`MERGE_BONUS_COEFFICIENT\`, \`MERGE_BONUS_CAP\`, \`CLOSED_PENALTY_CAP\`, \`RECENCY_WINDOW_DAYS\`, \`RECENCY_BONUS\`, \`RESPONSIVENESS_BONUS\`, \`HOSTILITY_PENALTY\`, \`SCORE_MIN\`, \`SCORE_MAX\`. Rationale comments above each.
- **New** \`docs/repo-scoring.md\` — plain-language formula, per-factor table, "what 5 vs 8 means", threshold interaction, staleness rule.
- **New** \`docs/anti-llm-policy.md\` — the three category definitions (\`explicit_ban\` / \`tool_ban\` / \`reject_framing\`), example phrases, false-positive-resistance design (why *"AI division will be closed at Q4 end"* does NOT match), appeal process, out-of-band signals caveat.
- **README** "How It Decides" section linking both docs.
- Cross-refs added to \`anti-llm-policy.ts\` module header and \`agents/issue-scout.md\` anti-LLM section.

### No behavior change
All 2037 core tests still pass. The scoring tests pin every weight independently and pass unchanged since the constants are just renamed versions of the previous inline literals.

Closes #1054.

## Test plan

- [x] \`pnpm test\` — 2037 core + 253 dashboard + 181 MCP all pass
- [x] \`pnpm run lint\` clean
- [x] Scoring tests (\`repo-score-manager.test.ts\`) and anti-LLM tests (\`anti-llm-policy.test.ts\`) verify no behavior drift from the constant extraction