### PR TITLE
fix: UM1 plugin/agent/workflow prose polish (M1, M4, M5, M6, M10, M14)

### DIFF
--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -66,7 +66,14 @@ GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli
 
 The CLI auto-filters repos in `aiPolicyBlocklist`. During every vetting, scan CONTRIBUTING.md, CODE_OF_CONDUCT.md, and README for anti-LLM policy language — this is a **hard skip** regardless of score (the whole workflow is AI-assisted). The matcher lives in `packages/core/src/core/anti-llm-policy.ts`; `vet --json` surfaces matches in reasons-to-skip. Categories: `explicit_ban` ("no AI-generated"), `tool_ban` ("no Copilot"), `reject_framing` ("we do not accept AI"). See `docs/anti-llm-policy.md` for the full category definitions and appeal process.
 
-**If matched:** (1) recommendation → `skip` with reason `"anti-LLM policy"`; (2) auto-exclude the repo (concatenate, don't replace — `--set aiPolicyBlocklist=…` replaces the whole value):
+**If matched:** (1) recommendation → `skip` with reason `"anti-LLM policy"`; (2) quote the matching language in the summary so the user can verify the match; (3) do NOT proceed even if score is high.
+
+**Ask before persisting the exclusion.** False positives are possible, and `aiPolicyBlocklist` is a permanent, cross-session filter. Present the match to the user and use AskUserQuestion with:
+- "Add `{OWNER}/{REPO}` to the anti-LLM blocklist" — "Never surface issues from this repo again"
+- "Skip this issue but leave the repo searchable" — "Treat as one-off; do not change config"
+- "Undo (false positive)" — "Don't skip; I'll review the match manually"
+
+Only if the user picks the first option, run the config update (concatenate — `--set aiPolicyBlocklist=…` replaces the whole value):
 
 ```bash
 CURRENT=$(GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" config --json | jq -r '.data.config.aiPolicyBlocklist // ""')
@@ -74,7 +81,7 @@ NEW="${CURRENT:+$CURRENT,}{OWNER}/{REPO}"
 GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" setup --set aiPolicyBlocklist="$NEW"
 ```
 
-(3) Quote the matching language in the summary. (4) Do NOT proceed even if score is high. Hidden signals (policy PRs, hidden comments) aren't document-scannable — note manually when observed.
+Hidden signals (policy PRs, hidden comments) aren't document-scannable — note manually when observed and offer to add the repo to the blocklist with the same confirmation prompt above.
 
 ## Search Process
 

--- a/agents/repo-evaluator.md
+++ b/agents/repo-evaluator.md
@@ -66,17 +66,19 @@ gh api repos/OWNER/REPO/contents/CONTRIBUTING.md --jq '.content' 2>/dev/null | b
 
 ## Metrics to Compute
 
-- **PR review time:** avg PR-open→first-review and open→merge; flag > 14 days.
+- **PR merge time:** avg time from `createdAt` to `mergedAt` on recent merged PRs (available from `gh pr list --state merged --json createdAt,mergedAt`); flag > 14 days.
 - **Merge rate:** merged / opened (last 90 days); >70% good, <30% concerning.
 - **Maintainer activity:** last commit date, contributors in last 90 days, issue response times.
 - **Community health:** CONTRIBUTING.md, issue templates, PR templates, code of conduct, recent releases.
+
+**Do not attempt to compute "time to first review" from `gh pr list` JSON.** That payload does not include review timestamps, so any such number would be fabricated. If you want review timing, fetch `gh api repos/OWNER/REPO/pulls/PULL_NUMBER/reviews` per PR — otherwise omit the metric.
 
 ## Scoring Rubric (1–10)
 
 | Factor | Weight | Criteria |
 |---|---|---|
 | Activity | 25% | Commits in last 30 days |
-| PR speed | 25% | Avg merge time < 7 days |
+| PR speed | 25% | Avg PR merge time < 7 days (from createdAt→mergedAt) |
 | Merge rate | 20% | >70% of PRs merged |
 | Responsiveness | 15% | Issues get responses < 3 days |
 | Guidelines | 10% | CONTRIBUTING.md, templates |
@@ -93,10 +95,12 @@ gh api repos/OWNER/REPO/contents/CONTRIBUTING.md --jq '.content' 2>/dev/null | b
 ⭐ X,XXX stars · 🍴 XXX forks · 📝 XX issues · 🔧 XX PRs · 📅 last commit Xd ago
 
 ### Health Metrics
-- **PR review:** avg first review Xd, avg merge Xd — [Fast/Moderate/Slow]
+- **PR merge time:** avg Xd on recent merged PRs — [Fast/Moderate/Slow]
 - **Merge rate (90d):** XX merged / XX opened = XX% — [High/Medium/Low]
 - **Maintainer activity:** X active, issue response [Quick/Moderate/Slow], last release Xd ago
 - **Community health:** [✓/✗] CONTRIBUTING · [✓/✗] issue templates · [✓/✗] PR templates · [✓/✗] code of conduct
+
+(Skip "first review" timing unless you actually fetched reviews via `gh api .../pulls/N/reviews` — do not estimate from list metadata.)
 
 ### Recent PR Samples
 | PR# | Title | Days to merge |
@@ -108,7 +112,7 @@ gh api repos/OWNER/REPO/contents/CONTRIBUTING.md --jq '.content' 2>/dev/null | b
 [Clear yes/no with reasoning]
 
 **What to expect:**
-- PR review in approximately X days
+- Merged PRs ship in approximately X days (based on recent merged-PR timing)
 - [Key pattern to be aware of]
 - [Best way to get maintainer attention]
 ```

--- a/commands/oss-dashboard.md
+++ b/commands/oss-dashboard.md
@@ -39,6 +39,29 @@ if [ -f "${DASHBOARD_PKG}" ] && { [ ! -f "${DASHBOARD_INDEX}" ] || [ -n "$(find 
   fi
 fi
 
+# Pick a platform-appropriate browser opener. $BROWSER wins when set.
+open_url() {
+  local url="$1"
+  if [ -n "$BROWSER" ] && command -v "$BROWSER" >/dev/null 2>&1; then
+    "$BROWSER" "$url" >/dev/null 2>&1 &
+  elif command -v open >/dev/null 2>&1; then        # macOS
+    open "$url" >/dev/null 2>&1 &
+  elif command -v xdg-open >/dev/null 2>&1; then    # Linux
+    xdg-open "$url" >/dev/null 2>&1 &
+  elif command -v wslview >/dev/null 2>&1; then     # WSL
+    wslview "$url" >/dev/null 2>&1 &
+  elif command -v cmd.exe >/dev/null 2>&1; then     # Git Bash / Cygwin on Windows
+    cmd.exe /c start "" "$url" >/dev/null 2>&1 &
+  else
+    return 1
+  fi
+}
+
+# Dashboard logs go here so crashes are debuggable instead of silently lost.
+LOG_DIR="$HOME/.oss-autopilot"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/dashboard.log"
+
 # Check if dashboard server is already running via PID file
 PID_FILE="$HOME/.oss-autopilot/dashboard-server.pid"
 if [ -f "$PID_FILE" ]; then
@@ -47,17 +70,18 @@ if [ -f "$PID_FILE" ]; then
   if [ -n "$PORT" ] && [ -n "$PID" ] && kill -0 "$PID" 2>/dev/null; then
     # Health check
     if curl -sf "http://127.0.0.1:$PORT/api/data" -o /dev/null 2>/dev/null; then
-      open "http://oss.localhost:$PORT"
-      echo '{"status":"already_running","url":"http://oss.localhost:'"$PORT"'"}'
+      open_url "http://oss.localhost:$PORT" || true
+      echo '{"status":"already_running","url":"http://oss.localhost:'"$PORT"'","logFile":"'"$LOG_FILE"'"}'
       exit 0
     fi
   fi
 fi
 
-# Launch server in background
+# Launch server in background, routing stderr/stdout to a log file for debugging.
 GITHUB_TOKEN=$(gh auth token 2>/dev/null || echo "$GITHUB_TOKEN")
 export GITHUB_TOKEN
-nohup node "${CLI_BUNDLE}" dashboard serve --port 3000 --no-open >/dev/null 2>&1 &
+{ echo "--- dashboard server started $(date -u +%FT%TZ) ---"; } >>"$LOG_FILE" 2>&1
+nohup node "${CLI_BUNDLE}" dashboard serve --port 3000 --no-open >>"$LOG_FILE" 2>&1 &
 
 # Wait for server to start (poll PID file + health check)
 for i in $(seq 1 25); do
@@ -65,14 +89,14 @@ for i in $(seq 1 25); do
   if [ -f "$PID_FILE" ]; then
     PORT=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync('$PID_FILE','utf-8')).port)}catch(e){console.log('')}")
     if [ -n "$PORT" ] && curl -sf "http://127.0.0.1:$PORT/api/data" -o /dev/null 2>/dev/null; then
-      open "http://oss.localhost:$PORT"
-      echo '{"status":"launched","url":"http://oss.localhost:'"$PORT"'"}'
+      open_url "http://oss.localhost:$PORT" || true
+      echo '{"status":"launched","url":"http://oss.localhost:'"$PORT"'","logFile":"'"$LOG_FILE"'"}'
       exit 0
     fi
   fi
 done
 
-echo '{"error":"Dashboard server failed to start within 5 seconds"}'
+echo '{"error":"Dashboard server failed to start within 5 seconds","logFile":"'"$LOG_FILE"'"}'
 exit 1
 ```
 
@@ -80,6 +104,6 @@ exit 1
 
 Parse the JSON output:
 
-- If `status` is `"already_running"`: Show `Dashboard: <url>` (already open in browser)
-- If `status` is `"launched"`: Show `Dashboard opened: <url>`
-- If `error` is present: Show the error message. If it's a build failure, suggest running `cd packages/core && npm run bundle` and `cd packages/dashboard && npm run build` manually.
+- If `status` is `"already_running"`: Show `Dashboard: <url>` (already open in browser). If the system didn't have a usable browser opener, tell the user to open the URL manually.
+- If `status` is `"launched"`: Show `Dashboard opened: <url>`. Same caveat for headless systems.
+- If `error` is present: Show the error message, plus `Logs: <logFile>` when the field is set so the user can inspect the dashboard server output. If the error is a build failure, suggest running `cd packages/core && npm run bundle` and `cd packages/dashboard && npm run build` manually.

--- a/commands/oss-search.md
+++ b/commands/oss-search.md
@@ -1,7 +1,7 @@
 ---
 name: oss-search
 description: "Search for new open source issues to contribute to — delegates to oss-scout"
-allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Task, mcp__*
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Task, mcp__plugin_oss-autopilot_*
 ---
 
 # OSS Issue Search

--- a/commands/oss.md
+++ b/commands/oss.md
@@ -1,7 +1,7 @@
 ---
 name: oss
 description: "Daily OSS contribution check - uses CLI with --json for structured data"
-allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Task, mcp__*
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Task, mcp__plugin_oss-autopilot_*
 ---
 
 # OSS Autopilot Daily Check
@@ -175,7 +175,7 @@ Use AskUserQuestion with these options:
 | "Just exploring" | "Take a look around — run /oss again anytime" |
 
 **Routing:**
-- **Search for issues** → Jump to "Handle Find New Issues" (same as the Execute section's search flow)
+- **Search for issues** → Invoke `/oss-search` directly (passing session state: `hasIssueList`, `availableCount`, `completedCount`, `issueListPath`). No intermediate hop.
 - **Import existing PRs** → Run the import command: `GITHUB_TOKEN=$(gh auth token 2>/dev/null || echo "$GITHUB_TOKEN") node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" init "$(gh api user --jq '.login')" --json`. If it succeeds, re-run `startup --json` (`GITHUB_TOKEN=$(gh auth token 2>/dev/null || echo "$GITHUB_TOKEN") node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" startup --json 2>/tmp/oss-startup-stderr.log`) and parse the result from the top (same routing as the initial startup call). If it fails, show the error and suggest checking `gh auth status`.
 - **Just exploring** → Show a brief tip: "Run `/oss` whenever you want to check on your contributions. It works best when you have a few open PRs to track." Then end.
 

--- a/commands/setup-oss.md
+++ b/commands/setup-oss.md
@@ -1,7 +1,7 @@
 ---
 name: setup-oss
 description: Configure OSS autopilot preferences
-allowed-tools: Bash, Write, Read, Glob, mcp__*
+allowed-tools: Bash, Write, Read, Glob, mcp__plugin_oss-autopilot_*
 ---
 
 # OSS Autopilot Setup

--- a/skills/oss-contribution/SKILL.md
+++ b/skills/oss-contribution/SKILL.md
@@ -152,7 +152,9 @@ Only comment on the issue itself when:
 
 ### If You Can't Solve It
 
-Move on silently. Don't comment that you tried and failed. Don't mark the issue in any way. Remove it from your list and continue to the next one.
+Move on silently. Don't comment that you tried and failed. Don't mark the issue on the upstream repo in any way. Remove it from your local list and continue to the next one.
+
+**Persistent skip (optional):** the `/oss` "Work Through Issues" workflow (`workflows/work-through-issues.md`, Phase C) can persist the skip to your local `skipped-issues.md` via the CLI's `skip-add` command so the same issue doesn't resurface in future searches. This is a local-only record — nothing is posted on GitHub.
 
 ### After Opening a PR
 


### PR DESCRIPTION
## Summary

Closes six sub-findings from umbrella issue #1055:

- **M1** — `/oss-dashboard` now opens the browser platform-agnostically (`$BROWSER` → `open` → `xdg-open` → `wslview` → `cmd.exe /c start`) instead of hardcoding the macOS `open`, and routes the dashboard server's stdout+stderr to `~/.oss-autopilot/dashboard.log` instead of `/dev/null` so crashes are debuggable.
- **M4** — `/oss` first-run routing now invokes `/oss-search` directly, removing the no-op hop through "Handle Find New Issues".
- **M5** — Narrowed `allowed-tools: mcp__*` → `mcp__plugin_oss-autopilot_*` on `/oss`, `/oss-search`, and `/setup-oss`. These commands never invoke non-oss-autopilot MCPs.
- **M6** — `agents/issue-scout.md` anti-LLM auto-exclude now asks the user via AskUserQuestion before persisting `aiPolicyBlocklist=…`. False positives no longer silently and permanently block a repo.
- **M10** — `agents/repo-evaluator.md` drops the fabricated "avg PR-open→first-review" metric — `gh pr list --json` doesn't return review timestamps, so the agent was inventing the number. Replaced with PR merge time from `createdAt`→`mergedAt` (which is real) plus an explicit warning to fetch `gh api .../pulls/N/reviews` if review timing is actually needed. Output template bullet updated to match.
- **M14** — `skills/oss-contribution/SKILL.md` §"If You Can't Solve It" now cross-references the `skip-add` persistence path in `workflows/work-through-issues.md` Phase C, clarifying it's local-only and nothing is posted on GitHub.

### Already closed in earlier cycles (no re-work)

- **M7, M8, M11, M12** — closed in H11 #1046 (agents reimplement CLI in prose).

### Deferred to dedicated follow-ups

- **M2** (oss-search markdown-shuffle → `list-move-tier` CLI command) — new CLI scope.
- **M3** (setup-oss CLI/markdown duplication) — larger refactor.
- **M9** (issue-scout vs repo-evaluator rubric divergence) — needs rubric merge design.
- **M13** (Failure Protocol vs workflow retry/skip fallbacks) — policy reconciliation.
- **M15** (split SKILL.md) — separate skill-design PR.

## Test plan

- [x] `pnpm run lint` passes
- [x] `pnpm test` passes (2037 core + 253 dashboard + 181 MCP = 2471 passing)
- [x] `npx prettier --check commands/ agents/ skills/` passes
- [x] Post-review spot-fix: `repo-evaluator.md` output template "PR review in approximately X days" bullet — reviewer caught it as a leftover first-review reference; rewritten to "Merged PRs ship in approximately X days"
- [ ] Verify no remaining `mcp__*` wildcard in `commands/` or `agents/` frontmatter after merge