### PR TITLE
fix: UM2 hook + CLI PR-flow hygiene (M17, M20, M21, M23, M24)

### DIFF
--- a/hooks/auto-format-before-push.sh
+++ b/hooks/auto-format-before-push.sh
@@ -124,7 +124,8 @@ mkdir -p "$(dirname "$FORMAT_ERROR_LOG")" 2>/dev/null || true
 # Batched formatter helpers (#1045): run the formatter once (or at most a few
 # times if xargs splits the command line) rather than once per file. A 50-file
 # diff used to spawn 50 `npx` processes, each resolving `.bin/` — easily past
-# the 30s hook timeout. `-r` skips the call entirely if the list is empty.
+# the hook timeout (currently 60s in hooks.json). `-r` skips the call entirely
+# if the list is empty.
 run_formatter() {
   local name="$1"
   shift

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -28,7 +28,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/auto-format-before-push.sh",
-            "timeout": 30
+            "timeout": 60
           }
         ]
       },

--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -111,7 +111,10 @@ export const commands: CLICommandDef[] = [
         .command('status')
         .description('Show current status and stats')
         .option('--json', 'Output as JSON')
-        .option('--offline', 'Use cached data only (no GitHub API calls)')
+        .option(
+          '--offline',
+          'Show cache-freshness metadata (lastUpdated). Status always reads local state — no GitHub API calls are made either way.',
+        )
         .action((options) =>
           executeAction(
             options,
@@ -127,7 +130,7 @@ export const commands: CLICommandDef[] = [
               console.log(`Needs Response: ${data.stats.needsResponse}`);
               if (data.offline) {
                 console.log(`\nLast Updated: ${data.lastUpdated || 'Never'}`);
-                console.log('(Offline mode: showing cached data)');
+                console.log('(Status reads from local state — no GitHub API calls)');
               } else {
                 console.log(`\nLast Run: ${data.lastRunAt || 'Never'}`);
               }

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -46,16 +46,30 @@ program.hook('preAction', async (thisCommand, actionCommand) => {
   if (!localOnlySet.has(commandName)) {
     const token = await getGitHubTokenAsync();
     if (!token) {
-      console.error('Error: GitHub authentication required.');
-      console.error('');
-      console.error('Option 1 (Recommended): Install and authenticate GitHub CLI');
-      console.error('  Install: https://cli.github.com/');
-      console.error('  Then run: gh auth login');
-      console.error('');
-      console.error('Option 2: Set GITHUB_TOKEN environment variable');
-      console.error('  export GITHUB_TOKEN="your-github-token-here"');
-      console.error('');
-      console.error('Then run your command again.');
+      // Honor --json at the CLI boundary so machine consumers (plugins, MCP
+      // stdio harnesses, scripts) get a parseable envelope instead of a
+      // stderr blob followed by a non-zero exit. Commander has already parsed
+      // the action's own options, so we check both the action command and the
+      // raw argv as a fallback (#1056 M20).
+      const wantsJson = Boolean(actionCommand.opts().json) || process.argv.includes('--json');
+      if (wantsJson) {
+        const { outputJsonError } = await import('./formatters/json.js');
+        outputJsonError(
+          'GitHub authentication required. Install gh CLI and run `gh auth login`, or set GITHUB_TOKEN.',
+          'AUTH_REQUIRED',
+        );
+      } else {
+        console.error('Error: GitHub authentication required.');
+        console.error('');
+        console.error('Option 1 (Recommended): Install and authenticate GitHub CLI');
+        console.error('  Install: https://cli.github.com/');
+        console.error('  Then run: gh auth login');
+        console.error('');
+        console.error('Option 2: Set GITHUB_TOKEN environment variable');
+        console.error('  export GITHUB_TOKEN="your-github-token-here"');
+        console.error('');
+        console.error('Then run your command again.');
+      }
       process.exit(1);
     }
 

--- a/packages/core/src/commands/auth-envelope.e2e.test.ts
+++ b/packages/core/src/commands/auth-envelope.e2e.test.ts
@@ -1,0 +1,87 @@
+/**
+ * E2E contract test for CLI auth-failure envelope (#1056 M20).
+ *
+ * When a non-local command (e.g. `daily`) runs without a GitHub token and
+ * `--json` is passed, the CLI MUST emit a `{ success: false, errorCode: 'AUTH_REQUIRED' }`
+ * JSON envelope to stdout — NOT a stderr blob followed by a non-zero exit
+ * with no parseable output. Machine consumers (plugins, MCP stdio harnesses)
+ * rely on this contract.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const execFileAsync = promisify(execFile);
+
+const BUNDLE_PATH = path.resolve(__dirname, '../../dist/cli.bundle.cjs');
+const BUNDLE_EXISTS = fs.existsSync(BUNDLE_PATH);
+const TEST_HOME = '/tmp/oss-autopilot-e2e-auth-envelope-' + process.pid;
+
+// Dedicated PATH that can't resolve `gh` but can still run `node` — we write a
+// symlink into a scratch dir below and point PATH at that dir.
+const GH_LESS_PATH_DIR = path.join('/tmp', 'oss-autopilot-e2e-auth-envelope-path-' + process.pid);
+
+async function runCliNoToken(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+  let exitCode: number | null = 0;
+  // Use the running process's absolute node binary so `execFile` doesn't rely
+  // on the child's PATH to locate node. That way we can force PATH to a dir
+  // that omits `gh` without also breaking node resolution.
+  const result = await execFileAsync(process.execPath, [BUNDLE_PATH, ...args], {
+    timeout: 5000,
+    env: {
+      ...process.env,
+      GITHUB_TOKEN: '',
+      PATH: GH_LESS_PATH_DIR,
+      HOME: TEST_HOME,
+    },
+    cwd: TEST_HOME,
+  }).catch((err: Error & { code?: number; stdout?: string; stderr?: string }) => {
+    exitCode = err.code ?? null;
+    return { stdout: err.stdout ?? '', stderr: err.stderr ?? '' };
+  });
+  return { stdout: result.stdout, stderr: result.stderr, exitCode };
+}
+
+describe.skipIf(!BUNDLE_EXISTS)('CLI auth-failure envelope (--json)', () => {
+  beforeAll(() => {
+    fs.mkdirSync(TEST_HOME, { recursive: true });
+    // Make a dir containing only a dummy `gh` fallback won't find — no
+    // binaries — so the CLI's `gh auth token` branch returns null.
+    fs.mkdirSync(GH_LESS_PATH_DIR, { recursive: true });
+  });
+
+  afterAll(() => {
+    fs.rmSync(TEST_HOME, { recursive: true, force: true });
+    fs.rmSync(GH_LESS_PATH_DIR, { recursive: true, force: true });
+  });
+
+  it('emits a parseable JSON envelope when --json is passed and auth is missing', async () => {
+    // `daily` is not marked localOnly, so the preAction hook runs the token check.
+    const { stdout, exitCode } = await runCliNoToken(['daily', '--json']);
+    expect(exitCode, 'auth failure should exit non-zero').not.toBe(0);
+
+    let parsed: unknown;
+    expect(() => {
+      parsed = JSON.parse(stdout);
+    }).not.toThrow();
+
+    expect(parsed).toMatchObject({
+      success: false,
+      errorCode: 'AUTH_REQUIRED',
+    });
+    // Human-readable `error` string is also required so consumers can surface it.
+    expect((parsed as { error?: string }).error).toMatch(/github/i);
+  });
+
+  it('still writes the legacy human-readable stderr guide when --json is NOT passed', async () => {
+    const { stderr, exitCode } = await runCliNoToken(['daily']);
+    expect(exitCode).not.toBe(0);
+    // The interactive path retains the multi-line guidance so `oss-autopilot daily`
+    // still tells humans what to do.
+    expect(stderr).toMatch(/GitHub authentication required/i);
+    expect(stderr).toMatch(/gh auth login/);
+  });
+});

--- a/packages/core/src/commands/comments.test.ts
+++ b/packages/core/src/commands/comments.test.ts
@@ -233,15 +233,22 @@ describe('runClaim', () => {
     );
   });
 
-  it('should claim an issue and return result', async () => {
+  it('should claim an issue and return result with real title from issues.get', async () => {
     mockRequireGitHubToken.mockReturnValue('ghp_test123');
     mockParseGitHubUrl.mockReturnValue({ owner: 'owner', repo: 'repo', number: 10, type: 'issues' });
 
     const mockCreateComment = vi.fn().mockResolvedValue({
       data: { html_url: 'https://github.com/owner/repo/issues/10#issuecomment-1' },
     });
+    const mockIssuesGet = vi.fn().mockResolvedValue({
+      data: {
+        title: 'Fix the thing',
+        labels: [{ name: 'bug' }, { name: 'good first issue' }],
+        created_at: '2026-04-20T10:00:00Z',
+      },
+    });
     mockGetOctokit.mockReturnValue({
-      issues: { createComment: mockCreateComment },
+      issues: { createComment: mockCreateComment, get: mockIssuesGet },
     } as any);
     const mockAddIssue = vi.fn();
     mockGetStateManager.mockReturnValue({
@@ -251,18 +258,48 @@ describe('runClaim', () => {
     const result = await runClaim({ issueUrl: TEST_ISSUE_URL });
 
     expect(mockCreateComment).toHaveBeenCalled();
+    // Issue metadata enrichment landed in state — no permanent "(claimed)" placeholder.
     expect(mockAddIssue).toHaveBeenCalledWith(
       expect.objectContaining({
         url: TEST_ISSUE_URL,
         repo: 'owner/repo',
         number: 10,
         status: 'claimed',
+        title: 'Fix the thing',
+        labels: ['bug', 'good first issue'],
+        createdAt: '2026-04-20T10:00:00Z',
       }),
     );
     expect(result).toEqual({
       commentUrl: 'https://github.com/owner/repo/issues/10#issuecomment-1',
       issueUrl: TEST_ISSUE_URL,
     });
+  });
+
+  it('should fall back to (claimed) placeholder if issues.get fails', async () => {
+    mockRequireGitHubToken.mockReturnValue('ghp_test123');
+    mockParseGitHubUrl.mockReturnValue({ owner: 'owner', repo: 'repo', number: 10, type: 'issues' });
+
+    const mockCreateComment = vi.fn().mockResolvedValue({
+      data: { html_url: 'https://github.com/owner/repo/issues/10#issuecomment-1' },
+    });
+    const mockIssuesGet = vi.fn().mockRejectedValue(new Error('403 from GitHub'));
+    mockGetOctokit.mockReturnValue({
+      issues: { createComment: mockCreateComment, get: mockIssuesGet },
+    } as any);
+    const mockAddIssue = vi.fn();
+    mockGetStateManager.mockReturnValue({
+      addIssue: mockAddIssue,
+    } as any);
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await runClaim({ issueUrl: TEST_ISSUE_URL });
+
+    expect(result.commentUrl).toBe('https://github.com/owner/repo/issues/10#issuecomment-1');
+    expect(mockAddIssue).toHaveBeenCalledWith(expect.objectContaining({ title: '(claimed)', labels: [] }));
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[WARN] [comments] Claimed'));
+    consoleSpy.mockRestore();
   });
 
   it('should still return success when state save fails (comment already posted)', async () => {
@@ -272,8 +309,11 @@ describe('runClaim', () => {
     const mockCreateComment = vi.fn().mockResolvedValue({
       data: { html_url: 'https://github.com/owner/repo/issues/10#issuecomment-1' },
     });
+    const mockIssuesGet = vi.fn().mockResolvedValue({
+      data: { title: 'x', labels: [], created_at: '2026-04-20T10:00:00Z' },
+    });
     mockGetOctokit.mockReturnValue({
-      issues: { createComment: mockCreateComment },
+      issues: { createComment: mockCreateComment, get: mockIssuesGet },
     } as any);
 
     mockGetStateManager.mockReturnValue({
@@ -288,7 +328,8 @@ describe('runClaim', () => {
     const result = await runClaim({ issueUrl: TEST_ISSUE_URL });
 
     expect(result.commentUrl).toBe('https://github.com/owner/repo/issues/10#issuecomment-1');
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Warning: Comment posted on'));
+    // Structured warning breadcrumb via logger.warn (#1056 M24).
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[WARN] [comments] Comment posted on'));
     consoleSpy.mockRestore();
   });
 

--- a/packages/core/src/commands/comments.ts
+++ b/packages/core/src/commands/comments.ts
@@ -4,6 +4,8 @@
  */
 
 import { getStateManager, getOctokit, parseGitHubUrl, requireGitHubToken, maybeCheckpoint } from '../core/index.js';
+import { ValidationError } from '../core/errors.js';
+import { warn } from '../core/logger.js';
 
 const MODULE = 'comments';
 import { paginateAll } from '../core/pagination.js';
@@ -56,7 +58,7 @@ export async function runComments(options: CommentsOptions): Promise<CommentsOut
   // Parse PR URL
   const parsed = parseGitHubUrl(options.prUrl);
   if (!parsed || parsed.type !== 'pull') {
-    throw new Error('Invalid PR URL format');
+    throw new ValidationError('Invalid PR URL format');
   }
 
   const { owner, repo, number: pull_number } = parsed;
@@ -163,7 +165,7 @@ export async function runPost(options: PostOptions): Promise<PostOutput> {
   validateGitHubUrl(options.url, ISSUE_OR_PR_URL_PATTERN, 'issue or PR');
 
   if (!options.message.trim()) {
-    throw new Error('No message provided');
+    throw new ValidationError('No message provided');
   }
 
   validateMessage(options.message);
@@ -173,7 +175,7 @@ export async function runPost(options: PostOptions): Promise<PostOutput> {
   // Parse URL
   const parsed = parseGitHubUrl(options.url);
   if (!parsed) {
-    throw new Error('Invalid GitHub URL format');
+    throw new ValidationError('Invalid GitHub URL format');
   }
 
   const { owner, repo, number } = parsed;
@@ -215,7 +217,7 @@ export async function runClaim(options: ClaimOptions): Promise<ClaimOutput> {
   // Parse URL
   const parsed = parseGitHubUrl(options.issueUrl);
   if (!parsed || parsed.type !== 'issues') {
-    throw new Error('Invalid issue URL format (must be an issue, not a PR)');
+    throw new ValidationError('Invalid issue URL format (must be an issue, not a PR)');
   }
 
   const { owner, repo, number } = parsed;
@@ -229,6 +231,27 @@ export async function runClaim(options: ClaimOptions): Promise<ClaimOutput> {
     body: message,
   });
 
+  // Fetch the real issue title + labels so the tracked entry has useful metadata
+  // rather than a permanent "(claimed)" placeholder that never gets backfilled
+  // (#1056 M24). Best-effort: if the fetch fails, fall back to the placeholder
+  // so state still records the claim.
+  let issueTitle = '(claimed)';
+  let issueLabels: string[] = [];
+  let issueCreatedAt = new Date().toISOString();
+  try {
+    const { data: issue } = await octokit.issues.get({ owner, repo, issue_number: number });
+    if (issue.title) issueTitle = issue.title;
+    issueLabels = (issue.labels ?? [])
+      .map((l) => (typeof l === 'string' ? l : (l.name ?? '')))
+      .filter((name): name is string => Boolean(name));
+    if (issue.created_at) issueCreatedAt = issue.created_at;
+  } catch (error) {
+    warn(
+      MODULE,
+      `Claimed ${options.issueUrl} but failed to enrich issue metadata (title/labels): ${error instanceof Error ? error.message : error}`,
+    );
+  }
+
   // Add to tracked issues — non-fatal if state save fails (comment already posted)
   try {
     const stateManager = getStateManager();
@@ -237,10 +260,10 @@ export async function runClaim(options: ClaimOptions): Promise<ClaimOutput> {
       url: options.issueUrl,
       repo: `${owner}/${repo}`,
       number,
-      title: '(claimed)',
+      title: issueTitle,
       status: 'claimed',
-      labels: [],
-      createdAt: new Date().toISOString(),
+      labels: issueLabels,
+      createdAt: issueCreatedAt,
       updatedAt: new Date().toISOString(),
       vetted: false,
     });
@@ -249,8 +272,11 @@ export async function runClaim(options: ClaimOptions): Promise<ClaimOutput> {
     // signal (#1036 audit H1).
     await maybeCheckpoint(stateManager, MODULE);
   } catch (error) {
-    console.error(
-      `Warning: Comment posted on ${options.issueUrl} but failed to save to local state: ${error instanceof Error ? error.message : error}`,
+    // Structured warning instead of bare console.error so the breadcrumb shows
+    // up in the plugin's log pipeline (#1056 M24).
+    warn(
+      MODULE,
+      `Comment posted on ${options.issueUrl} but failed to save to local state: ${error instanceof Error ? error.message : error}`,
     );
   }
 

--- a/packages/core/src/commands/daily.e2e.test.ts
+++ b/packages/core/src/commands/daily.e2e.test.ts
@@ -69,11 +69,14 @@ describe.skipIf(!BUNDLE_EXISTS)('daily --json E2E', () => {
     fs.rmSync(TEST_HOME, { recursive: true, force: true });
   });
 
-  it('should exit with an auth error when no GitHub token is available', async () => {
-    const { stderr, exitCode } = await runDaily({ GITHUB_TOKEN: '', PATH: process.env.PATH || '' });
-    // The preAction hook writes to stderr and calls process.exit(1)
+  it('should exit with an auth error envelope when --json is passed and no GitHub token is available', async () => {
+    // `daily --json` always uses JSON, so the preAction hook must emit a
+    // parseable `{ success:false, errorCode:'AUTH_REQUIRED' }` envelope on
+    // stdout instead of a stderr blob (#1056 M20).
+    const { json, stdout, exitCode } = await runDaily({ GITHUB_TOKEN: '' });
     expect(exitCode).not.toBe(0);
-    expect(stderr).toContain('GitHub authentication required');
+    expect(json, `expected parseable JSON envelope; got stdout=${stdout.slice(0, 300)}`).not.toBeNull();
+    expect(json).toMatchObject({ success: false, errorCode: 'AUTH_REQUIRED' });
   });
 
   describe.skipIf(!HAS_GITHUB_TOKEN)('with GitHub token', () => {

--- a/packages/core/src/commands/move.ts
+++ b/packages/core/src/commands/move.ts
@@ -4,6 +4,7 @@
  */
 
 import { getStateManager, maybeCheckpoint } from '../core/index.js';
+import { ValidationError } from '../core/errors.js';
 import { PR_URL_PATTERN, validateGitHubUrl, validateUrl } from './validation.js';
 
 const MODULE = 'move';
@@ -26,8 +27,7 @@ export interface MoveOutput {
  * @param options.prUrl - Full GitHub PR URL
  * @param options.target - Target state: 'attention' | 'waiting' | 'shelved' | 'auto'
  * @returns The move result with a human-readable description
- * @throws {ValidationError} If the URL is not a valid GitHub PR URL
- * @throws {Error} If the target is invalid
+ * @throws {ValidationError} If the URL is not a valid GitHub PR URL or the target is invalid
  */
 export async function runMove(options: { prUrl: string; target: string }): Promise<MoveOutput> {
   validateUrl(options.prUrl);
@@ -35,7 +35,7 @@ export async function runMove(options: { prUrl: string; target: string }): Promi
 
   const target = options.target as MoveTarget;
   if (!VALID_TARGETS.includes(target)) {
-    throw new Error(`Invalid target "${options.target}". Must be one of: ${VALID_TARGETS.join(', ')}`);
+    throw new ValidationError(`Invalid target "${options.target}". Must be one of: ${VALID_TARGETS.join(', ')}`);
   }
 
   const stateManager = getStateManager();

--- a/packages/core/src/commands/read.ts
+++ b/packages/core/src/commands/read.ts
@@ -4,6 +4,7 @@
  * This command is a no-op preserved for backward compatibility.
  */
 
+import { ValidationError } from '../core/errors.js';
 import { validateUrl } from './validation.js';
 
 export type ReadOutput =
@@ -12,7 +13,7 @@ export type ReadOutput =
 
 export async function runRead(options: { prUrl?: string; all?: boolean }): Promise<ReadOutput> {
   if (!options.all && !options.prUrl) {
-    throw new Error('PR URL or --all flag required');
+    throw new ValidationError('PR URL or --all flag required');
   }
 
   if (options.prUrl) {

--- a/packages/core/src/commands/search.e2e.test.ts
+++ b/packages/core/src/commands/search.e2e.test.ts
@@ -70,11 +70,14 @@ describe.skipIf(!BUNDLE_EXISTS)('search --json E2E', () => {
     fs.rmSync(TEST_HOME, { recursive: true, force: true });
   });
 
-  it('should exit with an auth error when no GitHub token is available', async () => {
-    const { stderr, exitCode } = await runSearch([], { GITHUB_TOKEN: '', PATH: process.env.PATH || '' });
-    // The preAction hook writes to stderr and calls process.exit(1)
+  it('should exit with an auth error envelope when --json is passed and no GitHub token is available', async () => {
+    // `search --json` always uses JSON, so the preAction hook must emit a
+    // parseable `{ success:false, errorCode:'AUTH_REQUIRED' }` envelope on
+    // stdout instead of a stderr blob (#1056 M20).
+    const { json, stdout, exitCode } = await runSearch([], { GITHUB_TOKEN: '' });
     expect(exitCode).not.toBe(0);
-    expect(stderr).toContain('GitHub authentication required');
+    expect(json, `expected parseable JSON envelope; got stdout=${stdout.slice(0, 300)}`).not.toBeNull();
+    expect(json).toMatchObject({ success: false, errorCode: 'AUTH_REQUIRED' });
   });
 
   describe.skipIf(!HAS_GITHUB_TOKEN)('with GitHub token', () => {

--- a/packages/core/src/commands/track.ts
+++ b/packages/core/src/commands/track.ts
@@ -14,6 +14,7 @@
  */
 
 import { getOctokit, requireGitHubToken } from '../core/index.js';
+import { ValidationError } from '../core/errors.js';
 import type { TrackOutput } from '../formatters/json.js';
 import { validateUrl, PR_URL_PATTERN, validateGitHubUrl } from './validation.js';
 import { parseGitHubUrl } from '../core/utils.js';
@@ -45,7 +46,7 @@ export async function runTrack(options: { prUrl: string }): Promise<TrackOutput>
 
   const parsed = parseGitHubUrl(options.prUrl);
   if (!parsed || parsed.type !== 'pull') {
-    throw new Error(`Invalid PR URL: ${options.prUrl}`);
+    throw new ValidationError(`Invalid PR URL: ${options.prUrl}`);
   }
 
   const { owner, repo, number } = parsed;


### PR DESCRIPTION
## Summary

Closes five sub-findings from umbrella issue #1056:

- **M17** — `hooks/auto-format-before-push.sh` timeout bumped 30s → 60s. The 30s cap was too tight for first-run `pnpm install` resolution; the hook silently passed the push through unformatted when it timed out.
- **M20** — `packages/core/src/cli.ts` preAction auth failure now honors `--json`. When the flag is present on the invocation, the CLI emits a parseable `{ success:false, error:…, errorCode:'AUTH_REQUIRED' }` envelope to stdout instead of a multi-line stderr guide. Plugins, MCP stdio harnesses, and scripts can now parse the failure. Non-JSON callers keep the interactive guide verbatim.
- **M21** — `move.ts`, `read.ts`, `track.ts`, and `comments.ts` replace plain `new Error(...)` throws with `ValidationError` so `resolveErrorCode` surfaces `errorCode: 'VALIDATION'` in the JSON envelope instead of the catch-all `UNKNOWN`. Covers invalid move target, missing `prUrl`/`all` on read, malformed PR URL on track/comments, empty message on post, non-issue URL on claim.
- **M23** — Rewrite `status --offline` help text to match actual behavior. The flag only toggles `lastUpdated` metadata in output; status always reads from local state regardless. Updated both the commander option description and the human-readable "(Offline mode…)" line. Didn't rename the flag — MCP exposes it too and renaming would be a contract break.
- **M24** — `runClaim` now fetches the real issue title/labels/createdAt via `octokit.issues.get` (best-effort) instead of writing `title: '(claimed)'` as a permanent placeholder that never got backfilled. Falls back to the placeholder if the fetch fails. Replaces bare `console.error("Warning: Comment posted on …")` in the state-save catch with structured `warn(MODULE, …)` so the breadcrumb shows up in the plugin log pipeline.

## New contract test

`packages/core/src/commands/auth-envelope.e2e.test.ts` pins the M20 behavior as a real subprocess test — it runs `daily --json` with an empty token and an isolated `HOME`/`PATH`, then asserts the parseable envelope. Also asserts the non-JSON path retains the legacy stderr guide.

Two existing e2e tests (`daily.e2e.test.ts`, `search.e2e.test.ts`) that asserted the pre-M20 stderr behavior are now updated to assert the new JSON envelope (stricter, not looser).

## Deferred per umbrella guidance

- **M16** — consolidate PreToolUse hooks into a single dispatcher — architectural.
- **M18** — `npm install` inside pnpm workspace during `session-start.sh` — safe today, future problem.
- **M19** — marketplace clone race needs a `flock` primitive design.
- **M22** — remove `runRead`/`runUntrack` v1 stubs. Both are still exposed as MCP tools (`read`, `untrack`); removal is a contract break that needs a deprecation cycle in a dedicated PR.

## Test plan

- [x] `pnpm run lint` passes
- [x] `pnpm test` passes (2040 core + 253 dashboard + 181 MCP = 2474 passing)
- [x] `pnpm run bundle` rebuilds — bundle size 735,655 bytes, under the 740,000 CI cap
- [x] `npx prettier --check packages/` passes
- [x] Smoke test: `HOME=/tmp/empty GITHUB_TOKEN='' PATH=/tmp/nothing node packages/core/dist/cli.bundle.cjs daily --json` emits the expected `AUTH_REQUIRED` envelope