### PR TITLE
fix: UM3 infra + core-domain quality (M25, M27, M30, M34)

### DIFF
--- a/packages/core/src/commands/daily.ts
+++ b/packages/core/src/commands/daily.ts
@@ -179,7 +179,8 @@ interface PartitionedPRs {
  */
 async function fetchPRData(prMonitor: PRMonitor, token: string, warnings: DailyWarning[]): Promise<FetchedPRData> {
   // Fetch all open PRs fresh from GitHub
-  const { prs, failures } = await prMonitor.fetchUserOpenPRs();
+  const fetchResult = await prMonitor.fetchUserOpenPRs();
+  const { prs, failures } = fetchResult;
 
   // Log any failures (but continue with successful checks)
   if (failures.length > 0) {
@@ -191,6 +192,19 @@ async function fetchPRData(prMonitor: PRMonitor, token: string, warnings: DailyW
       message: `${failures.length} PR fetch(es) failed`,
     });
     warn(MODULE, `${failures.length} PR fetch(es) failed`);
+  }
+
+  // Surface search-API truncation warnings (#1057 M25) so daily consumers
+  // see the partial-view signal in their `warnings` array rather than only
+  // in server logs.
+  if (fetchResult.warnings) {
+    for (const message of fetchResult.warnings) {
+      warnings.push({
+        phase: 'fetch',
+        operation: 'fetch open PRs (truncated)',
+        message,
+      });
+    }
   }
 
   // Build star filter from cached repoScores so low-star repos are excluded

--- a/packages/core/src/commands/dashboard-data.ts
+++ b/packages/core/src/commands/dashboard-data.ts
@@ -243,7 +243,7 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
   };
 
   const [
-    { prs, failures },
+    { prs, failures, warnings: fetchWarnings },
     recentlyClosedPRs,
     recentlyMergedPRs,
     mergedResult,
@@ -291,6 +291,16 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
 
   if (failures.length > 0) {
     warn(MODULE, `${failures.length} PR fetch(es) failed`);
+  }
+
+  // Surface search-API truncation warnings (#1057 M25) into the dashboard's
+  // partialFailures banner so a user with >1000 open PRs sees the "partial
+  // view" signal in the SPA rather than silently seeing an incomplete list.
+  if (fetchWarnings) {
+    for (const message of fetchWarnings) {
+      partialFailures.push(message);
+      warn(MODULE, message);
+    }
   }
 
   // Wrap all state mutations in a batch for a single disk write.

--- a/packages/core/src/core/ci-analysis.test.ts
+++ b/packages/core/src/core/ci-analysis.test.ts
@@ -46,6 +46,18 @@ describe('classifyCICheck', () => {
     expect(classifyCICheck('Meta Internal')).toBe('fork_limitation');
   });
 
+  // #1057 M34 — the plain `\binternal\b` pattern was too broad and would
+  // misclassify test-family checks named "Internal X Tests" as fork
+  // limitations. Tightened pattern excludes a small set of test-descriptor
+  // qualifiers so these are still treated as real CI.
+  it('should NOT classify "internal <test-type>" checks as fork_limitation', () => {
+    expect(classifyCICheck('Internal API Tests')).not.toBe('fork_limitation');
+    expect(classifyCICheck('Internal Integration Tests')).not.toBe('fork_limitation');
+    expect(classifyCICheck('Internal Unit Tests')).not.toBe('fork_limitation');
+    expect(classifyCICheck('Internal E2E')).not.toBe('fork_limitation');
+    expect(classifyCICheck('Internal Regression')).not.toBe('fork_limitation');
+  });
+
   it('should classify Blacksmith CI runners as infrastructure (#675)', () => {
     expect(classifyCICheck('Playwright Tests (blacksmith-8vcpu-ubuntu, beta)')).toBe('infrastructure');
     expect(classifyCICheck('Blacksmith / build')).toBe('infrastructure');

--- a/packages/core/src/core/ci-analysis.ts
+++ b/packages/core/src/core/ci-analysis.ts
@@ -26,7 +26,12 @@ const FORK_LIMITATION_PATTERNS: RegExp[] = [
   /chromatic/i,
   /percy/i,
   /cloudflare pages/i,
-  /\binternal\b/i,
+  // Tightened from plain `\binternal\b` (#1057 M34). Still catches the
+  // known "Facebook Internal", "Meta Internal", and "Internal - <thing>"
+  // fork-limitation checks (#675), but the negative lookahead prevents
+  // misclassifying legitimate test checks like "Internal API tests" or
+  // "Internal Integration Tests".
+  /\binternal\b(?!\s+(?:api|test|integration|smoke|unit|e2e|regression|functional))/i,
 ];
 
 /**

--- a/packages/core/src/core/http-cache.test.ts
+++ b/packages/core/src/core/http-cache.test.ts
@@ -200,6 +200,49 @@ describe('HttpCache', () => {
       expect(missing.size()).toBe(0);
     });
   });
+
+  // #1057 M27 — opportunistic max-entries cap on write, so long-lived
+  // sessions don't accumulate unbounded cache files between the daily
+  // `evictStale()` sweep.
+  describe('max-entries cap (opportunistic eviction on set)', () => {
+    it('caps the cache at maxEntries, evicting the oldest on overflow', () => {
+      const capped = new HttpCache(cacheDir, 3);
+
+      // Seed four entries; older files get older mtimes so eviction is
+      // deterministic. Without the sleep, the resolution may round all
+      // four mtimes to the same millisecond on some filesystems.
+      capped.set('/a', '"e1"', { k: 1 });
+      const aPath = path.join(cacheDir, crypto.createHash('sha256').update('/a').digest('hex') + '.json');
+      fs.utimesSync(aPath, 0, 0);
+
+      capped.set('/b', '"e2"', { k: 2 });
+      const bPath = path.join(cacheDir, crypto.createHash('sha256').update('/b').digest('hex') + '.json');
+      fs.utimesSync(bPath, 100, 100);
+
+      capped.set('/c', '"e3"', { k: 3 });
+      const cPath = path.join(cacheDir, crypto.createHash('sha256').update('/c').digest('hex') + '.json');
+      fs.utimesSync(cPath, 200, 200);
+
+      // Before the overflow: 3 entries, all present.
+      expect(capped.size()).toBe(3);
+
+      // Fourth write should trigger eviction of the oldest (/a).
+      capped.set('/d', '"e4"', { k: 4 });
+      expect(capped.size()).toBe(3);
+      expect(capped.get('/a')).toBeNull();
+      expect(capped.get('/b')).not.toBeNull();
+      expect(capped.get('/c')).not.toBeNull();
+      expect(capped.get('/d')).not.toBeNull();
+    });
+
+    it('disables the cap when maxEntries <= 0', () => {
+      const unbounded = new HttpCache(cacheDir, 0);
+      for (let i = 0; i < 10; i++) {
+        unbounded.set(`/k/${i}`, `"e${i}"`, { i });
+      }
+      expect(unbounded.size()).toBe(10);
+    });
+  });
 });
 
 describe('cachedRequest', () => {

--- a/packages/core/src/core/http-cache.ts
+++ b/packages/core/src/core/http-cache.ts
@@ -36,6 +36,16 @@ export interface CacheEntry {
 const DEFAULT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
 /**
+ * Soft cap on the number of entries kept on disk (#1057 M27). `set()`
+ * opportunistically evicts the oldest entries when the directory grows past
+ * this ceiling. The cap is deliberately high (2000) so it doesn't thrash a
+ * normal day's traffic — it's a belt-and-suspenders guard against unbounded
+ * growth on long-running sessions that accumulate cache files between the
+ * daily `evictStale()` sweep.
+ */
+const DEFAULT_MAX_ENTRIES = 2000;
+
+/**
  * File-based HTTP cache backed by `~/.oss-autopilot/cache/`.
  *
  * Each cache entry is stored as a separate JSON file keyed by the SHA-256
@@ -44,12 +54,14 @@ const DEFAULT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
  */
 export class HttpCache {
   private readonly cacheDir: string;
+  private readonly maxEntries: number;
 
   /** In-flight request deduplication map: URL -> Promise<response>. */
   private readonly inflightRequests = new Map<string, Promise<unknown>>();
 
-  constructor(cacheDir?: string) {
+  constructor(cacheDir?: string, maxEntries: number = DEFAULT_MAX_ENTRIES) {
     this.cacheDir = cacheDir ?? getCacheDir();
+    this.maxEntries = maxEntries;
   }
 
   /** Derive a filesystem-safe cache key from a URL. */
@@ -107,9 +119,54 @@ export class HttpCache {
     try {
       fs.writeFileSync(this.pathFor(url), JSON.stringify(entry), { encoding: 'utf-8', mode: 0o600 });
       debug(MODULE, `Cached response for ${url}`);
+      // Best-effort size cap (#1057 M27). Runs after each write rather than on
+      // a schedule so long-lived sessions can't accumulate past the cap.
+      this.evictIfExceeds(this.maxEntries);
     } catch (err) {
       // Non-fatal: cache write failure should not break the request
       debug(MODULE, `Failed to write cache for ${url}`, err);
+    }
+  }
+
+  /**
+   * If the cache directory exceeds `maxEntries`, evict the oldest entries
+   * (by mtime) until it's at the cap. Best-effort — any I/O failure is
+   * swallowed so cache-bookkeeping never breaks the request path.
+   */
+  private evictIfExceeds(maxEntries: number): void {
+    if (maxEntries <= 0) return;
+    try {
+      const entries = fs.readdirSync(this.cacheDir).filter((f) => f.endsWith('.json'));
+      if (entries.length <= maxEntries) return;
+
+      // Stat once; sort oldest first so we evict the stalest files.
+      const withMtime = entries
+        .map((file) => {
+          const fullPath = path.join(this.cacheDir, file);
+          try {
+            return { fullPath, mtimeMs: fs.statSync(fullPath).mtimeMs };
+          } catch {
+            return null;
+          }
+        })
+        .filter((e): e is { fullPath: string; mtimeMs: number } => e !== null)
+        .sort((a, b) => a.mtimeMs - b.mtimeMs);
+
+      const toEvict = withMtime.length - maxEntries;
+      let evicted = 0;
+      for (let i = 0; i < toEvict; i++) {
+        try {
+          fs.unlinkSync(withMtime[i].fullPath);
+          evicted++;
+        } catch {
+          // Another process may have raced us — ignore.
+        }
+      }
+      if (evicted > 0) {
+        debug(MODULE, `Capped cache at ${maxEntries} entries: evicted ${evicted} oldest`);
+      }
+    } catch {
+      // Cache dir missing / unreadable — not fatal.
     }
   }
 

--- a/packages/core/src/core/maintainer-analysis.test.ts
+++ b/packages/core/src/core/maintainer-analysis.test.ts
@@ -45,4 +45,50 @@ describe('extractMaintainerActionHints', () => {
     expect(result).toContain('demo_requested');
     expect(result).toContain('tests_requested');
   });
+
+  /**
+   * False-positive resistance tests (#1057 M30).
+   *
+   * These comments mention hint keywords *incidentally* — as past-tense status
+   * statements, unrelated context, or quoted patterns — and should NOT trigger
+   * action hints. When a test here fails, that means the pattern matcher got
+   * looser (or broader) and is now over-detecting. Tighten the rule, not this
+   * test.
+   *
+   * The repo's gold-standard for this style of pinning is
+   * anti-llm-policy.test.ts (13+ false-positive-resistance cases).
+   */
+  describe('false-positive resistance', () => {
+    describe('rebase_requested should NOT fire on past-tense rebase mentions', () => {
+      // These were the cases the umbrella audit called out — the old
+      // `includes('rebase')` matcher fired on them; the word-boundary regex
+      // tightening lets them through.
+      it.each(['After rebasing this was fine', 'I already rebased onto main', 'The rebaser rewrote history here'])(
+        'does not flag %p',
+        (comment) => {
+          const result = extractMaintainerActionHints(comment, 'approved');
+          expect(result).not.toContain('rebase_requested');
+        },
+      );
+    });
+
+    describe('unrelated commentary on hint topics should NOT fire', () => {
+      // These are cases where the substring matcher has a known limitation —
+      // it fires on incidental mentions (e.g. a user saying "the screenshot
+      // shows X" as context, not as a request). They are intentionally kept
+      // here as `.todo` so a future tightening pass (imperative-context
+      // detection) has a regression checkpoint. Removing `.todo` and making
+      // them assert `not.toContain(...)` is the definition of success.
+      it.todo("should not flag demo_requested on 'the screenshot shows the bug'");
+      it.todo("should not flag tests_requested on 'the existing unit tests pass'");
+      it.todo("should not flag docs_requested on 'the documentation confused me'");
+    });
+
+    // Reassure ourselves the tightening didn't break real requests.
+    it('still catches real rebase requests after tightening', () => {
+      expect(extractMaintainerActionHints('Please rebase', 'approved')).toContain('rebase_requested');
+      expect(extractMaintainerActionHints('rebase on main first', 'approved')).toContain('rebase_requested');
+      expect(extractMaintainerActionHints('Could you rebase this?', 'approved')).toContain('rebase_requested');
+    });
+  });
 });

--- a/packages/core/src/core/maintainer-analysis.ts
+++ b/packages/core/src/core/maintainer-analysis.ts
@@ -62,9 +62,15 @@ export function extractMaintainerActionHints(
     hints.push('docs_requested');
   }
 
-  // Rebase requests
-  const rebaseKeywords = ['rebase', 'merge conflict', 'out of date', 'behind main', 'behind master'];
-  if (rebaseKeywords.some((kw) => lower.includes(kw))) {
+  // Rebase requests.
+  //
+  // The `rebase` term uses a word-boundary regex so past-tense mentions like
+  // "after rebasing this was fine" or "I already rebased this" don't trigger
+  // a rebase_requested hint (#1057 M30). The other phrases are specific
+  // enough that plain substring matching is sufficient.
+  const rebasePhrases = ['merge conflict', 'out of date', 'behind main', 'behind master'];
+  const hasRebaseWord = /\brebase\b/i.test(commentBody);
+  if (hasRebaseWord || rebasePhrases.some((kw) => lower.includes(kw))) {
     hints.push('rebase_requested');
   }
 

--- a/packages/core/src/core/pr-monitor.test.ts
+++ b/packages/core/src/core/pr-monitor.test.ts
@@ -1661,6 +1661,59 @@ describe('fetchUserOpenPRs does not filter by excludeRepos/excludeOrgs (#591)', 
   });
 });
 
+// #1057 M25 — the GitHub Search API caps results at 1000, so a user with
+// >1000 open PRs silently gets a truncated list. fetchUserOpenPRs must
+// surface a warning for the caller (daily.ts) to include in the digest.
+describe('fetchUserOpenPRs surfaces 1000-cap truncation (#1057 M25)', () => {
+  it('returns warnings when total_count exceeds the 1000-result search cap', async () => {
+    vi.mocked(getStateManager).mockReturnValue(
+      makeStateManagerMock({
+        config: { githubUsername: 'heavyuser', excludeRepos: [], excludeOrgs: [] },
+      }),
+    );
+
+    mockOctokitInstance = {
+      search: {
+        issuesAndPullRequests: vi.fn().mockResolvedValue({
+          // 1500 > 1000 → truncation warning expected.
+          data: { total_count: 1500, items: [] },
+        }),
+      },
+    };
+
+    const monitor = new PRMonitor('fake-token');
+    const result = await monitor.fetchUserOpenPRs();
+
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings!.length).toBeGreaterThanOrEqual(1);
+    expect(result.warnings![0]).toMatch(/1500/);
+    expect(result.warnings![0]).toMatch(/1000/);
+    expect(result.warnings![0]).toMatch(/heavyuser/);
+  });
+
+  it('does NOT emit a warning when total_count <= 1000', async () => {
+    vi.mocked(getStateManager).mockReturnValue(
+      makeStateManagerMock({
+        config: { githubUsername: 'normaluser', excludeRepos: [], excludeOrgs: [] },
+      }),
+    );
+
+    mockOctokitInstance = {
+      search: {
+        issuesAndPullRequests: vi.fn().mockResolvedValue({
+          data: { total_count: 42, items: [] },
+        }),
+      },
+    };
+
+    const monitor = new PRMonitor('fake-token');
+    const result = await monitor.fetchUserOpenPRs();
+
+    // No warnings (absent field or empty array both acceptable).
+    expect(result.warnings ?? []).toEqual([]);
+  });
+});
+
 describe('isBotAuthor (#143)', () => {
   it('should identify [bot] suffix accounts', () => {
     expect(isBotAuthor('dependabot[bot]')).toBe(true);

--- a/packages/core/src/core/pr-monitor.ts
+++ b/packages/core/src/core/pr-monitor.ts
@@ -72,6 +72,13 @@ export interface PRCheckFailure {
 export interface FetchPRsResult {
   prs: FetchedPR[];
   failures: PRCheckFailure[];
+  /**
+   * Non-fatal warnings accumulated while fetching. Currently populated when
+   * the GitHub Search API's 1000-result ceiling truncates the user's PR
+   * list — callers (daily, dashboard) surface these so users know the data
+   * may be incomplete (#1057 M25).
+   */
+  warnings?: string[];
 }
 
 /**
@@ -133,10 +140,27 @@ export class PRMonitor {
 
     allItems.push(...firstPage.data.items);
     const totalCount = firstPage.data.total_count;
-    debug('pr-monitor', `Found ${totalCount} open PRs`);
+    debug(MODULE, `Found ${totalCount} open PRs`);
 
     // Fetch remaining pages if needed (GitHub search API returns max 1000 results)
-    const totalPages = Math.min(Math.ceil(totalCount / perPage), 10); // Cap at 1000 results
+    const SEARCH_API_RESULT_CAP = 1000;
+    const MAX_PAGES = Math.ceil(SEARCH_API_RESULT_CAP / perPage); // 10 pages at per_page=100
+    const totalPages = Math.min(Math.ceil(totalCount / perPage), MAX_PAGES);
+
+    // Non-fatal warnings threaded into the result (#1057 M25). When the
+    // Search API's hard 1000-result ceiling truncates the user's PR list we
+    // previously silently dropped the overflow; now the caller can surface
+    // it so the daily digest doesn't quietly report a partial view.
+    const warnings: string[] = [];
+    if (totalCount > SEARCH_API_RESULT_CAP) {
+      warnings.push(
+        `GitHub Search API returned ${totalCount} PRs for @${config.githubUsername}, ` +
+          `but results are capped at ${SEARCH_API_RESULT_CAP}. ` +
+          `Showing the ${SEARCH_API_RESULT_CAP} most recently updated PRs.`,
+      );
+      warn(MODULE, warnings[warnings.length - 1]);
+    }
+
     while (page < totalPages) {
       page++;
       const nextPage = await this.octokit.search.issuesAndPullRequests({
@@ -192,7 +216,7 @@ export class PRMonitor {
       return a.status === 'needs_addressing' ? -1 : 1;
     });
 
-    return { prs, failures };
+    return warnings.length > 0 ? { prs, failures, warnings } : { prs, failures };
   }
 
   /**


### PR DESCRIPTION
## Summary

Closes four sub-findings from umbrella issue #1057:

- **M25** — `pr-monitor.ts`, `daily.ts`, `dashboard-data.ts`. Added `warnings?: string[]` field to `FetchPRsResult`. When the GitHub Search API's 1000-result cap truncates a user's open-PR list, emit an explicit warning. Threaded into `DailyOutput.warnings` (daily consumer) **and** into `dashboardData.partialFailures` (dashboard SPA consumer) so the "partial view" signal reaches both UIs.
- **M27** — `http-cache.ts`. Added a soft max-entries cap (default 2000) with opportunistic mtime-ordered eviction on each `set()`. Guards long-running sessions from unbounded cache growth between daily `evictStale()` sweeps. Disabled when `maxEntries <= 0`. Size-check short-circuits before `stat` calls in the common under-cap case.
- **M30** — `maintainer-analysis.ts`. Tightened `rebase` keyword detection from `lower.includes('rebase')` to `/\brebase\b/i`. Past-tense status mentions ("after rebasing this was fine", "I already rebased") no longer fire the `rebase_requested` hint. Merge-conflict / out-of-date / behind-main phrases unchanged.
- **M34** — `ci-analysis.ts`. Tightened `/\binternal\b/i` fork-limitation pattern to a negative lookahead that excludes test-descriptor qualifiers. Still catches "Facebook Internal" / "Meta Internal" (the original #675 cases) but no longer misclassifies "Internal API Tests" / "Internal Integration Tests" as fork limitations.

## Review-feedback fix

Reviewer caught that `dashboard-data.ts` destructured `{ prs, failures }` and dropped the new `warnings` field — the M25 fix would have reached only the `daily` consumer. Updated to also destructure `warnings` and push entries into the existing `partialFailures` array so the SPA's "partial data" banner surfaces truncation too.

## Deferred per umbrella guidance

- **M26** — dashboard child-process leak. Existing timeout path already kills; remaining early-return paths only fire after child emitted `error`/`exit`.
- **M28** — `mergeMonthlyCounts` anti-regression. Already implemented in cycle 9 / C9 (#1035). Verified.
- **M29** — Gist ETag / conflict resolution. Design-heavy, deserves dedicated PR.
- **M31** — `utils.ts` 584-LOC split. Dedicated refactor PR.
- **M32/M33** — `daily-logic` split + types relocation. Coupled refactor.
- **M35** — write-side URL validation. Current read-side `warn()` already surfaces the signal.

## Test plan

- [x] `pnpm run lint` passes
- [x] `pnpm test` passes (2049 core + 253 dashboard + 181 MCP = 2483 passing, 3 new `.todo` placeholders)
- [x] `pnpm run bundle` rebuilds — cli.bundle.cjs 736,623 bytes, under the 740,000 CI cap
- [x] `npx prettier --check packages/` passes
- [x] New tests added:
  - `pr-monitor.test.ts` — 1000-cap truncation warning regression test
  - `maintainer-analysis.test.ts` — false-positive resistance suite
  - `ci-analysis.test.ts` — "Internal X Tests" not classified as fork_limitation
  - `http-cache.test.ts` — max-entries cap evicts the oldest entry