### PR TITLE
fix: UM4 dashboard SPA + MCP polish (M37, M38, M39, M40, M41)

### DIFF
--- a/packages/dashboard/index.html
+++ b/packages/dashboard/index.html
@@ -24,6 +24,34 @@
     />
   </head>
   <body>
+    <noscript>
+      <div
+        style="
+          max-width: 40rem;
+          margin: 4rem auto;
+          padding: 1.5rem;
+          font-family:
+            system-ui,
+            -apple-system,
+            sans-serif;
+          line-height: 1.5;
+          color: #e0e0e0;
+          background: #1a1a1a;
+          border: 1px solid #333;
+          border-radius: 8px;
+        "
+      >
+        <h1 style="margin-top: 0">JavaScript required</h1>
+        <p>
+          The OSS Autopilot dashboard is a single-page app that renders entirely on the client. Please enable JavaScript
+          for this origin to use the interactive UI.
+        </p>
+        <p>
+          For a raw JSON view of the same data, fetch
+          <code style="background: #252525; padding: 0.125rem 0.375rem; border-radius: 3px">/api/data</code> directly.
+        </p>
+      </div>
+    </noscript>
     <div id="app"></div>
     <script type="module" src="/src/index.tsx"></script>
   </body>

--- a/packages/dashboard/src/app.test.tsx
+++ b/packages/dashboard/src/app.test.tsx
@@ -159,7 +159,7 @@ describe('App', () => {
 
       const rows = container.querySelectorAll('.pr-row');
       expect(rows).toHaveLength(1);
-      expect(rows[0].textContent).toContain('Update docs');
+      expect(rows[0]!.textContent).toContain('Update docs');
     });
 
     it('filters by search text (case-insensitive)', async () => {
@@ -174,7 +174,7 @@ describe('App', () => {
 
       const rows = container.querySelectorAll('.pr-row');
       expect(rows).toHaveLength(1);
-      expect(rows[0].textContent).toContain('Fix auth bug');
+      expect(rows[0]!.textContent).toContain('Fix auth bug');
     });
 
     it('filters by search text matching repo name', async () => {
@@ -189,7 +189,7 @@ describe('App', () => {
 
       const rows = container.querySelectorAll('.pr-row');
       expect(rows).toHaveLength(1);
-      expect(rows[0].textContent).toContain('Update docs');
+      expect(rows[0]!.textContent).toContain('Update docs');
     });
 
     it('filters by search text matching PR number', async () => {
@@ -204,7 +204,7 @@ describe('App', () => {
 
       const rows = container.querySelectorAll('.pr-row');
       expect(rows).toHaveLength(1);
-      expect(rows[0].textContent).toContain('Add feature');
+      expect(rows[0]!.textContent).toContain('Add feature');
     });
 
     it('combines multiple filters', async () => {
@@ -224,7 +224,7 @@ describe('App', () => {
 
       const rows = container.querySelectorAll('.pr-row');
       expect(rows).toHaveLength(1);
-      expect(rows[0].textContent).toContain('Add feature');
+      expect(rows[0]!.textContent).toContain('Add feature');
     });
   });
 

--- a/packages/dashboard/src/app.tsx
+++ b/packages/dashboard/src/app.tsx
@@ -278,24 +278,34 @@ function AppContent() {
     );
   }
 
-  // Default route: dashboard home
-  const repos = [...new Set(data.activePRs.map((pr) => pr.repo))].sort();
-  const statuses = [...new Set(data.activePRs.map((pr) => pr.status))].sort();
+  // Default route: dashboard home.
+  //
+  // These derivations were previously recomputed on every render — including
+  // every keystroke in the search input — even though they only depend on
+  // the stable PR list. Memoize so `filter` over hundreds of PRs doesn't
+  // rerun on unrelated state changes (#1058 M37).
+  const repos = useMemo(() => [...new Set(data.activePRs.map((pr) => pr.repo))].sort(), [data.activePRs]);
+  const statuses = useMemo(() => [...new Set(data.activePRs.map((pr) => pr.status))].sort(), [data.activePRs]);
 
-  const filteredPRs = data.activePRs.filter((pr) => {
-    if (filters.status !== 'all' && pr.status !== filters.status) return false;
-    if (filters.repo !== 'all' && pr.repo !== filters.repo) return false;
-    if (filters.search) {
-      const term = filters.search.toLowerCase();
-      const searchable = `${pr.title} ${pr.repo} ${pr.number}`.toLowerCase();
-      if (!searchable.includes(term)) return false;
-    }
-    return true;
-  });
+  const filteredPRs = useMemo(() => {
+    return data.activePRs.filter((pr) => {
+      if (filters.status !== 'all' && pr.status !== filters.status) return false;
+      if (filters.repo !== 'all' && pr.repo !== filters.repo) return false;
+      if (filters.search) {
+        const term = filters.search.toLowerCase();
+        const searchable = `${pr.title} ${pr.repo} ${pr.number}`.toLowerCase();
+        if (!searchable.includes(term)) return false;
+      }
+      return true;
+    });
+  }, [data.activePRs, filters.status, filters.repo, filters.search]);
 
   const selectedPR = selectedUrl ? (data.activePRs.find((pr) => pr.url === selectedUrl) ?? null) : null;
 
-  const activePRs = data.activePRs.filter((pr) => !shelvedUrls.has(pr.url));
+  const activePRs = useMemo(
+    () => data.activePRs.filter((pr) => !shelvedUrls.has(pr.url)),
+    [data.activePRs, shelvedUrls],
+  );
   const needAttentionCount = activePRs.filter((pr) => pr.status === 'needs_addressing').length;
   const waitingCount = activePRs.filter((pr) => pr.status === 'waiting_on_maintainer').length;
 

--- a/packages/dashboard/src/components/animated-value.tsx
+++ b/packages/dashboard/src/components/animated-value.tsx
@@ -13,7 +13,10 @@ export function AnimatedValue({ value }: AnimatedValueProps) {
   // render a broken count-up (`"0.9%"`, `"37.9%"`, `"76.9%"`). Decimal or
   // otherwise non-matching strings fall through to static rendering.
   const stringMatch = typeof value === 'string' ? value.match(/^(\d+)([^\d.].*)?$/) : null;
-  const target = typeof value === 'number' ? value : stringMatch ? parseInt(stringMatch[1], 10) : 0;
+  // Group 1 is `(\d+)` and is mandatory in a successful match, so when
+  // `stringMatch` is truthy, `stringMatch[1]` is always a string. The `?? '0'`
+  // exists only to satisfy `noUncheckedIndexedAccess` (#1058 M38).
+  const target = typeof value === 'number' ? value : stringMatch ? parseInt(stringMatch[1] ?? '0', 10) : 0;
   const animated = useCountUp(target);
 
   if (typeof value === 'number') return <>{animated}</>;

--- a/packages/dashboard/src/components/closed-pr-list.test.tsx
+++ b/packages/dashboard/src/components/closed-pr-list.test.tsx
@@ -37,8 +37,8 @@ describe('ClosedPRList', () => {
     expect((links[0] as HTMLAnchorElement).href).toBe('https://github.com/a/b/pull/1');
     expect((links[0] as HTMLAnchorElement).target).toBe('_blank');
     expect((links[0] as HTMLAnchorElement).rel).toBe('noopener noreferrer');
-    expect(links[0].textContent).toBe('a/b#1');
-    expect(links[1].textContent).toBe('c/d#2');
+    expect(links[0]!.textContent).toBe('a/b#1');
+    expect(links[1]!.textContent).toBe('c/d#2');
   });
 
   it('shows formatted close dates', () => {
@@ -46,7 +46,7 @@ describe('ClosedPRList', () => {
     const dates = container.querySelectorAll('.merged-table-date');
     expect(dates).toHaveLength(2);
     // Just check they render (formatting depends on locale)
-    expect(dates[0].textContent).toBeTruthy();
+    expect(dates[0]!.textContent).toBeTruthy();
   });
 
   it('shows count in subtitle', () => {
@@ -74,8 +74,8 @@ describe('ClosedPRList', () => {
     const { container } = render(<ClosedPRList closedPRs={prs} onBack={() => {}} />);
     const headers = container.querySelectorAll('.merged-table th');
     expect(headers).toHaveLength(2);
-    expect(headers[0].textContent).toBe('PR');
-    expect(headers[1].textContent).toBe('Date Closed');
+    expect(headers[0]!.textContent).toBe('PR');
+    expect(headers[1]!.textContent).toBe('Date Closed');
   });
 
   it('renders correct number of table rows', () => {

--- a/packages/dashboard/src/components/filter-bar.test.tsx
+++ b/packages/dashboard/src/components/filter-bar.test.tsx
@@ -33,8 +33,8 @@ describe('FilterBar', () => {
 
     const statusSelect = selects[0] as HTMLSelectElement;
     expect(statusSelect.options).toHaveLength(3);
-    expect(statusSelect.options[1].textContent).toBe('Needs Addressing');
-    expect(statusSelect.options[2].textContent).toBe('Waiting on Maintainer');
+    expect(statusSelect.options[1]!.textContent).toBe('Needs Addressing');
+    expect(statusSelect.options[2]!.textContent).toBe('Waiting on Maintainer');
   });
 
   it('renders repo select with options', () => {

--- a/packages/dashboard/src/components/merged-pr-list.test.tsx
+++ b/packages/dashboard/src/components/merged-pr-list.test.tsx
@@ -42,8 +42,8 @@ describe('MergedPRList', () => {
     expect((links[0] as HTMLAnchorElement).href).toBe('https://github.com/a/b/pull/1');
     expect((links[0] as HTMLAnchorElement).target).toBe('_blank');
     expect((links[0] as HTMLAnchorElement).rel).toBe('noopener noreferrer');
-    expect(links[0].textContent).toBe('a/b#1');
-    expect(links[1].textContent).toBe('c/d#2');
+    expect(links[0]!.textContent).toBe('a/b#1');
+    expect(links[1]!.textContent).toBe('c/d#2');
   });
 
   it('shows formatted merge dates', () => {
@@ -51,7 +51,7 @@ describe('MergedPRList', () => {
     const dates = container.querySelectorAll('.merged-table-date');
     expect(dates).toHaveLength(2);
     // Just check they render (formatting depends on locale)
-    expect(dates[0].textContent).toBeTruthy();
+    expect(dates[0]!.textContent).toBeTruthy();
   });
 
   it('shows count in subtitle', () => {
@@ -71,13 +71,13 @@ describe('MergedPRList', () => {
     const { container } = render(<MergedPRList mergedPRs={prs} repoMetadata={repoMetadata} onBack={() => {}} />);
     const stars = container.querySelectorAll('.merged-table-stars');
     expect(stars).toHaveLength(2);
-    expect(stars[0].textContent).toContain('5.0k');
-    expect(stars[1].textContent).toContain('200');
+    expect(stars[0]!.textContent).toContain('5.0k');
+    expect(stars[1]!.textContent).toContain('200');
 
     const languages = container.querySelectorAll('.merged-table-language');
     expect(languages).toHaveLength(2);
-    expect(languages[0].textContent).toContain('TypeScript');
-    expect(languages[1].textContent).toContain('Python');
+    expect(languages[0]!.textContent).toContain('TypeScript');
+    expect(languages[1]!.textContent).toContain('Python');
   });
 
   it('renders gracefully without repoMetadata', () => {
@@ -85,13 +85,13 @@ describe('MergedPRList', () => {
     // Table cells still exist, but show dashes
     const stars = container.querySelectorAll('.merged-table-stars');
     expect(stars).toHaveLength(2);
-    expect(stars[0].textContent).toBe('—');
-    expect(stars[1].textContent).toBe('—');
+    expect(stars[0]!.textContent).toBe('—');
+    expect(stars[1]!.textContent).toBe('—');
 
     const languages = container.querySelectorAll('.merged-table-language');
     expect(languages).toHaveLength(2);
-    expect(languages[0].textContent).toBe('—');
-    expect(languages[1].textContent).toBe('—');
+    expect(languages[0]!.textContent).toBe('—');
+    expect(languages[1]!.textContent).toBe('—');
   });
 
   it('handles missing repo in metadata map', () => {
@@ -99,26 +99,26 @@ describe('MergedPRList', () => {
     const { container } = render(<MergedPRList mergedPRs={prs} repoMetadata={partialMetadata} onBack={() => {}} />);
     const stars = container.querySelectorAll('.merged-table-stars');
     expect(stars).toHaveLength(2);
-    expect(stars[0].textContent).toContain('1.0k');
-    expect(stars[1].textContent).toBe('—');
+    expect(stars[0]!.textContent).toContain('1.0k');
+    expect(stars[1]!.textContent).toBe('—');
 
     const languages = container.querySelectorAll('.merged-table-language');
     expect(languages).toHaveLength(2);
-    expect(languages[0].textContent).toContain('Go');
-    expect(languages[1].textContent).toBe('—');
+    expect(languages[0]!.textContent).toContain('Go');
+    expect(languages[1]!.textContent).toBe('—');
   });
 
   it('handles repo with stars but no language', () => {
     const metaNoLang = { 'a/b': { stars: 500, language: null } };
-    const { container } = render(<MergedPRList mergedPRs={[prs[0]]} repoMetadata={metaNoLang} onBack={() => {}} />);
+    const { container } = render(<MergedPRList mergedPRs={[prs[0]!]} repoMetadata={metaNoLang} onBack={() => {}} />);
     const stars = container.querySelectorAll('.merged-table-stars');
     expect(stars).toHaveLength(1);
-    expect(stars[0].textContent).toContain('500');
+    expect(stars[0]!.textContent).toContain('500');
 
     // Language cell exists but shows dash
     const languages = container.querySelectorAll('.merged-table-language');
     expect(languages).toHaveLength(1);
-    expect(languages[0].textContent).toBe('—');
+    expect(languages[0]!.textContent).toBe('—');
   });
 
   it('renders table headers with scope="col"', () => {
@@ -133,10 +133,10 @@ describe('MergedPRList', () => {
     const { container } = render(<MergedPRList mergedPRs={prs} onBack={() => {}} />);
     const headers = container.querySelectorAll('.merged-table th');
     expect(headers).toHaveLength(4);
-    expect(headers[0].textContent).toContain('PR');
-    expect(headers[1].textContent).toContain('Stars');
-    expect(headers[2].textContent).toContain('Language');
-    expect(headers[3].textContent).toContain('Date Merged');
+    expect(headers[0]!.textContent).toContain('PR');
+    expect(headers[1]!.textContent).toContain('Stars');
+    expect(headers[2]!.textContent).toContain('Language');
+    expect(headers[3]!.textContent).toContain('Date Merged');
   });
 
   it('renders correct number of table rows', () => {
@@ -148,46 +148,46 @@ describe('MergedPRList', () => {
   it('defaults to newest merge date first', () => {
     const { container } = render(<MergedPRList mergedPRs={prs} repoMetadata={repoMetadata} onBack={() => {}} />);
     const links = container.querySelectorAll('.merged-table-pr-link');
-    expect(links[0].textContent).toBe('a/b#1'); // Jun 10
-    expect(links[1].textContent).toBe('c/d#2'); // Jun 9
+    expect(links[0]!.textContent).toBe('a/b#1'); // Jun 10
+    expect(links[1]!.textContent).toBe('c/d#2'); // Jun 9
   });
 
   it('sorts by stars descending on click', () => {
     const { container } = render(<MergedPRList mergedPRs={prs} repoMetadata={repoMetadata} onBack={() => {}} />);
-    const starsHeader = container.querySelectorAll('.sortable-th')[1];
+    const starsHeader = container.querySelectorAll('.sortable-th')[1]!;
     fireEvent.click(starsHeader);
     const links = container.querySelectorAll('.merged-table-pr-link');
-    expect(links[0].textContent).toBe('a/b#1'); // 5000 stars
-    expect(links[1].textContent).toBe('c/d#2'); // 200 stars
+    expect(links[0]!.textContent).toBe('a/b#1'); // 5000 stars
+    expect(links[1]!.textContent).toBe('c/d#2'); // 200 stars
   });
 
   it('toggles sort direction on second click', () => {
     const { container } = render(<MergedPRList mergedPRs={prs} repoMetadata={repoMetadata} onBack={() => {}} />);
-    const starsHeader = container.querySelectorAll('.sortable-th')[1];
+    const starsHeader = container.querySelectorAll('.sortable-th')[1]!;
     fireEvent.click(starsHeader); // desc
     fireEvent.click(starsHeader); // asc
     const links = container.querySelectorAll('.merged-table-pr-link');
-    expect(links[0].textContent).toBe('c/d#2'); // 200 stars (asc)
-    expect(links[1].textContent).toBe('a/b#1'); // 5000 stars
+    expect(links[0]!.textContent).toBe('c/d#2'); // 200 stars (asc)
+    expect(links[1]!.textContent).toBe('a/b#1'); // 5000 stars
   });
 
   it('sorts by repo name ascending on click', () => {
     const { container } = render(<MergedPRList mergedPRs={prs} repoMetadata={repoMetadata} onBack={() => {}} />);
-    const prHeader = container.querySelectorAll('.sortable-th')[0];
+    const prHeader = container.querySelectorAll('.sortable-th')[0]!;
     fireEvent.click(prHeader);
     const links = container.querySelectorAll('.merged-table-pr-link');
-    expect(links[0].textContent).toBe('a/b#1');
-    expect(links[1].textContent).toBe('c/d#2');
+    expect(links[0]!.textContent).toBe('a/b#1');
+    expect(links[1]!.textContent).toBe('c/d#2');
   });
 
   it('sorts by language alphabetically on click', () => {
     const { container } = render(<MergedPRList mergedPRs={prs} repoMetadata={repoMetadata} onBack={() => {}} />);
-    const langHeader = container.querySelectorAll('.sortable-th')[2];
+    const langHeader = container.querySelectorAll('.sortable-th')[2]!;
     fireEvent.click(langHeader);
     const links = container.querySelectorAll('.merged-table-pr-link');
     // Python < TypeScript alphabetically
-    expect(links[0].textContent).toBe('c/d#2'); // Python
-    expect(links[1].textContent).toBe('a/b#1'); // TypeScript
+    expect(links[0]!.textContent).toBe('c/d#2'); // Python
+    expect(links[1]!.textContent).toBe('a/b#1'); // TypeScript
   });
 
   it('shows sort arrow on active column', () => {
@@ -199,7 +199,7 @@ describe('MergedPRList', () => {
 
   it('handles sorting without repoMetadata', () => {
     const { container } = render(<MergedPRList mergedPRs={prs} onBack={() => {}} />);
-    const starsHeader = container.querySelectorAll('.sortable-th')[1];
+    const starsHeader = container.querySelectorAll('.sortable-th')[1]!;
     fireEvent.click(starsHeader);
     // Should not crash — all stars default to 0
     const links = container.querySelectorAll('.merged-table-pr-link');

--- a/packages/dashboard/src/components/pr-detail.test.tsx
+++ b/packages/dashboard/src/components/pr-detail.test.tsx
@@ -86,9 +86,9 @@ describe('PRDetail', () => {
 
     const checks = container.querySelectorAll('.pr-detail-check');
     expect(checks).toHaveLength(2);
-    expect(checks[0].querySelector('.pr-detail-check-name')?.textContent).toBe('tests');
-    expect(checks[0].querySelector('.pr-detail-check-badge')?.textContent).toBe('Actionable');
-    expect(checks[1].querySelector('.pr-detail-check-badge')?.textContent).toBe('Fork Limitation');
+    expect(checks[0]!.querySelector('.pr-detail-check-name')?.textContent).toBe('tests');
+    expect(checks[0]!.querySelector('.pr-detail-check-badge')?.textContent).toBe('Actionable');
+    expect(checks[1]!.querySelector('.pr-detail-check-badge')?.textContent).toBe('Fork Limitation');
   });
 
   it('does not render checks section when classifiedChecks is empty', () => {

--- a/packages/dashboard/src/components/vetted-issue-list.test.tsx
+++ b/packages/dashboard/src/components/vetted-issue-list.test.tsx
@@ -106,9 +106,9 @@ describe('VettedIssueList', () => {
     ];
     const { container } = render(<VettedIssueList vettedIssues={makeOutput(items)} onBack={() => {}} />);
     const links = container.querySelectorAll('.merged-table-pr-link');
-    expect(links[0].textContent).toBe('owner/repo#2');
-    expect(links[1].textContent).toBe('owner/repo#3');
-    expect(links[2].textContent).toBe('owner/repo#1');
+    expect(links[0]!.textContent).toBe('owner/repo#2');
+    expect(links[1]!.textContent).toBe('owner/repo#3');
+    expect(links[2]!.textContent).toBe('owner/repo#1');
   });
 
   it('filters out items with score below 6', () => {

--- a/packages/dashboard/src/components/vetted-issue-list.tsx
+++ b/packages/dashboard/src/components/vetted-issue-list.tsx
@@ -20,13 +20,14 @@ function parseTierMeta(tier: string): { stars?: number; language?: string } {
   // Stars: (17.7k★) or (14k★) or (30k★) or (625★)
   let stars: number | undefined;
   const starsMatch = tier.match(/\(([\d.]+)([kK])?★\)/);
-  if (starsMatch) {
+  if (starsMatch && starsMatch[1] !== undefined) {
     const num = parseFloat(starsMatch[1]);
     stars = starsMatch[2] ? Math.round(num * 1000) : num;
   }
   // Language: last parenthesized text in the heading, e.g., (TypeScript), (Rust), (JS)
   const langMatches = [...tier.matchAll(/\(([^)★\d][^)]*)\)/g)];
-  const language = langMatches.length ? langMatches[langMatches.length - 1][1].trim() : undefined;
+  const lastMatch = langMatches[langMatches.length - 1];
+  const language = lastMatch?.[1]?.trim();
   return { stars, language };
 }
 

--- a/packages/dashboard/src/hooks/use-dashboard.test.ts
+++ b/packages/dashboard/src/hooks/use-dashboard.test.ts
@@ -372,9 +372,9 @@ describe('useDashboard', () => {
       const actionPosts = calls.filter((c) => c[0] === '/api/action');
       expect(actionPosts).toHaveLength(2);
 
-      const firstHeaders = actionPosts[0][1]?.headers as Record<string, string> | undefined;
+      const firstHeaders = actionPosts[0]![1]?.headers as Record<string, string> | undefined;
       expect(firstHeaders?.['X-CSRF-Token']).toBe('stale-token');
-      const retryHeaders = actionPosts[1][1]?.headers as Record<string, string> | undefined;
+      const retryHeaders = actionPosts[1]![1]?.headers as Record<string, string> | undefined;
       expect(retryHeaders?.['X-CSRF-Token']).toBe('fresh-token');
 
       // Retry's response wins — data state reflects the successful POST.

--- a/packages/dashboard/tsconfig.json
+++ b/packages/dashboard/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "bundler",
     "esModuleInterop": true,
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "outDir": "./dist",
     "rootDir": "./src",
     "declaration": false,

--- a/packages/dashboard/vite.config.ts
+++ b/packages/dashboard/vite.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     emptyOutDir: true,
+    // Emit source maps to dist/ for local debugging but don't reference them
+    // from the built JS, so prod users don't see `sourceMappingURL` (#1058 M39).
+    sourcemap: 'hidden',
   },
   server: {
     proxy: {

--- a/packages/mcp-server/src/index-main.test.ts
+++ b/packages/mcp-server/src/index-main.test.ts
@@ -21,6 +21,7 @@ vi.mock('@oss-autopilot/core/commands', () => ({
   runDismiss: vi.fn(),
   runUndismiss: vi.fn(),
   runMove: vi.fn(),
+  MAX_SEARCH_RESULTS: 100,
 }));
 
 vi.mock('@oss-autopilot/core', () => ({

--- a/packages/mcp-server/src/resources.test.ts
+++ b/packages/mcp-server/src/resources.test.ts
@@ -32,6 +32,7 @@ vi.mock('@oss-autopilot/core/commands', () => ({
   runDismiss: vi.fn(),
   runUndismiss: vi.fn(),
   runMove: vi.fn(),
+  MAX_SEARCH_RESULTS: 100,
 }));
 
 vi.mock('@oss-autopilot/core', () => ({

--- a/packages/mcp-server/src/tools-execution.test.ts
+++ b/packages/mcp-server/src/tools-execution.test.ts
@@ -100,15 +100,22 @@ describe('tool execution', () => {
       expect(mockRunSearch).toHaveBeenCalledWith({ maxResults: 5 });
     });
 
-    it('caps maxResults at 100 when exceeded', async () => {
-      mockRunSearch.mockResolvedValueOnce({ candidates: [] });
+    // Previously the handler silently clamped maxResults > 100 to the cap.
+    // After #1058 M41, the Zod schema rejects values over the cap with a
+    // proper JSON-RPC -32602 InvalidParams error so misuse is surfaced
+    // rather than silently papered over.
+    it('rejects maxResults exceeding the cap at the schema layer (#1058 M41)', async () => {
+      const result = await client.callTool({
+        name: 'search',
+        arguments: { maxResults: 500 },
+      });
 
-      await client.callTool({ name: 'search', arguments: { maxResults: 500 } });
-
-      expect(mockRunSearch).toHaveBeenCalledWith({ maxResults: 100 });
+      expect(result.isError).toBe(true);
+      const content = result.content[0] as { type: string; text: string };
+      expect(content.text).toMatch(/maxResults/i);
     });
 
-    it('returns error for invalid maxResults (-1)', async () => {
+    it('rejects invalid maxResults (-1) at the schema layer', async () => {
       const result = await client.callTool({
         name: 'search',
         arguments: { maxResults: -1 },
@@ -116,10 +123,11 @@ describe('tool execution', () => {
 
       expect(result.isError).toBe(true);
       const content = result.content[0] as { type: string; text: string };
-      expect(content.text).toContain('Invalid maxResults');
+      // Zod's structured error payload surfaces the field name.
+      expect(content.text).toMatch(/maxResults/i);
     });
 
-    it('returns error for non-integer maxResults (1.5)', async () => {
+    it('rejects non-integer maxResults (1.5) at the schema layer', async () => {
       const result = await client.callTool({
         name: 'search',
         arguments: { maxResults: 1.5 },
@@ -127,7 +135,7 @@ describe('tool execution', () => {
 
       expect(result.isError).toBe(true);
       const content = result.content[0] as { type: string; text: string };
-      expect(content.text).toContain('Invalid maxResults');
+      expect(content.text).toMatch(/maxResults/i);
     });
   });
 

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -146,18 +146,24 @@ export function registerTools(server: McpServer): void {
       description:
         'Search GitHub for beginner-friendly open-source issues to contribute to. Returns issues matching configured languages and interests.',
       inputSchema: {
-        maxResults: z.number().optional().describe('Maximum number of issues to return (default: 5)'),
+        // Zod schema replaces the prior manual throw inside the handler
+        // (#1058 M41). Invalid values now surface as proper schema
+        // validation errors via the MCP SDK rather than as generic
+        // `Error`-wrapped `isError: true` payloads.
+        maxResults: z
+          .number()
+          .int()
+          .min(1)
+          .max(MAX_SEARCH_RESULTS)
+          .optional()
+          .describe(
+            `Maximum number of issues to return (default: 5, max: ${MAX_SEARCH_RESULTS}). Must be a positive integer.`,
+          ),
       },
       annotations: { readOnlyHint: true },
     },
     wrapTool((args: { maxResults?: number }) => {
-      let maxResults = args.maxResults ?? 5;
-      if (!Number.isInteger(maxResults) || maxResults < 1) {
-        throw new Error(`Invalid maxResults: ${maxResults}. Must be a positive integer.`);
-      }
-      if (maxResults > MAX_SEARCH_RESULTS) {
-        maxResults = MAX_SEARCH_RESULTS;
-      }
+      const maxResults = args.maxResults ?? 5;
       return runSearch({ maxResults });
     }),
   );


### PR DESCRIPTION
## Summary

Closes five sub-findings from umbrella issue #1058:

- **M37** — `packages/dashboard/src/app.tsx`. Wrapped `filteredPRs`, `repos`, `statuses`, and `activePRs` derivations in `useMemo`. Previously these filter/map operations over all PRs re-ran on every render — including on every keystroke in the search input.
- **M38** — `packages/dashboard/tsconfig.json`. Enabled `noUncheckedIndexedAccess: true`. Production-code fixes in `animated-value.tsx` and `vetted-issue-list.tsx` were small and defensive. Test-file fixes added `!` at 40+ array-index access sites that already assert `toHaveLength` before indexing.
- **M39** — `packages/dashboard/vite.config.ts`. Set `build.sourcemap: 'hidden'` so source maps ship to `dist/` for local debugging without being referenced from the built JS (no prod-user exposure).
- **M40** — `packages/dashboard/index.html`. Added a `<noscript>` fallback with a "JavaScript required" message and a pointer to the `/api/data` JSON endpoint.
- **M41** — `packages/mcp-server/src/tools.ts`. Replaced the manual `maxResults` throw in the `search` handler with `z.number().int().min(1).max(MAX_SEARCH_RESULTS).optional()`. Invalid values now surface as proper JSON-RPC `-32602 InvalidParams` via the MCP SDK.

## Behavior contract change (M41)

The old handler silently clamped `maxResults > 100` to the cap. The new Zod schema **rejects** values over the cap with a proper `-32602` error. This is the documented-correct behavior; the clamping was "silent mis-behavior" against the documented cap. Only the MCP `search` tool changes — the CLI clamps with a warn; the MCP `find-issues` prompt still clamps silently. Neither has changed.

## Test updates

- `tools-execution.test.ts`: "caps at 100" became "rejects values exceeding the cap"; tests for `-1` and `1.5` now assert field-name match in the structured error payload.
- 3 MCP test files needed `MAX_SEARCH_RESULTS: 100` added to the `@oss-autopilot/core/commands` mock because the constant is now referenced at tool-registration time rather than only inside the handler closure.

## Deferred

- **M36** — self-host fonts. Licensing check + font file download scope.
- **M42** — MCP HTTP hot-path memoization. Needs load-test data before deciding between memoization vs. keeping the current per-request-instantiation pattern documented.

## Test plan

- [x] `pnpm run lint` passes
- [x] `pnpm test` passes (2049 core + 253 dashboard + 181 MCP = 2483 passing)
- [x] `pnpm run bundle` rebuilds — cli.bundle.cjs 736,680 bytes, under the 740,000 CI cap
- [x] `npx prettier --check packages/` passes
- [x] `tsc --noEmit` clean in dashboard with `noUncheckedIndexedAccess` enabled