### PR TITLE
chore: UL housekeeping nits L1-L9 (#1059)

### DIFF
--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -10,15 +10,24 @@ PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 messages=""
 NL=$'\n'
 
+# Rebuild flags (#1059 L1). Accumulated through Steps 1/1.5 and flushed as a
+# single consolidated line ("Rebuilt after plugin update: CLI, Dashboard
+# SPA.") rather than two separate system-reminder lines, which are quieter in
+# the session-start reminder stream.
+rebuilt_cli=false
+rebuilt_dashboard=false
+cli_rebuild_error=""
+dashboard_rebuild_error=""
+
 # Marketplace clone path; refresh is handled by safe-refresh-marketplace.sh in Step 2.
 MARKETPLACE_DIR="$HOME/.claude/plugins/marketplaces/oss-autopilot"
 
 # --- Step 1: Rebuild stale CLI bundle (if needed) ---
 if [ -f "${PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" ] && [ "${PLUGIN_ROOT}/packages/core/package.json" -nt "${PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" ]; then
   if (cd "${PLUGIN_ROOT}/packages/core" && npm install --silent 2>/dev/null && npm run bundle --silent 2>/dev/null); then
-    messages="CLI bundle rebuilt after plugin update."
+    rebuilt_cli=true
   else
-    messages="Warning: CLI bundle rebuild failed. Run /oss to retry, or: cd ${PLUGIN_ROOT}/packages/core && npm install && npm run bundle"
+    cli_rebuild_error="cd ${PLUGIN_ROOT}/packages/core && npm install && npm run bundle"
   fi
 fi
 
@@ -29,7 +38,10 @@ fi
 # (package.json is private, pinned at 0.1.0, and rarely touched).
 DASHBOARD_INDEX="${PLUGIN_ROOT}/packages/dashboard/dist/index.html"
 DASHBOARD_PKG="${PLUGIN_ROOT}/packages/dashboard/package.json"
-if [ -f "${DASHBOARD_PKG}" ] && { [ ! -f "${DASHBOARD_INDEX}" ] || [ -n "$(find "${PLUGIN_ROOT}/packages/dashboard/src" "${DASHBOARD_PKG}" "${PLUGIN_ROOT}/packages/dashboard/vite.config.ts" "${PLUGIN_ROOT}/packages/dashboard/tsconfig.json" -newer "${DASHBOARD_INDEX}" -print -quit 2>/dev/null)" ]; }; then
+# Exclude junk (DS_Store, editor swap files, backups, .git, node_modules) so
+# the stale-check doesn't rebuild on every session over an editor-touched
+# swap file (#1059 L3).
+if [ -f "${DASHBOARD_PKG}" ] && { [ ! -f "${DASHBOARD_INDEX}" ] || [ -n "$(find "${PLUGIN_ROOT}/packages/dashboard/src" "${DASHBOARD_PKG}" "${PLUGIN_ROOT}/packages/dashboard/vite.config.ts" "${PLUGIN_ROOT}/packages/dashboard/tsconfig.json" -type f ! -path '*/node_modules/*' ! -path '*/.git/*' ! -name '.DS_Store' ! -name '*~' ! -name '*.swp' ! -name '*.swo' ! -name '.#*' -newer "${DASHBOARD_INDEX}" -print -quit 2>/dev/null)" ]; }; then
   # Dashboard depends on @oss-autopilot/core types via workspace:* protocol.
   # Use pnpm if available (required for workspace: resolution), fall back to npm.
   if command -v pnpm &>/dev/null; then
@@ -38,10 +50,28 @@ if [ -f "${DASHBOARD_PKG}" ] && { [ ! -f "${DASHBOARD_INDEX}" ] || [ -n "$(find 
     dashboard_build() { cd "${PLUGIN_ROOT}/packages/dashboard" && npm install --silent 2>/dev/null && npm run build 2>/dev/null; }
   fi
   if (dashboard_build); then
-    messages="${messages:+${messages}${NL}}Dashboard SPA built successfully."
+    rebuilt_dashboard=true
   else
-    messages="${messages:+${messages}${NL}}Warning: Dashboard SPA build failed. To fix: cd ${PLUGIN_ROOT} && pnpm install && pnpm run build"
+    dashboard_rebuild_error="cd ${PLUGIN_ROOT} && pnpm install && pnpm run build"
   fi
+fi
+
+# Emit a single consolidated line for successful rebuilds, and separate warning
+# lines for any rebuild failures (errors are rarer and benefit from being
+# immediately legible). #1059 L1.
+rebuilt_parts=""
+if [ "$rebuilt_cli" = true ]; then rebuilt_parts="CLI"; fi
+if [ "$rebuilt_dashboard" = true ]; then
+  rebuilt_parts="${rebuilt_parts:+${rebuilt_parts}, }Dashboard SPA"
+fi
+if [ -n "$rebuilt_parts" ]; then
+  messages="${messages:+${messages}${NL}}Rebuilt after plugin update: ${rebuilt_parts}."
+fi
+if [ -n "$cli_rebuild_error" ]; then
+  messages="${messages:+${messages}${NL}}Warning: CLI bundle rebuild failed. Run /oss to retry, or: ${cli_rebuild_error}"
+fi
+if [ -n "$dashboard_rebuild_error" ]; then
+  messages="${messages:+${messages}${NL}}Warning: Dashboard SPA build failed. To fix: ${dashboard_rebuild_error}"
 fi
 
 # --- Step 2: Check for updates (every 6 hours) ---
@@ -59,8 +89,9 @@ if [ -n "$CURRENT" ]; then
   if [ "$should_check" = true ]; then
     mkdir -p "${HOME}/.oss-autopilot"
     LATEST=$(gh api repos/costajohnt/oss-autopilot/releases/latest --jq '.tag_name' 2>/dev/null | sed 's/^[^0-9]*//' || echo "")
-    # Validate LATEST looks like a version (digits and dots), not an error response
-    if [ -n "$LATEST" ] && echo "$LATEST" | grep -qE '^[0-9]+\.'; then
+    # Require full x.y.z semver so partial matches like "1.x" or release tag
+    # prefixes that happen to start with digits don't sneak through (#1059 L4).
+    if [ -n "$LATEST" ] && echo "$LATEST" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
       # Mark check as done only after a successful API response
       touch "$LAST_CHECK"
       if [ "$LATEST" != "$CURRENT" ]; then
@@ -113,7 +144,13 @@ if [ -n "$messages" ]; then
   if command -v jq &>/dev/null; then
     escaped=$(printf '%s' "$messages" | jq -Rrs '@json | .[1:-1]')
   else
-    escaped=$(printf '%s' "$messages" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g' | tr '\n' ' ')
+    # Fallback escaper: jq is preferred and is what produces fully-correct
+    # JSON. The sed path only handles the escapes BSD sed can match reliably
+    # (`\\`, `"`, `\t`, `\r`) — BSD sed treats `\b` as a word boundary and
+    # `\f` as the letter `f`, so attempting to escape those corrupts ordinary
+    # prose. Messages emitted by this hook never contain raw 0x08/0x0C bytes,
+    # so the gap is acceptable. See #1059 L2 for the investigation.
+    escaped=$(printf '%s' "$messages" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g; s/\r/\\r/g' | tr '\n' ' ')
   fi
   cat <<EOF
 {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -9,6 +9,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
+    "lint": "eslint src --ext .ts,.tsx",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/dashboard/src/app.tsx
+++ b/packages/dashboard/src/app.tsx
@@ -120,6 +120,14 @@ function AppContent() {
     routeHeadingRef.current?.focus({ preventScroll: false });
   }, [path]);
 
+  // Glanceable tab title (#1059 L8). Prefix the needs-addressing count so
+  // users with a backgrounded tab can see "(2) OSS Autopilot" and react.
+  // Counting here instead of memoing because the dep list is already minimal.
+  useEffect(() => {
+    const needCount = data?.activePRs?.filter((pr) => pr.status === 'needs_addressing').length ?? 0;
+    document.title = needCount > 0 ? `(${needCount}) OSS Autopilot` : 'OSS Autopilot Dashboard';
+  }, [data?.activePRs]);
+
   const shelvedUrls = useMemo(() => new Set(data?.shelvedPRUrls ?? []), [data?.shelvedPRUrls]);
 
   if (loading && !data) {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -13,19 +13,80 @@ export { registerPrompts } from './prompts.js';
 
 const MAX_BODY_BYTES = 1_048_576; // 1 MiB
 
+const HELP_TEXT = `
+OSS Autopilot MCP Server
+
+Usage:
+  oss-autopilot-mcp                      Run stdio transport (for MCP clients that spawn subprocesses)
+  oss-autopilot-mcp --http [--port N]    Run Streamable HTTP transport on 127.0.0.1 (default port 3001)
+
+Flags:
+  --http           Use HTTP transport instead of stdio
+  --port <N>       Port for HTTP transport (1-65535, default 3001; accepts --port=N or --port N)
+  --help, -h       Show this help and exit
+  --version, -v    Show version and exit
+
+See docs/mcp.md in the oss-autopilot repo for client configuration examples.
+`.trim();
+
+async function readVersion(): Promise<string> {
+  // Read our own package.json so `--version` doesn't drift from the npm manifest.
+  try {
+    const { readFileSync } = await import('node:fs');
+    const { fileURLToPath } = await import('node:url');
+    const { dirname, resolve } = await import('node:path');
+    const here = typeof __dirname === 'string' ? __dirname : dirname(fileURLToPath(import.meta.url));
+    const raw = readFileSync(resolve(here, '..', 'package.json'), 'utf-8');
+    return String(JSON.parse(raw).version ?? 'unknown');
+  } catch {
+    return 'unknown';
+  }
+}
+
 export async function main() {
   const args = process.argv.slice(2);
+
+  // `--help` / `--version` short-circuit BEFORE we try to spin up any
+  // transport (#1059 L9). Previously `npx @oss-autopilot/mcp --help` fell
+  // through to stdio mode and hung waiting on stdin.
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(HELP_TEXT);
+    return;
+  }
+  if (args.includes('--version') || args.includes('-v')) {
+    console.log(await readVersion());
+    return;
+  }
+
   const httpMode = args.includes('--http');
 
   if (httpMode) {
-    // Parse port from --port=N or --port N
+    // Parse port from --port=N or --port N.
+    //
+    // Validates the raw argument before parseInt (#1059 L6) — previously
+    // `--port abc` silently became NaN → terse error with no hint at the
+    // real problem. Now we reject non-numeric values with a clear message.
     const portArg = args.find((a) => a.startsWith('--port='));
     const portIdx = args.indexOf('--port');
     let port = 3001;
+    let portRaw: string | undefined;
     if (portArg) {
-      port = parseInt(portArg.split('=')[1], 10);
+      portRaw = portArg.split('=')[1];
     } else if (portIdx >= 0) {
-      port = parseInt(args[portIdx + 1], 10);
+      portRaw = args[portIdx + 1];
+      if (portRaw === undefined) {
+        // Bare `--port` with no value — don't silently fall back to the
+        // default; the user meant to specify something (#1059 L6 follow-up).
+        console.error('Missing value for --port. Usage: --port <N> or --port=<N>.');
+        process.exit(1);
+      }
+    }
+    if (portRaw !== undefined) {
+      if (!/^\d+$/.test(portRaw)) {
+        console.error(`Invalid --port value: "${portRaw}". Must be an integer between 1 and 65535.`);
+        process.exit(1);
+      }
+      port = parseInt(portRaw, 10);
     }
 
     if (isNaN(port) || port < 1 || port > 65535) {

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -81,8 +81,14 @@ async function ensureGistInit(): Promise<void> {
 
 /** Standard MCP text content result. */
 function ok(data: unknown) {
+  // Explicit `undefined` guard (#1059 L5). `JSON.stringify(undefined)` returns
+  // the value `undefined` (not `"undefined"`), so the old `?? 'null'` fallback
+  // engaged but rendered a misleading "null" string. Tools that legitimately
+  // return no data now serialize to the empty-object literal, which is both
+  // valid JSON and a truthful representation.
+  const text = data === undefined ? '{}' : JSON.stringify(data, null, 2);
   return {
-    content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) ?? 'null' }],
+    content: [{ type: 'text' as const, text }],
   };
 }
 


### PR DESCRIPTION
## Summary

Closes the remaining low-severity housekeeping nits from umbrella issue #1059. L10 was already present in `workflows/reference.md` at line 82 — no change needed.

- **L1** — `hooks/session-start.sh`: consolidate successful rebuild messages into one line ("Rebuilt after plugin update: CLI, Dashboard SPA."). Errors stay as separate lines for legibility.
- **L2** — `hooks/session-start.sh`: keep the JSON-escape sed fallback scoped to escapes BSD sed handles reliably (`\\`, `"`, `\t`, `\r`). My first attempt added `\b` / `\f` escapes and the reviewer caught that BSD sed treats those as word-boundary / literal-`f` — so `"CLI bundle rebuilt"` became `"CLI \bundle re\built"`. Reverted to the safe four.
- **L3** — `hooks/session-start.sh`: dashboard stale-check `find` now has `-type f` and excludes `node_modules`, `.git`, `.DS_Store`, editor swap/backup files.
- **L4** — `hooks/session-start.sh`: tighten update-check tag regex from `^[0-9]+\.` to `^[0-9]+\.[0-9]+\.[0-9]+`.
- **L5** — `packages/mcp-server/src/tools.ts`: `ok()` explicitly guards `data === undefined` and returns `'{}'` instead of the misleading `'null'` fallback.
- **L6** — `packages/mcp-server/src/index.ts`: validate `--port` value with `/^\d+$/` before `parseInt`. Rejects `--port abc` with a clear message; rejects bare `--port` with "Missing value for --port".
- **L7** — `packages/dashboard/package.json`: add `lint` script referencing the root eslint config.
- **L8** — `packages/dashboard/src/app.tsx`: dynamic `<title>` via `useEffect` — shows `(N) OSS Autopilot` when N PRs need addressing.
- **L9** — `packages/mcp-server/src/index.ts`: handle `--help`/`-h` and `--version`/`-v` BEFORE transport setup. Previously `npx @oss-autopilot/mcp --help` fell through to stdio and hung on stdin.

## Review-feedback fixes

- **C1 (L2)**: original change added `\b`/`\f` sed escapes which corrupt plain text on BSD sed — reverted to 4-escape set, updated comment to explain the gap.
- **R1 (L6)**: added explicit error for bare `--port` with no value.

## Test plan

- [x] `pnpm run lint` passes (including new `dashboard` lint script)
- [x] `pnpm test` passes (2049 core + 253 dashboard + 181 MCP = 2483 passing)
- [x] `pnpm run bundle` rebuilds — cli.bundle.cjs 736,680 bytes, under the 740,000 cap
- [x] `bash -n hooks/session-start.sh` passes
- [x] Smoke test: `node mcp.bundle --help` returns the help text cleanly (no hang)
- [x] Smoke test: `node mcp.bundle --version` prints version
- [x] Smoke test: `node mcp.bundle --http --port abc` exits 1 with clear error
- [x] Smoke test: `node mcp.bundle --http --port` (bare) exits 1 with "Missing value for --port"
- [x] Smoke test: `printf 'CLI bundle rebuilt.' | sed '...'` no longer corrupts to `'CLI \bundle re\built.'`