### PR TITLE
docs: refresh stale stat claims + dashboard README (#1006, #1007)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ A Preact SPA that auto-opens when you run `/oss` — PR management, charts, cont
 
 **Three deployment models** — Claude Code plugin with 7 specialized agents, MCP server for Cursor/Claude Desktop/Codex/Windsurf, and a standalone CLI with `--json` structured output. Same core, different interfaces.
 
-**Deterministic core, AI orchestration layer** — Critical logic (PR status classification, CI failure analysis, state management) lives in tested TypeScript, not in prompts. The CLI returns structured JSON that agents consume. CI failures are categorized into a deterministic taxonomy — actionable vs. fork limitation vs. auth gate vs. infrastructure — rather than asking an LLM each time. 2,200+ tests validate the core independently of any LLM.
+**Deterministic core, AI orchestration layer** — Critical logic (PR status classification, CI failure analysis, state management) lives in tested TypeScript, not in prompts. The CLI returns structured JSON that agents consume. CI failures are categorized into a deterministic taxonomy — actionable vs. fork limitation vs. auth gate vs. infrastructure — rather than asking an LLM each time. 2,400+ tests validate the core independently of any LLM.
 
 **Production-grade GitHub API integration** — ETag-based HTTP caching, automatic rate limit backoff with retries, bounded concurrency pools, and paginated fetching. Handles the full complexity of fork-based contribution workflows: correct diff ranges, squash commit counting, and `--head` flag handling for cross-fork PRs. Designed to run daily without hitting API limits.
 
@@ -104,7 +104,7 @@ A Preact SPA that auto-opens when you run `/oss` — PR management, charts, cont
 
 **Security discipline** — State files written with `0o600` permissions, data directory created with `0o700`. Concurrent state write protection prevents corruption from parallel runs. Runtime schema validation via Zod on every state file read. XSS prevention tested. Input validation hardened across CLI arguments and API responses.
 
-**Automated release pipeline** — Conventional commits feed into release-please for automatic versioning and changelogs, with CI/CD publishing to npm on merge. 140+ published releases since March 2026, with 170+ changelog versions spanning the full v0.1.0 → v1.15.x history.
+**Automated release pipeline** — Conventional commits feed into release-please for automatic versioning and changelogs, with CI/CD publishing to npm on merge. 148+ published releases since March 2026, with 170+ changelog versions spanning the full v0.1.0 → v1.16.x history.
 
 Every feature in the list above was driven by real usage — capacity warnings came from overcommitting, "skip comment when code speaks for itself" came from over-commenting, diminishing returns detection came from spending too long searching. The tool is shaped by the contributions it manages.
 
@@ -187,8 +187,8 @@ All commands return `{ success, data, error, timestamp }` with `--json`.
 
 | Metric | Value |
 |--------|-------|
-| Releases | 140+ published (170+ changelog versions, v0.1.0 → v1.15.x) |
-| Tests | 2,200+ across 100+ files |
+| Releases | 148+ published (170+ changelog versions, v0.1.0 → v1.16.x) |
+| Tests | 2,400+ across 115+ files |
 | Issues + PRs | 1,000+ |
 | Time span | Jan 2026 → present |
 | npm packages | 3 |

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -53,7 +53,7 @@ pnpm --filter @oss-autopilot/dashboard test         # one-shot
 pnpm --filter @oss-autopilot/dashboard test:watch   # watch mode
 ```
 
-Tests use `vitest` + `@testing-library/preact` + `jsdom`. Current count: 227 tests across 18 files (see root [README](../../README.md#by-the-numbers) for the full project totals).
+Tests use `vitest` + `@testing-library/preact` + `jsdom`. Current count: 253 tests across 21 files (see root [README](../../README.md#by-the-numbers) for the full project totals).
 
 ## File layout
 


### PR DESCRIPTION
## Summary

Closes #1006 and closes #1007.

### #1006 — stale README numbers
Refresh three numeric claims in root `README.md`:
- "2,200+ tests" → **2,400+** (actual: 2049 + 253 + 181 = 2,483 passing)
- "across 100+ files" → **115+ files** (actual count via `find`)
- "140+ published releases" → **148+** (actual paginated count from GH API)
- Version range "v0.1.0 → v1.15.x" → **v0.1.0 → v1.16.x** (current version is 1.16.2)

### #1007 — missing dashboard README
The file `packages/dashboard/README.md` already exists (80 lines, matching the sibling READMEs' tone). The issue text was stale on that point. This PR also corrects the one stale stat inside it ("227 tests across 18 files" → "253 tests across 21 files") so the file reflects current totals and the issue can be cleanly closed.

## Test plan

- [x] `npx prettier --check README.md packages/dashboard/README.md` passes
- [x] Each stat verified against a live source (`pnpm test`, `find`, `gh api --paginate`)