### PR TITLE
feat(dashboard): live demo features — chart entrance + Shift+C (#940)

### DIFF
--- a/packages/dashboard/src/app.test.tsx
+++ b/packages/dashboard/src/app.test.tsx
@@ -512,6 +512,45 @@ describe('App', () => {
 
       expect(container.querySelector('.celebration-toast')).toBeFalsy();
     });
+
+    // #940 — demo-mode Shift+C shortcut fires the celebration on demand.
+    it('fires a celebration when Shift+C is pressed globally', async () => {
+      localStorage.setItem('oss-autopilot-merged-count', '5');
+      const data = makeDashboardData({
+        stats: { activePRs: 0, shelvedPRs: 0, mergedPRs: 5, closedPRs: 0, mergeRate: '100%' },
+      });
+      mockFetchOk(data);
+
+      const { container } = render(<App />);
+      await waitFor(() => expect(container.querySelector('.dashboard')).toBeTruthy());
+
+      // No toast yet — merged count hasn't changed.
+      expect(container.querySelector('.celebration-toast')).toBeFalsy();
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'C', shiftKey: true }));
+
+      await waitFor(() => expect(container.querySelector('.celebration-toast')).toBeTruthy());
+      expect(container.querySelector('.celebration-toast')?.textContent).toMatch(/new PRs? merged/i);
+    });
+
+    it('does NOT fire Shift+C while the user is typing in an input', async () => {
+      localStorage.setItem('oss-autopilot-merged-count', '5');
+      const data = makeDashboardData({
+        stats: { activePRs: 1, shelvedPRs: 0, mergedPRs: 5, closedPRs: 0, mergeRate: '100%' },
+        activePRs: [makePR({ repo: 'a/b', title: 'search for this', status: 'needs_addressing' })],
+      });
+      mockFetchOk(data);
+
+      const { container } = render(<App />);
+      await waitFor(() => expect(container.querySelector('.filter-input')).toBeTruthy());
+
+      const search = container.querySelector('.filter-input') as HTMLInputElement;
+      search.focus();
+      search.dispatchEvent(new KeyboardEvent('keydown', { key: 'C', shiftKey: true, bubbles: true }));
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(container.querySelector('.celebration-toast')).toBeFalsy();
+    });
   });
 
   // ── Route navigation (#966) ───────────────────────────────────────

--- a/packages/dashboard/src/app.tsx
+++ b/packages/dashboard/src/app.tsx
@@ -128,6 +128,24 @@ function AppContent() {
     document.title = needCount > 0 ? `(${needCount}) OSS Autopilot` : 'OSS Autopilot Dashboard';
   }, [data?.activePRs]);
 
+  // Global Shift+C fires a celebration (#940). Ignored when the user is
+  // typing into an input/textarea/contenteditable so the shortcut doesn't
+  // steal keystrokes during search or note-taking.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (!e.shiftKey || e.key !== 'C') return;
+      const target = e.target as HTMLElement | null;
+      if (target) {
+        const tag = target.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || target.isContentEditable) return;
+      }
+      e.preventDefault();
+      triggerCelebration();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [triggerCelebration]);
+
   const shelvedUrls = useMemo(() => new Set(data?.shelvedPRUrls ?? []), [data?.shelvedPRUrls]);
 
   if (loading && !data) {

--- a/packages/dashboard/src/components/chart-panel.tsx
+++ b/packages/dashboard/src/components/chart-panel.tsx
@@ -122,6 +122,8 @@ export function ChartPanel({ monthlyMerged, monthlyOpened, monthlyClosed, topRep
       options: {
         responsive: true,
         maintainAspectRatio: false,
+        // Entrance animation (#940) — visible for demos, tasteful for daily use.
+        animation: { duration: 1500, easing: 'easeOutQuart' },
         plugins: { legend: legendOpts },
         scales: {
           x: scaleOpts,
@@ -172,6 +174,9 @@ export function ChartPanel({ monthlyMerged, monthlyOpened, monthlyClosed, topRep
       options: {
         responsive: true,
         maintainAspectRatio: false,
+        // Entrance animation (#940) matched with the line chart so both charts
+        // "come alive" together when the dashboard loads.
+        animation: { duration: 1500, easing: 'easeOutQuart' },
         indexAxis: 'y',
         plugins: { legend: legendOpts },
         scales: {

--- a/packages/dashboard/src/hooks/use-celebration.ts
+++ b/packages/dashboard/src/hooks/use-celebration.ts
@@ -124,7 +124,14 @@ function playConfettiIfAllowed(): void {
 export function useCelebration(mergedCount: number | undefined): {
   celebration: Celebration | null;
   dismiss: () => void;
-  trigger: () => void;
+  /**
+   * Fire a celebration toast on demand (#940). The optional `delta` controls
+   * the message copy ("1 new PR merged." vs "3 new PRs merged."). Defaults to
+   * 3 so the demo-mode button has a realistic-looking message. Does NOT touch
+   * localStorage — the stored merged count is unaffected so the organic
+   * on-increase celebration still fires later on a real merge.
+   */
+  trigger: (delta?: number) => void;
 } {
   const [celebration, setCelebration] = useState<Celebration | null>(null);
 
@@ -152,9 +159,11 @@ export function useCelebration(mergedCount: number | undefined): {
 
   const dismiss = useCallback(() => setCelebration(null), []);
 
-  const trigger = useCallback(() => {
+  const trigger = useCallback((delta = 3) => {
     playConfettiIfAllowed();
-    setCelebration({ message: 'Party time!', shownAt: Date.now() });
+    const safeDelta = Number.isFinite(delta) && delta > 0 ? Math.floor(delta) : 3;
+    const message = safeDelta === 1 ? '1 new PR merged. Great work!' : `${safeDelta} new PRs merged. Great work!`;
+    setCelebration({ message, shownAt: Date.now() });
   }, []);
 
   return { celebration, dismiss, trigger };


### PR DESCRIPTION
## Summary

Closes #940. Feature 1 (AnimatedValue count-up on stat cards) already shipped in a prior cycle; this PR closes the remaining two features:

- **Chart entrance animation** — both Chart.js instances in `chart-panel.tsx` now animate on load (`duration: 1500, easing: 'easeOutQuart'`). Config-only tweak — no new files or tests needed, as the issue spec dictated.
- **On-demand celebration trigger** — `useCelebration.trigger()` now accepts an optional `delta` param (default 3). Message copy adapts for "1 new PR merged" vs "N new PRs merged". Does not touch localStorage.
- **Global Shift+C shortcut** — window keydown listener in `app.tsx` fires the celebration. Ignored when the focus target is `<input>`, `<textarea>`, or `contenteditable` so the shortcut doesn't steal keystrokes during search/note-taking.

## Tests

- 2 new assertions in `app.test.tsx`:
  - `Shift+C` fires the celebration toast
  - `Shift+C` while focused in `.filter-input` is a no-op
- Dashboard suite: **255/255** passing (was 253).

## Test plan

- [x] `pnpm test` — 2049 + 255 + 181 = 2,485 passing
- [x] `pnpm run lint` clean
- [x] `pnpm --filter @oss-autopilot/dashboard run typecheck` clean
- [x] `npx prettier --check packages/` clean