### PR TITLE
fix(release-please): track server.json version under mcp-server

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -26,7 +26,19 @@
       "component": "mcp",
       "bump-minor-pre-major": true,
       "draft": false,
-      "prerelease": false
+      "prerelease": false,
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "packages/mcp-server/server.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "packages/mcp-server/server.json",
+          "jsonpath": "$.packages[0].version"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Problem

The open release-please PR #1062 has **red CI on every matrix job** (Node 20/22/24 × macOS/Ubuntu) because the MCP drift-guard step fails:

\`\`\`
##[error]MCP server.json version (3.1.3 / 3.1.3) does not match package.json (3.1.4). Bump server.json to match.
\`\`\`

Release-please bumped \`packages/mcp-server/package.json\` from 3.1.3 → 3.1.4, but \`packages/mcp-server/server.json\` (which the drift-guard cross-references) stayed at 3.1.3 because it was not listed in \`release-please-config.json\`.

## Fix

Add \`server.json\` as an \`extra-files\` entry under the \`packages/mcp-server\` component. Two jsonpath selectors cover both version sites inside that file (the top-level \`$.version\` on line 10 and \`$.packages[0].version\` on line 15).

## What happens after merge

Release-please will regenerate PR #1062 automatically. The next regenerate cycle will:
- Bump \`server.json\`'s top-level \`version\` from 3.1.3 → 3.1.4
- Bump \`server.json\`'s \`packages[0].version\` from 3.1.3 → 3.1.4

Drift-guard will pass; the release PR turns green and can be merged to cut the release.

## Test plan

- [x] \`jq empty release-please-config.json\` — valid JSON
- [x] \`npx prettier --check release-please-config.json\` — formatted
- [x] Matches release-please config schema shape used for \`packages/core/package.json\` and \`.claude-plugin/plugin.json\` in the sibling component