### PR TITLE
fix(release-please): server.json path is relative to component root

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -30,12 +30,12 @@
       "extra-files": [
         {
           "type": "json",
-          "path": "packages/mcp-server/server.json",
+          "path": "server.json",
           "jsonpath": "$.version"
         },
         {
           "type": "json",
-          "path": "packages/mcp-server/server.json",
+          "path": "server.json",
           "jsonpath": "$.packages[0].version"
         }
       ]


### PR DESCRIPTION
## Summary

Follow-up to #1098. The previous config used a repo-root-relative path for \`server.json\`, but release-please prepends the component root (\`packages/mcp-server/\`) to the \`path\` field in \`extra-files\`. The release-please run logged:

\`\`\`
⚠ file packages/mcp-server/packages/mcp-server/server.json did not exist
\`\`\`

…so the server.json bump was silently skipped, and #1062 stayed red on the MCP drift-guard.

## Fix

Change the \`path\` in both extra-files entries from \`packages/mcp-server/server.json\` to \`server.json\` (component-root relative). Matches the pattern release-please uses internally (you can see the same behavior for the node release-type's default package.json targeting).

## Expected outcome

After merge, release-please will regenerate #1062 with:
- \`server.json\` top-level \`$.version\` bumped to 3.1.4
- \`server.json\` \`$.packages[0].version\` bumped to 3.1.4

Drift-guard passes; release PR turns green.