### PR TITLE
fix(startup): focus dashboard tab on /oss when server is already running

### DIFF
--- a/packages/core/src/commands/startup.test.ts
+++ b/packages/core/src/commands/startup.test.ts
@@ -437,6 +437,10 @@ describe('runStartup behavior', () => {
     launchDashboardServer.mockResolvedValue(null);
   });
 
+  function expectBrowserOpenedWith(url: string): void {
+    expect(execFile).toHaveBeenCalledWith(expect.any(String), expect.arrayContaining([url]), expect.any(Function));
+  }
+
   it('should NOT open browser when totalActivePRs is 0', async () => {
     const daily = makeDailyOutput(0);
     executeDailyCheck.mockResolvedValue(daily);
@@ -540,16 +544,12 @@ describe('runStartup behavior', () => {
     const result = await runStartup();
 
     // Opens SPA URL
-    expect(execFile).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.arrayContaining(['http://oss.localhost:3000']),
-      expect.any(Function),
-    );
+    expectBrowserOpenedWith('http://oss.localhost:3000');
     expect(result.dashboardUrl).toBe('http://oss.localhost:3000');
     expect(result.daily?.briefSummary).toContain('Dashboard opened in browser');
   });
 
-  it('should refresh existing dashboard instead of opening new tab (#830)', async () => {
+  it('should refresh existing dashboard and focus it in the browser (#830)', async () => {
     const daily = makeDailyOutput(3);
     executeDailyCheck.mockResolvedValue(daily);
     launchDashboardServer.mockResolvedValue({ url: 'http://oss.localhost:3001', port: 3001, alreadyRunning: true });
@@ -558,13 +558,15 @@ describe('runStartup behavior', () => {
     const result = await runStartup();
 
     expect(result.dashboardUrl).toBe('http://oss.localhost:3001');
-    // Should NOT open a new browser tab
-    expect(execFile).not.toHaveBeenCalled();
     // Should trigger a refresh on the running server
     expect(fetchSpy).toHaveBeenCalledWith(
       'http://127.0.0.1:3001/api/refresh',
       expect.objectContaining({ method: 'POST' }),
     );
+    // Should always call the OS browser-opener: native `open`/`xdg-open`/`start`
+    // focus an existing tab matching the URL instead of duplicating it, so
+    // surfacing the dashboard after /oss is safe here.
+    expectBrowserOpenedWith('http://oss.localhost:3001');
     expect(result.daily?.briefSummary).toContain('Dashboard refreshed');
     expect(result.daily?.briefSummary).not.toContain('Dashboard opened in browser');
     fetchSpy.mockRestore();
@@ -581,8 +583,10 @@ describe('runStartup behavior', () => {
 
     // Startup should succeed despite refresh failure
     expect(result.dashboardUrl).toBe('http://oss.localhost:3001');
-    expect(execFile).not.toHaveBeenCalled();
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Could not trigger dashboard refresh'));
+    // Browser open is independent of refresh health: still focus the dashboard
+    // so the user sees cached data rather than nothing.
+    expectBrowserOpenedWith('http://oss.localhost:3001');
     // Should say "running" not "refreshed" when refresh fails
     expect(result.daily?.briefSummary).toContain('Dashboard running');
     expect(result.daily?.briefSummary).not.toContain('Dashboard refreshed');
@@ -602,8 +606,9 @@ describe('runStartup behavior', () => {
     const result = await runStartup();
 
     expect(result.dashboardUrl).toBe('http://oss.localhost:3001');
-    expect(execFile).not.toHaveBeenCalled();
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Dashboard refresh returned 429'));
+    // Browser open still happens: user gets stale-but-visible data instead of silent nothing.
+    expectBrowserOpenedWith('http://oss.localhost:3001');
     // Should say "running" not "refreshed" on non-200
     expect(result.daily?.briefSummary).toContain('Dashboard running');
     fetchSpy.mockRestore();

--- a/packages/core/src/commands/startup.ts
+++ b/packages/core/src/commands/startup.ts
@@ -252,9 +252,15 @@ export async function runStartup(): Promise<StartupOutput> {
           const refreshed = await triggerDashboardRefresh(spaResult.port);
           dashboardStatus = refreshed ? 'refreshed' : 'running';
         } else {
-          openInBrowser(spaResult.url);
           dashboardStatus = 'opened';
         }
+        // Always surface the dashboard: `open`/`xdg-open`/`start` focus an
+        // existing tab matching the URL instead of duplicating it, so this is
+        // safe whether the server was just started or was already running.
+        // Closes #830 properly. The original fix assumed "server running"
+        // implied "tab open", but the user can close the tab while the daemon
+        // keeps running, leaving subsequent /oss runs with no visible dashboard.
+        openInBrowser(spaResult.url);
       } else {
         console.error('[STARTUP] Dashboard SPA assets not found. Build with: cd packages/dashboard && pnpm run build');
       }


### PR DESCRIPTION
## Summary
- `/oss` now always surfaces the dashboard in the browser, not only on cold-start. Fixes the case where the user closes the dashboard tab while the server keeps running and subsequent `/oss` invocations silently refresh an invisible daemon.
- Aligns `/oss` behavior with `/oss-dashboard`, which already always opens the URL.
- Updates the three #830-era tests that asserted `execFile` must NOT be called when `alreadyRunning: true`; they now assert the browser open IS called. Also extracts a small `expectBrowserOpenedWith` helper used across four call sites.

## Why #830's concern still holds
`open` (macOS), `xdg-open` (Linux), and `start` (Windows) plus the default browser focus an existing tab matching the URL instead of duplicating it. So the original "don't spam new tabs on every /oss" fix from #830 remains satisfied by the OS/browser behavior, not by skipping the call.

## Test plan
- [x] `npx vitest run src/commands/startup.test.ts` — 41 passed
- [x] `pnpm test` — full workspace suite green (core 2049 / dashboard 255 / mcp-server 181)
- [x] `pnpm run lint` — clean
- [x] `pnpm run format:check` — clean
- [ ] Manual: run `/oss` with an existing dashboard server + no tab open, confirm the tab is surfaced