### PR TITLE
fix(pr-monitor): warn when configured username does not match authenticated viewer

### DIFF
--- a/packages/core/src/core/pr-monitor.test.ts
+++ b/packages/core/src/core/pr-monitor.test.ts
@@ -1714,6 +1714,146 @@ describe('fetchUserOpenPRs surfaces 1000-cap truncation (#1057 M25)', () => {
   });
 });
 
+// A stale/placeholder githubUsername (e.g. "example-user") silently returns
+// zero Search results with no error — the dashboard then looks like a fresh
+// install with no PRs. fetchUserOpenPRs must cross-check the authenticated
+// viewer and surface a mismatch warning instead of silently reporting zero.
+describe('fetchUserOpenPRs detects username/viewer mismatch when total_count is 0', () => {
+  it('warns when configured username does not match authenticated viewer', async () => {
+    vi.mocked(getStateManager).mockReturnValue(
+      makeStateManagerMock({
+        config: { githubUsername: 'example-user', excludeRepos: [], excludeOrgs: [] },
+      }),
+    );
+
+    mockOctokitInstance = {
+      search: {
+        issuesAndPullRequests: vi.fn().mockResolvedValue({
+          data: { total_count: 0, items: [] },
+        }),
+      },
+      users: {
+        getAuthenticated: vi.fn().mockResolvedValue({ data: { login: 'costajohnt' } }),
+      },
+    };
+
+    const monitor = new PRMonitor('fake-token');
+    const result = await monitor.fetchUserOpenPRs();
+
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings!.length).toBe(1);
+    expect(result.warnings![0]).toMatch(/example-user/);
+    expect(result.warnings![0]).toMatch(/costajohnt/);
+    expect(result.warnings![0]).toMatch(/config username costajohnt/);
+  });
+
+  it('does not warn when configured username matches authenticated viewer (case-insensitive)', async () => {
+    vi.mocked(getStateManager).mockReturnValue(
+      makeStateManagerMock({
+        config: { githubUsername: 'CostaJohnT', excludeRepos: [], excludeOrgs: [] },
+      }),
+    );
+
+    mockOctokitInstance = {
+      search: {
+        issuesAndPullRequests: vi.fn().mockResolvedValue({
+          data: { total_count: 0, items: [] },
+        }),
+      },
+      users: {
+        getAuthenticated: vi.fn().mockResolvedValue({ data: { login: 'costajohnt' } }),
+      },
+    };
+
+    const monitor = new PRMonitor('fake-token');
+    const result = await monitor.fetchUserOpenPRs();
+
+    expect(result.warnings ?? []).toEqual([]);
+  });
+
+  it('does not perform the mismatch check when total_count > 0', async () => {
+    vi.mocked(getStateManager).mockReturnValue(
+      makeStateManagerMock({
+        config: { githubUsername: 'example-user', excludeRepos: [], excludeOrgs: [] },
+      }),
+    );
+
+    const getAuthenticatedSpy = vi.fn();
+    mockOctokitInstance = {
+      search: {
+        issuesAndPullRequests: vi.fn().mockResolvedValue({
+          // One item that the own-repo filter will drop — mirrors a real GH response shape
+          // (total_count agrees with items.length) while exercising the non-zero guard path.
+          data: {
+            total_count: 1,
+            items: [{ pull_request: {}, html_url: 'https://github.com/example-user/self/pull/1' }],
+          },
+        }),
+      },
+      users: { getAuthenticated: getAuthenticatedSpy },
+    };
+
+    const monitor = new PRMonitor('fake-token');
+    await monitor.fetchUserOpenPRs();
+
+    // Guardrail is strictly for the zero-result surprise; non-zero paths skip the extra API call.
+    expect(getAuthenticatedSpy).not.toHaveBeenCalled();
+  });
+
+  it('swallows non-fatal getAuthenticated failures (guardrail is advisory)', async () => {
+    vi.mocked(getStateManager).mockReturnValue(
+      makeStateManagerMock({
+        config: { githubUsername: 'example-user', excludeRepos: [], excludeOrgs: [] },
+      }),
+    );
+
+    mockOctokitInstance = {
+      search: {
+        issuesAndPullRequests: vi.fn().mockResolvedValue({
+          data: { total_count: 0, items: [] },
+        }),
+      },
+      users: {
+        getAuthenticated: vi.fn().mockRejectedValue(new Error('Service timeout')),
+      },
+    };
+
+    const monitor = new PRMonitor('fake-token');
+    const result = await monitor.fetchUserOpenPRs();
+
+    // No warning emitted because we couldn't confirm the mismatch, and no error thrown.
+    expect(result.warnings ?? []).toEqual([]);
+    expect(result.prs).toEqual([]);
+  });
+
+  it('rethrows rate-limit / auth errors from getAuthenticated', async () => {
+    vi.mocked(getStateManager).mockReturnValue(
+      makeStateManagerMock({
+        config: { githubUsername: 'example-user', excludeRepos: [], excludeOrgs: [] },
+      }),
+    );
+
+    // 401 means the token is revoked/expired — the very failure mode this guardrail
+    // should surface. The unauthenticated Search above still returns total_count: 0
+    // for a bogus author, so swallowing the 401 would silently downgrade a broken
+    // token to "looks like a fresh install."
+    const authError = Object.assign(new Error('Bad credentials'), { status: 401 });
+    mockOctokitInstance = {
+      search: {
+        issuesAndPullRequests: vi.fn().mockResolvedValue({
+          data: { total_count: 0, items: [] },
+        }),
+      },
+      users: {
+        getAuthenticated: vi.fn().mockRejectedValue(authError),
+      },
+    };
+
+    const monitor = new PRMonitor('fake-token');
+    await expect(monitor.fetchUserOpenPRs()).rejects.toThrow('Bad credentials');
+  });
+});
+
 describe('isBotAuthor (#143)', () => {
   it('should identify [bot] suffix accounts', () => {
     expect(isBotAuthor('dependabot[bot]')).toBe(true);

--- a/packages/core/src/core/pr-monitor.ts
+++ b/packages/core/src/core/pr-monitor.ts
@@ -20,7 +20,13 @@ import { daysBetween, parseGitHubUrl, extractOwnerRepo, isOwnRepo, DEFAULT_CONCU
 import { FetchedPR, DailyDigest, ClosedPR, MergedPR, StarFilter } from './types.js';
 import { determineStatus } from './status-determination.js';
 import { runWorkerPool } from './concurrency.js';
-import { ConfigurationError, ValidationError, errorMessage, getHttpStatusCode } from './errors.js';
+import {
+  ConfigurationError,
+  ValidationError,
+  errorMessage,
+  getHttpStatusCode,
+  isRateLimitOrAuthError,
+} from './errors.js';
 import { paginateAll } from './pagination.js';
 import { debug, warn, timed } from './logger.js';
 import { getHttpCache, cachedRequest } from './http-cache.js';
@@ -152,6 +158,35 @@ export class PRMonitor {
     // previously silently dropped the overflow; now the caller can surface
     // it so the daily digest doesn't quietly report a partial view.
     const warnings: string[] = [];
+
+    // Guardrail: if the Search API returned zero PRs, cross-check the
+    // configured username against the authenticated viewer. A real failure
+    // mode was a stale/placeholder username (e.g. "example-user") silently
+    // producing zero results with no error — the dashboard just showed
+    // "0 active PRs" and looked like a fresh install. getAuthenticated is
+    // advisory; a failure here never breaks the fetch.
+    if (totalCount === 0) {
+      try {
+        const { data: viewer } = await this.octokit.users.getAuthenticated();
+        if (viewer.login.toLowerCase() !== config.githubUsername.toLowerCase()) {
+          const message =
+            `Configured GitHub username @${config.githubUsername} does not match ` +
+            `authenticated user @${viewer.login}. Did you mean to run ` +
+            `\`oss-autopilot config username ${viewer.login}\`? Zero PRs returned.`;
+          warnings.push(message);
+          warn(MODULE, message);
+        }
+      } catch (err) {
+        // Rate-limit/401/403 errors must abort the run just like every sibling
+        // fetch in this pipeline — swallowing them here would mask the exact
+        // class of failure the guardrail is meant to surface (e.g. revoked
+        // token returning 401 while the unauthenticated Search above still
+        // succeeds with zero results).
+        if (isRateLimitOrAuthError(err)) throw err;
+        debug(MODULE, `Could not cross-check viewer login: ${errorMessage(err)}`);
+      }
+    }
+
     if (totalCount > SEARCH_API_RESULT_CAP) {
       warnings.push(
         `GitHub Search API returned ${totalCount} PRs for @${config.githubUsername}, ` +


### PR DESCRIPTION
## Summary
- When `fetchUserOpenPRs` returns zero PRs, cross-check the configured `githubUsername` against `octokit.users.getAuthenticated()`. Mismatches emit a warning via the existing `warnings[]` → `partialFailures` → dashboard banner pipeline.
- Rate-limit / 401 / 403 from `getAuthenticated` are rethrown (matches the pattern in `fetchDashboardData`'s `trackingCatch`). Other errors are swallowed to `debug` since the guardrail is strictly advisory.
- Gated on `total_count === 0` so steady-state runs pay no extra API cost.

## Why
Real incident today: `state.json` carried the literal string `"example-user"` as `githubUsername` (didn't match my real login `costajohnt`). GitHub's Search API returns `total_count: 0` for bogus authors with no error, so the dashboard quietly rendered "0 active PRs" for hours as if it were a fresh install. This converts that silent-zero mode into a loud, actionable warning with the exact fix command.

## False-positive risk
Low. A contributor using a bot token to track their human account's PRs only trips the warning when the human currently has zero open PRs — rare, and the message is clearly advisory ("Did you mean...?") rather than a hard error.

## Test plan
- [x] `npx vitest run src/core/pr-monitor.test.ts -t "mismatch"` — 5 passed (mismatch warning, case-insensitive match, not invoked when count > 0, non-fatal error is swallowed, rate-limit / auth errors rethrow)
- [x] `pnpm test` — 2054 core / 255 dashboard / 181 mcp-server, all green
- [x] `pnpm run lint` + `pnpm run format:check` — clean
- [ ] Manual: temporarily flip `state.json` githubUsername to a bogus value, confirm the dashboard banner surfaces the warning

## Related
- Closes the silent-failure mode exposed while debugging the "0 active PRs" issue in [#1100](https://github.com/costajohnt/oss-autopilot/pull/1100)
- Follows the `warnings[]` convention introduced in #1057 (M25) and the `partialFailures` routing from #1035