### PR TITLE
fix(startup): always launch dashboard and auto-repair placeholder usernames

### DIFF
--- a/packages/core/src/commands/startup.test.ts
+++ b/packages/core/src/commands/startup.test.ts
@@ -441,17 +441,28 @@ describe('runStartup behavior', () => {
     expect(execFile).toHaveBeenCalledWith(expect.any(String), expect.arrayContaining([url]), expect.any(Function));
   }
 
-  it('should NOT open browser when totalActivePRs is 0', async () => {
+  it('should still launch SPA when totalActivePRs is 0 (dashboard empty-state is fine)', async () => {
+    // Regression: the old `> 0` gate swallowed the dashboard for misconfigured
+    // username, transient API flakes, and users between contributions. The
+    // dashboard's own empty-state UI renders zero PRs cleanly, so launch it
+    // whenever setup + auth succeed.
     const daily = makeDailyOutput(0);
     executeDailyCheck.mockResolvedValue(daily);
+    launchDashboardServer.mockResolvedValue({
+      url: 'http://localhost:3000',
+      port: 3000,
+      alreadyRunning: false,
+    });
 
     const result = await runStartup();
 
-    expect(execFile).not.toHaveBeenCalled();
-    expect(result.daily?.briefSummary).not.toContain('Dashboard opened in browser');
+    expect(launchDashboardServer).toHaveBeenCalled();
+    expectBrowserOpenedWith('http://localhost:3000');
+    expect(result.dashboardUrl).toBe('http://localhost:3000');
+    expect(result.daily?.briefSummary).toContain('Dashboard opened in browser');
   });
 
-  it('should log error when SPA unavailable and totalActivePRs > 0', async () => {
+  it('should log error and surface dashboardError when SPA assets are unavailable', async () => {
     const daily = makeDailyOutput(3);
     executeDailyCheck.mockResolvedValue(daily);
     launchDashboardServer.mockResolvedValue(null);
@@ -462,6 +473,9 @@ describe('runStartup behavior', () => {
     expect(launchDashboardServer).toHaveBeenCalled();
     expect(execFile).not.toHaveBeenCalled();
     expect(result.dashboardUrl).toBeUndefined();
+    // JSON consumers need a structured signal, not just a stderr line, since
+    // the dashboard is now always attempted and missing-URL is ambiguous.
+    expect(result.dashboardError).toMatch(/SPA assets not found/);
     expect(result.daily?.briefSummary).not.toContain('Dashboard opened in browser');
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('SPA assets not found'));
     consoleSpy.mockRestore();
@@ -615,18 +629,23 @@ describe('runStartup behavior', () => {
     consoleSpy.mockRestore();
   });
 
-  it('should not launch SPA when totalActivePRs is 0', async () => {
+  it('launches SPA even when totalActivePRs is 0 (covers misconfig + transient + between-PRs)', async () => {
     const daily = makeDailyOutput(0);
     executeDailyCheck.mockResolvedValue(daily);
+    launchDashboardServer.mockResolvedValue({
+      url: 'http://localhost:3000',
+      port: 3000,
+      alreadyRunning: false,
+    });
 
     const result = await runStartup();
 
-    expect(launchDashboardServer).not.toHaveBeenCalled();
-    expect(execFile).not.toHaveBeenCalled();
-    expect(result.dashboardUrl).toBeUndefined();
+    expect(launchDashboardServer).toHaveBeenCalled();
+    expectBrowserOpenedWith('http://localhost:3000');
+    expect(result.dashboardUrl).toBe('http://localhost:3000');
   });
 
-  it('should log error when SPA launch throws', async () => {
+  it('should surface dashboardError and log when SPA launch throws', async () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const daily = makeDailyOutput(5);
     executeDailyCheck.mockResolvedValue(daily);
@@ -634,11 +653,15 @@ describe('runStartup behavior', () => {
 
     const result = await runStartup();
 
-    // Should not crash — dashboard is unavailable but startup continues
+    // Should not crash — dashboard is unavailable but startup continues.
     expect(result.dashboardUrl).toBeUndefined();
     expect(execFile).not.toHaveBeenCalled();
     expect(result.daily?.briefSummary).not.toContain('Dashboard opened in browser');
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('SPA dashboard launch failed'), 'spawn ENOENT');
+    // Structured signal for JSON consumers (plugin layer, MCP), plus the
+    // existing stderr line for humans tailing logs.
+    expect(result.dashboardError).toMatch(/SPA dashboard launch failed/);
+    expect(result.dashboardError).toMatch(/spawn ENOENT/);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('SPA dashboard launch failed'));
     consoleSpy.mockRestore();
   });
 

--- a/packages/core/src/commands/startup.ts
+++ b/packages/core/src/commands/startup.ts
@@ -238,35 +238,43 @@ export async function runStartup(): Promise<StartupOutput> {
   // 3. Run daily check
   const daily = await executeDailyCheck(token);
 
-  // 4. Launch interactive SPA dashboard
-  // Skip opening on first run (0 PRs) — the welcome flow handles onboarding
+  // 4. Launch interactive SPA dashboard.
+  //
+  // Launched unconditionally once setup and auth pass. A prior heuristic skipped
+  // launch whenever `totalActivePRs === 0`, assuming that meant a genuine first
+  // run and deferring to the CLI's welcome flow. That gate also swallowed the
+  // dashboard in three legitimate cases: a misconfigured/stale `githubUsername`
+  // (Search API returns zero), transient GitHub API flakes (state still holds
+  // merged PRs but the live count is zero), and users genuinely between PRs.
+  // The dashboard's own empty-state UI renders "no PRs" cleanly, so always
+  // surfacing it is the right default.
   let dashboardUrl: string | undefined;
   let dashboardStatus: 'opened' | 'refreshed' | 'running' | undefined;
+  let dashboardError: string | undefined;
 
-  if (daily.digest.summary.totalActivePRs > 0) {
-    try {
-      const spaResult = await launchDashboardServer();
-      if (spaResult) {
-        dashboardUrl = spaResult.url;
-        if (spaResult.alreadyRunning) {
-          const refreshed = await triggerDashboardRefresh(spaResult.port);
-          dashboardStatus = refreshed ? 'refreshed' : 'running';
-        } else {
-          dashboardStatus = 'opened';
-        }
-        // Always surface the dashboard: `open`/`xdg-open`/`start` focus an
-        // existing tab matching the URL instead of duplicating it, so this is
-        // safe whether the server was just started or was already running.
-        // Closes #830 properly. The original fix assumed "server running"
-        // implied "tab open", but the user can close the tab while the daemon
-        // keeps running, leaving subsequent /oss runs with no visible dashboard.
-        openInBrowser(spaResult.url);
+  try {
+    const spaResult = await launchDashboardServer();
+    if (spaResult) {
+      dashboardUrl = spaResult.url;
+      if (spaResult.alreadyRunning) {
+        const refreshed = await triggerDashboardRefresh(spaResult.port);
+        dashboardStatus = refreshed ? 'refreshed' : 'running';
       } else {
-        console.error('[STARTUP] Dashboard SPA assets not found. Build with: cd packages/dashboard && pnpm run build');
+        dashboardStatus = 'opened';
       }
-    } catch (error) {
-      console.error('[STARTUP] SPA dashboard launch failed:', errorMessage(error));
+      // `open`/`xdg-open`/`start` focus an existing tab matching the URL
+      // instead of duplicating it, so this is safe whether the server was
+      // just started or was already running. Closes #830 properly — a user
+      // can close the dashboard tab while the daemon keeps running, leaving
+      // subsequent /oss runs with no visible dashboard if we didn't re-open.
+      openInBrowser(spaResult.url);
+    } else {
+      dashboardError = 'Dashboard SPA assets not found. Build with: cd packages/dashboard && pnpm run build';
+      console.error(`[STARTUP] ${dashboardError}`);
     }
+  } catch (error) {
+    dashboardError = `SPA dashboard launch failed: ${errorMessage(error)}`;
+    console.error(`[STARTUP] ${dashboardError}`);
   }
 
   // Append dashboard status to brief summary
@@ -287,6 +295,7 @@ export async function runStartup(): Promise<StartupOutput> {
     autoDetected,
     daily,
     dashboardUrl,
+    dashboardError,
     issueList,
   };
 }

--- a/packages/core/src/core/pr-monitor.test.ts
+++ b/packages/core/src/core/pr-monitor.test.ts
@@ -1714,15 +1714,17 @@ describe('fetchUserOpenPRs surfaces 1000-cap truncation (#1057 M25)', () => {
   });
 });
 
-// A stale/placeholder githubUsername (e.g. "example-user") silently returns
+// A stale githubUsername (e.g. a renamed GitHub account) silently returns
 // zero Search results with no error — the dashboard then looks like a fresh
 // install with no PRs. fetchUserOpenPRs must cross-check the authenticated
 // viewer and surface a mismatch warning instead of silently reporting zero.
+// Known placeholder strings (see KNOWN_PLACEHOLDER_USERNAMES) take a separate
+// auto-repair path covered by the suite below.
 describe('fetchUserOpenPRs detects username/viewer mismatch when total_count is 0', () => {
   it('warns when configured username does not match authenticated viewer', async () => {
     vi.mocked(getStateManager).mockReturnValue(
       makeStateManagerMock({
-        config: { githubUsername: 'example-user', excludeRepos: [], excludeOrgs: [] },
+        config: { githubUsername: 'renamed-account', excludeRepos: [], excludeOrgs: [] },
       }),
     );
 
@@ -1742,7 +1744,7 @@ describe('fetchUserOpenPRs detects username/viewer mismatch when total_count is 
 
     expect(result.warnings).toBeDefined();
     expect(result.warnings!.length).toBe(1);
-    expect(result.warnings![0]).toMatch(/example-user/);
+    expect(result.warnings![0]).toMatch(/renamed-account/);
     expect(result.warnings![0]).toMatch(/costajohnt/);
     expect(result.warnings![0]).toMatch(/config username costajohnt/);
   });
@@ -1774,7 +1776,7 @@ describe('fetchUserOpenPRs detects username/viewer mismatch when total_count is 
   it('does not perform the mismatch check when total_count > 0', async () => {
     vi.mocked(getStateManager).mockReturnValue(
       makeStateManagerMock({
-        config: { githubUsername: 'example-user', excludeRepos: [], excludeOrgs: [] },
+        config: { githubUsername: 'renamed-account', excludeRepos: [], excludeOrgs: [] },
       }),
     );
 
@@ -1786,7 +1788,7 @@ describe('fetchUserOpenPRs detects username/viewer mismatch when total_count is 
           // (total_count agrees with items.length) while exercising the non-zero guard path.
           data: {
             total_count: 1,
-            items: [{ pull_request: {}, html_url: 'https://github.com/example-user/self/pull/1' }],
+            items: [{ pull_request: {}, html_url: 'https://github.com/renamed-account/self/pull/1' }],
           },
         }),
       },
@@ -1803,7 +1805,7 @@ describe('fetchUserOpenPRs detects username/viewer mismatch when total_count is 
   it('swallows non-fatal getAuthenticated failures (guardrail is advisory)', async () => {
     vi.mocked(getStateManager).mockReturnValue(
       makeStateManagerMock({
-        config: { githubUsername: 'example-user', excludeRepos: [], excludeOrgs: [] },
+        config: { githubUsername: 'renamed-account', excludeRepos: [], excludeOrgs: [] },
       }),
     );
 
@@ -1829,7 +1831,7 @@ describe('fetchUserOpenPRs detects username/viewer mismatch when total_count is 
   it('rethrows rate-limit / auth errors from getAuthenticated', async () => {
     vi.mocked(getStateManager).mockReturnValue(
       makeStateManagerMock({
-        config: { githubUsername: 'example-user', excludeRepos: [], excludeOrgs: [] },
+        config: { githubUsername: 'renamed-account', excludeRepos: [], excludeOrgs: [] },
       }),
     );
 
@@ -1843,6 +1845,147 @@ describe('fetchUserOpenPRs detects username/viewer mismatch when total_count is 
         issuesAndPullRequests: vi.fn().mockResolvedValue({
           data: { total_count: 0, items: [] },
         }),
+      },
+      users: {
+        getAuthenticated: vi.fn().mockRejectedValue(authError),
+      },
+    };
+
+    const monitor = new PRMonitor('fake-token');
+    await expect(monitor.fetchUserOpenPRs()).rejects.toThrow('Bad credentials');
+  });
+});
+
+// Known-placeholder usernames (e.g. "example-user" from doc snippets or an
+// aborted setup) silently produce zero Search results. fetchUserOpenPRs must
+// auto-repair the config from the authenticated viewer *before* the search
+// so the first /oss run actually surfaces the user's PRs.
+describe('fetchUserOpenPRs auto-repairs known placeholder usernames', () => {
+  it('repairs the config and issues the search with the viewer login', async () => {
+    const updateConfigSpy = vi.fn();
+    const stateManagerMock = makeStateManagerMock({
+      config: { githubUsername: 'example-user', excludeRepos: [], excludeOrgs: [] },
+    });
+    stateManagerMock.updateConfig = updateConfigSpy;
+    vi.mocked(getStateManager).mockReturnValue(stateManagerMock);
+
+    const searchSpy = vi.fn().mockResolvedValue({ data: { total_count: 0, items: [] } });
+    const getAuthenticatedSpy = vi.fn().mockResolvedValue({ data: { login: 'costajohnt' } });
+    mockOctokitInstance = {
+      search: { issuesAndPullRequests: searchSpy },
+      users: { getAuthenticated: getAuthenticatedSpy },
+    };
+
+    const monitor = new PRMonitor('fake-token');
+    const result = await monitor.fetchUserOpenPRs();
+
+    // Config was persisted to the authenticated viewer's login.
+    expect(updateConfigSpy).toHaveBeenCalledWith({ githubUsername: 'costajohnt' });
+    // The search used the repaired username, not the placeholder.
+    expect(searchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ q: expect.stringContaining('author:costajohnt') }),
+    );
+    expect(searchSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ q: expect.stringContaining('author:example-user') }),
+    );
+    // Pre-fetch repair already reconciled the usernames — the post-fetch
+    // guardrail must not spend a second getAuthenticated call to re-confirm.
+    expect(getAuthenticatedSpy).toHaveBeenCalledTimes(1);
+    // Warning surfaces the repair so the daily digest shows what changed.
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings!.some((w) => /placeholder/i.test(w) && /costajohnt/.test(w))).toBe(true);
+  });
+
+  it('skips persisting when the authenticated viewer login is empty or also a placeholder', async () => {
+    const updateConfigSpy = vi.fn();
+    const stateManagerMock = makeStateManagerMock({
+      config: { githubUsername: 'example-user', excludeRepos: [], excludeOrgs: [] },
+    });
+    stateManagerMock.updateConfig = updateConfigSpy;
+    vi.mocked(getStateManager).mockReturnValue(stateManagerMock);
+
+    mockOctokitInstance = {
+      search: {
+        issuesAndPullRequests: vi.fn().mockResolvedValue({ data: { total_count: 0, items: [] } }),
+      },
+      users: {
+        // Whitespace-only login — treat as unusable rather than swapping one
+        // broken config for another.
+        getAuthenticated: vi.fn().mockResolvedValue({ data: { login: '   ' } }),
+      },
+    };
+
+    const monitor = new PRMonitor('fake-token');
+    const result = await monitor.fetchUserOpenPRs();
+
+    expect(updateConfigSpy).not.toHaveBeenCalled();
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings!.some((w) => /unusable/i.test(w))).toBe(true);
+  });
+
+  it('skips repair when the username is not a known placeholder', async () => {
+    vi.mocked(getStateManager).mockReturnValue(
+      makeStateManagerMock({
+        config: { githubUsername: 'real-user', excludeRepos: [], excludeOrgs: [] },
+      }),
+    );
+
+    const getAuthenticatedSpy = vi.fn().mockResolvedValue({ data: { login: 'real-user' } });
+    mockOctokitInstance = {
+      search: {
+        issuesAndPullRequests: vi.fn().mockResolvedValue({ data: { total_count: 5, items: [] } }),
+      },
+      users: { getAuthenticated: getAuthenticatedSpy },
+    };
+
+    const monitor = new PRMonitor('fake-token');
+    const result = await monitor.fetchUserOpenPRs();
+
+    // Non-placeholder + non-zero search → neither the pre-fetch repair nor the
+    // post-fetch guardrail should call getAuthenticated.
+    expect(getAuthenticatedSpy).not.toHaveBeenCalled();
+    expect(result.warnings ?? []).toEqual([]);
+  });
+
+  it('swallows non-fatal viewer lookup failures and falls through to the normal fetch', async () => {
+    vi.mocked(getStateManager).mockReturnValue(
+      makeStateManagerMock({
+        config: { githubUsername: 'example-user', excludeRepos: [], excludeOrgs: [] },
+      }),
+    );
+
+    mockOctokitInstance = {
+      search: {
+        issuesAndPullRequests: vi.fn().mockResolvedValue({ data: { total_count: 0, items: [] } }),
+      },
+      users: {
+        getAuthenticated: vi.fn().mockRejectedValue(new Error('Service timeout')),
+      },
+    };
+
+    const monitor = new PRMonitor('fake-token');
+    const result = await monitor.fetchUserOpenPRs();
+
+    // When repair can't run, we do NOT throw — but we DO emit a warning so
+    // the daily digest shows that auto-repair was attempted and failed.
+    // Without the warning, a user in this state sees zero PRs with no
+    // breadcrumb to follow.
+    expect(result.prs).toEqual([]);
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings!.some((w) => /Could not auto-repair/i.test(w))).toBe(true);
+  });
+
+  it('rethrows rate-limit / auth errors from viewer lookup', async () => {
+    vi.mocked(getStateManager).mockReturnValue(
+      makeStateManagerMock({
+        config: { githubUsername: 'example-user', excludeRepos: [], excludeOrgs: [] },
+      }),
+    );
+
+    const authError = Object.assign(new Error('Bad credentials'), { status: 401 });
+    mockOctokitInstance = {
+      search: {
+        issuesAndPullRequests: vi.fn().mockResolvedValue({ data: { total_count: 0, items: [] } }),
       },
       users: {
         getAuthenticated: vi.fn().mockRejectedValue(authError),

--- a/packages/core/src/core/pr-monitor.ts
+++ b/packages/core/src/core/pr-monitor.ts
@@ -56,6 +56,32 @@ export { isConditionalChecklistItem } from './checklist-analysis.js';
 export { determineStatus } from './status-determination.js';
 
 /**
+ * Known placeholder values that can end up in `config.githubUsername` from
+ * doc snippets, example configs, or aborted setup flows. When the configured
+ * username matches one of these, the PR fetch silently returns zero results
+ * and the dashboard looks like a fresh install. Detecting these lets us
+ * auto-repair the config from the authenticated viewer before fetching.
+ *
+ * Entries must be lowercase — `Lowercase<string>` on the source tuple makes
+ * a non-lowercase entry a compile error, keeping the case-insensitive lookup
+ * contract type-checked instead of comment-documented.
+ */
+const PLACEHOLDER_USERNAMES: readonly Lowercase<string>[] = [
+  'example-user',
+  'your-username',
+  'your-github-username',
+] as const;
+const KNOWN_PLACEHOLDER_USERNAMES: ReadonlySet<string> = new Set(PLACEHOLDER_USERNAMES);
+
+function isPlaceholderUsername(username: string): boolean {
+  return KNOWN_PLACEHOLDER_USERNAMES.has(username.toLowerCase());
+}
+
+// Module-private on purpose: callers should only use the predicate so the
+// `.toLowerCase()` contract can't be bypassed by reading the set directly.
+export { isPlaceholderUsername };
+
+/**
  * Check if a PR has a merge conflict based on GitHub's mergeable flag and mergeable_state.
  * Returns true when mergeable is explicitly false or the mergeable_state is 'dirty'.
  *
@@ -79,10 +105,13 @@ export interface FetchPRsResult {
   prs: FetchedPR[];
   failures: PRCheckFailure[];
   /**
-   * Non-fatal warnings accumulated while fetching. Currently populated when
-   * the GitHub Search API's 1000-result ceiling truncates the user's PR
-   * list — callers (daily, dashboard) surface these so users know the data
-   * may be incomplete (#1057 M25).
+   * Non-fatal warnings accumulated while fetching. Populated by:
+   * - Placeholder auto-repair (stale/example `githubUsername` replaced with
+   *   the authenticated viewer's login before the search runs).
+   * - Post-fetch viewer-mismatch guardrail (configured username differs
+   *   from the authenticated viewer when the search returned zero PRs).
+   * - Search API 1000-result truncation (#1057 M25).
+   * Callers (daily, dashboard) surface these so users see the signal.
    */
   warnings?: string[];
 }
@@ -123,13 +152,69 @@ export class PRMonitor {
    * ```
    */
   async fetchUserOpenPRs(): Promise<FetchPRsResult> {
-    const config = this.stateManager.getState().config;
+    const initialConfig = this.stateManager.getState().config;
 
-    if (!config.githubUsername) {
+    if (!initialConfig.githubUsername) {
       throw new ConfigurationError('No GitHub username configured. Run setup first.');
     }
 
-    debug('pr-monitor', `Fetching open PRs for @${config.githubUsername}...`);
+    // Non-fatal warnings threaded into the result (#1057 M25). When the
+    // Search API's hard 1000-result ceiling truncates the user's PR list we
+    // previously silently dropped the overflow; now the caller can surface
+    // it so the daily digest doesn't quietly report a partial view.
+    const warnings: string[] = [];
+
+    // Username used for the search — mutated below if the pre-fetch placeholder
+    // repair fires. Writing to config is separate from rebinding this local.
+    let searchUsername = initialConfig.githubUsername;
+
+    // Proactive placeholder repair: if the configured username is a known
+    // placeholder (e.g. "example-user" carried over from docs or an aborted
+    // setup), cross-check against the authenticated viewer and persist the
+    // corrected name before fetching. Without this, the search silently
+    // returns zero results and the dashboard looks like a fresh install.
+    // Errors here are non-fatal; rate-limit/auth failures still abort so we
+    // don't mask a revoked token by downgrading to a no-op.
+    let didRepair = false;
+    if (isPlaceholderUsername(searchUsername)) {
+      try {
+        const { data: viewer } = await this.octokit.users.getAuthenticated();
+        const newLogin = viewer.login?.trim();
+        // Guard against an empty/whitespace viewer login (enterprise proxies,
+        // stubbed Octokit clients) and against the pathological case where the
+        // authenticated viewer's login is itself one of our placeholder strings
+        // — persisting either would swap one broken config for another.
+        if (!newLogin || isPlaceholderUsername(newLogin)) {
+          const message =
+            `Placeholder username "${searchUsername}" detected but authenticated viewer ` +
+            `returned an unusable login (${JSON.stringify(viewer.login)}); skipping auto-repair.`;
+          warnings.push(message);
+          warn(MODULE, message);
+        } else {
+          this.stateManager.updateConfig({ githubUsername: newLogin });
+          searchUsername = newLogin;
+          didRepair = true;
+          const message =
+            `Configured GitHub username "${initialConfig.githubUsername}" looks like a placeholder. ` +
+            `Auto-repaired to "${newLogin}" using the authenticated viewer.`;
+          warnings.push(message);
+          warn(MODULE, message);
+        }
+      } catch (err) {
+        if (isRateLimitOrAuthError(err)) throw err;
+        // Non-fatal viewer-lookup failures (5xx, network, unexpected shape):
+        // surface as a warning (not debug) so the daily digest shows that
+        // auto-repair was attempted and couldn't complete. Falls through to
+        // the normal fetch with the placeholder, which will then return zero
+        // results — the post-fetch guardrail skips its own getAuthenticated
+        // attempt since this one already failed the same way.
+        const message = `Could not auto-repair placeholder username "${searchUsername}": ${errorMessage(err)}`;
+        warnings.push(message);
+        warn(MODULE, message);
+      }
+    }
+
+    debug('pr-monitor', `Fetching open PRs for @${searchUsername}...`);
 
     // Search for all open PRs authored by the user with pagination
     const allItems: typeof firstPage.data.items = [];
@@ -137,7 +222,7 @@ export class PRMonitor {
     const perPage = 100;
 
     const firstPage = await this.octokit.search.issuesAndPullRequests({
-      q: `is:pr is:open is:public author:${config.githubUsername}`,
+      q: `is:pr is:open is:public author:${searchUsername}`,
       sort: 'updated',
       order: 'desc',
       per_page: perPage,
@@ -153,24 +238,18 @@ export class PRMonitor {
     const MAX_PAGES = Math.ceil(SEARCH_API_RESULT_CAP / perPage); // 10 pages at per_page=100
     const totalPages = Math.min(Math.ceil(totalCount / perPage), MAX_PAGES);
 
-    // Non-fatal warnings threaded into the result (#1057 M25). When the
-    // Search API's hard 1000-result ceiling truncates the user's PR list we
-    // previously silently dropped the overflow; now the caller can surface
-    // it so the daily digest doesn't quietly report a partial view.
-    const warnings: string[] = [];
-
     // Guardrail: if the Search API returned zero PRs, cross-check the
-    // configured username against the authenticated viewer. A real failure
-    // mode was a stale/placeholder username (e.g. "example-user") silently
-    // producing zero results with no error — the dashboard just showed
-    // "0 active PRs" and looked like a fresh install. getAuthenticated is
-    // advisory; a failure here never breaks the fetch.
-    if (totalCount === 0) {
+    // configured username against the authenticated viewer. This catches
+    // stale usernames (e.g. a renamed GitHub account) that are not in the
+    // known-placeholder set. Skipped when the pre-fetch repair already
+    // reconciled the two — no need to spend a second getAuthenticated call
+    // just to confirm a match we already established.
+    if (totalCount === 0 && !didRepair) {
       try {
         const { data: viewer } = await this.octokit.users.getAuthenticated();
-        if (viewer.login.toLowerCase() !== config.githubUsername.toLowerCase()) {
+        if (viewer.login.toLowerCase() !== searchUsername.toLowerCase()) {
           const message =
-            `Configured GitHub username @${config.githubUsername} does not match ` +
+            `Configured GitHub username @${searchUsername} does not match ` +
             `authenticated user @${viewer.login}. Did you mean to run ` +
             `\`oss-autopilot config username ${viewer.login}\`? Zero PRs returned.`;
           warnings.push(message);
@@ -189,7 +268,7 @@ export class PRMonitor {
 
     if (totalCount > SEARCH_API_RESULT_CAP) {
       warnings.push(
-        `GitHub Search API returned ${totalCount} PRs for @${config.githubUsername}, ` +
+        `GitHub Search API returned ${totalCount} PRs for @${searchUsername}, ` +
           `but results are capped at ${SEARCH_API_RESULT_CAP}. ` +
           `Showing the ${SEARCH_API_RESULT_CAP} most recently updated PRs.`,
       );
@@ -199,7 +278,7 @@ export class PRMonitor {
     while (page < totalPages) {
       page++;
       const nextPage = await this.octokit.search.issuesAndPullRequests({
-        q: `is:pr is:open is:public author:${config.githubUsername}`,
+        q: `is:pr is:open is:public author:${searchUsername}`,
         sort: 'updated',
         order: 'desc',
         per_page: perPage,
@@ -220,7 +299,7 @@ export class PRMonitor {
         warn('pr-monitor', `Skipping PR with unparseable URL: ${item.html_url}`);
         return false;
       }
-      if (isOwnRepo(parsed.owner, config.githubUsername)) return false;
+      if (isOwnRepo(parsed.owner, searchUsername)) return false;
       return true;
     });
 

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -362,6 +362,13 @@ export interface StartupOutput {
   daily?: DailyOutput;
   /** URL of the interactive SPA dashboard server, when running (e.g., "http://localhost:3000") */
   dashboardUrl?: string;
+  /**
+   * Set when the dashboard launch or refresh failed (assets missing, port
+   * conflict, spawn error, etc.). The dashboard is always attempted, so JSON
+   * consumers — which previously saw only a missing `dashboardUrl` — now have
+   * a structured signal to surface or recover from the failure.
+   */
+  dashboardError?: string;
   issueList?: IssueListInfo;
 }
 
@@ -384,6 +391,7 @@ export function toCompactStartupOutput(output: StartupOutput): CompactStartupOut
     ...rest,
     daily: daily ? toCompactDailyOutput(daily) : undefined,
     dashboardUrl: output.dashboardUrl,
+    dashboardError: output.dashboardError,
     issueList: output.issueList,
   };
 }


### PR DESCRIPTION
## Summary

- Dashboard now launches on every `/oss` run once setup and auth pass — not just when the PR count is nonzero. The prior gate misfired for misconfigured usernames, transient GitHub API flakes, and users genuinely between contributions.
- `fetchUserOpenPRs` detects known placeholder usernames (`example-user`, `your-username`, `your-github-username`) and auto-repairs `config.githubUsername` from the authenticated viewer before the search runs, so the first `/oss` run surfaces real PRs instead of a silent empty state.
- `StartupOutput` gains a `dashboardError` field so JSON consumers (plugin layer, MCP) can see the failure mode when launch does not produce a URL.

## Why

A user ran `/oss` and saw "📊 0 Active PRs | all on track" despite having 21+ open PRs. Root causes:

1. `state.json` had `githubUsername: "example-user"` (a placeholder, origin unclear — likely a copy-paste from docs during initial setup). PR #1101 added a warning but required manual `oss-autopilot config username <name>` to fix.
2. The Search API returned zero results for `author:example-user`, which triggered the `totalActivePRs > 0` dashboard gate — so the user also got no browser tab.

Both symptoms came from the same "false zero" state. The fix addresses both so future users don't need to diagnose this chain.

## Behavior

### Dashboard gate
- Before: `if (daily.digest.summary.totalActivePRs > 0) launchDashboardServer()` — skipped for any zero-PR state.
- After: always launch. The dashboard's empty-state UI handles zero PRs cleanly.

### Placeholder auto-repair
- Before the search: if `config.githubUsername` is in `KNOWN_PLACEHOLDER_USERNAMES`, fetch the authenticated viewer and persist `viewer.login` to config. The search then runs with the correct username.
- Validation: if `viewer.login` is empty/whitespace or itself a placeholder, skip persisting — a warning surfaces rather than swapping one broken config for another.
- Non-fatal viewer-lookup failures (5xx, network) surface as daily warnings, not debug noise — users see that repair was attempted and failed.
- Rate-limit / 401 / 403 still abort, matching the existing guardrail's contract.
- The existing post-fetch mismatch guardrail (for non-placeholder stale usernames, e.g. a renamed GitHub account) is skipped when pre-fetch repair already reconciled, removing a redundant `getAuthenticated` call.

### Dashboard error surfacing
- `StartupOutput.dashboardError` is set when the SPA assets are missing or `launchDashboardServer` throws, giving JSON consumers a structured signal instead of a missing-URL ambiguity.

## Files

- `packages/core/src/commands/startup.ts` — removed the gate, added `dashboardError` threading
- `packages/core/src/commands/startup.test.ts` — flipped the two "should not launch" tests, added `dashboardError` coverage
- `packages/core/src/core/pr-monitor.ts` — `KNOWN_PLACEHOLDER_USERNAMES` (typed `Lowercase<string>[]`), `isPlaceholderUsername` predicate, pre-fetch repair block, `didRepair` short-circuit on post-fetch guardrail, `searchUsername` local rebind
- `packages/core/src/core/pr-monitor.test.ts` — migrated existing mismatch tests from `example-user` to `renamed-account`, added 4 new tests for auto-repair (happy path, viewer-validation, non-fatal failure emits warning, rate-limit rethrows)
- `packages/core/src/formatters/json.ts` — added `dashboardError?: string` to `StartupOutput`

## Test plan

- [x] `pnpm run lint` — clean
- [x] `npx tsc -p packages/core --noEmit` — clean
- [x] `pnpm test` — 2059 core + 255 dashboard + 181 mcp-server tests pass
- [x] `pnpm run bundle` — rebuilt successfully
- [x] End-to-end: `/oss` now shows 22 active PRs with dashboard URL (was "0 Active PRs | all on track" with no URL before)
- [x] Review loop: code-reviewer, silent-failure-hunter, code-simplifier, type-design-analyzer — all findings addressed
- [ ] CI green