### PR TITLE
fix(dashboard): eliminate 'process is not defined' in browser bundle

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,10 @@
     "./commands": {
       "import": "./dist/commands/index.js",
       "types": "./dist/commands/index.d.ts"
+    },
+    "./dashboard-schema": {
+      "import": "./dist/core/dashboard-data-schema.js",
+      "types": "./dist/core/dashboard-data-schema.d.ts"
     }
   },
   "files": [

--- a/packages/dashboard/src/hooks/use-dashboard.ts
+++ b/packages/dashboard/src/hooks/use-dashboard.ts
@@ -1,5 +1,8 @@
 import { useState, useEffect, useCallback, useRef } from 'preact/hooks';
-import { validateDashboardData } from '@oss-autopilot/core';
+// Use the dedicated subpath export so Vite only bundles the pure zod schema,
+// not the core barrel (which eagerly loads state/pr-monitor/etc. — Node-only
+// modules that throw `process is not defined` in the browser bundle).
+import { validateDashboardData } from '@oss-autopilot/core/dashboard-schema';
 import type { DashboardData, ActionRequest } from '../types';
 
 // Module-scoped CSRF token cache — the server returns X-CSRF-Token on every


### PR DESCRIPTION
## Summary

- The dashboard SPA was importing \`validateDashboardData\` via the \`@oss-autopilot/core\` barrel, which eagerly re-exports Node-only modules (\`state.ts\`, \`pr-monitor.ts\`, \`utils.ts\`). Those call \`process.cwd()\` / \`process.env.GITHUB_TOKEN\` / \`process.platform\` at module init, which throws \`ReferenceError: process is not defined\` in the browser, leaving the dashboard blank.
- Added a dedicated \`./dashboard-schema\` subpath export in \`@oss-autopilot/core\` and pointed the dashboard hook at it. The schema file is pure (only imports \`zod\`), so Vite now bundles only the schema + zod.

## Why this matters now

PR #1103 changed startup to always launch the dashboard, so every \`/oss\` run now exposes this packaging bug that had been latent when the gate was skipping the launch on zero-PR runs. User-facing symptom: blank dashboard at \`localhost:3000\` with a single console error.

## Side effects (all good)

- Dashboard bundle: **251 KB → 110 KB** (removed ~140 KB of unused Node runtime code).
- Modules transformed: **176 → 119**.
- Zero \`process.*\` references in the built bundle (verified via grep).

## Test plan

- [x] \`pnpm run lint\` — clean
- [x] \`pnpm --filter @oss-autopilot/core run test\` — 2059 passed
- [x] \`pnpm --filter @oss-autopilot/dashboard run test\` — 255 passed
- [x] \`pnpm --filter @oss-autopilot/dashboard run build\` — succeeds, bundle has 0 \`process\` refs
- [x] Manual: served the rebuilt bundle, dashboard loads without the \`process is not defined\` error
- [ ] CI green