### PR TITLE
fix(dashboard): stop lazy chart init from calling ChartPanel on remount

### DIFF
--- a/packages/dashboard/src/components/chart-panel-lazy.test.tsx
+++ b/packages/dashboard/src/components/chart-panel-lazy.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/preact';
+
+// Stub the dynamic import target with a plain component so we don't pull
+// Chart.js into jsdom. The LazyChartPanel resolves this module via
+// `import('./chart-panel')`, mirroring production behavior minus the canvas
+// work.
+vi.mock('./chart-panel', () => ({
+  ChartPanel: (props: { theme: string }) => <div data-testid="chart-panel">{props.theme}</div>,
+}));
+
+import { LazyChartPanel } from './chart-panel-lazy';
+
+const defaultProps = {
+  monthlyMerged: {},
+  topRepos: [],
+  theme: 'dark' as const,
+};
+
+afterEach(() => cleanup());
+
+describe('LazyChartPanel', () => {
+  it('survives unmount+remount after the lazy chunk has resolved', async () => {
+    // First mount: module-scope cache is empty, so the effect kicks off the
+    // dynamic import, then setComponent populates the cached reference.
+    // Before the import resolves we should see the skeleton and no chart —
+    // this pins the null-initializer path so a future refactor that breaks
+    // `useState(() => cached)` when `cached` is null also trips this test.
+    const first = render(<LazyChartPanel {...defaultProps} />);
+    expect(first.queryByTestId('chart-panel')).toBeNull();
+    expect(first.container.querySelector('[aria-busy="true"]')).not.toBeNull();
+    await waitFor(() => expect(first.queryByTestId('chart-panel')).not.toBeNull());
+    first.unmount();
+
+    // Second mount: `cached` is now the ChartPanel function. Passing a bare
+    // function to useState triggers its lazy-initializer path and invokes the
+    // component with undefined props. Wrapping `cached` in an initializer
+    // closure (`() => cached`) sidesteps it.
+    const second = render(<LazyChartPanel {...defaultProps} />);
+    expect(second.queryByTestId('chart-panel')).not.toBeNull();
+  });
+});

--- a/packages/dashboard/src/components/chart-panel-lazy.tsx
+++ b/packages/dashboard/src/components/chart-panel-lazy.tsx
@@ -54,7 +54,12 @@ function ChartSkeleton() {
 }
 
 export function LazyChartPanel(props: ChartPanelProps) {
-  const [Component, setComponent] = useState<ComponentType<ChartPanelProps> | null>(cached);
+  // Wrap `cached` in an initializer: useState treats a bare function initial
+  // value as a lazy initializer and calls it once as `fn(undefined)`. After
+  // the dynamic import resolves, `cached` is the ChartPanel function, so on
+  // any subsequent mount the unwrapped form would evaluate `ChartPanel(undefined)`
+  // during init and crash on the props destructure.
+  const [Component, setComponent] = useState<ComponentType<ChartPanelProps> | null>(() => cached);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Fix `LazyChartPanel` so navigating `/ → /merged → back` (or any remount path that lands back on the home route) no longer crashes the dashboard with `Cannot destructure property 'monthlyMerged' of 'undefined'`.
- Root cause: Preact's `useState(initial)` treats any function initial value as a lazy initializer and invokes it as `fn(undefined)`. The module-scope `cached` in `chart-panel-lazy.tsx` is `null` on first mount but holds the `ChartPanel` function after the dynamic import resolves, so any remount was evaluating `ChartPanel(undefined)` during init and tripping the error boundary. Wrapping in `() => cached` stores the reference instead of calling it.
- Adds a regression test that mounts, waits for the lazy chunk, unmounts, and remounts. The test asserts both the initial skeleton (null-initializer path) and the re-mounted component so a future refactor of either path fails loudly.

## Test plan

- [x] New test fails against the unfixed code with the exact `invokeOrReturn → ChartPanel(undefined)` stack.
- [x] New test passes with the fix applied.
- [x] `pnpm run lint` clean.
- [x] Dashboard suite 256/256 pass.
- [x] `tsc --noEmit` clean.
- [x] Real-browser smoke on a repo-built bundle: `/` → push `/merged` → `history.back()` lands back on `/` with the dashboard and chart rendered and zero console errors.