### PR TITLE
fix(core): validate URLs on write-side of addMergedPRs/addClosedPRs (#1120)

### DIFF
--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -151,6 +151,7 @@ export const commands: CLICommandDef[] = [
         .option('--show', 'Display current persistence mode and Gist ID')
         .option('--sync', 'Force push state to Gist (no-op if not in Gist mode)')
         .option('--unlink', 'Switch from Gist back to local persistence')
+        .option('--validate', 'When used with --show, also report stored PR entries with unparseable URLs')
         .option('--json', 'Output as JSON')
         .action(async (options) => {
           if (options.unlink) {
@@ -182,12 +183,23 @@ export const commands: CLICommandDef[] = [
             // Default: --show
             await executeAction(
               options,
-              async () => (await import('./commands/state-cmd.js')).runStateShow(),
+              async () => (await import('./commands/state-cmd.js')).runStateShow({ validate: !!options.validate }),
               (data) => {
                 console.log(`\nPersistence: ${data.persistence}`);
                 if (data.gistId) console.log(`Gist ID: ${data.gistId}`);
                 if (data.gistDegraded) console.log('Status: DEGRADED (using local cache)');
-                console.log(`Last run: ${data.lastRunAt ?? 'Never'}\n`);
+                console.log(`Last run: ${data.lastRunAt ?? 'Never'}`);
+                if (data.invalidEntries) {
+                  if (data.invalidEntries.length === 0) {
+                    console.log('Validation: no invalid PR URLs in stored state.');
+                  } else {
+                    console.log(`Validation: ${data.invalidEntries.length} stored PR(s) with invalid URLs:`);
+                    for (const e of data.invalidEntries) {
+                      console.log(`  [${e.kind}] ${e.url}  ${e.title}`);
+                    }
+                  }
+                }
+                console.log('');
               },
             );
           }

--- a/packages/core/src/commands/dashboard-data.ts
+++ b/packages/core/src/commands/dashboard-data.ts
@@ -309,14 +309,20 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
     stateManager.batch(() => {
       // Store new merged PRs incrementally (dedupes by URL)
       try {
-        stateManager.addMergedPRs(newMergedPRs);
+        const { dropped } = stateManager.addMergedPRs(newMergedPRs);
+        if (dropped > 0) {
+          partialFailures.push(`Dropped ${dropped} merged PR(s) with invalid URLs before persistence`);
+        }
       } catch (error) {
         warn(MODULE, `Failed to store merged PRs: ${errorMessage(error)}`);
       }
 
       // Store new closed PRs incrementally (dedupes by URL)
       try {
-        stateManager.addClosedPRs(newClosedPRs);
+        const { dropped } = stateManager.addClosedPRs(newClosedPRs);
+        if (dropped > 0) {
+          partialFailures.push(`Dropped ${dropped} closed PR(s) with invalid URLs before persistence`);
+        }
       } catch (error) {
         warn(MODULE, `Failed to store closed PRs: ${errorMessage(error)}`);
       }

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -133,4 +133,4 @@ export type {
   CheckSetupOutput,
 } from './setup.js';
 export type { DailyCheckResult } from './daily.js';
-export type { StateShowOutput, StateSyncOutput, StateUnlinkOutput } from './state-cmd.js';
+export type { StateShowOutput, StateSyncOutput, StateUnlinkOutput, InvalidUrlEntry } from './state-cmd.js';

--- a/packages/core/src/commands/state-cmd.contract.test.ts
+++ b/packages/core/src/commands/state-cmd.contract.test.ts
@@ -17,10 +17,14 @@ vi.mock('../core/state-persistence.js', () => ({
   atomicWriteFileSync: vi.fn(),
 }));
 
-vi.mock('../core/utils.js', () => ({
-  getStatePath: vi.fn().mockReturnValue('/fake/state.json'),
-  getGistIdPath: vi.fn().mockReturnValue('/fake/gist-id'),
-}));
+vi.mock('../core/utils.js', async () => {
+  const actual = await vi.importActual<typeof import('../core/utils.js')>('../core/utils.js');
+  return {
+    ...actual,
+    getStatePath: vi.fn().mockReturnValue('/fake/state.json'),
+    getGistIdPath: vi.fn().mockReturnValue('/fake/gist-id'),
+  };
+});
 
 vi.mock('fs', async () => {
   const actual = await vi.importActual<typeof import('fs')>('fs');

--- a/packages/core/src/commands/state-cmd.test.ts
+++ b/packages/core/src/commands/state-cmd.test.ts
@@ -13,10 +13,14 @@ vi.mock('../core/state-persistence.js', () => ({
   atomicWriteFileSync: vi.fn(),
 }));
 
-vi.mock('../core/utils.js', () => ({
-  getStatePath: vi.fn(),
-  getGistIdPath: vi.fn(),
-}));
+vi.mock('../core/utils.js', async () => {
+  const actual = await vi.importActual<typeof import('../core/utils.js')>('../core/utils.js');
+  return {
+    ...actual,
+    getStatePath: vi.fn(),
+    getGistIdPath: vi.fn(),
+  };
+});
 
 vi.mock('../core/logger.js', () => ({
   warn: vi.fn(),
@@ -123,6 +127,56 @@ describe('runStateShow', () => {
     const result = await runStateShow();
 
     expect(result.lastRunAt).toBeUndefined();
+  });
+
+  it('omits invalidEntries unless validate is requested', async () => {
+    const sm = {
+      ...makeStateManagerMock({ config: { persistence: 'local' } }),
+      isGistDegraded: vi.fn().mockReturnValue(false),
+      getMergedPRs: vi.fn().mockReturnValue([]),
+      getClosedPRs: vi.fn().mockReturnValue([]),
+    };
+    mockGetStateManager.mockReturnValue(sm as any);
+
+    const result = await runStateShow();
+    expect(result.invalidEntries).toBeUndefined();
+  });
+
+  it('reports invalid stored URLs when validate=true (#1120)', async () => {
+    const sm = {
+      ...makeStateManagerMock({ config: { persistence: 'local' } }),
+      isGistDegraded: vi.fn().mockReturnValue(false),
+      getMergedPRs: vi.fn().mockReturnValue([
+        { url: 'https://github.com/a/b/pull/1', title: 'OK', mergedAt: '2025-06-10T00:00:00Z' },
+        { url: 'garbage', title: 'Bad merged', mergedAt: '2025-06-09T00:00:00Z' },
+      ]),
+      getClosedPRs: vi
+        .fn()
+        .mockReturnValue([{ url: 'not-a-url', title: 'Bad closed', closedAt: '2025-06-08T00:00:00Z' }]),
+    };
+    mockGetStateManager.mockReturnValue(sm as any);
+
+    const result = await runStateShow({ validate: true });
+
+    expect(result.invalidEntries).toEqual([
+      { kind: 'merged', url: 'garbage', title: 'Bad merged' },
+      { kind: 'closed', url: 'not-a-url', title: 'Bad closed' },
+    ]);
+  });
+
+  it('returns empty invalidEntries when validate=true and all URLs are valid', async () => {
+    const sm = {
+      ...makeStateManagerMock({ config: { persistence: 'local' } }),
+      isGistDegraded: vi.fn().mockReturnValue(false),
+      getMergedPRs: vi
+        .fn()
+        .mockReturnValue([{ url: 'https://github.com/a/b/pull/1', title: 'OK', mergedAt: '2025-06-10T00:00:00Z' }]),
+      getClosedPRs: vi.fn().mockReturnValue([]),
+    };
+    mockGetStateManager.mockReturnValue(sm as any);
+
+    const result = await runStateShow({ validate: true });
+    expect(result.invalidEntries).toEqual([]);
   });
 
   it('defaults persistence to "local" when config.persistence is not set', async () => {

--- a/packages/core/src/commands/state-cmd.ts
+++ b/packages/core/src/commands/state-cmd.ts
@@ -6,16 +6,24 @@
 import * as fs from 'fs';
 import { getStateManager, resetStateManager } from '../core/state.js';
 import { atomicWriteFileSync } from '../core/state-persistence.js';
-import { getStatePath, getGistIdPath } from '../core/utils.js';
+import { getStatePath, getGistIdPath, parseGitHubUrl } from '../core/utils.js';
 import { warn } from '../core/logger.js';
 
 const MODULE = 'state-cmd';
+
+export interface InvalidUrlEntry {
+  kind: 'merged' | 'closed';
+  url: string;
+  title: string;
+}
 
 export interface StateShowOutput {
   persistence: 'local' | 'gist';
   gistId: string | null;
   gistDegraded: boolean;
   lastRunAt: string | undefined;
+  /** Present only when validate=true. Existing entries with unparseable URLs. */
+  invalidEntries?: InvalidUrlEntry[];
 }
 
 export interface StateSyncOutput {
@@ -29,15 +37,34 @@ export interface StateUnlinkOutput {
   previousGistId: string | null;
 }
 
-export async function runStateShow(): Promise<StateShowOutput> {
+export async function runStateShow(options: { validate?: boolean } = {}): Promise<StateShowOutput> {
   const sm = getStateManager();
   const state = sm.getState();
-  return {
+  const output: StateShowOutput = {
     persistence: state.config.persistence ?? 'local',
     gistId: state.gistId ?? null,
     gistDegraded: sm.isGistDegraded(),
     lastRunAt: state.lastRunAt,
   };
+  if (options.validate) {
+    output.invalidEntries = collectInvalidUrlEntries(sm);
+  }
+  return output;
+}
+
+function collectInvalidUrlEntries(sm: ReturnType<typeof getStateManager>): InvalidUrlEntry[] {
+  const invalid: InvalidUrlEntry[] = [];
+  for (const pr of sm.getMergedPRs()) {
+    if (parseGitHubUrl(pr.url) === null) {
+      invalid.push({ kind: 'merged', url: pr.url, title: pr.title });
+    }
+  }
+  for (const pr of sm.getClosedPRs()) {
+    if (parseGitHubUrl(pr.url) === null) {
+      invalid.push({ kind: 'closed', url: pr.url, title: pr.title });
+    }
+  }
+  return invalid;
 }
 
 export async function runStateSync(): Promise<StateSyncOutput> {

--- a/packages/core/src/core/state.test.ts
+++ b/packages/core/src/core/state.test.ts
@@ -728,6 +728,36 @@ describe('StateManager merged PRs', () => {
 
       expect(stateManager.getMergedPRs()).toHaveLength(1);
     });
+
+    it('drops entries with invalid URLs and reports the count (#1120)', () => {
+      const valid = { url: 'https://github.com/a/b/pull/1', title: 'Valid', mergedAt: '2025-06-10T00:00:00Z' };
+      const bogus = { url: 'not-a-real-url', title: 'Bogus', mergedAt: '2025-06-09T00:00:00Z' };
+      const nonGithub = {
+        url: 'https://example.com/foo/bar/pull/1',
+        title: 'Non-GitHub',
+        mergedAt: '2025-06-08T00:00:00Z',
+      };
+
+      const result = stateManager.addMergedPRs([valid, bogus, nonGithub]);
+
+      expect(result).toEqual({ added: 1, dropped: 2 });
+      expect(stateManager.getMergedPRs()).toEqual([valid]);
+    });
+
+    it('returns added/dropped counts on a normal add', () => {
+      const pr = { url: 'https://github.com/a/b/pull/1', title: 'PR 1', mergedAt: '2025-06-10T00:00:00Z' };
+      expect(stateManager.addMergedPRs([pr])).toEqual({ added: 1, dropped: 0 });
+    });
+
+    it('returns zero counts on empty input', () => {
+      expect(stateManager.addMergedPRs([])).toEqual({ added: 0, dropped: 0 });
+    });
+
+    it('returns zero added when all inputs are duplicates of stored entries', () => {
+      const pr = { url: 'https://github.com/a/b/pull/1', title: 'PR 1', mergedAt: '2025-06-10T00:00:00Z' };
+      stateManager.addMergedPRs([pr]);
+      expect(stateManager.addMergedPRs([pr])).toEqual({ added: 0, dropped: 0 });
+    });
   });
 
   describe('getMergedPRWatermark', () => {
@@ -825,6 +855,16 @@ describe('StateManager merged PRs', () => {
       stateManager.addClosedPRs([pr]);
 
       expect(stateManager.getClosedPRs()).toHaveLength(1);
+    });
+
+    it('drops entries with invalid URLs and reports the count (#1120)', () => {
+      const valid = { url: 'https://github.com/a/b/pull/1', title: 'Valid', closedAt: '2025-06-10T00:00:00Z' };
+      const bogus = { url: 'garbage', title: 'Bogus', closedAt: '2025-06-09T00:00:00Z' };
+
+      const result = stateManager.addClosedPRs([valid, bogus]);
+
+      expect(result).toEqual({ added: 1, dropped: 1 });
+      expect(stateManager.getClosedPRs()).toEqual([valid]);
     });
   });
 

--- a/packages/core/src/core/state.ts
+++ b/packages/core/src/core/state.ts
@@ -30,12 +30,34 @@ import type { Stats } from './repo-score-manager.js';
 import { debug, warn } from './logger.js';
 import { errorMessage, ConfigurationError, ConcurrencyError } from './errors.js';
 import { GistStateStore, type OctokitLike } from './gist-state-store.js';
-import { getStatePath, getStateCachePath } from './utils.js';
+import { getStatePath, getStateCachePath, parseGitHubUrl } from './utils.js';
 
 export { acquireLock, releaseLock, atomicWriteFileSync } from './state-persistence.js';
 export type { Stats } from './repo-score-manager.js';
 
 const MODULE = 'state';
+
+/**
+ * Validate stored-PR URL shape before persistence (mirror of the read-side
+ * filter in dashboard-data#storedToMergedPRs/storedToClosedPRs). Bad URLs are
+ * logged at warn level so operators see the drop in the daily output.
+ */
+function filterValidUrlEntries<T extends { url: string }>(
+  entries: T[],
+  kind: 'merged' | 'closed',
+): { valid: T[]; dropped: number } {
+  const valid: T[] = [];
+  let dropped = 0;
+  for (const entry of entries) {
+    if (parseGitHubUrl(entry.url) === null) {
+      warn(MODULE, `Dropping ${kind} PR with invalid URL: ${entry.url}`);
+      dropped++;
+      continue;
+    }
+    valid.push(entry);
+  }
+  return { valid, dropped };
+}
 
 /**
  * Push state to the backing Gist when Gist mode is active. Best-effort:
@@ -396,18 +418,25 @@ export class StateManager {
 
   /**
    * Add merged PRs to storage, deduplicating by URL.
+   * Entries with URLs that fail {@link parseGitHubUrl} are dropped before
+   * persistence (read-side filters in dashboard-data already skip them, but
+   * this prevents the bad data from reaching disk in the first place).
    * @param prs - Merged PRs to add (duplicates by URL are ignored)
+   * @returns count of entries added vs. dropped (invalid URL)
    */
-  addMergedPRs(prs: StoredMergedPR[]): void {
-    if (prs.length === 0) return;
+  addMergedPRs(prs: StoredMergedPR[]): { added: number; dropped: number } {
+    if (prs.length === 0) return { added: 0, dropped: 0 };
+    const { valid, dropped } = filterValidUrlEntries(prs, 'merged');
+    if (valid.length === 0) return { added: 0, dropped };
     if (!this.state.mergedPRs) this.state.mergedPRs = [];
     const existingUrls = new Set(this.state.mergedPRs.map((pr) => pr.url));
-    const newPRs = prs.filter((pr) => !existingUrls.has(pr.url));
-    if (newPRs.length === 0) return;
+    const newPRs = valid.filter((pr) => !existingUrls.has(pr.url));
+    if (newPRs.length === 0) return { added: 0, dropped };
     this.state.mergedPRs.push(...newPRs);
     this.state.mergedPRs.sort((a, b) => b.mergedAt.localeCompare(a.mergedAt));
     debug(MODULE, `Added ${newPRs.length} merged PRs (total: ${this.state.mergedPRs.length})`);
     this.autoSave();
+    return { added: newPRs.length, dropped };
   }
 
   /** Returns the most recent merge date, used as a watermark for incremental fetching. */
@@ -424,18 +453,25 @@ export class StateManager {
 
   /**
    * Add closed PRs to storage, deduplicating by URL.
+   * Entries with URLs that fail {@link parseGitHubUrl} are dropped before
+   * persistence (read-side filters in dashboard-data already skip them, but
+   * this prevents the bad data from reaching disk in the first place).
    * @param prs - Closed PRs to add (duplicates by URL are ignored)
+   * @returns count of entries added vs. dropped (invalid URL)
    */
-  addClosedPRs(prs: StoredClosedPR[]): void {
-    if (prs.length === 0) return;
+  addClosedPRs(prs: StoredClosedPR[]): { added: number; dropped: number } {
+    if (prs.length === 0) return { added: 0, dropped: 0 };
+    const { valid, dropped } = filterValidUrlEntries(prs, 'closed');
+    if (valid.length === 0) return { added: 0, dropped };
     if (!this.state.closedPRs) this.state.closedPRs = [];
     const existingUrls = new Set(this.state.closedPRs.map((pr) => pr.url));
-    const newPRs = prs.filter((pr) => !existingUrls.has(pr.url));
-    if (newPRs.length === 0) return;
+    const newPRs = valid.filter((pr) => !existingUrls.has(pr.url));
+    if (newPRs.length === 0) return { added: 0, dropped };
     this.state.closedPRs.push(...newPRs);
     this.state.closedPRs.sort((a, b) => b.closedAt.localeCompare(a.closedAt));
     debug(MODULE, `Added ${newPRs.length} closed PRs (total: ${this.state.closedPRs.length})`);
     this.autoSave();
+    return { added: newPRs.length, dropped };
   }
 
   /** Returns the most recent close date, used as a watermark for incremental fetching. */


### PR DESCRIPTION
Closes #1120.

## Summary
- Validate stored-PR URLs at write time so garbage from v1 migrations, hand-edits, or importer bugs never reaches `state.json`.
- `addMergedPRs` / `addClosedPRs` now drop invalid entries with `warn()` and return `{ added, dropped }`. `dashboard-data` surfaces the drop count via `partialFailures`.
- Adds `oss-autopilot state --validate` (and the matching `--json` field) so operators can audit existing `state.json` for unparseable URLs.

## Why
Read-side filters in `dashboard-data#storedToMergedPRs / storedToClosedPRs` already skip bad URLs, but the bad rows stayed on disk forever. This closes the write-side gap symmetrically.

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm test` (2067 tests pass)
- [x] New tests cover: invalid-URL drop with count, empty input, all-duplicates, validate-omitted, validate-with-mix, validate-all-clean
- [x] `state --json` golden snapshot unchanged when `--validate` absent (additive contract)
- [x] `pnpm run bundle` (esbuild + mcp-server)