### PR TITLE
chore(hooks): pnpm-aware install in session-start.sh (#1113)

### DIFF
--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -23,11 +23,25 @@ dashboard_rebuild_error=""
 MARKETPLACE_DIR="$HOME/.claude/plugins/marketplaces/oss-autopilot"
 
 # --- Step 1: Rebuild stale CLI bundle (if needed) ---
+# Use pnpm if available (this is a pnpm workspace; running `npm install` from
+# packages/core/ would generate a stray package-lock.json next to pnpm-lock.yaml
+# and confuse pnpm on the next install). Fall back to npm for end users that
+# only have npm — works today because @oss-autopilot/core has no workspace:*
+# deps. Mirrors the Step 1.5 dashboard pattern.
 if [ -f "${PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" ] && [ "${PLUGIN_ROOT}/packages/core/package.json" -nt "${PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" ]; then
-  if (cd "${PLUGIN_ROOT}/packages/core" && npm install --silent 2>/dev/null && npm run bundle --silent 2>/dev/null); then
+  if command -v pnpm &>/dev/null; then
+    cli_build() { cd "${PLUGIN_ROOT}" && pnpm install --silent 2>/dev/null && pnpm --silent --filter @oss-autopilot/core run bundle 2>/dev/null; }
+  else
+    cli_build() { cd "${PLUGIN_ROOT}/packages/core" && npm install --silent 2>/dev/null && npm run bundle --silent 2>/dev/null; }
+  fi
+  if (cli_build); then
     rebuilt_cli=true
   else
-    cli_rebuild_error="cd ${PLUGIN_ROOT}/packages/core && npm install && npm run bundle"
+    if command -v pnpm &>/dev/null; then
+      cli_rebuild_error="cd ${PLUGIN_ROOT} && pnpm install && pnpm --filter @oss-autopilot/core run bundle"
+    else
+      cli_rebuild_error="cd ${PLUGIN_ROOT}/packages/core && npm install && npm run bundle"
+    fi
   fi
 fi
 


### PR DESCRIPTION
Closes #1113.

## Summary
- Replace `npm install` (run from `packages/core/`) in the Step 1 CLI rebuild path with the pnpm-or-fallback pattern already used in Step 1.5 for the dashboard.
- Prefer `cd \$PLUGIN_ROOT && pnpm install && pnpm --filter @oss-autopilot/core run bundle` when pnpm is on PATH; otherwise the existing `cd packages/core && npm install && npm run bundle` runs.
- Adapts the recovery hint string so copy-paste points at whichever tool actually ran.

## Why
Running `npm install` from a pnpm workspace package generates a stray `package-lock.json` next to `pnpm-lock.yaml` and confuses pnpm on the next install. It's latent today (no `workspace:*` deps in `@oss-autopilot/core`), but trips the moment one is added.

## Test plan
- [x] `bash -n hooks/session-start.sh` (syntax)
- [x] `pnpm run lint`
- [x] `pnpm test`
- [x] Pattern matches the existing Step 1.5 dashboard build, which already uses the same shape