### PR TITLE
chore: deprecate read/untrack v1 stubs (#1112)

### DIFF
--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -398,13 +398,14 @@ export const commands: CLICommandDef[] = [
   },
 
   // ── Untrack ────────────────────────────────────────────────────────────
+  // Slated for removal in v4 (#1112).
   {
     name: 'untrack',
     localOnly: true,
     register(program) {
       program
         .command('untrack <pr-url>')
-        .description('[DEPRECATED] No-op in v2. Use `shelve` to hide a PR from the daily digest.')
+        .description('[DEPRECATED, removed in v4] No-op in v2. Use `shelve` to hide a PR from the daily digest.')
         .option('--json', 'Output as JSON')
         .action((prUrl, options) =>
           executeAction(
@@ -412,8 +413,9 @@ export const commands: CLICommandDef[] = [
             async () => (await import('./commands/track.js')).runUntrack({ prUrl }),
             () => {
               // Stderr so scripts piping stdout don't see the deprecation notice.
-              console.error('[DEPRECATED] `untrack` is a no-op in v2. PRs are fetched fresh on each daily run —');
-              console.error('there is no local tracking list to remove from. Use `shelve` to hide a PR instead.');
+              console.error('[DEPRECATED] `untrack` is a no-op in v2 and will be removed in v4. PRs are fetched');
+              console.error('fresh on each daily run — there is no local tracking list to remove from. Use');
+              console.error('`shelve` to hide a PR from the daily digest instead.');
             },
           ),
         );
@@ -421,13 +423,14 @@ export const commands: CLICommandDef[] = [
   },
 
   // ── Read ───────────────────────────────────────────────────────────────
+  // Slated for removal in v4 (#1112).
   {
     name: 'read',
     localOnly: true,
     register(program) {
       program
         .command('read [pr-url]')
-        .description('Mark PR comments as read')
+        .description('[DEPRECATED, removed in v4] No-op in v2. PR read state is not tracked locally.')
         .option('--all', 'Mark all PRs as read')
         .option('--json', 'Output as JSON')
         .action((prUrl, options) =>
@@ -435,9 +438,10 @@ export const commands: CLICommandDef[] = [
             options,
             async () => (await import('./commands/read.js')).runRead({ prUrl, all: options.all }),
             () => {
-              console.log(
-                'Note: In v2, PR read state is not tracked locally. PRs are fetched fresh on each daily run.',
-              );
+              // Stderr so scripts piping stdout don't see the deprecation notice.
+              console.error('[DEPRECATED] `read` is a no-op in v2 and will be removed in v4. PR read state is');
+              console.error('not tracked locally — PRs are fetched fresh on each daily run, so all comments');
+              console.error('appear every time. Use `shelve` to hide a PR from the daily digest instead.');
             },
           ),
         );

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -150,12 +150,11 @@ describe('MCP tool registrations', () => {
 
   describe('annotations', () => {
     // track is read-only in v2: fetches metadata from GitHub, does not persist (#1001).
-    // untrack is a no-op in v2 (#1001) — deprecated, also read-only since it doesn't mutate state.
-    const readOnlyTools = ['status', 'search', 'vet', 'comments', 'check-setup', 'track', 'untrack'];
+    // untrack and read are no-ops in v2 (#1001, #1112) — deprecated, also read-only.
+    const readOnlyTools = ['status', 'search', 'vet', 'comments', 'check-setup', 'track', 'untrack', 'read'];
     const mutatingTools = [
       'daily',
       'startup',
-      'read',
       'post',
       'claim',
       'config',

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -222,30 +222,33 @@ export function registerTools(server: McpServer): void {
     wrapTool(runTrack),
   );
 
-  // 6. untrack — Deprecated no-op (v2 has no local tracking list)
+  // 6. untrack — Deprecated no-op (v2 has no local tracking list).
+  // Slated for removal in MCP server v4 (#1112).
   server.registerTool(
     'untrack',
     {
       description:
-        '[DEPRECATED] No-op in v2. PRs are fetched fresh on each daily run, so there is no local tracking list to remove from. Use `shelve` to hide a PR from the daily digest instead.',
+        '[DEPRECATED, REMOVED IN v4] No-op in v2. PRs are fetched fresh on each daily run, so there is no local tracking list to remove from. Use `shelve` to hide a PR from the daily digest instead.',
       inputSchema: {
         prUrl: githubPrUrlSchema.describe('Full GitHub PR URL (ignored — command is a no-op)'),
       },
-      annotations: { readOnlyHint: true },
+      annotations: { title: '[deprecated] untrack', readOnlyHint: true },
     },
     wrapTool(runUntrack),
   );
 
-  // 7. read — Mark notifications as read
+  // 7. read — Deprecated no-op (v2 doesn't track read state locally).
+  // Slated for removal in MCP server v4 (#1112).
   server.registerTool(
     'read',
     {
-      description: 'Mark PR notifications as read. Requires either prUrl or all to be specified.',
+      description:
+        '[DEPRECATED, REMOVED IN v4] No-op in v2. PR read state is not tracked locally — PRs are fetched fresh on each daily run, so all comments appear every time. Use `shelve` to hide a PR you do not want to see in the digest.',
       inputSchema: {
         prUrl: githubPrUrlSchema.optional().describe('Full GitHub PR URL to mark as read. Omit to use --all instead.'),
         all: z.boolean().optional().describe('If true, mark all PRs as read'),
       },
-      annotations: { readOnlyHint: false, destructiveHint: false },
+      annotations: { title: '[deprecated] read', readOnlyHint: true, destructiveHint: false },
     },
     wrapTool(runRead),
   );


### PR DESCRIPTION
Closes #1112.

Step 1 of the rollout. Adds deprecation notices on the MCP and CLI surfaces with no behavior change.

## Summary
- MCP `read` and `untrack` tool descriptions gain `[DEPRECATED, REMOVED IN v4]` prefix and a "use shelve" pointer.
- Both tools get a `title` annotation prefixed `[deprecated]` so clients that render tool titles separately surface the state.
- CLI `--help` for `read` is updated to match the deprecated pattern (`untrack` already had one, but the v4 removal target is new for both).
- Both commands now emit a 3-line stderr deprecation notice when invoked.
- `read` is reclassified read-only in the MCP tool-annotations test — it's a no-op, so it does not mutate state.

## Follow-ups (filed)
- #1132 — hide commands in `--help` (next minor)
- #1133 — remove stubs entirely (v4 major; MCP contract break)

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm test` (181 mcp + 256 dashboard + 2067 core, all green)
- [x] No behavior change verified: `runRead({all:true})` still returns the v2 message