### PR TITLE
docs(skills): scope Failure Protocol to unexpected failures (#1110)

### DIFF
--- a/skills/oss-contribution/SKILL.md
+++ b/skills/oss-contribution/SKILL.md
@@ -264,7 +264,16 @@ Some situations require the human contributor, not an AI tool:
 
 ## Failure Protocol
 
-When a task or approach fails, **STOP and report back to the user** with what failed and why. Do not silently switch strategies or improvise workarounds — let the user decide how to proceed. Documented fallbacks (e.g., gh CLI fallback) are permitted if the user is informed first. Undocumented or improvised fallbacks are never permitted.
+When a task or approach fails, **STOP and report back to the user** with what failed and why. Don't silently switch strategies or improvise workarounds — let the user decide how to proceed.
+
+This protocol governs **unexpected** failures: a tool crashing, an external command returning an error you weren't prepared for, a check producing output you don't know how to handle, an assumption turning out to be wrong. In those cases: stop, report what failed, ask.
+
+It does **not** override decision points that the workflow itself documents. The `/oss` workflows surface explicit fallback choices in several places (e.g., "if retry fails, offer retry / skip / done for now"). Those branches were planned, are surfaced to the user, and are exactly the kind of "let the user decide" behavior this protocol asks for. Follow them as written.
+
+In short:
+
+- **Documented branch in a workflow** (a step that names its fallback options) → follow it; surface the choices to the user; do what they pick.
+- **Improvised fallback** (substituting a different command, retrying with no plan, swapping in a less-specific approach because the first didn't work) → never. Stop and ask.
 
 ## Resources
 


### PR DESCRIPTION
Closes #1110.

## Summary
Reword `skills/oss-contribution/SKILL.md` §Failure Protocol so the scope is unambiguous:
- It governs **unexpected** failures — stop and ask.
- It does **not** override workflow-documented decision points whose explicit fallback options were planned and surface to the user (those are exactly the "let the user decide" behavior the protocol asks for).

## Why
The previous wording's "do not silently switch strategies" clause could be read as forbidding the multi-step retry / skip / done-for-now branches that `work-through-issues.md` and `draft-first-workflow.md` use at decision points. Those branches comply with the spirit of the protocol (they surface choices to the user — nothing runs silently), but the wording was ambiguous. This PR closes that gap.

No behavior change to the workflow files; they already surface choices rather than retrying silently.

## Test plan
- [x] Read each `retry`/`skip`/`done for now` branch in the two workflow files; confirmed every one surfaces a choice rather than improvising
- [x] `pnpm run lint`