### PR TITLE
docs(skills): split overloaded oss-contribution skill (#1109)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -62,7 +62,9 @@ Seven specialized agents handle specific tasks autonomously:
 
 ### Skills (`skills/`)
 
-- `oss-contribution/SKILL.md` — Best practices for open source contribution etiquette, PR descriptions, commit messages, and maintainer interaction.
+- `oss-contribution/SKILL.md` — Index for the contribution skill family. Universal rules: minimal-diff discipline, working on issues, time management, failure protocol.
+- `pr-etiquette/SKILL.md` — Review-feedback responses, PR descriptions, dormant-PR follow-up cadence, PR quality checklist, communication style.
+- `contribution-ethics/SKILL.md` — AI attribution rules, AI-tell avoidance in maintainer-visible writing, when to defer to a human contributor.
 
 ### Hooks (`hooks/`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,9 @@ The system has three layers:
 Repo root (also the Claude Code plugin directory):
 ├── commands/oss.md, setup-oss.md       # Plugin slash commands
 ├── agents/*.md                          # 7 specialized agents
-├── skills/oss-contribution/SKILL.md     # Contribution best practices skill
+├── skills/oss-contribution/SKILL.md     # Contribution index (universal rules)
+├── skills/pr-etiquette/SKILL.md         # Review responses, PR descriptions, dormant follow-up
+├── skills/contribution-ethics/SKILL.md  # AI attribution, AI-tell avoidance, defer-to-human
 ├── hooks/session-start.sh               # Plugin session start hook
 ├── workflows/*.md                       # Workflow orchestration files
 ├── .claude-plugin/plugin.json           # Plugin manifest

--- a/commands/oss-help.md
+++ b/commands/oss-help.md
@@ -44,13 +44,13 @@ These agents activate automatically when relevant, or you can ask for them direc
 5. /oss              → Monitor PR until merged
 ```
 
-## Skill
+## Skills
 
-The **oss-contribution** skill provides best practices for:
-- Writing PR descriptions and commit messages
-- Responding to maintainer feedback
-- Following repository contribution guidelines
-- Open source etiquette (working on issues, draft PRs, etc.)
+Three sibling skills cover OSS contribution best practices:
+
+- **oss-contribution** (index): universal rules — minimal-diff discipline, working on issues, time management, failure protocol.
+- **pr-etiquette**: review-feedback responses, PR descriptions, dormant-PR follow-up cadence, PR quality checklist, communication style.
+- **contribution-ethics**: AI attribution rules, AI-tell avoidance in maintainer-visible writing, when to defer to a human contributor.
 
 ## Optional: Enhanced Code Review
 

--- a/skills/contribution-ethics/SKILL.md
+++ b/skills/contribution-ethics/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: Contribution Ethics
+description: This skill should be used when writing commits, PRs, or comments that will be visible to OSS maintainers — it covers the no-AI-attribution rule, AI-tell avoidance in writing, and the situations where a human contributor should respond instead of the AI tool. Sibling to oss-contribution and pr-etiquette.
+version: 1.0.0
+---
+
+# Contribution Ethics
+
+How to behave ethically when contributing to OSS as an AI-assisted contributor: attribution, AI-tell avoidance in maintainer-visible writing, and knowing when to defer to a human.
+
+## Attribution
+
+### Do
+
+- Attribute work properly (co-authors for human pair work)
+- Give credit to human contributors in PR descriptions
+- Share knowledge with other contributors
+
+### Don't
+
+Add AI attribution to commits or PRs:
+
+- No `Co-Authored-By: Claude` trailers
+- No "Generated with Claude Code" in PR descriptions
+- No robot emoji attributions
+- No mentions of AI assistance in comments
+
+These rules are absolute. Contributions submitted to upstream repos must appear as solely from the human contributor unless that repo's contribution guidelines explicitly require AI disclosure.
+
+Other related "don't"s:
+
+- Claim credit for others' work
+- Submit low-quality PRs just for contribution graphs
+- Spam repos with trivial changes
+
+## AI-Tell Avoidance in Writing
+
+AI-generated comments have recognizable patterns. Avoid these in any maintainer-visible writing (PR descriptions, review responses, issue comments):
+
+- **No changelogs in comments.** "Changes in the latest commit:" with bullet points is a dead giveaway. Describe what you did in a sentence, or let the diff speak.
+- **Vary your openings.** Don't start every response with "Thanks for the review!" or "Good catch!" Sometimes just jump to the substance.
+- **Match their length.** If the maintainer wrote two sentences, don't respond with four paragraphs.
+- **Read the whole thread first.** Asking about something explained three comments up is the fastest way to lose credibility.
+- **Mean what you say.** Don't defend a position then immediately abandon it. Push back or agree — pick one.
+- **Figure things out yourself.** If a maintainer says "add a screenshot," look at existing examples. Don't ask them to explain the tooling.
+
+## When to Defer to the Human Contributor
+
+Some situations require the human contributor, not an AI tool:
+
+- **Maintainer frustration or AI accusations** — respond honestly and personally
+- **Visual/subjective tasks** — screenshots, design opinions, UX judgments
+- **Heated discussions** — any thread about AI ethics, contribution policies, or governance
+- **Process questions with obvious answers** — look at existing examples instead of asking
+
+If any of these come up, surface the situation to the human and let them respond.
+
+## See Also
+
+- `oss-contribution` skill — universal contribution rules (minimal-diff discipline, working on issues, time management, failure protocol).
+- `pr-etiquette` skill — review responses, PR descriptions, dormant-PR follow-up, PR quality checklist, communication style.

--- a/skills/oss-contribution/SKILL.md
+++ b/skills/oss-contribution/SKILL.md
@@ -1,20 +1,28 @@
 ---
 name: OSS Contribution Best Practices
 description: This skill should be used when the user is working on open source contributions, responding to maintainer feedback, writing PR descriptions, working on issues, following up on dormant PRs, or needs guidance on open source etiquette and best practices.
-version: 1.1.0
+version: 2.0.0
 ---
 
 # Open Source Contribution Best Practices
 
 **Reference:** Based on [opensource.guide](https://opensource.guide/how-to-contribute/)
 
+This skill is the index. The detail topics live in two sibling skills that load on demand:
+
+- **`pr-etiquette`** — responding to code review feedback, writing PR descriptions, dormant-PR follow-up cadence, PR quality checklist, communication etiquette.
+- **`contribution-ethics`** — AI attribution rules, AI-tell avoidance in maintainer-visible writing, when to defer to a human.
+
+Both are linked below. Use this file for the universal rules that apply to every contribution regardless of stage; jump to the sibling skills when you're at a specific stage in the cycle.
+
 ## Core Principles
 
 **Be a good open source citizen:**
-1. Respect maintainers' time - they're often unpaid volunteers
+
+1. Respect maintainers' time — they're often unpaid volunteers
 2. Read contribution guidelines before contributing
 3. Communicate clearly and professionally
-4. Be patient - open source moves at its own pace
+4. Be patient — open source moves at its own pace
 5. Give back to the community when you can
 
 ## Minimal Diff Discipline
@@ -22,106 +30,12 @@ version: 1.1.0
 Every line in a PR diff must be directly related to the issue being fixed. Unrelated formatting changes (whitespace, quote style, trailing commas, import reordering, line breaks) make diffs noisy, harder to review, and signal carelessness. Maintainers will flag or reject PRs with formatting bloat.
 
 **Rules:**
+
 1. **Only touch lines the fix requires.** Don't reorder imports, change quote styles, fix whitespace, or add trailing commas in existing code — unless those changes are part of the fix itself.
 2. **Scope formatter output.** If the repo's formatter must be run (e.g., CI requires it), review the formatter's changes afterward. Use `git diff` to identify formatting-only changes. Use `git checkout -- {files}` only for files where ALL changes are formatting-only. For files with mixed changes, use targeted edits to surgically remove formatting hunks. (In interactive terminal contexts, `git add -p` can also be used for hunk-level staging.)
 3. **Match the repo's style, don't impose your own.** If the repo uses single quotes, use single quotes in your new code. If it uses tabs, use tabs. Never convert existing style to a different one.
 
 **When formatting IS the fix:** If the issue itself is about formatting (e.g., "run prettier on codebase", "fix inconsistent indentation"), then formatting changes are in scope. In all other cases, they are not.
-
-## Responding to Code Review Feedback
-
-### Mindset
-
-Maintainer feedback is a gift - they're investing time to help you improve. Even critical feedback should be received gracefully.
-
-### Response Approach
-
-- Address every point they raise
-- Keep it short. One or two sentences is usually enough.
-- Push updates promptly after discussion
-- Mark conversations as resolved after addressing
-- If you feel resistance to a request, investigate deeper — the maintainer likely knows something you don't. If you still think there's an issue after investigating, raise it to the human contributor — never override the maintainer
-
-### Assumptions and Verification
-
-When a maintainer requests changes, these rules govern how you respond:
-
-1. **Maintainer is right by default.** If a maintainer says "do X," your starting assumption is that X is correct and appropriate for their codebase. Do not second-guess their judgment about their own project.
-
-2. **Verify, never assume.** Before running any tool (linter, formatter, type checker), check the project's CI configuration to confirm that tool is actually enforced. Read `.pre-commit-config.yaml`, `.github/workflows/`, `Makefile`, or equivalent before deciding what to run. A tool that exists in `devDependencies` but is not in CI is not authoritative.
-
-3. **Try before estimating scope.** When asked to make a change, attempt the simplest implementation first. Do not respond with effort estimates, propose TODOs, or suggest deferring to a follow-up PR. If the change turns out to be genuinely complex after attempting it, report what you found to the human.
-
-4. **Pushback = escalate, don't override.** If you believe a maintainer's request is incorrect or harmful, raise the concern to the human contributor. Never push back on a maintainer directly, never ignore the request, and never silently do something different from what was asked.
-
-5. **No TODOs as substitutes.** A maintainer asking for a change expects the change in this PR. Responding with a TODO comment or "I'll handle this in a follow-up" is not an acceptable response unless the maintainer explicitly suggested that approach.
-
-### Pre-Push Review Checkpoint
-
-Before pushing commits that address review feedback:
-
-1. Run the project's code review tooling on your diff (the pr-review-toolkit agents if installed, otherwise the built-in pre-commit-reviewer)
-2. Fix any issues found (bugs, style violations, missing error handling)
-3. Re-run until clean — no actionable findings
-4. Only then push your changes
-
-This prevents maintainers from seeing issues that could have been caught locally. It's especially important when responding to feedback — pushing sloppy fix-up commits undermines credibility.
-
-### PR Readiness Gate (Mandatory)
-
-A PR is NEVER "ready" until all of these pass:
-
-1. **Local lint/type check**: Run the repo's linters and type checkers
-2. **Test suite**: Run the full test suite locally
-3. **Code review**: Run review agents (pr-review-toolkit or pre-commit-reviewer)
-4. **Fix and re-run**: Fix all findings, re-run checks
-5. **Convergence**: Repeat until zero Critical/Recommended findings
-6. **Push and verify CI**: Push and confirm CI passes remotely
-7. **Only then** declare the PR ready for maintainer review
-
-The tool should NEVER say "PR is ready", "work is complete", or "changes are done" without having run through this complete loop. This applies to:
-- New contributions (draft-first workflow)
-- Responses to maintainer feedback
-- CI fix pushes
-- Any commit that will be seen by maintainers
-
-### Things to Avoid
-
-- Being defensive or dismissive
-- Long justifications for every decision
-- Ignoring feedback points
-- Taking days to respond
-- Assuming what tools the project's CI enforces without checking CI config files
-- Substituting TODOs or "follow-up PR" proposals for changes the maintainer requested in this PR
-- Running tools not enforced by CI and treating their output as authoritative
-
-## Writing Good PR Descriptions
-
-### Structure
-
-```markdown
-## Summary
-[1-2 sentences explaining what this PR does]
-
-## Problem
-[What problem does this solve? Link to issue if applicable]
-
-## Solution
-[Brief explanation of your approach]
-
-## Testing
-[How you tested the changes]
-
-## Screenshots (if UI changes)
-[Before/after screenshots]
-```
-
-### Tips
-
-- Link to related issues: "Fixes #123" or "Closes #123"
-- Keep it concise - maintainers review many PRs
-- Highlight anything unusual or that needs special attention
-- Don't pad with unnecessary sections
 
 ## Working on Issues
 
@@ -146,6 +60,7 @@ The PR itself is the claim. A separate "I'm working on this" comment is unnecess
 ### When to Comment on the Issue
 
 Only comment on the issue itself when:
+
 - You need clarification from the maintainer before starting
 - The approach is ambiguous and you want confirmation
 - The issue is old and you want to confirm it's still relevant
@@ -160,16 +75,6 @@ Move on silently. Don't comment that you tried and failed. Don't mark the issue 
 
 - Reference the issue in the PR body: "Fixes #123" or "Closes #123"
 - Only comment on the issue if the PR needs additional context
-
-## Following Up on Dormant PRs
-
-- **7 days:** Light check-in ("Anything else needed from my side?")
-- **14 days:** Direct follow-up ("Still on your radar? Happy to make changes.")
-- **30 days:** Final check ("Understand if priorities shifted. Let me know!")
-
-Be patient, not pushy. Only follow up once per timeframe. Check if maintainers are active elsewhere before escalating.
-
-**Workflow:** `workflows/dormant-pr-follow-up.md` operationalizes this cadence — run via the `/oss` router or the action menu. It surfaces dormant PRs, buckets them into tiers, and drafts a tier-appropriate follow-up through the `draft-review-post` skill (never auto-posts).
 
 ## Time Management
 
@@ -187,81 +92,6 @@ Be patient, not pushy. Only follow up once per timeframe. Check if maintainers a
 - Don't let PRs go stale
 - Know when to close and move on
 
-## PR Quality Checklist
-
-Before submitting any PR, verify:
-
-### Required
-- [ ] **Issue Reference**: PR links to issue (`Closes #X` or `Fixes #X`)
-- [ ] **Description Quality**: Explains what changed and why
-- [ ] **Title Quality**: Descriptive, properly formatted (e.g., `fix: resolve login timeout`)
-- [ ] **Focused Changes**: One logical change per PR (< 10 files, < 400 lines ideal)
-- [ ] **Minimal Diff**: No unrelated formatting changes (whitespace, quotes, imports, trailing commas)
-
-### Conditional
-- [ ] **Tests Included**: If project requires tests, add them
-- [ ] **Docs Updated**: If behavior changed, update docs
-
-### Optional
-- [ ] **Branch Naming**: Follows convention (`feature/`, `fix/`, `docs/`)
-- [ ] **Screenshots**: Included for UI changes
-
-**Tip:** Use the `pr-compliance-checker` agent to validate your PR before requesting review.
-
-## Communication Etiquette
-
-### Always
-- Be patient - maintainers are often volunteers
-- Respond promptly to feedback (within 24-48 hours)
-- Keep discussions public and constructive
-- Accept decisions gracefully, even if you disagree
-
-### Never
-- Argue or be defensive
-- Ping maintainers repeatedly
-- Take rejection personally
-- Ignore feedback points
-- Make demands or set ultimatums
-
-### Writing Style (Avoiding AI Tells)
-
-AI-generated comments have recognizable patterns. Avoid these:
-
-- **No changelogs in comments.** "Changes in the latest commit:" with bullet points is a dead giveaway. Describe what you did in a sentence, or let the diff speak.
-- **Vary your openings.** Don't start every response with "Thanks for the review!" or "Good catch!" Sometimes just jump to the substance.
-- **Match their length.** If the maintainer wrote two sentences, don't respond with four paragraphs.
-- **Read the whole thread first.** Asking about something explained three comments up is the fastest way to lose credibility.
-- **Mean what you say.** Don't defend a position then immediately abandon it. Push back or agree -- pick one.
-- **Figure things out yourself.** If a maintainer says "add a screenshot," look at existing examples. Don't ask them to explain the tooling.
-
-### When to Respond Personally
-
-Some situations require the human contributor, not an AI tool:
-
-- **Maintainer frustration or AI accusations** — respond honestly and personally
-- **Visual/subjective tasks** — screenshots, design opinions, UX judgments
-- **Heated discussions** — any thread about AI ethics, contribution policies, or governance
-- **Process questions with obvious answers** — look at existing examples instead of asking
-
-## Contribution Ethics
-
-### Do
-
-- Attribute work properly (co-authors for human pair work)
-- Give credit to human contributors in PR descriptions
-- Share knowledge with other contributors
-
-### Don't
-
-- Add AI attribution to commits or PRs:
-  - No `Co-Authored-By: Claude` trailers
-  - No "Generated with Claude Code" in PR descriptions
-  - No robot emoji attributions
-  - No mentions of AI assistance in comments
-- Claim credit for others' work
-- Submit low-quality PRs just for contribution graphs
-- Spam repos with trivial changes
-
 ## Failure Protocol
 
 When a task or approach fails, **STOP and report back to the user** with what failed and why. Don't silently switch strategies or improvise workarounds — let the user decide how to proceed.
@@ -274,6 +104,11 @@ In short:
 
 - **Documented branch in a workflow** (a step that names its fallback options) → follow it; surface the choices to the user; do what they pick.
 - **Improvised fallback** (substituting a different command, retrying with no plan, swapping in a less-specific approach because the first didn't work) → never. Stop and ask.
+
+## See Also
+
+- `pr-etiquette` skill — review responses, PR descriptions, dormant-PR follow-up, PR quality checklist, communication style.
+- `contribution-ethics` skill — AI attribution rules, AI-tell avoidance, when to defer to a human.
 
 ## Resources
 

--- a/skills/pr-etiquette/SKILL.md
+++ b/skills/pr-etiquette/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: PR Etiquette
+description: This skill should be used when responding to maintainer review feedback, writing or reviewing PR descriptions, following up on dormant PRs, validating PR quality before submission, or deciding how to communicate with maintainers. Sibling to oss-contribution and contribution-ethics.
+version: 1.0.0
+---
+
+# PR Etiquette
+
+How to communicate around a pull request — review responses, descriptions, follow-up cadence, and the readiness gate. Pair with the `oss-contribution` skill (universal rules) and `contribution-ethics` (attribution + AI-tell avoidance).
+
+## Responding to Code Review Feedback
+
+### Mindset
+
+Maintainer feedback is a gift — they're investing time to help you improve. Even critical feedback should be received gracefully.
+
+### Response Approach
+
+- Address every point they raise
+- Keep it short. One or two sentences is usually enough.
+- Push updates promptly after discussion
+- Mark conversations as resolved after addressing
+- If you feel resistance to a request, investigate deeper — the maintainer likely knows something you don't. If you still think there's an issue after investigating, raise it to the human contributor — never override the maintainer
+
+### Assumptions and Verification
+
+When a maintainer requests changes, these rules govern how you respond:
+
+1. **Maintainer is right by default.** If a maintainer says "do X," your starting assumption is that X is correct and appropriate for their codebase. Do not second-guess their judgment about their own project.
+
+2. **Verify, never assume.** Before running any tool (linter, formatter, type checker), check the project's CI configuration to confirm that tool is actually enforced. Read `.pre-commit-config.yaml`, `.github/workflows/`, `Makefile`, or equivalent before deciding what to run. A tool that exists in `devDependencies` but is not in CI is not authoritative.
+
+3. **Try before estimating scope.** When asked to make a change, attempt the simplest implementation first. Do not respond with effort estimates, propose TODOs, or suggest deferring to a follow-up PR. If the change turns out to be genuinely complex after attempting it, report what you found to the human.
+
+4. **Pushback = escalate, don't override.** If you believe a maintainer's request is incorrect or harmful, raise the concern to the human contributor. Never push back on a maintainer directly, never ignore the request, and never silently do something different from what was asked.
+
+5. **No TODOs as substitutes.** A maintainer asking for a change expects the change in this PR. Responding with a TODO comment or "I'll handle this in a follow-up" is not an acceptable response unless the maintainer explicitly suggested that approach.
+
+### Pre-Push Review Checkpoint
+
+Before pushing commits that address review feedback:
+
+1. Run the project's code review tooling on your diff (the pr-review-toolkit agents if installed, otherwise the built-in pre-commit-reviewer)
+2. Fix any issues found (bugs, style violations, missing error handling)
+3. Re-run until clean — no actionable findings
+4. Only then push your changes
+
+This prevents maintainers from seeing issues that could have been caught locally. It's especially important when responding to feedback — pushing sloppy fix-up commits undermines credibility.
+
+### PR Readiness Gate (Mandatory)
+
+A PR is NEVER "ready" until all of these pass:
+
+1. **Local lint/type check**: Run the repo's linters and type checkers
+2. **Test suite**: Run the full test suite locally
+3. **Code review**: Run review agents (pr-review-toolkit or pre-commit-reviewer)
+4. **Fix and re-run**: Fix all findings, re-run checks
+5. **Convergence**: Repeat until zero Critical/Recommended findings
+6. **Push and verify CI**: Push and confirm CI passes remotely
+7. **Only then** declare the PR ready for maintainer review
+
+The tool should NEVER say "PR is ready", "work is complete", or "changes are done" without having run through this complete loop. This applies to:
+
+- New contributions (draft-first workflow)
+- Responses to maintainer feedback
+- CI fix pushes
+- Any commit that will be seen by maintainers
+
+### Things to Avoid
+
+- Being defensive or dismissive
+- Long justifications for every decision
+- Ignoring feedback points
+- Taking days to respond
+- Assuming what tools the project's CI enforces without checking CI config files
+- Substituting TODOs or "follow-up PR" proposals for changes the maintainer requested in this PR
+- Running tools not enforced by CI and treating their output as authoritative
+
+## Writing Good PR Descriptions
+
+### Structure
+
+```markdown
+## Summary
+
+[1-2 sentences explaining what this PR does]
+
+## Problem
+
+[What problem does this solve? Link to issue if applicable]
+
+## Solution
+
+[Brief explanation of your approach]
+
+## Testing
+
+[How you tested the changes]
+
+## Screenshots (if UI changes)
+
+[Before/after screenshots]
+```
+
+### Tips
+
+- Link to related issues: "Fixes #123" or "Closes #123"
+- Keep it concise — maintainers review many PRs
+- Highlight anything unusual or that needs special attention
+- Don't pad with unnecessary sections
+
+## Following Up on Dormant PRs
+
+- **7 days:** Light check-in ("Anything else needed from my side?")
+- **14 days:** Direct follow-up ("Still on your radar? Happy to make changes.")
+- **30 days:** Final check ("Understand if priorities shifted. Let me know!")
+
+Be patient, not pushy. Only follow up once per timeframe. Check if maintainers are active elsewhere before escalating.
+
+**Workflow:** `workflows/dormant-pr-follow-up.md` operationalizes this cadence — run via the `/oss` router or the action menu. It surfaces dormant PRs, buckets them into tiers, and drafts a tier-appropriate follow-up through the `draft-review-post` skill (never auto-posts).
+
+## PR Quality Checklist
+
+Before submitting any PR, verify:
+
+### Required
+
+- [ ] **Issue Reference**: PR links to issue (`Closes #X` or `Fixes #X`)
+- [ ] **Description Quality**: Explains what changed and why
+- [ ] **Title Quality**: Descriptive, properly formatted (e.g., `fix: resolve login timeout`)
+- [ ] **Focused Changes**: One logical change per PR (< 10 files, < 400 lines ideal)
+- [ ] **Minimal Diff**: No unrelated formatting changes (whitespace, quotes, imports, trailing commas)
+
+### Conditional
+
+- [ ] **Tests Included**: If project requires tests, add them
+- [ ] **Docs Updated**: If behavior changed, update docs
+
+### Optional
+
+- [ ] **Branch Naming**: Follows convention (`feature/`, `fix/`, `docs/`)
+- [ ] **Screenshots**: Included for UI changes
+
+**Tip:** Use the `pr-compliance-checker` agent to validate your PR before requesting review.
+
+## Communication Etiquette
+
+### Always
+
+- Be patient — maintainers are often volunteers
+- Respond promptly to feedback (within 24-48 hours)
+- Keep discussions public and constructive
+- Accept decisions gracefully, even if you disagree
+
+### Never
+
+- Argue or be defensive
+- Ping maintainers repeatedly
+- Take rejection personally
+- Ignore feedback points
+- Make demands or set ultimatums
+
+For AI-tell avoidance specifically (recognizable AI patterns to avoid in maintainer-visible writing) and the rules on when to defer to a human, see the `contribution-ethics` skill.
+
+## See Also
+
+- `oss-contribution` skill — universal contribution rules (minimal-diff discipline, working on issues, time management, failure protocol).
+- `contribution-ethics` skill — AI attribution rules, AI-tell avoidance, when to defer to a human.

--- a/workflows/dormant-pr-follow-up.md
+++ b/workflows/dormant-pr-follow-up.md
@@ -2,7 +2,7 @@
 
 > **Session state:** Expects `data.daily.digest.openPRs` from a recent `daily --json` run.
 > **Input validation:** See "AskUserQuestion Validation Protocol" in `workflows/reference.md`.
-> **Policy:** Operationalizes the 7/14/30-day cadence defined in `skills/oss-contribution/SKILL.md` §6 "Following Up on Dormant PRs".
+> **Policy:** Operationalizes the 7/14/30-day cadence defined in `skills/pr-etiquette/SKILL.md` §"Following Up on Dormant PRs".
 
 Surfaces PRs that are waiting on maintainer response and offers the user a chance to send a polite follow-up. Runs only on user initiative — never auto-posts comments.
 
@@ -97,7 +97,7 @@ Per the skill: **only one follow-up per timeframe.** The workflow does not track
 
 ## Cross-references
 
-- Policy: `skills/oss-contribution/SKILL.md` §6 "Following Up on Dormant PRs".
+- Policy: `skills/pr-etiquette/SKILL.md` §"Following Up on Dormant PRs".
 - Draft/post protocol: `draft-review-post` skill (mandatory for any externally-visible comment).
 - Router: `commands/oss.md`.
 - Menu integration: `workflows/action-menu.md`.

--- a/workflows/pre-commit-review.md
+++ b/workflows/pre-commit-review.md
@@ -359,7 +359,7 @@ When in doubt, lean toward skipping — the diff already communicates the functi
 1. Draft a brief response comment:
    - Keep it to one or two sentences describing what you changed — avoid bullet-point changelogs
    - Mention anything intentionally left unchanged only if the maintainer will wonder about it
-   - Match the thread's tone and length (see `oss-contribution` skill for writing style guidelines)
+   - Match the thread's tone and length (see the `contribution-ethics` skill for AI-tell avoidance and the `pr-etiquette` skill for general response style)
 
 2. **Output the drafted comment as a blockquote in your text response** so the user can read it.
 


### PR DESCRIPTION
Closes #1109.

## Summary
Split the 269-line `skills/oss-contribution/SKILL.md` into three focused skills:

- `oss-contribution/SKILL.md` (117 lines) — index; universal rules (minimal-diff discipline, working on issues, time management, failure protocol).
- `pr-etiquette/SKILL.md` (168 lines, new) — review-feedback responses, PR descriptions, dormant-PR follow-up cadence, PR quality checklist, communication etiquette.
- `contribution-ethics/SKILL.md` (61 lines, new) — AI attribution rules, AI-tell avoidance, when to defer to a human contributor.

Each new skill has its own frontmatter description so the loader can match on the specific topic rather than pulling the whole family.

## Cross-references updated
- `ARCHITECTURE.md` — skills section lists all three
- `CLAUDE.md` — file-tree comment updated
- `commands/oss-help.md` — Skill section now lists all three
- `workflows/dormant-pr-follow-up.md` — "§6 of oss-contribution" → `pr-etiquette` §"Following Up on Dormant PRs"
- `workflows/pre-commit-review.md` — style-guide pointer now references `contribution-ethics` + `pr-etiquette`

## Acceptance check
- [x] Each resulting skill fits comfortably under the per-skill budget (largest is 168 lines, was 269).
- [x] Every workflow / agent / doc reference to the old skill is updated.
- [x] No behavior change — same rules, reorganized.

## Test plan
- [x] `pnpm run lint`
- [x] `grep -rn "oss-contribution" --include="*.md"` confirms remaining mentions are intentional (architecture/help/CLAUDE.md tree)