### PR TITLE
refactor(commands): collapse /setup-oss CLI + markdown duplicate flows (#1106)

### DIFF
--- a/commands/setup-oss.md
+++ b/commands/setup-oss.md
@@ -10,7 +10,9 @@ Customize your OSS Autopilot preferences. This is **optional** — the tool work
 
 > **Input validation:** See "AskUserQuestion Validation Protocol" in `workflows/reference.md`.
 
-## Step 0: Ensure CLI is Built and Check Availability
+## Step 0: Ensure CLI is Built and Available
+
+This flow delegates entirely to the CLI. There is no markdown-only fallback — if the CLI cannot be built, ask the user to install Node 20+ and re-run.
 
 Build the CLI on first run (auto-installs deps):
 
@@ -22,25 +24,23 @@ if [ ! -f "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" ]; then
 fi
 ```
 
-**If output starts with `BUILD_FAILED`**: Tell the user the CLI build failed and show the error lines. Suggest: `cd ${CLAUDE_PLUGIN_ROOT}/packages/core && npm install && npm run bundle`. Common causes: missing Node.js 20+, stale `node_modules`.
+**If the build succeeded but the bundle file still isn't there**, or **if `node` is unavailable**: Stop the flow and tell the user:
 
-Then check if it's working:
+> "OSS Autopilot setup needs the CLI. Install Node.js 20+ from <https://nodejs.org>, then re-run `/setup-oss`. (Alternative: build manually with `cd ${CLAUDE_PLUGIN_ROOT}/packages/core && npm install && npm run bundle`.)"
+
+**If output starts with `BUILD_FAILED`**: Show the error lines and the same install/re-run guidance. Common causes: missing Node 20+, stale `node_modules`, no network for `npm install`.
+
+Then verify the CLI is callable:
 
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" checkSetup --json 2>/dev/null
 ```
 
-**If CLI returns valid JSON:**
-- Use CLI commands for all setup (Steps 1-CLI through 7-CLI below)
-
-**If CLI is NOT available (build failed or node unavailable):**
-- Fall back to markdown-based setup (Steps 1 through 10 below)
+If this also fails, surface the install/re-run guidance and stop.
 
 ---
 
-# CLI-Based Setup (Preferred)
-
-## Step 1-CLI: Check Current Status
+## Step 1: Check Current Status
 
 Run the setup command to see current configuration:
 
@@ -55,9 +55,10 @@ Options: "Yes, reconfigure" or "No, keep current settings"
 
 If they choose to keep current settings, show current config and exit.
 
-## Step 2-CLI: Get GitHub Username
+## Step 2: Get GitHub Username
 
 Get the username from gh CLI:
+
 ```bash
 gh api user --jq '.login'
 ```
@@ -66,11 +67,12 @@ Confirm with user:
 > "I detected your GitHub username as **@USERNAME**. Is this correct?"
 
 If confirmed, set it:
+
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" setup --set username=USERNAME --json
 ```
 
-## Step 3-CLI: Gather Preferences
+## Step 3: Gather Preferences
 
 Use AskUserQuestion to collect preferences, then set each via CLI:
 
@@ -121,6 +123,7 @@ node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" setup --set label
 Map selections: "Beginner" → `beginner`, "Intermediate" → `intermediate`, "Advanced" → `advanced`.
 
 If "Skip" is selected, skip. Otherwise:
+
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" setup --set scope=beginner,intermediate --json
 ```
@@ -132,6 +135,7 @@ node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" setup --set scope
 Map selections: "Nonprofit/Social Impact" → `nonprofit`, "Developer Tools" → `devtools`, "Infrastructure/Cloud" → `infrastructure`, "Web Frameworks" → `web-frameworks`, "Data/ML" → `data-ml`, "Education" → `education`.
 
 If "No preference" is selected, skip. Otherwise:
+
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" setup --set projectCategories=devtools,infrastructure --json
 ```
@@ -140,6 +144,7 @@ node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" setup --set proje
 - "Any GitHub organizations you'd like to prioritize? (comma-separated, or skip)"
 
 If user provides orgs:
+
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" setup --set preferredOrgs=vercel,remix-run --json
 ```
@@ -153,6 +158,7 @@ If yes, ask for the file path:
 - Options: "open-source/potential-issue-list.md (default)", "Enter custom path"
 
 If a path is provided, validate it exists:
+
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" setup --set issueListPath="PATH" --json
 ```
@@ -173,6 +179,7 @@ Options:
 ```
 
 Save the chosen path:
+
 ```bash
 GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" config --set skippedIssuesPath="{path}" --json
 ```
@@ -196,6 +203,7 @@ This sets the global `squashByDefault` setting.
 - Options: "Inline (default) — print diff in CLI", "SourceTree — open repo in SourceTree", "VS Code — open diff in VS Code", "Custom command"
 
 Apply based on selection:
+
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" setup --set diffTool=VALUE --json
 ```
@@ -209,7 +217,7 @@ If user selects "Custom command", ask for the command string:
 node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" setup --set diffToolCustomCommand="COMMAND" --json
 ```
 
-## Step 4-CLI: Verify GitHub Access
+## Step 4: Verify GitHub Access
 
 Before marking setup complete, verify that the token actually works by making a lightweight API call:
 
@@ -220,29 +228,31 @@ gh api user --jq '.login' 2>/dev/null
 **If this fails** (empty output or error), do NOT proceed. Tell the user:
 > "GitHub authentication check failed. Please verify your credentials: run `gh auth status` to check, or re-authenticate with `gh auth login`."
 
-**If this succeeds**, confirm the returned username matches the one from Step 2-CLI and proceed to Step 5-CLI.
+**If this succeeds**, confirm the returned username matches the one from Step 2 and proceed to Step 5.
 
-## Step 5-CLI: Mark Setup Complete
+## Step 5: Mark Setup Complete
 
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" setup --set complete=true --json
 ```
 
-## Step 6-CLI: Import Existing PRs
+## Step 6: Import Existing PRs
 
 Ask user:
 > "Would you like me to import your existing open PRs?"
 
 If yes:
+
 ```bash
 GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" init USERNAME --json
 ```
 
 This fetches all open PRs from GitHub and adds them to tracking.
 
-## Step 7-CLI: Confirmation
+## Step 7: Confirmation
 
 Show summary:
+
 ```markdown
 ## Setup Complete!
 
@@ -271,217 +281,6 @@ Show summary:
 ```
 
 **Note:** The `squashByDefault` setting is stored in `~/.oss-autopilot/state.json` config and can be changed via `config squashByDefault VALUE` or `setup --set squashByDefault=VALUE`.
-
----
-
-# Markdown-Based Setup (Fallback)
-
-Use this section only if the CLI is not available.
-
-## Step 1: Check Current Status
-
-Check if `.claude/oss-autopilot/config.md` exists.
-
-If it exists and has `setupComplete: true`, ask:
-> "Setup is already complete. Would you like to reconfigure your settings?"
-
-Options: "Yes, reconfigure" or "No, keep current settings"
-
-If they choose to keep current settings, show current config and exit.
-
-## Step 2: Detect GitHub Access
-
-Determine how to access GitHub. Check in this order:
-
-### Option 1: MCP Server
-Check if a GitHub MCP server is available by looking for tools like:
-- `mcp__github__*` (official GitHub MCP)
-- `mcp__*github*` (other GitHub MCP servers)
-
-If found, note this for later use and try to get the authenticated user.
-
-### Option 2: GitHub CLI (`gh`)
-Check if `gh` CLI is authenticated:
-```bash
-gh auth status
-```
-
-If authenticated, use `gh` for setup.
-
-### Option 3: No GitHub Access
-If neither is available, explain options:
-> "I need access to GitHub to set up OSS Autopilot. You have two options:
->
-> **Option 1: GitHub CLI (Recommended)**
-> - Install: https://cli.github.com/
-> - Authenticate: `gh auth login`
->
-> **Option 2: GitHub MCP Server**
-> - Add a GitHub MCP server to your Claude Code configuration
-> - This provides richer API access and avoids rate limits
->
-> After setting up access, run `/setup-oss` again."
-
-Then STOP.
-
-## Step 3: Get GitHub Username
-
-**Using gh CLI:**
-```bash
-gh api user --jq '.login'
-```
-
-**Using MCP (if available):**
-Use the appropriate MCP tool to get the authenticated user.
-
-Confirm with user:
-> "I detected your GitHub username as **@USERNAME**. Is this correct?"
-
-If incorrect, ask them to enter their username.
-
-## Step 4: Gather Preferences
-
-Use AskUserQuestion to collect preferences. Ask these in sequence:
-
-**Question 1: Max Active PRs**
-- "How many PRs do you want to work on at once?"
-- Options: "5 (light)", "10 (moderate)", "15 (active)", "20 (heavy)"
-
-**Question 2: Dormant Threshold**
-- "After how many days of inactivity should a PR be flagged as dormant?"
-- Options: "14 days", "21 days", "30 days (default)", "45 days"
-
-**Question 3: Warning Threshold**
-- "When should I warn you about approaching dormancy?"
-- Options: "5 days before", "7 days before", "10 days before"
-
-**Question 4: Languages** (multi-select)
-- "What programming languages do you want to contribute to?"
-- Options: "TypeScript", "JavaScript", "Python", "Go", "Rust"
-- Allow multiple selections
-
-**Question 5: Issue Labels** (multi-select)
-- "What types of issues should I search for?"
-- Options: "good first issue", "help wanted", "bug", "enhancement", "documentation"
-- Allow multiple selections
-
-**Question 6: Issue Scope Tiers** (multi-select)
-- "What scope of issues do you want to discover? Scope tiers add extra labels to your search beyond your custom labels above."
-- Options: "Beginner (good first issue, help wanted, easy, up-for-grabs)", "Intermediate (enhancement, feature, contributions welcome)", "Advanced (proposal, RFC, accepted, design)", "Skip (use only my custom labels)"
-
-Map selections: "Beginner" → `beginner`, "Intermediate" → `intermediate`, "Advanced" → `advanced`.
-
-If "Skip" is selected, omit the `scope` field from the config (or set it to an empty list).
-
-**Question 7: Project Categories** (multi-select)
-- "What types of projects interest you?"
-- Options: "Nonprofit/Social Impact", "Developer Tools", "Infrastructure/Cloud", "Web Frameworks", "Data/ML", "Education", "No preference (skip)"
-
-Map selections to values: nonprofit, devtools, infrastructure, web-frameworks, data-ml, education.
-
-**Question 8: Preferred Organizations** (free text)
-- "Any GitHub organizations you'd like to prioritize? (comma-separated, or skip)"
-
-**Question 9: Curated Issue List**
-- "Do you maintain a curated list of potential issues to work on?"
-- Options: "Yes", "No"
-
-If yes, ask for the file path:
-- "What's the path to your issue list file? (relative to your notes/project root)"
-- Options: "open-source/potential-issue-list.md (default)", "Enter custom path"
-
-If a path is provided, try to read it to verify it exists. If it doesn't exist, warn but continue — the user may create it later.
-
-### Skipped Issues File
-
-If the user configured an issue list path, ask:
-
-```
-Question: "Where should skipped/rejected issues be tracked? This prevents re-surfacing issues you've already vetted and rejected. Entries auto-expire after 90 days."
-
-Options:
-1. "Use default ({issueListDir}/skipped-issues.md)" — "Same folder as your issue list"
-2. "Custom path" — "Specify a different location"
-3. "Don't track skipped issues" — "May see duplicates in search results"
-```
-
-Save the chosen path:
-```bash
-GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" config --set skippedIssuesPath="{path}" --json
-```
-
-If "Don't track", skip — no config change needed (the search flow handles missing skip files gracefully).
-
-**Question 10: Squash Commits Before Review**
-- "Should PRs be squashed into a single commit before marking ready for review?"
-- Options: "Yes, always squash (Recommended)", "No, keep individual commits", "Ask me each time"
-
-This sets the global `squashByDefault` setting.
-
-## Step 5: Verify GitHub Access
-
-Before creating config files, verify that the token actually works:
-
-```bash
-gh api user --jq '.login'
-```
-
-**If this fails**, do NOT proceed. Tell the user:
-> "GitHub authentication check failed. Please verify your credentials: run `gh auth status` to check."
-
-**If this succeeds**, confirm the username matches and proceed.
-
-## Step 6: Offer to Import Existing PRs
-
-Ask user:
-> "Would you like me to import your existing open PRs?"
-
-If yes, fetch and import:
-
-**Using gh CLI:**
-```bash
-# IMPORTANT: Use 'gh search prs' to find PRs across ALL of GitHub, not just current repo
-gh search prs --author USERNAME --state open --json repository,number,title,url,updatedAt --limit 100
-```
-
-Note: `gh pr list` only searches the current repo. Always use `gh search prs` to find PRs across all repositories.
-
-**Using MCP:**
-Use `mcp__github__search_issues` with query `is:pr is:open author:USERNAME`
-
-Parse results and add each PR to tracked-prs.md.
-
-## Step 7: Confirmation
-
-Show summary:
-
-```markdown
-## Setup Complete!
-
-### Your Configuration
-- **Username**: @USERNAME
-- **Max PRs**: NUMBER
-- **Dormant**: NUMBER days
-- **Languages**: list
-- **Labels**: list
-- **Scope Tiers**: list or "None (custom labels only)"
-- **Project Categories**: list or "No preference"
-- **Preferred Orgs**: list or "None"
-- **GitHub Access**: via [gh CLI / MCP server]
-- **Issue List**: PATH or "Not configured"
-- **Squash PRs**: Yes (default) / No / Ask each time
-- **Score Threshold**: NUMBER/10
-
-### Imported PRs
-- X open PRs imported
-
-### Next Steps
-- Run `/oss` to check your PRs and find new contribution opportunities
-- Run `/oss-help` for a full reference card of commands and agents
-
-### Optional Enhancement
-- **Enhanced code review**: Install the `pr-review-toolkit` plugin for parallel specialized code review (5 agents instead of 1). Search for it in the plugin marketplace. The built-in pre-commit reviewer works without it.
-```
 
 ---
 


### PR DESCRIPTION
Closes #1106.

## Summary
Drop the markdown-fallback flow in `commands/setup-oss.md` and route the entire `/setup-oss` experience through the CLI. When the CLI cannot be built or `node` is missing, surface an "install Node 20+ and re-run" message instead of switching to a second flow.

File drops from **493 → 292 lines** (~40% smaller).

## Why
The markdown-fallback gathered preferences via AskUserQuestion but had no way to persist them — its config writes targeted `.claude/oss-autopilot/config.md`, which nothing in the current code writes (and which `startup.ts` reads only as a legacy fallback for old installs). The fallback effectively asked the user 11 questions and then dropped the answers on the floor; better to point the user at the install fix instead.

## Test plan
- [x] `pnpm run lint`
- [x] Read the new file end-to-end; flow stays coherent without the parallel section
- [x] `grep -rn "Markdown-Based Setup\|Step 1-CLI"` returns no results, confirming the removal is complete