### PR TITLE
feat(cli): list-move-tier command (#1107)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 
 env:
   # Bundle size thresholds (bytes). Update via PR when increases are justified.
-  BUNDLE_MAX_CORE: 740000 # ~722 KB (increased for doctor command + config-key registry, #1038/#1039)
+  BUNDLE_MAX_CORE: 760000 # ~742 KB (increased for list-move-tier command, #1107)
   BUNDLE_MAX_MCP: 2000000 # ~1953 KB
   STARTUP_WARN_MS: 500 # Warn if CLI startup exceeds 500ms
 

--- a/commands/oss-search.md
+++ b/commands/oss-search.md
@@ -156,7 +156,16 @@ Use AskUserQuestion:
 
    **Important:** `searchRoundScores` should use the **unfiltered** mean (all vetted scores) so diminishing returns detection remains accurate.
 
-4. Update list entries with results — move issues that passed the threshold to their vet-recommended tier (`## Pursue`, `## Maybe`, `## Skip`) based on the agent's recommendation field
+4. Update list entries with results — move each surviving issue into its vet-recommended tier (`## Pursue`, `## Maybe`, `## Skip`) using the deterministic CLI helper (#1107):
+
+   ```bash
+   node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" list-move-tier "{issue_url}" \
+     --tier {pursue|maybe|skip} \
+     --list-path "{issueListPath}" \
+     --json
+   ```
+
+   The command preserves blank lines and sub-bullets between entries, is idempotent (re-running with the same tier is a no-op), and creates the target tier section if it doesn't already exist.
 
 5. Track round scores: `searchRoundScores.push(mean of all scores)` (unfiltered — includes scores below threshold)
 

--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -375,6 +375,47 @@ export const commands: CLICommandDef[] = [
     },
   },
 
+  // ── List Move Tier ─────────────────────────────────────────────────────
+  {
+    name: 'list-move-tier',
+    localOnly: true,
+    register(program) {
+      program
+        .command('list-move-tier <issue-url>')
+        .description('Move an issue between Pursue / Maybe / Skip sections of a curated list (#1107)')
+        .requiredOption('--tier <tier>', 'Target tier: pursue, maybe, or skip')
+        .requiredOption('--list-path <file>', 'Path to the markdown issue list')
+        .option('--json', 'Output as JSON')
+        .action((issueUrl, options) =>
+          executeAction(
+            options,
+            async () => {
+              const tier = String(options.tier).toLowerCase();
+              if (tier !== 'pursue' && tier !== 'maybe' && tier !== 'skip') {
+                throw new Error(`Invalid --tier "${options.tier}". Must be one of: pursue, maybe, skip.`);
+              }
+              return (await import('./commands/list-move-tier.js')).runListMoveTier({
+                issueUrl,
+                tier,
+                listPath: options.listPath,
+              });
+            },
+            (data) => {
+              if (data.moved) {
+                const fromLabel = data.fromTier ? ` (from ${data.fromTier})` : '';
+                const countLabel = data.count > 1 ? ` × ${data.count}` : '';
+                console.log(`Moved ${data.url} to ${data.toTier}${fromLabel}${countLabel}`);
+                console.log(`  File: ${data.filePath}`);
+              } else {
+                console.log(`No move: ${data.url} — ${data.reason ?? 'unchanged'}`);
+                console.log(`  File: ${data.filePath}`);
+              }
+            },
+          ),
+        );
+    },
+  },
+
   // ── Track ──────────────────────────────────────────────────────────────
   {
     name: 'track',

--- a/packages/core/src/cli.test.ts
+++ b/packages/core/src/cli.test.ts
@@ -112,6 +112,7 @@ describe('LOCAL_ONLY_COMMANDS (derived from registry)', () => {
     'clear-override',
     'stats',
     'skip-add',
+    'list-move-tier',
   ];
 
   const expectedTokenRequired = [
@@ -376,6 +377,7 @@ describe('Command registration', () => {
       'stats',
       'state',
       'skip-add',
+      'list-move-tier',
     ];
 
     for (const name of expectedCommands) {

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -82,6 +82,14 @@ export { runStateUnlink } from './state-cmd.js';
 
 /** Parse a curated markdown issue list file into structured issue items. */
 export { runParseList, pruneIssueList } from './parse-list.js';
+/** Move an issue between Pursue / Maybe / Skip sections of a curated list (#1107). */
+export {
+  runListMoveTier,
+  moveIssueToTier,
+  type Tier,
+  type ListMoveTierOptions,
+  type ListMoveTierOutput,
+} from './list-move-tier.js';
 /** Check if new files are properly referenced/integrated. */
 export { runCheckIntegration } from './check-integration.js';
 /** System-health diagnostic — verifies tokens, bundle, state, scout, rate limit. */

--- a/packages/core/src/commands/list-move-tier.test.ts
+++ b/packages/core/src/commands/list-move-tier.test.ts
@@ -91,9 +91,10 @@ describe('moveIssueToTier (pure transform)', () => {
     const maybeSection = result.content.slice(result.content.indexOf('## Maybe'), result.content.indexOf('## Skip'));
     expect(pursueSection).not.toContain(URL_A);
     expect(maybeSection).not.toContain(URL_A);
-    // Both copies should now be in Skip
+    // Both copies should now be in Skip — count occurrences via split (avoids
+    // building a RegExp from a literal URL string).
     const skipSection = result.content.slice(result.content.indexOf('## Skip'));
-    expect(skipSection.match(new RegExp(URL_A.replace(/[/.]/g, '\\$&'), 'g'))?.length).toBe(2);
+    expect(skipSection.split(URL_A).length - 1).toBe(2);
   });
 
   it('creates the target tier section when missing', () => {

--- a/packages/core/src/commands/list-move-tier.test.ts
+++ b/packages/core/src/commands/list-move-tier.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for list-move-tier (#1107).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { moveIssueToTier, runListMoveTier } from './list-move-tier.js';
+
+const URL_A = 'https://github.com/foo/bar/issues/1';
+const URL_B = 'https://github.com/foo/bar/issues/2';
+const URL_C = 'https://github.com/baz/qux/issues/42';
+
+describe('moveIssueToTier (pure transform)', () => {
+  it('moves an entry from Pursue to Skip and preserves sub-bullets', () => {
+    const content = [
+      '# My List',
+      '',
+      '## Pursue',
+      '',
+      `- [Issue A](${URL_A})`,
+      '  - **Score 8/10**',
+      '  - Quick start: do X',
+      `- [Issue B](${URL_B})`,
+      '',
+      '## Skip',
+      '',
+      `- [Existing](${URL_C})`,
+      '',
+    ].join('\n');
+
+    const result = moveIssueToTier(content, URL_A, 'skip');
+
+    expect(result.moved).toBe(true);
+    expect(result.fromTier).toBe('Pursue');
+    expect(result.count).toBe(1);
+
+    // The sub-bullets should travel with the issue line
+    expect(result.content).toContain(`- [Issue A](${URL_A})\n  - **Score 8/10**\n  - Quick start: do X`);
+
+    // It should land under "## Skip" before the existing entry
+    const skipIdx = result.content.indexOf('## Skip');
+    const newEntryIdx = result.content.indexOf(`[Issue A](${URL_A})`);
+    const existingIdx = result.content.indexOf(`[Existing](${URL_C})`);
+    expect(skipIdx).toBeLessThan(newEntryIdx);
+    expect(newEntryIdx).toBeLessThan(existingIdx);
+
+    // Pursue should no longer contain Issue A
+    const pursueSection = result.content.slice(result.content.indexOf('## Pursue'), result.content.indexOf('## Skip'));
+    expect(pursueSection).not.toContain(URL_A);
+    expect(pursueSection).toContain(URL_B);
+  });
+
+  it('returns moved=false when the issue URL is not found', () => {
+    const content = '## Pursue\n\n- nothing here\n';
+    const result = moveIssueToTier(content, URL_A, 'maybe');
+    expect(result.moved).toBe(false);
+    expect(result.count).toBe(0);
+    expect(result.reason).toMatch(/not found/);
+    expect(result.content).toBe(content);
+  });
+
+  it('is idempotent — already in target tier is a no-op', () => {
+    const content = ['## Pursue', '', `- [A](${URL_A})`, ''].join('\n');
+    const result = moveIssueToTier(content, URL_A, 'pursue');
+    expect(result.moved).toBe(false);
+    expect(result.fromTier).toBe('Pursue');
+    expect(result.reason).toMatch(/already/);
+    expect(result.content).toBe(content);
+  });
+
+  it('moves multiple matches when the same URL appears more than once', () => {
+    const content = [
+      '## Pursue',
+      '',
+      `- [A first](${URL_A})`,
+      '',
+      '## Maybe',
+      '',
+      `- [A duplicate](${URL_A})`,
+      '',
+    ].join('\n');
+
+    const result = moveIssueToTier(content, URL_A, 'skip');
+
+    expect(result.moved).toBe(true);
+    expect(result.count).toBe(2);
+    // Both Pursue and Maybe should be empty of A
+    const pursueSection = result.content.slice(result.content.indexOf('## Pursue'), result.content.indexOf('## Maybe'));
+    const maybeSection = result.content.slice(result.content.indexOf('## Maybe'), result.content.indexOf('## Skip'));
+    expect(pursueSection).not.toContain(URL_A);
+    expect(maybeSection).not.toContain(URL_A);
+    // Both copies should now be in Skip
+    const skipSection = result.content.slice(result.content.indexOf('## Skip'));
+    expect(skipSection.match(new RegExp(URL_A.replace(/[/.]/g, '\\$&'), 'g'))?.length).toBe(2);
+  });
+
+  it('creates the target tier section when missing', () => {
+    const content = ['# Index', '', '## Pursue', '', `- [A](${URL_A})`, ''].join('\n');
+    const result = moveIssueToTier(content, URL_A, 'skip');
+    expect(result.moved).toBe(true);
+    expect(result.content).toContain('## Skip');
+    expect(result.content).toContain(`[A](${URL_A})`);
+  });
+
+  it('preserves blank lines and prose between entries', () => {
+    const content = [
+      '## Pursue',
+      '',
+      '<!-- pursue notes -->',
+      '',
+      `- [A](${URL_A})`,
+      '',
+      `- [B](${URL_B})`,
+      '',
+      '## Skip',
+      '',
+    ].join('\n');
+
+    const result = moveIssueToTier(content, URL_A, 'skip');
+    expect(result.moved).toBe(true);
+    // Pursue should still have its leading comment and Issue B
+    expect(result.content).toContain('<!-- pursue notes -->');
+    expect(result.content).toContain(`[B](${URL_B})`);
+    // Issue A should be in Skip
+    const skipSection = result.content.slice(result.content.indexOf('## Skip'));
+    expect(skipSection).toContain(URL_A);
+  });
+});
+
+describe('runListMoveTier (filesystem)', () => {
+  let tmpDir: string;
+  let listPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'list-move-tier-test-'));
+    listPath = path.join(tmpDir, 'list.md');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('reads, moves, writes, and returns the resolved file path', async () => {
+    fs.writeFileSync(listPath, ['## Pursue', '', `- [A](${URL_A})`, ''].join('\n'));
+    const out = await runListMoveTier({ issueUrl: URL_A, tier: 'skip', listPath });
+    expect(out.moved).toBe(true);
+    expect(out.toTier).toBe('skip');
+    expect(out.fromTier).toBe('Pursue');
+    expect(out.filePath).toBe(path.resolve(listPath));
+    expect(out.url).toBe(URL_A);
+    expect(out.count).toBe(1);
+
+    const after = fs.readFileSync(listPath, 'utf-8');
+    expect(after).toContain('## Skip');
+    expect(after.indexOf('## Skip')).toBeLessThan(after.indexOf(URL_A));
+  });
+
+  it('throws when the file does not exist', async () => {
+    await expect(runListMoveTier({ issueUrl: URL_A, tier: 'skip', listPath })).rejects.toThrow(/File not found/);
+  });
+
+  it('does not touch the file when the URL is not present', async () => {
+    const original = '## Pursue\n\n- [Other](https://github.com/x/y/issues/9)\n';
+    fs.writeFileSync(listPath, original);
+    const before = fs.statSync(listPath).mtimeMs;
+    // small delay to allow mtime resolution
+    await new Promise((r) => setTimeout(r, 10));
+    const out = await runListMoveTier({ issueUrl: URL_A, tier: 'pursue', listPath });
+    expect(out.moved).toBe(false);
+    expect(out.count).toBe(0);
+    const after = fs.statSync(listPath).mtimeMs;
+    expect(after).toBe(before); // no write happened
+    expect(fs.readFileSync(listPath, 'utf-8')).toBe(original);
+  });
+});

--- a/packages/core/src/commands/list-move-tier.ts
+++ b/packages/core/src/commands/list-move-tier.ts
@@ -1,0 +1,235 @@
+/**
+ * list-move-tier command (#1107).
+ *
+ * Move an issue line — and any indented sub-bullets that belong to it —
+ * between the `## Pursue`, `## Maybe`, and `## Skip` sections of a curated
+ * issue-list markdown file. Replaces the model-driven prose rewrite that
+ * lived in /oss-search with a deterministic file manipulation.
+ *
+ * Idempotent: re-running with the same target tier is a no-op.
+ *
+ * No GitHub calls — pure read/transform/write of a local file.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { errorMessage } from '../core/errors.js';
+
+export type Tier = 'pursue' | 'maybe' | 'skip';
+
+const TIER_HEADERS: Record<Tier, string> = {
+  pursue: '## Pursue',
+  maybe: '## Maybe',
+  skip: '## Skip',
+};
+
+export interface ListMoveTierOptions {
+  issueUrl: string;
+  tier: Tier;
+  listPath: string;
+}
+
+export interface ListMoveTierOutput {
+  /** Whether anything moved (false when the URL isn't in the list, or it was already in the target tier). */
+  moved: boolean;
+  /** Fully-resolved file path that was inspected. */
+  filePath: string;
+  /** The issue URL that was searched for. */
+  url: string;
+  /** The target tier (always normalized to one of pursue/maybe/skip). */
+  toTier: Tier;
+  /** The tier the issue was moved out of, if it had one. Absent when not found or already in target. */
+  fromTier?: string;
+  /** Number of matching entries moved. Should normally be 1; >1 means the list contained duplicate entries (all moved). */
+  count: number;
+  /** Human-readable explanation when `moved` is false. */
+  reason?: string;
+}
+
+interface IssueBlock {
+  /** Index of the issue line itself in the source `lines` array. */
+  start: number;
+  /** Exclusive end index — first line not part of this block. */
+  end: number;
+  /** The tier this block was found under, or undefined if unsectioned. */
+  tier: string | undefined;
+}
+
+/** Identify which "## Pursue|Maybe|Skip" section a line index sits under, if any. */
+function tierForLine(lines: string[], lineIndex: number): string | undefined {
+  for (let i = lineIndex - 1; i >= 0; i--) {
+    const m = lines[i].match(/^##\s+(.+?)\s*$/);
+    if (m) return m[1].trim();
+    // A higher-level heading also resets — we don't reach back across `# Foo`.
+    if (/^#\s+/.test(lines[i])) return undefined;
+  }
+  return undefined;
+}
+
+/** Locate every issue block (issue line + any sub-bullets) that mentions the URL. */
+function findIssueBlocks(lines: string[], issueUrl: string): IssueBlock[] {
+  const blocks: IssueBlock[] = [];
+  // Use exact substring match on the URL — no regex escaping pitfalls and
+  // the URL itself contains no markdown delimiters that would split a line.
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // Top-level list item — `- `, `* `, `+ `, or `1.` at the start (with no leading whitespace).
+    const isTopLevelListItem = /^[-*+]\s|^\d+\.\s/.test(line);
+    if (!isTopLevelListItem || !line.includes(issueUrl)) continue;
+
+    // Capture indented sub-bullets that follow this line.
+    let end = i + 1;
+    while (end < lines.length && /^\s{2,}/.test(lines[end])) {
+      end++;
+    }
+    blocks.push({ start: i, end, tier: tierForLine(lines, i) });
+    i = end - 1; // continue past the captured sub-bullets
+  }
+  return blocks;
+}
+
+/** Find the line index of the target tier's `## ...` header, or undefined if absent. */
+function findTierHeaderIndex(lines: string[], tier: Tier): number | undefined {
+  const expected = TIER_HEADERS[tier].toLowerCase();
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/^##\s+(.+?)\s*$/);
+    if (m && `## ${m[1].trim()}`.toLowerCase() === expected) {
+      return i;
+    }
+  }
+  return undefined;
+}
+
+/** Find the insertion point for a new entry under a tier's header — the first
+ * blank line or next-section boundary after the header. Returns an index where
+ * splice() can insert. */
+function findTierInsertionIndex(lines: string[], headerIndex: number): number {
+  for (let i = headerIndex + 1; i < lines.length; i++) {
+    // Stop at the next heading of the same or shallower depth.
+    if (/^#{1,2}\s+/.test(lines[i])) return i;
+  }
+  return lines.length;
+}
+
+/**
+ * Pure transform — accepts the file content and returns the rewritten content
+ * plus a summary of what changed. Exported for unit testing.
+ */
+export function moveIssueToTier(
+  content: string,
+  issueUrl: string,
+  targetTier: Tier,
+): { content: string; moved: boolean; fromTier?: string; count: number; reason?: string } {
+  // Preserve the trailing newline if present so we don't accidentally strip it.
+  const hadTrailingNewline = content.endsWith('\n');
+  const lines = (hadTrailingNewline ? content.slice(0, -1) : content).split('\n');
+
+  const blocks = findIssueBlocks(lines, issueUrl);
+  if (blocks.length === 0) {
+    return { content, moved: false, count: 0, reason: 'issue URL not found in the list' };
+  }
+
+  const targetHeader = TIER_HEADERS[targetTier];
+  // If every match is already in the target tier, no-op (idempotent).
+  if (blocks.every((b) => b.tier !== undefined && `## ${b.tier}`.toLowerCase() === targetHeader.toLowerCase())) {
+    return {
+      content,
+      moved: false,
+      fromTier: blocks[0].tier,
+      count: blocks.length,
+      reason: 'already in target tier',
+    };
+  }
+
+  // Extract the blocks (highest start index first so earlier indices stay
+  // valid as we splice). Capture the original tier for reporting.
+  const sortedBlocks = [...blocks].sort((a, b) => b.start - a.start);
+  const extracted: { tier: string | undefined; lines: string[] }[] = [];
+  for (const block of sortedBlocks) {
+    extracted.push({ tier: block.tier, lines: lines.slice(block.start, block.end) });
+    lines.splice(block.start, block.end - block.start);
+  }
+  // We popped in reverse order; reverse to restore source order.
+  extracted.reverse();
+
+  // Ensure the target section exists. If not, append a new header at the end
+  // of the document.
+  let headerIndex = findTierHeaderIndex(lines, targetTier);
+  if (headerIndex === undefined) {
+    // Append a blank line (if none precedes) and the new header.
+    if (lines.length > 0 && lines[lines.length - 1].trim() !== '') {
+      lines.push('');
+    }
+    lines.push(targetHeader);
+    headerIndex = lines.length - 1;
+    // Add a blank line after the header so insertion below stays clean.
+    lines.push('');
+  }
+
+  // Insert the extracted blocks at the top of the target section (just after
+  // the header, after any leading blank line).
+  let insertAt = headerIndex + 1;
+  // Skip a single immediate blank line so entries land before the blank that
+  // already separates the section header from its first item, not before the
+  // header.
+  if (insertAt < lines.length && lines[insertAt].trim() === '') {
+    insertAt += 1;
+  }
+  // Don't cross into a different section.
+  const sectionBoundary = findTierInsertionIndex(lines, headerIndex);
+  if (insertAt > sectionBoundary) insertAt = sectionBoundary;
+
+  const flattened: string[] = [];
+  for (const e of extracted) {
+    flattened.push(...e.lines);
+  }
+  lines.splice(insertAt, 0, ...flattened);
+
+  let next = lines.join('\n');
+  if (hadTrailingNewline) next += '\n';
+
+  // Report fromTier as the original tier of the first match. (Multi-match
+  // moves across multiple source tiers are uncommon enough that one label is
+  // fine; the count surfaces the multiplicity if needed.)
+  return {
+    content: next,
+    moved: true,
+    fromTier: extracted[0].tier,
+    count: extracted.length,
+  };
+}
+
+export async function runListMoveTier(options: ListMoveTierOptions): Promise<ListMoveTierOutput> {
+  const filePath = path.resolve(options.listPath);
+
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`File not found: ${filePath}`);
+  }
+
+  let content: string;
+  try {
+    content = fs.readFileSync(filePath, 'utf-8');
+  } catch (error) {
+    throw new Error(`Failed to read file: ${errorMessage(error)}`, { cause: error });
+  }
+
+  const result = moveIssueToTier(content, options.issueUrl, options.tier);
+
+  if (result.moved) {
+    try {
+      fs.writeFileSync(filePath, result.content, 'utf-8');
+    } catch (error) {
+      throw new Error(`Failed to write file: ${errorMessage(error)}`, { cause: error });
+    }
+  }
+
+  return {
+    moved: result.moved,
+    filePath,
+    url: options.issueUrl,
+    toTier: options.tier,
+    fromTier: result.fromTier,
+    count: result.count,
+    reason: result.reason,
+  };
+}

--- a/packages/core/src/commands/list-move-tier.ts
+++ b/packages/core/src/commands/list-move-tier.ts
@@ -55,13 +55,22 @@ interface IssueBlock {
   tier: string | undefined;
 }
 
+/** Extract the heading text from a line that starts with `## ` (returns undefined otherwise).
+ * Avoids regex on the heading body so a long whitespace prefix can't trigger
+ * backtracking in static analyzers (CodeQL js/polynomial-redos).
+ */
+function parseLevel2Heading(line: string): string | undefined {
+  if (line.startsWith('## ')) return line.slice(3).trim();
+  return undefined;
+}
+
 /** Identify which "## Pursue|Maybe|Skip" section a line index sits under, if any. */
 function tierForLine(lines: string[], lineIndex: number): string | undefined {
   for (let i = lineIndex - 1; i >= 0; i--) {
-    const m = lines[i].match(/^##\s+(.+)$/);
-    if (m) return m[1].trim();
+    const heading = parseLevel2Heading(lines[i]);
+    if (heading !== undefined) return heading;
     // A higher-level heading also resets — we don't reach back across `# Foo`.
-    if (/^#\s+/.test(lines[i])) return undefined;
+    if (lines[i].startsWith('# ')) return undefined;
   }
   return undefined;
 }
@@ -92,8 +101,8 @@ function findIssueBlocks(lines: string[], issueUrl: string): IssueBlock[] {
 function findTierHeaderIndex(lines: string[], tier: Tier): number | undefined {
   const expected = TIER_HEADERS[tier].toLowerCase();
   for (let i = 0; i < lines.length; i++) {
-    const m = lines[i].match(/^##\s+(.+)$/);
-    if (m && `## ${m[1].trim()}`.toLowerCase() === expected) {
+    const heading = parseLevel2Heading(lines[i]);
+    if (heading !== undefined && `## ${heading}`.toLowerCase() === expected) {
       return i;
     }
   }

--- a/packages/core/src/commands/list-move-tier.ts
+++ b/packages/core/src/commands/list-move-tier.ts
@@ -58,7 +58,7 @@ interface IssueBlock {
 /** Identify which "## Pursue|Maybe|Skip" section a line index sits under, if any. */
 function tierForLine(lines: string[], lineIndex: number): string | undefined {
   for (let i = lineIndex - 1; i >= 0; i--) {
-    const m = lines[i].match(/^##\s+(.+?)\s*$/);
+    const m = lines[i].match(/^##\s+(.+)$/);
     if (m) return m[1].trim();
     // A higher-level heading also resets — we don't reach back across `# Foo`.
     if (/^#\s+/.test(lines[i])) return undefined;
@@ -92,7 +92,7 @@ function findIssueBlocks(lines: string[], issueUrl: string): IssueBlock[] {
 function findTierHeaderIndex(lines: string[], tier: Tier): number | undefined {
   const expected = TIER_HEADERS[tier].toLowerCase();
   for (let i = 0; i < lines.length; i++) {
-    const m = lines[i].match(/^##\s+(.+?)\s*$/);
+    const m = lines[i].match(/^##\s+(.+)$/);
     if (m && `## ${m[1].trim()}`.toLowerCase() === expected) {
       return i;
     }

--- a/workflows/reference.md
+++ b/workflows/reference.md
@@ -43,6 +43,9 @@ Local-only commands (no GitHub token needed): `status`, `setup`, `checkSetup`, `
 
 # Append an issue URL to the skipped-issues file (auto-culled after 90 days)
 <prefix> skip-add <issue-url> --json [--path <file>]
+
+# Move an issue between Pursue / Maybe / Skip sections of a curated list (#1107)
+<prefix> list-move-tier <issue-url> --tier <pursue|maybe|skip> --list-path <file> --json
 ```
 
 ### PR Management


### PR DESCRIPTION
Closes #1107.

## Summary
New CLI helper that moves an issue line — with any indented sub-bullets — between the `## Pursue`, `## Maybe`, and `## Skip` sections of a curated markdown list. Replaces the deterministic markdown shuffle that `/oss-search` was asking the model to do.

```
oss-autopilot list-move-tier <issue-url> --tier <pursue|maybe|skip> --list-path <file> [--json]
```

## Behavior
- Locates the issue line by exact URL match across all sections.
- Captures any indented sub-bullets (score, quick-start, etc.) so they travel with the entry.
- Removes the block from its current tier, re-inserts it at the top of the target tier (creating the section if missing).
- Preserves blank lines, comments, and surrounding prose.
- Idempotent — moving an entry already in the target tier is a no-op (no write).
- Handles duplicate URLs by moving every match.
- Pure file manipulation, no GitHub calls. `localOnly` (no token required).

## Acceptance check
- [x] New CLI command registered in `cli-registry.ts` and exported from `commands/index.ts`.
- [x] `/oss-search` step 4 markdown shuffle replaced with a single call to the new command.
- [x] Unit tests covering: no matching issue, multiple matches, missing tier section, preserved comments / blank lines between entries, idempotent re-run, fs read/write happy path, fs missing-file failure, no-write-when-no-match.

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm test` (2077 core + 256 dashboard + 181 mcp green)
- [x] `pnpm run bundle` (esbuild + mcp)
- [x] Live smoke test against `/tmp/test-list.md` confirmed move output:
  ```
  Moved https://github.com/foo/bar/issues/1 to skip (from Pursue)
  ```