### PR TITLE
refactor(core): split daily-logic + relocate cross-layer types (#1117)

### DIFF
--- a/packages/core/src/commands/daily-render.ts
+++ b/packages/core/src/commands/daily-render.ts
@@ -1,0 +1,236 @@
+/**
+ * Rendering functions for the daily digest.
+ *
+ * Extracted from src/core/daily-logic.ts under #1117 so that
+ * core/daily-logic.ts can be a pure-aggregations module with no console
+ * or markdown output mixed in. The aggregations live in core because
+ * other surfaces (dashboard, MCP) consume them too.
+ *
+ *   - formatActionHint — human-readable maintainer action hint label
+ *   - formatBriefSummary — single-line status string
+ *   - formatSummary — multi-line markdown summary
+ *   - printDigest — console.log-based plain-text rendering
+ *
+ * Tests for these renderers live alongside the aggregations test
+ * (daily-logic.test.ts) — pure rendering, easy to assert on string output.
+ */
+
+import { formatRelativeTime } from '../core/dates.js';
+import type {
+  CapacityAssessment,
+  CommentedIssue,
+  CommentedIssueWithResponse,
+  DailyDigest,
+  MaintainerActionHint,
+} from '../core/types.js';
+
+/**
+ * Format a maintainer action hint as a human-readable label.
+ */
+export function formatActionHint(hint: MaintainerActionHint): string {
+  switch (hint) {
+    case 'demo_requested':
+      return 'demo/screenshot requested';
+    case 'tests_requested':
+      return 'tests requested';
+    case 'changes_requested':
+      return 'code changes requested';
+    case 'docs_requested':
+      return 'documentation requested';
+    case 'rebase_requested':
+      return 'rebase requested';
+  }
+}
+
+/**
+ * Format a brief one-liner summary for the action-first flow.
+ *
+ * @returns One-line status string (e.g., "3 Active PRs | 1 needs attention | 2 issue replies")
+ */
+export function formatBriefSummary(digest: DailyDigest, issueCount: number, issueResponseCount: number = 0): string {
+  const attentionText = issueCount > 0 ? `${issueCount} need${issueCount === 1 ? 's' : ''} attention` : 'all on track';
+  const issueReplyText =
+    issueResponseCount > 0 ? ` | ${issueResponseCount} issue repl${issueResponseCount === 1 ? 'y' : 'ies'}` : '';
+  return `\u{1F4CA} ${digest.summary.totalActivePRs} Active PRs | ${attentionText}${issueReplyText}`;
+}
+
+/**
+ * Format the full dashboard summary as markdown.
+ * Used in JSON output for Claude to display verbatim — includes all PR sections,
+ * issue replies, and capacity status.
+ */
+export function formatSummary(
+  digest: DailyDigest,
+  capacity: CapacityAssessment,
+  issueResponses: CommentedIssueWithResponse[] = [],
+): string {
+  const lines: string[] = [];
+
+  lines.push('## OSS Dashboard');
+  lines.push('');
+  lines.push(
+    `\u{1F4CA} **${digest.summary.totalActivePRs} Active PRs** | ${digest.summary.totalMergedAllTime} Merged | ${digest.summary.mergeRate}% Merge Rate`,
+  );
+  lines.push('✓ Dashboard generated — say "open dashboard" to view in browser');
+  lines.push('');
+
+  if (digest.needsAddressingPRs.length > 0) {
+    lines.push('### ❌ Needs Addressing');
+    for (const pr of digest.needsAddressingPRs) {
+      lines.push(`- [${pr.repo}#${pr.number}](${pr.url}): ${pr.title}`);
+      lines.push(`  └─ ${pr.displayLabel} ${pr.displayDescription}`);
+    }
+    lines.push('');
+  }
+
+  if (digest.waitingOnMaintainerPRs.length > 0) {
+    lines.push('### ⏳ Waiting on Maintainer');
+    for (const pr of digest.waitingOnMaintainerPRs) {
+      lines.push(`- [${pr.repo}#${pr.number}](${pr.url}): ${pr.title}`);
+      lines.push(`  └─ ${pr.displayDescription}`);
+    }
+    lines.push('');
+  }
+
+  if (digest.recentlyMergedPRs.length > 0) {
+    lines.push('### \u{1F389} Recently Merged');
+    for (const pr of digest.recentlyMergedPRs) {
+      const mergedDate = pr.mergedAt ? new Date(pr.mergedAt).toLocaleDateString() : '';
+      lines.push(`- [${pr.repo}#${pr.number}](${pr.url}): ${pr.title}${mergedDate ? ` (merged ${mergedDate})` : ''}`);
+    }
+    lines.push('');
+  }
+
+  if (digest.recentlyClosedPRs.length > 0) {
+    lines.push('### \u{1F6AB} Recently Closed');
+    for (const pr of digest.recentlyClosedPRs) {
+      const closedDate = pr.closedAt ? new Date(pr.closedAt).toLocaleDateString() : '';
+      lines.push(`- [${pr.repo}#${pr.number}](${pr.url}): ${pr.title}${closedDate ? ` (closed ${closedDate})` : ''}`);
+    }
+    lines.push('');
+  }
+
+  if (digest.autoUnshelvedPRs.length > 0) {
+    lines.push('### \u{1F514} Auto-Unshelved');
+    lines.push('> These PRs were shelved but a maintainer engaged — moved back to active.');
+    for (const pr of digest.autoUnshelvedPRs) {
+      lines.push(`- [${pr.repo}#${pr.number}](${pr.url}): ${pr.title} (${pr.status.replace(/_/g, ' ')})`);
+    }
+    lines.push('');
+  }
+
+  if (digest.shelvedPRs.length > 0) {
+    lines.push('### \u{1F4E6} Shelved');
+    for (const pr of digest.shelvedPRs) {
+      lines.push(`- [${pr.repo}#${pr.number}](${pr.url}): ${pr.title}`);
+    }
+    lines.push('');
+  }
+
+  if (issueResponses.length > 0) {
+    lines.push('### \u{1F4AC} Issue Replies');
+    for (const issue of issueResponses) {
+      lines.push(`- [${issue.repo}#${issue.number}](${issue.url}): ${issue.title}`);
+      const timeAgo = formatRelativeTime(issue.lastResponseAt);
+      lines.push(
+        `  └─ @${issue.lastResponseAuthor}: "${issue.lastResponseBody.slice(0, 80)}${issue.lastResponseBody.length > 80 ? '...' : ''}"${timeAgo ? ` (${timeAgo})` : ''}`,
+      );
+    }
+    lines.push('');
+  }
+
+  const capacityIcon = capacity.hasCapacity ? '✅' : '⚠️';
+  const capacityLabel = capacity.hasCapacity ? 'Ready for new work' : 'Focus on existing PRs';
+  const shelvedNote = capacity.shelvedPRCount > 0 ? ` + ${capacity.shelvedPRCount} shelved` : '';
+  lines.push(
+    `**Capacity:** ${capacityIcon} ${capacityLabel} (${capacity.activePRCount}/${capacity.maxActivePRs} PRs${shelvedNote})`,
+  );
+
+  return lines.join('\n');
+}
+
+/**
+ * Print digest to console as plain text. Unified renderer: uses the same
+ * section ordering as {@link formatSummary} but outputs plain text with
+ * console.log instead of markdown links.
+ */
+export function printDigest(
+  digest: DailyDigest,
+  capacity: CapacityAssessment,
+  commentedIssues: CommentedIssue[] = [],
+): void {
+  console.log('\n\u{1F4CA} OSS Daily Check\n');
+  console.log(`Active PRs: ${digest.summary.totalActivePRs}`);
+  console.log(`Needing Attention: ${digest.summary.totalNeedingAttention}`);
+  console.log(`Merged (all time): ${digest.summary.totalMergedAllTime}`);
+  console.log(`Merge Rate: ${digest.summary.mergeRate}%`);
+  console.log(`\nCapacity: ${capacity.hasCapacity ? '✅ Ready for new work' : '⚠️  Focus on existing work'}`);
+  console.log(`  ${capacity.reason}\n`);
+
+  if (digest.needsAddressingPRs.length > 0) {
+    console.log('❌ Needs Addressing:');
+    for (const pr of digest.needsAddressingPRs) {
+      console.log(`  - ${pr.repo}#${pr.number}: ${pr.title}`);
+      console.log(`    ${pr.displayLabel} ${pr.displayDescription}`);
+    }
+    console.log('');
+  }
+
+  if (digest.waitingOnMaintainerPRs.length > 0) {
+    console.log('⏳ Waiting on Maintainer:');
+    for (const pr of digest.waitingOnMaintainerPRs) {
+      console.log(`  - ${pr.repo}#${pr.number}: ${pr.title}`);
+      console.log(`    ${pr.displayDescription}`);
+    }
+    console.log('');
+  }
+
+  if (digest.recentlyMergedPRs.length > 0) {
+    console.log('\u{1F389} Recently Merged:');
+    for (const pr of digest.recentlyMergedPRs) {
+      const mergedDate = pr.mergedAt ? new Date(pr.mergedAt).toLocaleDateString() : '';
+      console.log(`  - ${pr.repo}#${pr.number}: ${pr.title}${mergedDate ? ` (merged ${mergedDate})` : ''}`);
+    }
+    console.log('');
+  }
+
+  if (digest.recentlyClosedPRs.length > 0) {
+    console.log('\u{1F6AB} Recently Closed:');
+    for (const pr of digest.recentlyClosedPRs) {
+      const closedDate = pr.closedAt ? new Date(pr.closedAt).toLocaleDateString() : '';
+      console.log(`  - ${pr.repo}#${pr.number}: ${pr.title}${closedDate ? ` (closed ${closedDate})` : ''}`);
+    }
+    console.log('');
+  }
+
+  if (digest.autoUnshelvedPRs.length > 0) {
+    console.log('\u{1F514} Auto-Unshelved:');
+    for (const pr of digest.autoUnshelvedPRs) {
+      console.log(`  - ${pr.repo}#${pr.number}: ${pr.title} (${pr.status.replace(/_/g, ' ')})`);
+    }
+    console.log('');
+  }
+
+  if (digest.shelvedPRs.length > 0) {
+    console.log('\u{1F4E6} Shelved:');
+    for (const pr of digest.shelvedPRs) {
+      console.log(`  - ${pr.repo}#${pr.number}: ${pr.title}`);
+    }
+    console.log('');
+  }
+
+  const issueResponses = commentedIssues.filter((i): i is CommentedIssueWithResponse => i.status === 'new_response');
+  if (issueResponses.length > 0) {
+    console.log('\u{1F4AC} Issue Replies:');
+    for (const issue of issueResponses) {
+      console.log(`  - ${issue.repo}#${issue.number}: ${issue.title}`);
+      console.log(
+        `    @${issue.lastResponseAuthor}: ${issue.lastResponseBody.slice(0, 80)}${issue.lastResponseBody.length > 80 ? '...' : ''}`,
+      );
+    }
+    console.log('');
+  }
+
+  console.log('Run with --json for structured output');
+  console.log('Run "dashboard serve" for browser view');
+}

--- a/packages/core/src/core/daily-logic.ts
+++ b/packages/core/src/core/daily-logic.ts
@@ -1,17 +1,20 @@
 /**
- * Domain logic extracted from src/commands/daily.ts.
+ * Domain aggregation logic extracted from src/commands/daily.ts.
  *
- * Pure or near-pure functions that operate on FetchedPR data:
+ * Pure or near-pure functions that operate on FetchedPR data and produce
+ * the data types that the renderers / JSON output consume:
  *   - computeRepoSignals / groupPRsByRepo — per-repo aggregations
  *   - assessCapacity — capacity assessment against active PRs
  *   - collectActionableIssues — ordered list of issues needing attention
  *   - computeActionMenu — pre-computed action menu for orchestration
  *   - toShelvedPRRef — lightweight projection for digest display
- *   - formatActionHint — human-readable maintainer action hint label
- *   - formatBriefSummary / formatSummary / printDigest — rendering
+ *
+ * Rendering functions (formatActionHint, formatBriefSummary, formatSummary,
+ * printDigest) live in src/commands/daily-render.ts (#1117). This file
+ * re-exports them at the bottom so existing imports keep working without
+ * a sweep.
  */
 
-import { formatRelativeTime } from './utils.js';
 import { warn } from './logger.js';
 import { errorMessage } from './errors.js';
 import { getStateManager } from './state.js';
@@ -20,22 +23,18 @@ import type {
   FetchedPRStatus,
   StalenessTier,
   ActionReason,
-  DailyDigest,
   AgentState,
   ShelvedPRRef,
-  MaintainerActionHint,
   ComputedRepoSignals,
   RepoGroup,
   CommentedIssue,
   CommentedIssueWithResponse,
-} from './types.js';
-import type {
   CapacityAssessment,
   ActionableIssue,
   ActionableIssueType,
   ActionMenu,
   ActionMenuItem,
-} from '../formatters/json.js';
+} from './types.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -329,26 +328,6 @@ export function collectActionableIssues(prs: FetchedPR[], lastDigestAt?: string)
 }
 
 /**
- * Format a maintainer action hint as a human-readable label.
- * @param hint - The maintainer action hint enum value
- * @returns Human-readable label (e.g., "tests requested")
- */
-export function formatActionHint(hint: MaintainerActionHint): string {
-  switch (hint) {
-    case 'demo_requested':
-      return 'demo/screenshot requested';
-    case 'tests_requested':
-      return 'tests requested';
-    case 'changes_requested':
-      return 'code changes requested';
-    case 'docs_requested':
-      return 'documentation requested';
-    case 'rebase_requested':
-      return 'rebase requested';
-  }
-}
-
-/**
  * Compute the action menu from PR data and capacity.
  * The orchestration layer can insert issue-list options (e.g., "Pick from list")
  * using the context flags.
@@ -430,221 +409,10 @@ export function computeActionMenu(
 }
 
 // ---------------------------------------------------------------------------
-// Rendering / formatting
+// Rendering re-exports (back-compat)
 // ---------------------------------------------------------------------------
-
-/**
- * Format a brief one-liner summary for the action-first flow.
- *
- * @param digest - The daily digest containing PR summary stats
- * @param issueCount - Number of actionable issues needing attention
- * @param issueResponseCount - Number of issue replies from maintainers
- * @returns One-line status string (e.g., "3 Active PRs | 1 needs attention | 2 issue replies")
- */
-export function formatBriefSummary(digest: DailyDigest, issueCount: number, issueResponseCount: number = 0): string {
-  const attentionText = issueCount > 0 ? `${issueCount} need${issueCount === 1 ? 's' : ''} attention` : 'all on track';
-  const issueReplyText =
-    issueResponseCount > 0 ? ` | ${issueResponseCount} issue repl${issueResponseCount === 1 ? 'y' : 'ies'}` : '';
-  return `\u{1F4CA} ${digest.summary.totalActivePRs} Active PRs | ${attentionText}${issueReplyText}`;
-}
-
-/**
- * Format the full dashboard summary as markdown.
- * Used in JSON output for Claude to display verbatim — includes all PR sections,
- * issue replies, and capacity status.
- *
- * @param digest - The daily digest with all PR categories
- * @param capacity - Current capacity assessment for display
- * @param issueResponses - Issue replies from maintainers to display
- * @returns Multi-line markdown string suitable for terminal or chat display
- */
-export function formatSummary(
-  digest: DailyDigest,
-  capacity: CapacityAssessment,
-  issueResponses: CommentedIssueWithResponse[] = [],
-): string {
-  const lines: string[] = [];
-
-  // Header
-  lines.push('## OSS Dashboard');
-  lines.push('');
-  lines.push(
-    `\u{1F4CA} **${digest.summary.totalActivePRs} Active PRs** | ${digest.summary.totalMergedAllTime} Merged | ${digest.summary.mergeRate}% Merge Rate`,
-  );
-  lines.push('\u2713 Dashboard generated \u2014 say "open dashboard" to view in browser');
-  lines.push('');
-
-  // Needs Addressing
-  if (digest.needsAddressingPRs.length > 0) {
-    lines.push('### \u274C Needs Addressing');
-    for (const pr of digest.needsAddressingPRs) {
-      lines.push(`- [${pr.repo}#${pr.number}](${pr.url}): ${pr.title}`);
-      lines.push(`  \u2514\u2500 ${pr.displayLabel} ${pr.displayDescription}`);
-    }
-    lines.push('');
-  }
-
-  // Waiting on Maintainer
-  if (digest.waitingOnMaintainerPRs.length > 0) {
-    lines.push('### \u23F3 Waiting on Maintainer');
-    for (const pr of digest.waitingOnMaintainerPRs) {
-      lines.push(`- [${pr.repo}#${pr.number}](${pr.url}): ${pr.title}`);
-      lines.push(`  \u2514\u2500 ${pr.displayDescription}`);
-    }
-    lines.push('');
-  }
-
-  // Recently Merged (wins!)
-  if (digest.recentlyMergedPRs.length > 0) {
-    lines.push('### \u{1F389} Recently Merged');
-    for (const pr of digest.recentlyMergedPRs) {
-      const mergedDate = pr.mergedAt ? new Date(pr.mergedAt).toLocaleDateString() : '';
-      lines.push(`- [${pr.repo}#${pr.number}](${pr.url}): ${pr.title}${mergedDate ? ` (merged ${mergedDate})` : ''}`);
-    }
-    lines.push('');
-  }
-
-  // Recently Closed (closed without merge)
-  if (digest.recentlyClosedPRs.length > 0) {
-    lines.push('### \u{1F6AB} Recently Closed');
-    for (const pr of digest.recentlyClosedPRs) {
-      const closedDate = pr.closedAt ? new Date(pr.closedAt).toLocaleDateString() : '';
-      lines.push(`- [${pr.repo}#${pr.number}](${pr.url}): ${pr.title}${closedDate ? ` (closed ${closedDate})` : ''}`);
-    }
-    lines.push('');
-  }
-
-  // Auto-unshelved (important: maintainer engagement on shelved PRs)
-  if (digest.autoUnshelvedPRs.length > 0) {
-    lines.push('### \u{1F514} Auto-Unshelved');
-    lines.push('> These PRs were shelved but a maintainer engaged \u2014 moved back to active.');
-    for (const pr of digest.autoUnshelvedPRs) {
-      lines.push(`- [${pr.repo}#${pr.number}](${pr.url}): ${pr.title} (${pr.status.replace(/_/g, ' ')})`);
-    }
-    lines.push('');
-  }
-
-  // Shelved PRs (dimmed, excluded from capacity)
-  if (digest.shelvedPRs.length > 0) {
-    lines.push('### \u{1F4E6} Shelved');
-    for (const pr of digest.shelvedPRs) {
-      lines.push(`- [${pr.repo}#${pr.number}](${pr.url}): ${pr.title}`);
-    }
-    lines.push('');
-  }
-
-  // Issue Replies
-  if (issueResponses.length > 0) {
-    lines.push('### \u{1F4AC} Issue Replies');
-    for (const issue of issueResponses) {
-      lines.push(`- [${issue.repo}#${issue.number}](${issue.url}): ${issue.title}`);
-      const timeAgo = formatRelativeTime(issue.lastResponseAt);
-      lines.push(
-        `  \u2514\u2500 @${issue.lastResponseAuthor}: "${issue.lastResponseBody.slice(0, 80)}${issue.lastResponseBody.length > 80 ? '...' : ''}"${timeAgo ? ` (${timeAgo})` : ''}`,
-      );
-    }
-    lines.push('');
-  }
-
-  // Capacity
-  const capacityIcon = capacity.hasCapacity ? '\u2705' : '\u26A0\uFE0F';
-  const capacityLabel = capacity.hasCapacity ? 'Ready for new work' : 'Focus on existing PRs';
-  const shelvedNote = capacity.shelvedPRCount > 0 ? ` + ${capacity.shelvedPRCount} shelved` : '';
-  lines.push(
-    `**Capacity:** ${capacityIcon} ${capacityLabel} (${capacity.activePRCount}/${capacity.maxActivePRs} PRs${shelvedNote})`,
-  );
-
-  return lines.join('\n');
-}
-
-/**
- * Print digest to console as plain text.
- * Unified renderer: uses the same section ordering as {@link formatSummary}
- * but outputs plain text with console.log instead of markdown links.
- *
- * @param digest - The daily digest with all PR categories
- * @param capacity - Current capacity assessment for display
- * @param commentedIssues - All commented issues (filtered to responses internally)
- */
-export function printDigest(
-  digest: DailyDigest,
-  capacity: CapacityAssessment,
-  commentedIssues: CommentedIssue[] = [],
-): void {
-  console.log('\n\u{1F4CA} OSS Daily Check\n');
-  console.log(`Active PRs: ${digest.summary.totalActivePRs}`);
-  console.log(`Needing Attention: ${digest.summary.totalNeedingAttention}`);
-  console.log(`Merged (all time): ${digest.summary.totalMergedAllTime}`);
-  console.log(`Merge Rate: ${digest.summary.mergeRate}%`);
-  console.log(
-    `\nCapacity: ${capacity.hasCapacity ? '\u2705 Ready for new work' : '\u26A0\uFE0F  Focus on existing work'}`,
-  );
-  console.log(`  ${capacity.reason}\n`);
-
-  if (digest.needsAddressingPRs.length > 0) {
-    console.log('\u274C Needs Addressing:');
-    for (const pr of digest.needsAddressingPRs) {
-      console.log(`  - ${pr.repo}#${pr.number}: ${pr.title}`);
-      console.log(`    ${pr.displayLabel} ${pr.displayDescription}`);
-    }
-    console.log('');
-  }
-
-  if (digest.waitingOnMaintainerPRs.length > 0) {
-    console.log('\u23F3 Waiting on Maintainer:');
-    for (const pr of digest.waitingOnMaintainerPRs) {
-      console.log(`  - ${pr.repo}#${pr.number}: ${pr.title}`);
-      console.log(`    ${pr.displayDescription}`);
-    }
-    console.log('');
-  }
-
-  if (digest.recentlyMergedPRs.length > 0) {
-    console.log('\u{1F389} Recently Merged:');
-    for (const pr of digest.recentlyMergedPRs) {
-      const mergedDate = pr.mergedAt ? new Date(pr.mergedAt).toLocaleDateString() : '';
-      console.log(`  - ${pr.repo}#${pr.number}: ${pr.title}${mergedDate ? ` (merged ${mergedDate})` : ''}`);
-    }
-    console.log('');
-  }
-
-  if (digest.recentlyClosedPRs.length > 0) {
-    console.log('\u{1F6AB} Recently Closed:');
-    for (const pr of digest.recentlyClosedPRs) {
-      const closedDate = pr.closedAt ? new Date(pr.closedAt).toLocaleDateString() : '';
-      console.log(`  - ${pr.repo}#${pr.number}: ${pr.title}${closedDate ? ` (closed ${closedDate})` : ''}`);
-    }
-    console.log('');
-  }
-
-  if (digest.autoUnshelvedPRs.length > 0) {
-    console.log('\u{1F514} Auto-Unshelved:');
-    for (const pr of digest.autoUnshelvedPRs) {
-      console.log(`  - ${pr.repo}#${pr.number}: ${pr.title} (${pr.status.replace(/_/g, ' ')})`);
-    }
-    console.log('');
-  }
-
-  if (digest.shelvedPRs.length > 0) {
-    console.log('\u{1F4E6} Shelved:');
-    for (const pr of digest.shelvedPRs) {
-      console.log(`  - ${pr.repo}#${pr.number}: ${pr.title}`);
-    }
-    console.log('');
-  }
-
-  const issueResponses = commentedIssues.filter((i): i is CommentedIssueWithResponse => i.status === 'new_response');
-  if (issueResponses.length > 0) {
-    console.log('\u{1F4AC} Issue Replies:');
-    for (const issue of issueResponses) {
-      console.log(`  - ${issue.repo}#${issue.number}: ${issue.title}`);
-      console.log(
-        `    @${issue.lastResponseAuthor}: ${issue.lastResponseBody.slice(0, 80)}${issue.lastResponseBody.length > 80 ? '...' : ''}`,
-      );
-    }
-    console.log('');
-  }
-
-  console.log('Run with --json for structured output');
-  console.log('Run "dashboard serve" for browser view');
-}
+//
+// The actual implementations live in src/commands/daily-render.ts. Existing
+// callers that import these from `core/daily-logic` continue to work; new
+// callers should import from `commands/daily-render` directly.
+export { formatActionHint, formatBriefSummary, formatSummary, printDigest } from '../commands/daily-render.js';

--- a/packages/core/src/core/test-utils.ts
+++ b/packages/core/src/core/test-utils.ts
@@ -16,9 +16,9 @@ import type {
   IssueVettingResult,
   ProjectHealth,
   RepoScore,
+  CapacityAssessment,
 } from './types.js';
 import { DEFAULT_CONFIG, INITIAL_STATE } from './types.js';
-import type { CapacityAssessment } from '../formatters/json.js';
 import type { StateManager, Stats } from './state.js';
 // ---------------------------------------------------------------------------
 // FetchedPR

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -373,3 +373,76 @@ export interface IssueCandidate {
   viabilityScore: number; // 0-100 scale
   searchPriority: SearchPriority; // Priority level for sorting
 }
+
+// ── Daily aggregation types (formerly in formatters/json.ts; relocated #1117) ──
+// These describe domain data that core/daily-aggregations.ts produces. They
+// previously sat in formatters/json.ts, which forced core/ to import from
+// formatters/ — a cross-layer dependency we've now removed.
+
+export interface CapacityAssessment {
+  hasCapacity: boolean;
+  activePRCount: number;
+  maxActivePRs: number;
+  shelvedPRCount: number;
+  criticalIssueCount: number;
+  reason: string;
+}
+
+export type ActionableIssueType =
+  | 'ci_failing'
+  | 'merge_conflict'
+  | 'needs_response'
+  | 'needs_changes'
+  | 'incomplete_checklist';
+
+export interface ActionableIssue {
+  type: ActionableIssueType;
+  pr: FetchedPR;
+  label: string; // e.g., "[CI Failing]"
+  /** True if the PR was created after the last daily digest (first time seen). */
+  isNewContribution: boolean;
+}
+
+/**
+ * Compact version of ActionableIssue for JSON output.
+ * References the PR by URL instead of embedding the full object,
+ * since the full PR is already available in digest.openPRs.
+ */
+export interface CompactActionableIssue {
+  type: ActionableIssueType;
+  prUrl: string;
+  label: string;
+  /** True if the PR was created after the last daily digest (first time seen). */
+  isNewContribution: boolean;
+}
+
+/**
+ * A single action menu item pre-computed by the CLI.
+ * The orchestration layer can use these directly in AskUserQuestion prompts.
+ */
+export interface ActionMenuItem {
+  /** Stable identifier for routing (e.g., "address_all", "search", "done"). */
+  key: string;
+  /** Display text for the option (e.g., "Work through all 3 issues (Recommended)"). */
+  label: string;
+  /** Explanation shown below the label. */
+  description: string;
+  /** Present when the action would exceed the user's PR capacity limit (#765). */
+  capacityWarning?: string;
+}
+
+/**
+ * Pre-computed action menu for the orchestration layer.
+ */
+export interface ActionMenu {
+  /** Ordered list of menu items. */
+  items: ActionMenuItem[];
+  /** Context flags for the orchestration layer to decide on issue-list options. */
+  context: {
+    hasActionableIssues: boolean;
+    actionableCount: number;
+    hasCapacity: boolean;
+    hasIssueResponses: boolean;
+    issueResponseCount: number;
+  };
+}

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -6,8 +6,29 @@
 import type { FetchedPR, DailyDigest, AgentState, RepoGroup, CommentedIssue, ShelvedPRRef } from '../core/types.js';
 import type { ContributionStats } from '../core/stats.js';
 import type { PRCheckFailure } from '../core/pr-monitor.js';
-import type { SearchPriority } from '../core/types.js';
+import type {
+  SearchPriority,
+  CapacityAssessment,
+  ActionableIssue,
+  ActionableIssueType,
+  CompactActionableIssue,
+  ActionMenuItem,
+  ActionMenu,
+} from '../core/types.js';
 import type { CIFormatterDiagnosis, FormatterDetectionResult } from '../core/formatter-detection.js';
+
+// Re-export the daily aggregation types from their canonical home in core/types.
+// External consumers and downstream tests have historically imported them from
+// here; the re-exports keep that surface stable while removing the cross-layer
+// dependency in core/ (#1117).
+export type {
+  CapacityAssessment,
+  ActionableIssue,
+  ActionableIssueType,
+  CompactActionableIssue,
+  ActionMenuItem,
+  ActionMenu,
+};
 
 export type ErrorCode =
   | 'AUTH_REQUIRED'
@@ -28,76 +49,11 @@ export interface JsonOutput<T = unknown> {
   timestamp: string;
 }
 
-export interface CapacityAssessment {
-  hasCapacity: boolean;
-  activePRCount: number;
-  maxActivePRs: number;
-  shelvedPRCount: number;
-  criticalIssueCount: number;
-  reason: string;
-}
-
-export type ActionableIssueType =
-  | 'ci_failing'
-  | 'merge_conflict'
-  | 'needs_response'
-  | 'needs_changes'
-  | 'incomplete_checklist';
-
-export interface ActionableIssue {
-  type: ActionableIssueType;
-  pr: FetchedPR;
-  label: string; // e.g., "[CI Failing]"
-  /** True if the PR was created after the last daily digest (first time seen). */
-  isNewContribution: boolean;
-}
-
-/**
- * Compact version of ActionableIssue for JSON output.
- * References the PR by URL instead of embedding the full object,
- * since the full PR is already available in digest.openPRs.
- * Uses URL (globally unique) instead of number to avoid cross-repo collisions.
- */
-export interface CompactActionableIssue {
-  type: ActionableIssueType;
-  prUrl: string;
-  label: string;
-  /** True if the PR was created after the last daily digest (first time seen). */
-  isNewContribution: boolean;
-}
-
-/**
- * A single action menu item pre-computed by the CLI.
- * The orchestration layer can use these directly in AskUserQuestion prompts.
- */
-export interface ActionMenuItem {
-  /** Stable identifier for routing (e.g., "address_all", "search", "done"). */
-  key: string;
-  /** Display text for the option (e.g., "Work through all 3 issues (Recommended)"). */
-  label: string;
-  /** Explanation shown below the label. */
-  description: string;
-  /** Present when the action would exceed the user's PR capacity limit (#765). */
-  capacityWarning?: string;
-}
-
-/**
- * Pre-computed action menu for the orchestration layer.
- * Contains the menu items the CLI can determine from PR data and capacity,
- * plus context flags so the orchestration can insert issue-list options.
- */
-export interface ActionMenu {
-  /** Ordered list of menu items. The orchestration may insert issue-list items after the CLI-generated items (address_all, issue_replies) or at the start when none exist. */
-  items: ActionMenuItem[];
-  /** Context flags for the orchestration layer to decide on issue-list options. */
-  context: {
-    hasActionableIssues: boolean;
-    actionableCount: number;
-    hasCapacity: boolean;
-    hasIssueResponses: boolean;
-    issueResponseCount: number;
-  };
-}
+// CapacityAssessment, ActionableIssue, ActionableIssueType,
+// CompactActionableIssue, ActionMenuItem, and ActionMenu are now defined in
+// `../core/types.ts` and re-exported above. Their definitions used to live
+// here, but core/ already produces these values in daily-aggregations.ts —
+// keeping the canonical type next to its producer (#1117).
 
 /**
  * Deduplicated daily digest for JSON output (#287).


### PR DESCRIPTION
Closes #1117.

## Summary
Two coupled changes:

1. **Relocate cross-layer types.** Moved `CapacityAssessment`, `ActionableIssue`, `ActionableIssueType`, `CompactActionableIssue`, `ActionMenuItem`, `ActionMenu` from `formatters/json.ts` to `core/types.ts`. `formatters/json.ts` re-exports them so external importers don't break.

2. **Split rendering out of `daily-logic.ts`.**
   - `core/daily-logic.ts` is now pure aggregations.
   - `commands/daily-render.ts` (new) holds `formatActionHint`, `formatBriefSummary`, `formatSummary`, `printDigest`.
   - `daily-logic.ts` re-exports the rendering symbols at the bottom so existing test imports keep working.

## Why
Before: `core/daily-logic.ts` and `core/test-utils.ts` imported types from `formatters/json.ts` — `core/` reaching into `formatters/` is a backwards layer dependency. Rendering and aggregations were intertwined in the same file, so any aggregations test pulled the renderers into the import graph.

After: `core/` no longer imports from `formatters/` (verified by grep). Aggregations are independently testable without `console.log` mocking. Renderers live next to their commands-layer consumers.

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm test` — 2077 core + 256 dashboard + 181 mcp pass without modification
- [x] `pnpm run bundle`
- [x] `grep -rn "from.*formatters/" packages/core/src/core/` returns empty