### PR TITLE
chore(dashboard): self-host Google Fonts (#1119)

### DIFF
--- a/packages/dashboard/LICENSE-FONTS
+++ b/packages/dashboard/LICENSE-FONTS
@@ -1,0 +1,56 @@
+Self-hosted fonts shipped with the OSS Autopilot dashboard
+==========================================================
+
+The dashboard self-hosts the following fonts (see #1119). Each is distributed
+under the SIL Open Font License v1.1 (OFL-1.1), which permits redistribution
+and bundling with applications. Fonts are sourced via the @fontsource npm
+packages, which mirror the Google Fonts releases.
+
+Plus Jakarta Sans
+-----------------
+
+  Designer: Tokotype Foundry
+  Source:   https://github.com/tokotype/PlusJakartaSans
+  License:  SIL Open Font License v1.1
+            https://github.com/tokotype/PlusJakartaSans/blob/master/OFL.txt
+
+  Copyright 2020 The Plus Jakarta Sans Project Authors
+
+JetBrains Mono
+--------------
+
+  Designer: JetBrains
+  Source:   https://github.com/JetBrains/JetBrainsMono
+  License:  SIL Open Font License v1.1
+            https://github.com/JetBrains/JetBrainsMono/blob/master/OFL.txt
+
+  Copyright 2020 The JetBrains Mono Project Authors
+
+SIL Open Font License v1.1 (excerpt)
+------------------------------------
+
+The fonts are licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1. Neither the Font Software nor any of its individual components,
+   in Original or Modified Versions, may be sold by itself.
+
+2. Original or Modified Versions of the Font Software may be bundled,
+   redistributed and/or sold with any software, provided that each copy
+   contains the above copyright notice and this license. These can be
+   included either as stand-alone text files, human-readable headers or
+   in the appropriate machine-readable metadata fields within text or
+   binary files as long as those fields can be easily viewed by the user.
+
+3. No Modified Version of the Font Software may use the Reserved Font
+   Name(s) unless explicit written permission is granted by the
+   corresponding Copyright Holder. This restriction only applies to the
+   primary font name as presented to the users.
+
+(Full text: see the upstream OFL.txt files referenced above.)

--- a/packages/dashboard/index.html
+++ b/packages/dashboard/index.html
@@ -16,12 +16,7 @@
         }
       })();
     </script>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap"
-      rel="stylesheet"
-    />
+    <!-- Fonts are self-hosted (#1119) — see src/fonts.css. No third-party fetches. -->
   </head>
   <body>
     <noscript>

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -31,6 +31,8 @@
     "preact-iso": "^2.11.1"
   },
   "devDependencies": {
+    "@fontsource/jetbrains-mono": "^5.2.8",
+    "@fontsource/plus-jakarta-sans": "^5.2.8",
     "@preact/preset-vite": "^2.10.4",
     "@testing-library/preact": "^3.2.4",
     "@types/canvas-confetti": "^1.9.0",

--- a/packages/dashboard/src/fonts.css
+++ b/packages/dashboard/src/fonts.css
@@ -1,0 +1,21 @@
+/*
+ * Self-hosted fonts (#1119).
+ *
+ * Sources @fontsource (npm) — pre-bundled woff2 files for Plus Jakarta Sans
+ * and JetBrains Mono. Vite copies the woff2 files into dist/assets/ at build
+ * time and rewrites the URLs.
+ *
+ * Latin subset only — the dashboard ships in English; we don't need cyrillic /
+ * vietnamese / latin-ext for the current UI. Cuts bundle weight by ~75%.
+ *
+ * Both fonts are licensed under the SIL Open Font License v1.1; see
+ * LICENSE-FONTS in this directory for the full text and attribution.
+ */
+
+@import '@fontsource/plus-jakarta-sans/latin-400.css';
+@import '@fontsource/plus-jakarta-sans/latin-500.css';
+@import '@fontsource/plus-jakarta-sans/latin-600.css';
+@import '@fontsource/plus-jakarta-sans/latin-700.css';
+@import '@fontsource/plus-jakarta-sans/latin-800.css';
+@import '@fontsource/jetbrains-mono/latin-400.css';
+@import '@fontsource/jetbrains-mono/latin-500.css';

--- a/packages/dashboard/src/index.tsx
+++ b/packages/dashboard/src/index.tsx
@@ -1,6 +1,7 @@
 import { render } from 'preact';
 import { App } from './app';
 import { ErrorBoundary } from './error-boundary';
+import './fonts.css';
 import './styles.css';
 
 const root = document.getElementById('app');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,12 @@ importers:
         specifier: ^2.11.1
         version: 2.11.1(preact-render-to-string@6.6.6(preact@10.29.1))(preact@10.29.1)
     devDependencies:
+      '@fontsource/jetbrains-mono':
+        specifier: ^5.2.8
+        version: 5.2.8
+      '@fontsource/plus-jakarta-sans':
+        specifier: ^5.2.8
+        version: 5.2.8
       '@preact/preset-vite':
         specifier: ^2.10.4
         version: 2.10.4(@babel/core@7.29.0)(preact@10.29.1)(rollup@4.59.0)(vite@8.0.7(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3))
@@ -521,6 +527,12 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
+
+  '@fontsource/jetbrains-mono@5.2.8':
+    resolution: {integrity: sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==}
+
+  '@fontsource/plus-jakarta-sans@5.2.8':
+    resolution: {integrity: sha512-P5qE49fqdeD+7DXH1KBxmMPlB17LTz1zvBhFH0tFzfnYTKVJVyb0pR6plh0ZGXxcB+Oayb54FZZw3V42/DawTw==}
 
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
@@ -2760,6 +2772,10 @@ snapshots:
       levn: 0.4.1
 
   '@exodus/bytes@1.15.0': {}
+
+  '@fontsource/jetbrains-mono@5.2.8': {}
+
+  '@fontsource/plus-jakarta-sans@5.2.8': {}
 
   '@gerrit0/mini-shiki@3.23.0':
     dependencies:


### PR DESCRIPTION
Closes #1119.

## Summary
- Replace the three `fonts.googleapis.com` / `fonts.gstatic.com` `<link>` tags in `packages/dashboard/index.html` with self-hosted fonts via the `@fontsource` npm packages.
- Latin subset only (the dashboard is English-only), weights 400/500/600/700/800 for Plus Jakarta Sans and 400/500 for JetBrains Mono.
- Vite bundles the woff2/woff files into `dist/assets/` at build time. Zero third-party requests on load.
- Adds `packages/dashboard/LICENSE-FONTS` with OFL-1.1 attribution.

## Why
The dashboard ingests GitHub tokens and tracks contributions. Loading fonts from a third-party domain every render leaks usage data, breaks on offline / restricted networks, and adds a third-party RTT to first paint.

## Bundle impact
- woff2: 103.4 KB total (5 weights × ~12 KB Plus Jakarta + 2 weights × ~21 KB JetBrains Mono)
- woff fallback: 135.5 KB (kept for legacy browser parity with the fontsource defaults; modern browsers prefer woff2)
- One-time cost per session — much better than the prior third-party RTT + fonts.gstatic.com cache miss.

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm test` (256 dashboard + 2077 core + 181 mcp pass)
- [x] `pnpm run build` (vite emits the woff2/woff assets correctly; index.html no longer references fonts.googleapis.com)
- [x] `grep -rn "googleapis\|gstatic" packages/dashboard/` returns empty