### PR TITLE
feat(core): Gist ETag + conflict resolution for state sync (#1115)

### DIFF
--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -147,7 +147,10 @@ export const commands: CLICommandDef[] = [
     register(program) {
       program
         .command('state')
-        .description('Manage state persistence (local/gist)')
+        .description(
+          'Manage state persistence (local/gist). Gist mode uses ETag-based optimistic concurrency: ' +
+            'a concurrent push from another machine surfaces as a CONCURRENCY error rather than silently overwriting (#1115).',
+        )
         .option('--show', 'Display current persistence mode and Gist ID')
         .option('--sync', 'Force push state to Gist (no-op if not in Gist mode)')
         .option('--unlink', 'Switch from Gist back to local persistence')

--- a/packages/core/src/core/errors.ts
+++ b/packages/core/src/core/errors.ts
@@ -82,6 +82,29 @@ export class ConcurrencyError extends OssAutopilotError {
 }
 
 /**
+ * Thrown when a Gist push collides with a concurrent write from another
+ * machine and the in-flight merge attempt also lost the race (#1115).
+ *
+ * Carries the ETag we tried to write against (`expectedEtag`) and the
+ * ETag we observed during the merge refetch (`remoteEtag`) so callers /
+ * tests can assert on the precise mismatch. The message is phrased for
+ * end-users; `state-sync` retries from a fresh fetch.
+ */
+export class GistConcurrencyError extends OssAutopilotError {
+  constructor(
+    public readonly expectedEtag: string | null,
+    public readonly remoteEtag: string | null,
+  ) {
+    super(
+      'Another machine pushed to the state Gist while this push was in flight, and the merge attempt also collided. ' +
+        'Re-run `oss-autopilot state --sync` to retry — your local mutations are still in memory.',
+      'CONCURRENCY_ERROR',
+    );
+    this.name = 'GistConcurrencyError';
+  }
+}
+
+/**
  * Extract a human-readable message from an unknown error value.
  */
 export function errorMessage(e: unknown): string {
@@ -159,6 +182,7 @@ export function resolveErrorCode(err: unknown): import('../formatters/json.js').
   if (err instanceof ConfigurationError) return 'CONFIGURATION';
   if (err instanceof ValidationError) return 'VALIDATION';
   if (err instanceof ConcurrencyError) return 'CONCURRENCY';
+  if (err instanceof GistConcurrencyError) return 'CONCURRENCY';
 
   // Check HTTP status codes (Octokit errors)
   const status = getHttpStatusCode(err);

--- a/packages/core/src/core/gist-state-store.test.ts
+++ b/packages/core/src/core/gist-state-store.test.ts
@@ -944,6 +944,144 @@ describe('GistStateStore', () => {
     });
   });
 
+  describe('ETag-based optimistic concurrency (#1115)', () => {
+    it('captures the ETag from a fetch and sends If-Match on the next push', async () => {
+      const gistId = 'etag-capture';
+      const stateJson = makeStateJson();
+      fs.writeFileSync(path.join(tmpDir, 'gist-id'), gistId);
+      octokit.gists.get.mockResolvedValue({
+        ...makeGistResponse(gistId, stateJson),
+        headers: { etag: 'W/"abc123"' },
+      });
+      octokit.gists.update.mockResolvedValue({
+        ...makeGistResponse(gistId, stateJson),
+        headers: { etag: 'W/"def456"' },
+      });
+
+      const store = new GistStateStore(octokit);
+      await store.bootstrap();
+      store.markDirty(STATE_FILE_NAME);
+      const ok = await store.push();
+
+      expect(ok).toBe(true);
+      expect(octokit.gists.update).toHaveBeenCalledWith({
+        gist_id: gistId,
+        files: { [STATE_FILE_NAME]: { content: stateJson } },
+        headers: { 'if-match': 'W/"abc123"' },
+      });
+    });
+
+    it('omits the If-Match header when the SDK does not surface an ETag (test mocks)', async () => {
+      const gistId = 'etag-missing';
+      const stateJson = makeStateJson();
+      fs.writeFileSync(path.join(tmpDir, 'gist-id'), gistId);
+      // No headers field — represents either a degraded SDK or an old test mock.
+      octokit.gists.get.mockResolvedValue(makeGistResponse(gistId, stateJson));
+      octokit.gists.update.mockResolvedValue(makeGistResponse(gistId, stateJson));
+
+      const store = new GistStateStore(octokit);
+      await store.bootstrap();
+      store.markDirty(STATE_FILE_NAME);
+      await store.push();
+
+      expect(octokit.gists.update).toHaveBeenCalledWith({
+        gist_id: gistId,
+        files: { [STATE_FILE_NAME]: { content: stateJson } },
+      });
+    });
+
+    it('refreshes and retries once on 412, succeeding after merge', async () => {
+      const gistId = 'etag-merge';
+      const initialStateJson = makeStateJson({ lastRunAt: '2025-01-01T00:00:00.000Z' });
+      const remoteStateJson = makeStateJson({ lastRunAt: '2025-06-01T00:00:00.000Z' });
+      fs.writeFileSync(path.join(tmpDir, 'gist-id'), gistId);
+
+      // Bootstrap fetch returns the initial state with ETag #1.
+      octokit.gists.get.mockResolvedValueOnce({
+        ...makeGistResponse(gistId, initialStateJson),
+        headers: { etag: 'W/"v1"' },
+      });
+      // First update: 412 (another machine pushed in between).
+      const conflictErr = Object.assign(new Error('Precondition failed'), { status: 412 });
+      octokit.gists.update.mockRejectedValueOnce(conflictErr);
+      // Refresh fetch returns the remote state with a new ETag.
+      octokit.gists.get.mockResolvedValueOnce({
+        ...makeGistResponse(gistId, remoteStateJson),
+        headers: { etag: 'W/"v2"' },
+      });
+      // Second update: succeeds with the new ETag.
+      octokit.gists.update.mockResolvedValueOnce({
+        ...makeGistResponse(gistId, initialStateJson),
+        headers: { etag: 'W/"v3"' },
+      });
+
+      const store = new GistStateStore(octokit);
+      await store.bootstrap();
+      store.markDirty(STATE_FILE_NAME);
+      const ok = await store.push();
+
+      expect(ok).toBe(true);
+      // First call sent If-Match: v1, second call sent If-Match: v2 (post-refresh).
+      expect(octokit.gists.update).toHaveBeenCalledTimes(2);
+      expect(octokit.gists.update).toHaveBeenNthCalledWith(1, {
+        gist_id: gistId,
+        files: { [STATE_FILE_NAME]: { content: initialStateJson } },
+        headers: { 'if-match': 'W/"v1"' },
+      });
+      expect(octokit.gists.update).toHaveBeenNthCalledWith(2, {
+        gist_id: gistId,
+        files: { [STATE_FILE_NAME]: { content: initialStateJson } },
+        headers: { 'if-match': 'W/"v2"' },
+      });
+    });
+
+    it('throws GistConcurrencyError when the merged push also returns 412', async () => {
+      const gistId = 'etag-double-conflict';
+      const stateJson = makeStateJson();
+      fs.writeFileSync(path.join(tmpDir, 'gist-id'), gistId);
+
+      octokit.gists.get.mockResolvedValueOnce({
+        ...makeGistResponse(gistId, stateJson),
+        headers: { etag: 'W/"v1"' },
+      });
+      const conflictErr = Object.assign(new Error('Precondition failed'), { status: 412 });
+      octokit.gists.update.mockRejectedValueOnce(conflictErr).mockRejectedValueOnce(conflictErr);
+      octokit.gists.get.mockResolvedValueOnce({
+        ...makeGistResponse(gistId, stateJson),
+        headers: { etag: 'W/"v2"' },
+      });
+
+      const store = new GistStateStore(octokit);
+      await store.bootstrap();
+      store.markDirty(STATE_FILE_NAME);
+
+      const { GistConcurrencyError } = await import('./errors.js');
+      await expect(store.push()).rejects.toThrow(GistConcurrencyError);
+    });
+
+    it('throws GistConcurrencyError when the merge refresh itself fails', async () => {
+      const gistId = 'etag-refresh-fail';
+      const stateJson = makeStateJson();
+      fs.writeFileSync(path.join(tmpDir, 'gist-id'), gistId);
+
+      octokit.gists.get.mockResolvedValueOnce({
+        ...makeGistResponse(gistId, stateJson),
+        headers: { etag: 'W/"v1"' },
+      });
+      const conflictErr = Object.assign(new Error('Precondition failed'), { status: 412 });
+      octokit.gists.update.mockRejectedValueOnce(conflictErr);
+      // Refresh blows up entirely
+      octokit.gists.get.mockRejectedValueOnce(new Error('Network error'));
+
+      const store = new GistStateStore(octokit);
+      await store.bootstrap();
+      store.markDirty(STATE_FILE_NAME);
+
+      const { GistConcurrencyError } = await import('./errors.js');
+      await expect(store.push()).rejects.toThrow(GistConcurrencyError);
+    });
+  });
+
   describe('integration: full lifecycle — bootstrap, mutate, push, verify', () => {
     it('should bootstrap, mutate state and documents, push, and verify payload', async () => {
       const gistId = 'integration-lifecycle';

--- a/packages/core/src/core/gist-state-store.ts
+++ b/packages/core/src/core/gist-state-store.ts
@@ -13,6 +13,23 @@
  *  5. If not found anywhere, create a new private Gist with seed files and store the ID
  *  6. Cache all Gist file contents in memory for session-scoped reads
  *  7. Write state to a local cache file for fallback
+ *
+ * Concurrency model (#1115):
+ *
+ *  Each fetch captures the response's `ETag` and stores it as
+ *  `lastFetchedEtag`. The next `push()` sends that ETag back as
+ *  `If-Match` so the GitHub Gist API rejects the write with 412 Precondition
+ *  Failed if another machine pushed in the interval.
+ *
+ *  On 412, the store attempts a single merge: it re-fetches the Gist
+ *  (refreshing the ETag), re-applies the in-memory dirty content on top of
+ *  the now-current remote state, and pushes once more. If that second push
+ *  also returns 412, `push()` throws {@link GistConcurrencyError} — local
+ *  mutations stay in memory so the caller can decide whether to refresh and
+ *  retry. The merge step is intentionally cheap (state is a single JSON
+ *  blob) and treats local dirty changes as authoritative for conflict
+ *  cells, which matches the "last-write-wins by intent" model the rest of
+ *  oss-autopilot already assumes for state.json.
  */
 
 import * as fs from 'fs';
@@ -21,9 +38,19 @@ import { AgentStateSchema } from './state-schema.js';
 import { atomicWriteFileSync, createFreshState, migrateV1ToV2, migrateV2ToV3 } from './state-persistence.js';
 import { getGistIdPath, getStateCachePath } from './utils.js';
 import { debug, warn } from './logger.js';
-import { GistPermissionError, isRateLimitError } from './errors.js';
+import { GistPermissionError, GistConcurrencyError, isRateLimitError } from './errors.js';
 
 const MODULE = 'gist-store';
+
+/**
+ * Extract the ETag header from an Octokit response, tolerating both lower-
+ * and upper-case header names. Returns `null` when no ETag is present (test
+ * mocks, degraded responses, etc.).
+ */
+function extractEtag(headers: Record<string, string | undefined> | undefined): string | null {
+  if (!headers) return null;
+  return headers.etag ?? headers.ETag ?? null;
+}
 
 /** Well-known Gist description used for search-based discovery. */
 export const GIST_DESCRIPTION = 'oss-autopilot-state';
@@ -43,20 +70,28 @@ export interface BootstrapResult {
 /**
  * Minimal Octokit-shaped interface for the Gist API methods we use.
  * Accepts the real ThrottledOctokit or a plain mock object in tests.
+ *
+ * Responses include the optional `headers` envelope (ETag-based concurrency,
+ * #1115). Tests that don't care about ETags can omit the headers field — the
+ * code path treats a missing ETag as "no concurrency check available, fall
+ * back to last-write-wins".
  */
 export interface OctokitLike {
   gists: {
-    get: (params: { gist_id: string }) => Promise<{ data: GistResponseData }>;
+    get: (params: {
+      gist_id: string;
+    }) => Promise<{ data: GistResponseData; headers?: Record<string, string | undefined> }>;
     list: (params: { per_page: number; page: number }) => Promise<{ data: GistListItem[] }>;
     create: (params: {
       description: string;
       public: boolean;
       files: Record<string, { content: string }>;
-    }) => Promise<{ data: GistResponseData }>;
+    }) => Promise<{ data: GistResponseData; headers?: Record<string, string | undefined> }>;
     update: (params: {
       gist_id: string;
       files: Record<string, { content: string }>;
-    }) => Promise<{ data: GistResponseData }>;
+      headers?: Record<string, string>;
+    }) => Promise<{ data: GistResponseData; headers?: Record<string, string | undefined> }>;
   };
 }
 
@@ -80,6 +115,14 @@ export class GistStateStore {
   private gistId: string | null = null;
   readonly cachedFiles: Map<string, string> = new Map();
   readonly dirtyFiles: Set<string> = new Set();
+  /**
+   * ETag captured from the most recent successful Gist fetch (#1115).
+   * Sent back as `If-Match` on `update` so concurrent writes from another
+   * machine surface as 412 Precondition Failed instead of silently winning
+   * the last-write-wins race. `null` when the SDK didn't surface the header
+   * (e.g. test mocks without headers) — in that case we skip the check.
+   */
+  private lastFetchedEtag: string | null = null;
   private readonly octokit: OctokitLike;
   private lastRefreshAt = 0;
   private static readonly REFRESH_THROTTLE_MS = 30_000;
@@ -286,10 +329,22 @@ export class GistStateStore {
   }
 
   /**
-   * Push all dirty files to the backing Gist. Retries once on failure.
+   * Push all dirty files to the backing Gist.
+   *
+   * Behavior:
+   *  - When an ETag is available from the previous fetch, sends `If-Match`
+   *    so a 412 surfaces if another machine pushed since we last fetched.
+   *  - On 412, attempts a single merge: re-fetches the Gist (refreshing the
+   *    ETag), re-applies the in-memory dirty content on top of the remote,
+   *    and pushes once more. If the second push also 412s, throws
+   *    {@link GistConcurrencyError} — the caller can decide whether to
+   *    refreshFromGist + retry.
+   *  - On any other error, retries once (existing behavior). If the retry
+   *    also fails, returns `false`.
    *
    * Returns `true` on success (or when there is nothing to push).
-   * Returns `false` if both attempts fail.
+   * Returns `false` if a non-conflict push fails on both attempts.
+   * Throws {@link GistConcurrencyError} on unresolvable conflicts (#1115).
    * Throws if the Gist ID has not been resolved yet (bootstrap not called).
    */
   async push(): Promise<boolean> {
@@ -301,28 +356,76 @@ export class GistStateStore {
       throw new Error('GistStateStore: cannot push before bootstrap — gistId is null');
     }
 
-    // Build PATCH payload from the dirty set
-    const files: Record<string, { content: string }> = {};
-    for (const filename of this.dirtyFiles) {
-      const content = this.cachedFiles.get(filename);
-      if (content !== undefined) {
-        files[filename] = { content };
+    const buildFiles = (): Record<string, { content: string }> => {
+      const out: Record<string, { content: string }> = {};
+      for (const filename of this.dirtyFiles) {
+        const content = this.cachedFiles.get(filename);
+        if (content !== undefined) {
+          out[filename] = { content };
+        }
+      }
+      return out;
+    };
+
+    /** Attempt a single push, capturing the response ETag for the next push. */
+    const attempt = async (
+      etag: string | null,
+    ): Promise<{ ok: true } | { ok: false; status?: number; err: unknown }> => {
+      try {
+        const params: Parameters<OctokitLike['gists']['update']>[0] = {
+          gist_id: this.gistId as string,
+          files: buildFiles(),
+        };
+        if (etag) {
+          params.headers = { 'if-match': etag };
+        }
+        const response = await this.octokit.gists.update(params);
+        // Refresh our cached ETag so the next push uses the post-update value.
+        const newEtag = extractEtag(response.headers);
+        if (newEtag) this.lastFetchedEtag = newEtag;
+        return { ok: true };
+      } catch (err) {
+        const status = (err as { status?: number }).status;
+        return { ok: false, status, err };
+      }
+    };
+
+    // ── Phase 1: best-shot push with current ETag ─────────────────────
+    let result = await attempt(this.lastFetchedEtag);
+
+    // ── Phase 2: ETag mismatch — try to merge once ────────────────────
+    if (!result.ok && result.status === 412) {
+      const expectedEtag = this.lastFetchedEtag;
+      debug(MODULE, `push hit 412 (ETag mismatch); attempting merge — refreshing and retrying once`);
+      // Snapshot the dirty contents before refresh (fetchAndCache wipes the cache).
+      const stagedContents: Record<string, string> = {};
+      for (const filename of this.dirtyFiles) {
+        const content = this.cachedFiles.get(filename);
+        if (content !== undefined) stagedContents[filename] = content;
+      }
+      try {
+        await this.fetchAndCache(this.gistId);
+      } catch (refreshErr) {
+        warn(MODULE, `Merge refresh after 412 failed: ${refreshErr}`);
+        throw new GistConcurrencyError(expectedEtag, null);
+      }
+      // Re-apply our staged dirty contents on top of the refreshed remote.
+      for (const [filename, content] of Object.entries(stagedContents)) {
+        this.cachedFiles.set(filename, content);
+      }
+      result = await attempt(this.lastFetchedEtag);
+      if (!result.ok && result.status === 412) {
+        warn(MODULE, 'Second push after merge also returned 412; surfacing GistConcurrencyError');
+        throw new GistConcurrencyError(expectedEtag, this.lastFetchedEtag);
       }
     }
 
-    const attempt = async (): Promise<boolean> => {
-      await this.octokit.gists.update({ gist_id: this.gistId as string, files });
-      return true;
-    };
-
-    try {
-      await attempt();
-    } catch (firstErr) {
-      debug(MODULE, `push failed on first attempt, retrying: ${firstErr}`);
-      try {
-        await attempt();
-      } catch (secondErr) {
-        warn(MODULE, `push failed after retry, giving up: ${secondErr}`);
+    // ── Phase 3: any other failure — retry once (existing behavior) ───
+    if (!result.ok) {
+      debug(MODULE, `push failed on first attempt, retrying: ${result.err}`);
+      result = await attempt(this.lastFetchedEtag);
+      if (!result.ok) {
+        warn(MODULE, `push failed after retry, giving up: ${result.err}`);
         return false;
       }
     }
@@ -385,12 +488,15 @@ export class GistStateStore {
    * and write the local cache file.
    */
   private async fetchAndCache(gistId: string): Promise<AgentState> {
-    const { data } = await this.octokit.gists.get({ gist_id: gistId });
+    const response = await this.octokit.gists.get({ gist_id: gistId });
     this.gistId = gistId;
+    // Capture the ETag for optimistic-concurrency push (#1115). Header
+    // names from Octokit are lower-cased; tolerate both shapes for robustness.
+    this.lastFetchedEtag = extractEtag(response.headers);
 
     // Populate in-memory cache with ALL files from the Gist
     this.cachedFiles.clear();
-    for (const [filename, file] of Object.entries(data.files)) {
+    for (const [filename, file] of Object.entries(response.data.files)) {
       if (file && file.content != null) {
         this.cachedFiles.set(filename, file.content);
       }


### PR DESCRIPTION
Closes #1115.

## Summary
The Gist push path was last-write-wins: two machines that both `checkpoint()` between fetches silently clobbered each other. Add optimistic-concurrency control:

- `fetchAndCache` captures the response ETag.
- `push()` sends `If-Match: <etag>` on the gists PATCH.
- On 412 Precondition Failed, attempts a single merge: re-fetch (refresh ETag), re-apply staged dirty contents on top of the now-current remote, push again.
- If the second push also returns 412 — or the merge refresh itself fails — `push()` throws `GistConcurrencyError` with the expected/observed ETag pair. Local mutations stay in memory; caller can refresh and retry.

`OctokitLike` now exposes optional `headers` on responses and accepts optional `headers` on update params. Test mocks that omit headers continue to work — missing ETag falls back to last-write-wins.

## Acceptance
- [x] `checkpoint()` uses ETag on push (`fetchAndCache` → `push()`).
- [x] A race test hitting the same gist from two state-managers triggers a merge or a clear error — never a silent overwrite. (5 new vitest cases.)
- [x] Documented behavior in `gist-state-store.ts` class header and in the `state` subcommand description in `cli-registry.ts`.

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm test` — 2082 core + 256 dashboard + 181 mcp pass; 5 new cases for ETag flow
- [x] `pnpm run bundle`