### PR TITLE
refactor(core): Zod-validated --json boundary helper + status migration (#1105)

### DIFF
--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -11,7 +11,8 @@
 
 import type { Command } from 'commander';
 import { errorMessage, resolveErrorCode } from './core/errors.js';
-import { outputJson, outputJsonError } from './formatters/json.js';
+import { outputJson, outputJsonError, outputJsonValidated } from './formatters/json.js';
+import type { ZodType } from 'zod';
 
 interface CLICommandDef {
   /** Command name (used to build the local-only set for the preAction hook). */
@@ -46,11 +47,20 @@ async function executeAction<T>(
   options: { json?: boolean },
   run: () => Promise<T>,
   display: (data: T) => void | Promise<void>,
+  /** Optional Zod schema. When provided, the JSON output is validated against
+   * it (#1105). On mismatch, executeAction throws and the standard error
+   * envelope fires — surfacing a contract drift instead of silently shipping
+   * a broken shape. */
+  schema?: ZodType<T>,
 ): Promise<void> {
   try {
     const data = await run();
     if (options.json) {
-      outputJson(data);
+      if (schema) {
+        outputJsonValidated(schema, data);
+      } else {
+        outputJson(data);
+      }
     } else {
       await display(data);
     }
@@ -115,8 +125,9 @@ export const commands: CLICommandDef[] = [
           '--offline',
           'Show cache-freshness metadata (lastUpdated). Status always reads local state — no GitHub API calls are made either way.',
         )
-        .action((options) =>
-          executeAction(
+        .action(async (options) => {
+          const { StatusOutputSchema } = await import('./formatters/json.js');
+          await executeAction(
             options,
             async () => {
               const { runStatus } = await import('./commands/status.js');
@@ -136,8 +147,9 @@ export const commands: CLICommandDef[] = [
               }
               console.log('\nRun with --json for structured output');
             },
-          ),
-        );
+            StatusOutputSchema,
+          );
+        });
     },
   },
 

--- a/packages/core/src/formatters/json.test.ts
+++ b/packages/core/src/formatters/json.test.ts
@@ -4,11 +4,15 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { z } from 'zod';
 import {
   jsonSuccess,
   jsonError,
   outputJson,
   outputJsonError,
+  formatJson,
+  outputJsonValidated,
+  StatusOutputSchema,
   toCompactDailyOutput,
   toCompactStartupOutput,
   type DailyOutput,
@@ -311,5 +315,92 @@ describe('toCompactStartupOutput (#763)', () => {
 
     expect(compact.authError).toBe('No token');
     expect(compact.daily).toBeUndefined();
+  });
+});
+
+describe('formatJson (#1105)', () => {
+  const SmallSchema = z.object({
+    name: z.string(),
+    count: z.number().int().nonnegative(),
+  });
+
+  it('wraps schema-conformant data in the standard envelope', () => {
+    const out = formatJson(SmallSchema, { name: 'foo', count: 3 });
+    expect(out.success).toBe(true);
+    expect(out.data).toEqual({ name: 'foo', count: 3 });
+    expect(out.timestamp).toMatch(ISO_8601_REGEX);
+  });
+
+  it('throws a contract-drift error with field paths on mismatch', () => {
+    expect(() => formatJson(SmallSchema, { name: 'foo', count: -1 })).toThrow(/contract drift.*count/i);
+    expect(() => formatJson(SmallSchema, { name: 'foo' })).toThrow(/contract drift.*count/i);
+    expect(() => formatJson(SmallSchema, { name: 42, count: 0 })).toThrow(/contract drift.*name/i);
+  });
+
+  it('rejects extra fields by default? (Zod default is to strip unless strict)', () => {
+    // The default Zod object schema strips unknown keys rather than rejecting,
+    // so this passes through validation. Surface that explicitly so a future
+    // contributor doesn't expect strict behavior accidentally.
+    const out = formatJson(SmallSchema, { name: 'foo', count: 3, extra: 'ignored' });
+    expect(out.data).toEqual({ name: 'foo', count: 3 });
+  });
+
+  it('validates real StatusOutputSchema-conformant data round-trip', () => {
+    const data = {
+      stats: {
+        mergedPRs: 5,
+        closedPRs: 1,
+        activeIssues: 2,
+        trustedProjects: 4,
+        mergeRate: '83%',
+        needsResponse: 1,
+      },
+      lastRunAt: '2026-04-25T00:00:00.000Z',
+    };
+    const out = formatJson(StatusOutputSchema, data);
+    expect(out.success).toBe(true);
+    expect(out.data).toMatchObject(data);
+  });
+
+  it('rejects StatusOutputSchema input where stats.mergeRate is the wrong type', () => {
+    const data = {
+      stats: {
+        mergedPRs: 5,
+        closedPRs: 1,
+        activeIssues: 2,
+        trustedProjects: 4,
+        mergeRate: 0.83, // should be string per the schema
+        needsResponse: 1,
+      },
+      lastRunAt: '2026-04-25T00:00:00.000Z',
+    };
+    expect(() => formatJson(StatusOutputSchema, data)).toThrow(/contract drift.*stats\.mergeRate/i);
+  });
+});
+
+describe('outputJsonValidated (#1105)', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('prints the validated envelope to stdout', () => {
+    const Schema = z.object({ ok: z.literal(true) });
+    outputJsonValidated(Schema, { ok: true });
+    const printed = consoleSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(printed);
+    expect(parsed.success).toBe(true);
+    expect(parsed.data).toEqual({ ok: true });
+  });
+
+  it('throws on contract drift before printing', () => {
+    const Schema = z.object({ ok: z.literal(true) });
+    expect(() => outputJsonValidated(Schema, { ok: false })).toThrow(/contract drift/i);
+    expect(consoleSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -3,6 +3,7 @@
  * Provides structured output that can be consumed by scripts and plugins
  */
 
+import { z, type ZodType } from 'zod';
 import type { FetchedPR, DailyDigest, AgentState, RepoGroup, CommentedIssue, ShelvedPRRef } from '../core/types.js';
 import type { ContributionStats } from '../core/stats.js';
 import type { PRCheckFailure } from '../core/pr-monitor.js';
@@ -224,19 +225,21 @@ export function compactRepoGroups(groups: RepoGroup[]): CompactRepoGroup[] {
   }));
 }
 
-export interface StatusOutput {
-  stats: {
-    mergedPRs: number;
-    closedPRs: number;
-    activeIssues: number;
-    trustedProjects: number;
-    mergeRate: string;
-    needsResponse: number;
-  };
-  lastRunAt: string;
-  offline?: boolean;
-  lastUpdated?: string;
-}
+export const StatusOutputSchema = z.object({
+  stats: z.object({
+    mergedPRs: z.number().int().nonnegative(),
+    closedPRs: z.number().int().nonnegative(),
+    activeIssues: z.number().int().nonnegative(),
+    trustedProjects: z.number().int().nonnegative(),
+    mergeRate: z.string(),
+    needsResponse: z.number().int().nonnegative(),
+  }),
+  lastRunAt: z.string(),
+  offline: z.boolean().optional(),
+  lastUpdated: z.string().optional(),
+});
+
+export type StatusOutput = z.infer<typeof StatusOutputSchema>;
 
 export interface SearchOutput {
   candidates: Array<{
@@ -536,4 +539,40 @@ export function outputJson<T>(data: T): void {
  */
 export function outputJsonError(message: string, errorCode?: ErrorCode): void {
   console.log(JSON.stringify(jsonError(message, errorCode), null, 2));
+}
+
+/**
+ * Validate `data` against a Zod schema and wrap the result in the standard
+ * JSON output envelope (#1105 long-term ask from #965).
+ *
+ * Throws a contract-drift `Error` if `data` doesn't match the schema. The
+ * error's message lists the failing field paths so a developer can find the
+ * drift quickly. Use this at the `--json` boundary of every CLI command —
+ * whenever the producer adds, renames, or drops a field that doesn't match
+ * the schema, the test harness fails immediately rather than silently
+ * shipping a contract break to consumers (plugin layer, MCP server,
+ * downstream scripts).
+ *
+ * @example
+ *   import { formatJson, StatusOutputSchema } from '../formatters/json.js';
+ *   const envelope = formatJson(StatusOutputSchema, await runStatus());
+ *   console.log(JSON.stringify(envelope, null, 2));
+ */
+export function formatJson<T>(schema: ZodType<T>, data: unknown): JsonOutput<T> {
+  const result = schema.safeParse(data);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((i) => `${i.path.length > 0 ? i.path.join('.') : '<root>'}: ${i.message}`)
+      .join('; ');
+    throw new Error(`--json contract drift: command output does not match its declared schema. ${issues}`);
+  }
+  return jsonSuccess(result.data);
+}
+
+/**
+ * `outputJson(data)` plus Zod validation. Same throwing semantics as
+ * {@link formatJson}; the validated envelope is what gets printed.
+ */
+export function outputJsonValidated<T>(schema: ZodType<T>, data: unknown): void {
+  console.log(JSON.stringify(formatJson(schema, data), null, 2));
 }


### PR DESCRIPTION
Closes #1105.

Lands the foundation for runtime --json contract enforcement plus the first command migration. Follow-ups (#1146, #1147, #1148) cover the remaining commands one schema at a time.

## Summary
- `formatJson(schema, data)` helper in `formatters/json.ts` that validates with Zod and throws a contract-drift error listing failing field paths on mismatch, otherwise returns the standard `jsonSuccess` envelope.
- `outputJsonValidated(schema, data)` wraps `formatJson` with `console.log`.
- `StatusOutputSchema` exported from `formatters/json.ts`.
- `cli-registry.ts` `executeAction` gains an optional `schema` parameter — passing it routes through `outputJsonValidated`.
- The `status` command is migrated as the first proof of pattern. Other commands keep the existing `outputJson` path until their schemas are in (#1146 daily, #1147 search, #1148 rest).

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm test` — 31 formatter + 88 core test files pass; 8 new cases for the Zod path
- [x] `pnpm run bundle`