### PR TITLE
chore(cli): hide deprecated read/untrack from --help (#1132)

### DIFF
--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -460,7 +460,7 @@ export const commands: CLICommandDef[] = [
     localOnly: true,
     register(program) {
       program
-        .command('untrack <pr-url>')
+        .command('untrack <pr-url>', { hidden: true })
         .description('[DEPRECATED, removed in v4] No-op in v2. Use `shelve` to hide a PR from the daily digest.')
         .option('--json', 'Output as JSON')
         .action((prUrl, options) =>
@@ -485,7 +485,7 @@ export const commands: CLICommandDef[] = [
     localOnly: true,
     register(program) {
       program
-        .command('read [pr-url]')
+        .command('read [pr-url]', { hidden: true })
         .description('[DEPRECATED, removed in v4] No-op in v2. PR read state is not tracked locally.')
         .option('--all', 'Mark all PRs as read')
         .option('--json', 'Output as JSON')


### PR DESCRIPTION
Closes #1132. Step 2 of the deprecation rollout from #1112.

## Summary
- Pass `{ hidden: true }` to `commander`'s `.command()` for `read` and `untrack` so they're absent from `oss-autopilot --help`.
- Both commands still execute when invoked explicitly — `hidden` only affects help output. Scripts that hard-code them keep working, and the stderr deprecation notice still fires.

## Why
Step 1 (#1112) added the [DEPRECATED, REMOVED IN v4] prefixes to the descriptions. Step 2 stops surfacing them in `--help` so new users don't discover them through the standard help listing.

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm test` (2082 + 256 + 181 pass)
- [x] `pnpm run bundle`
- [x] `node packages/core/dist/cli.bundle.cjs --help | grep -E "untrack|read|shelve"` confirms read/untrack are gone, shelve remains
- [x] `node packages/core/dist/cli.bundle.cjs untrack <url> --json` still produces the v2 no-op envelope