### PR TITLE
refactor(core): Zod-validated --json output for daily command (#1146)

### DIFF
--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -95,10 +95,12 @@ export const commands: CLICommandDef[] = [
               const { runDaily } = await import('./commands/daily.js');
               const data = await runDaily();
               if (options.compact) {
-                const { toCompactDailyOutput } = await import('./formatters/json.js');
-                outputJson(toCompactDailyOutput(data));
+                const { toCompactDailyOutput, outputJsonValidated, CompactDailyOutputSchema } =
+                  await import('./formatters/json.js');
+                outputJsonValidated(CompactDailyOutputSchema, toCompactDailyOutput(data));
               } else {
-                outputJson(data);
+                const { outputJsonValidated, DailyOutputSchema } = await import('./formatters/json.js');
+                outputJsonValidated(DailyOutputSchema, data);
               }
             } else {
               const { runDailyForDisplay, printDigest } = await import('./commands/daily.js');

--- a/packages/core/src/formatters/json.test.ts
+++ b/packages/core/src/formatters/json.test.ts
@@ -13,6 +13,8 @@ import {
   formatJson,
   outputJsonValidated,
   StatusOutputSchema,
+  DailyOutputSchema,
+  CompactDailyOutputSchema,
   toCompactDailyOutput,
   toCompactStartupOutput,
   type DailyOutput,
@@ -402,5 +404,60 @@ describe('outputJsonValidated (#1105)', () => {
     const Schema = z.object({ ok: z.literal(true) });
     expect(() => outputJsonValidated(Schema, { ok: false })).toThrow(/contract drift/i);
     expect(consoleSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('DailyOutputSchema (#1146)', () => {
+  it('round-trips a fully populated DailyOutput from the fixture', () => {
+    const fixture = makeMockDailyOutput();
+    const out = formatJson(DailyOutputSchema, fixture);
+    expect(out.success).toBe(true);
+  });
+
+  it('rejects drift: missing top-level field', () => {
+    const fixture = makeMockDailyOutput();
+    const broken = { ...fixture, summary: undefined } as unknown;
+    expect(() => formatJson(DailyOutputSchema, broken)).toThrow(/contract drift.*summary/i);
+  });
+
+  it('rejects drift: needsAddressingPRs not a string array', () => {
+    const fixture = makeMockDailyOutput();
+    const broken = {
+      ...fixture,
+      digest: { ...fixture.digest, needsAddressingPRs: [{ url: 'x' }] },
+    };
+    expect(() => formatJson(DailyOutputSchema, broken)).toThrow(/contract drift.*needsAddressingPRs/i);
+  });
+
+  it('rejects drift: actionMenu missing context flag', () => {
+    const fixture = makeMockDailyOutput();
+    const broken = {
+      ...fixture,
+      actionMenu: {
+        items: fixture.actionMenu.items,
+        context: {
+          hasActionableIssues: true,
+          actionableCount: 1,
+          hasCapacity: true,
+          // hasIssueResponses removed
+          issueResponseCount: 0,
+        },
+      },
+    } as unknown;
+    expect(() => formatJson(DailyOutputSchema, broken)).toThrow(/contract drift.*hasIssueResponses/i);
+  });
+});
+
+describe('CompactDailyOutputSchema (#1146)', () => {
+  it('round-trips toCompactDailyOutput(fixture)', () => {
+    const compact = toCompactDailyOutput(makeMockDailyOutput());
+    const out = formatJson(CompactDailyOutputSchema, compact);
+    expect(out.success).toBe(true);
+  });
+
+  it('rejects drift: failureCount as a string', () => {
+    const compact = toCompactDailyOutput(makeMockDailyOutput());
+    const broken = { ...compact, failureCount: '0' } as unknown;
+    expect(() => formatJson(CompactDailyOutputSchema, broken)).toThrow(/contract drift.*failureCount/i);
   });
 });

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -241,6 +241,147 @@ export const StatusOutputSchema = z.object({
 
 export type StatusOutput = z.infer<typeof StatusOutputSchema>;
 
+// ── Daily output schemas (#1146) ─────────────────────────────────────
+//
+// FetchedPR / CommentedIssue / PRCheckFailure are large heterogeneous shapes
+// whose state-schema counterparts already use `z.any()` / pass-through
+// validation. We mirror that here — strict on the wrapper (so drift in
+// top-level keys / category arrays surfaces immediately) and tolerant on the
+// opaque payload entries.
+
+const FetchedPRPassthroughSchema = z.record(z.string(), z.unknown());
+const CommentedIssuePassthroughSchema = z.record(z.string(), z.unknown());
+const PRCheckFailurePassthroughSchema = z.record(z.string(), z.unknown());
+
+const ShelvedPRRefStrictSchema = z.object({
+  number: z.number(),
+  url: z.string(),
+  title: z.string(),
+  repo: z.string(),
+  daysSinceActivity: z.number(),
+  status: z.string(),
+});
+
+const RecentClosedPRSchema = z.object({
+  number: z.number(),
+  url: z.string(),
+  title: z.string(),
+  closedAt: z.string(),
+});
+
+const RecentMergedPRSchema = z.object({
+  number: z.number(),
+  url: z.string(),
+  title: z.string(),
+  mergedAt: z.string(),
+});
+
+const DailyDigestSummarySchemaStrict = z.object({
+  totalActivePRs: z.number(),
+  totalNeedingAttention: z.number(),
+  totalMergedAllTime: z.number(),
+  mergeRate: z.number(),
+});
+
+const DailyDigestCompactSchema = z.object({
+  generatedAt: z.string(),
+  openPRs: z.array(FetchedPRPassthroughSchema),
+  needsAddressingPRs: z.array(z.string()),
+  waitingOnMaintainerPRs: z.array(z.string()),
+  recentlyClosedPRs: z.array(RecentClosedPRSchema),
+  recentlyMergedPRs: z.array(RecentMergedPRSchema),
+  shelvedPRs: z.array(ShelvedPRRefStrictSchema),
+  autoUnshelvedPRs: z.array(ShelvedPRRefStrictSchema),
+  summary: DailyDigestSummarySchemaStrict,
+});
+
+const CapacityAssessmentSchema = z.object({
+  hasCapacity: z.boolean(),
+  activePRCount: z.number().int().nonnegative(),
+  maxActivePRs: z.number().int().nonnegative(),
+  shelvedPRCount: z.number().int().nonnegative(),
+  criticalIssueCount: z.number().int().nonnegative(),
+  reason: z.string(),
+});
+
+const ActionableIssueTypeSchema = z.enum([
+  'ci_failing',
+  'merge_conflict',
+  'needs_response',
+  'needs_changes',
+  'incomplete_checklist',
+]);
+
+const CompactActionableIssueSchema = z.object({
+  type: ActionableIssueTypeSchema,
+  prUrl: z.string(),
+  label: z.string(),
+  isNewContribution: z.boolean(),
+});
+
+const ActionMenuItemSchema = z.object({
+  key: z.string(),
+  label: z.string(),
+  description: z.string(),
+  capacityWarning: z.string().optional(),
+});
+
+const ActionMenuSchema = z.object({
+  items: z.array(ActionMenuItemSchema),
+  context: z.object({
+    hasActionableIssues: z.boolean(),
+    actionableCount: z.number().int().nonnegative(),
+    hasCapacity: z.boolean(),
+    hasIssueResponses: z.boolean(),
+    issueResponseCount: z.number().int().nonnegative(),
+  }),
+});
+
+const CompactRepoGroupSchema = z.object({
+  repo: z.string(),
+  prUrls: z.array(z.string()),
+});
+
+const DailyWarningPhaseSchema = z.enum([
+  'fetch',
+  'repo-scores',
+  'analytics',
+  'scout-sync',
+  'partition',
+  'dismiss-filter',
+  'gist-checkpoint',
+]);
+
+const DailyWarningSchema = z.object({
+  phase: DailyWarningPhaseSchema,
+  operation: z.string(),
+  message: z.string(),
+});
+
+export const DailyOutputSchema = z.object({
+  digest: DailyDigestCompactSchema,
+  capacity: CapacityAssessmentSchema,
+  summary: z.string(),
+  briefSummary: z.string(),
+  actionableIssues: z.array(CompactActionableIssueSchema),
+  actionMenu: ActionMenuSchema,
+  commentedIssues: z.array(CommentedIssuePassthroughSchema),
+  repoGroups: z.array(CompactRepoGroupSchema),
+  failures: z.array(PRCheckFailurePassthroughSchema),
+  warnings: z.array(DailyWarningSchema),
+});
+
+export const CompactDailyOutputSchema = z.object({
+  digest: DailyDigestCompactSchema,
+  capacity: CapacityAssessmentSchema,
+  briefSummary: z.string(),
+  actionableIssues: z.array(CompactActionableIssueSchema),
+  actionMenu: ActionMenuSchema,
+  commentedIssues: z.array(CommentedIssuePassthroughSchema),
+  failureCount: z.number().int().nonnegative(),
+  warnings: z.array(DailyWarningSchema),
+});
+
 export interface SearchOutput {
   candidates: Array<{
     issue: {


### PR DESCRIPTION
Closes #1146.

## Summary
- `DailyOutputSchema` and `CompactDailyOutputSchema` exported from `formatters/json.ts`. Strict on the wrapper (drift in top-level keys, category arrays, or context flags fails immediately); FetchedPR / CommentedIssue / PRCheckFailure entries pass through as opaque records — same loose validation `DailyDigestSchema` already uses for FetchedPR.
- `cli-registry.ts` daily action uses `outputJsonValidated` for both `--json` and `--json --compact`.
- 5 new test cases: round-trip the existing `makeMockDailyOutput` fixture, plus four drift cases (missing `summary`, wrong type on `needsAddressingPRs`, missing `actionMenu.context.hasIssueResponses`, wrong type on `failureCount`).

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm test` (37 formatter + full suite pass)
- [x] `pnpm run bundle`

Follow-ups #1147 (search) and #1148 (rest of CLI) remain open.