### PR TITLE
feat: /pr-ready slash command + wait-for-ci.sh helper

### DIFF
--- a/commands/pr-ready.md
+++ b/commands/pr-ready.md
@@ -1,0 +1,91 @@
+---
+name: pr-ready
+description: Run the project's pre-commit review loop to determine whether the current branch is ready to push — lint, tests, parallel pr-review-toolkit agents, fix-and-re-run until convergence
+allowed-tools: Bash, Read, Glob, Grep, Agent, TaskCreate, TaskUpdate, Edit, Write
+---
+
+# /pr-ready
+
+This command drives the **mandatory pre-commit review loop** that the project's CLAUDE.md describes. It does not push or open a PR — it tells you whether the branch is ready to.
+
+## What it does
+
+For the diff currently uncommitted-and-staged or already on the local branch (whichever applies):
+
+1. **Verify branch hygiene** — confirm we're not on `main`, the working tree has work to evaluate, and main has been pulled recently. If the working tree is clean and the branch matches main, abort with "nothing to review".
+
+2. **Run the project's lint+format checks**:
+   - `pnpm run lint`
+   - `pnpm run format:check` (if the project's `package.json` defines it)
+   - Surface any failures inline; do not auto-fix unless the user explicitly asks.
+
+3. **Run the full test suite**: `pnpm test`. Block readiness on any failure.
+
+4. **Dispatch the pr-review-toolkit agents in parallel** against the diff:
+   - `pr-review-toolkit:code-reviewer` — bugs, dead code, consistency
+   - `pr-review-toolkit:silent-failure-hunter` — error handling gaps
+   - `pr-review-toolkit:code-simplifier` — refactoring opportunities
+
+   For larger PRs (>15 files or new test surface), additionally run:
+   - `pr-review-toolkit:pr-test-analyzer` — coverage gaps
+   - `pr-review-toolkit:comment-analyzer` — outdated/over-explanatory comments
+   - `pr-review-toolkit:type-design-analyzer` — when new types are introduced
+
+5. **Triage findings**:
+   - **Critical** and **Recommended** findings: report inline; the loop is not converged until they're resolved.
+   - **Minor** findings: report but do not block.
+   - **Out-of-scope** findings (e.g., a pre-existing issue in adjacent code): list them as "deferred" and recommend filing follow-up issues.
+
+6. **Iterate**: after the user fixes findings (or asks the command to fix straightforward ones), **re-run only the agents that had findings** plus `code-reviewer` as a baseline. Do NOT re-run all five every loop — that's wasteful and slow.
+
+7. **Convergence**: stop when zero Critical/Recommended findings remain. Hard cap at 5 iterations; if the loop hasn't converged, stop and report.
+
+8. **Final gate**: re-run `pnpm run lint` and `pnpm test` after the last fix. A clean diff that converged on review but breaks lint/tests is not ready.
+
+9. **Report**:
+   - **READY**: branch passes lint, tests, and review-toolkit. Print the suggested commit message stub and the next-step command (e.g., `git push -u origin <branch>`).
+   - **NOT READY**: list the remaining blockers in priority order.
+
+## When to use
+
+- After implementing a feature or fix and before staging the commit.
+- After fixing review feedback locally, before pushing the response commits.
+- Before opening a PR, as the last sanity check the project's CLAUDE.md mandates.
+
+Roughly equivalent to running the project's "Pre-Commit Code Review" workflow (`workflows/pre-commit-review.md`) by hand, but with the loop, convergence check, and final lint/test gate automated.
+
+## When NOT to use
+
+- For an external repo where you don't have the project's `pnpm` scripts wired up — fall back to the `pr-review-toolkit:review-pr` skill instead.
+- For a documentation-only change where the review-toolkit's code-focused agents don't add signal. (Lint/format check is still useful.)
+
+## Output format
+
+Always end with one of these two stanzas:
+
+```
+## ✅ Ready to push
+
+Suggested commit message:
+  <conventional-commit-format-line>
+
+  <body explaining why>
+
+Next step: git push -u origin <branch> && gh pr create --base main --head <branch> ...
+```
+
+```
+## ❌ Not ready
+
+Blockers (in priority order):
+  1. <one-line blocker>
+  2. <one-line blocker>
+
+Pass count: <N> review iterations · convergence: <converged|stuck>
+```
+
+## Notes
+
+- **Don't auto-commit or auto-push.** The user controls whether the work lands. This command answers "is the work ready?", not "ship it".
+- **Cite findings by file:line.** Cheap pointer back to the change makes follow-up trivial.
+- **Track iteration via TaskCreate**: one task per review-loop pass (subject `pr-ready pass N`, status `in_progress` while running, `completed` when the pass finishes). Mid-loop interrupt-and-resume stays clean.

--- a/scripts/wait-for-ci.sh
+++ b/scripts/wait-for-ci.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# wait-for-ci.sh — poll `gh pr checks` until every required check has a
+# terminal status (pass / fail / skipping). Exits 0 if all checks passed,
+# 1 if any failed, 2 on usage error.
+#
+# Usage:
+#   scripts/wait-for-ci.sh <pr-number> [--repo OWNER/REPO] [--interval N] [--timeout SEC]
+#
+# Defaults:
+#   --repo costajohnt/oss-autopilot
+#   --interval 25 seconds between polls
+#   --timeout 600 seconds (10 minutes)
+#
+# Why this exists: `gh pr checks --watch` is unreliable in some terminals
+# (exits mid-stream, miscounts queued runs, swallows status). The
+# until-loop here is what the issue-batch skill documents — extracted so
+# any contributor can invoke it without rewriting the loop.
+
+set -uo pipefail
+
+PR=""
+REPO="costajohnt/oss-autopilot"
+INTERVAL=25
+TIMEOUT=600
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/wait-for-ci.sh <pr-number> [--repo OWNER/REPO] [--interval N] [--timeout SEC]
+
+Polls until every check on the PR has a terminal status. Prints the final
+table and exits 0 if all required checks passed, 1 if any failed.
+EOF
+  exit 2
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo) REPO="$2"; shift 2 ;;
+    --interval) INTERVAL="$2"; shift 2 ;;
+    --timeout) TIMEOUT="$2"; shift 2 ;;
+    -h|--help) usage ;;
+    *)
+      if [ -z "$PR" ]; then
+        PR="$1"
+        shift
+      else
+        echo "Unexpected arg: $1" >&2
+        usage
+      fi
+      ;;
+  esac
+done
+
+if [ -z "$PR" ]; then
+  echo "Missing PR number." >&2
+  usage
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI not found on PATH." >&2
+  exit 2
+fi
+
+start_ts=$(date +%s)
+
+while true; do
+  out=$(gh pr checks "$PR" --repo "$REPO" 2>&1)
+  rc=$?
+  if [ "$rc" -ne 0 ] && ! echo "$out" | grep -qE 'pass|fail|skip|pending|queued'; then
+    echo "gh pr checks failed: $out" >&2
+    exit 2
+  fi
+
+  # Each check is one line of `gh pr checks` output. A line is "settled"
+  # when its status column is one of pass / fail / skipping. "pending" and
+  # "queued" mean still in flight.
+  total=$(echo "$out" | grep -cE 'pass|fail|skipping|pending|queued')
+  settled=$(echo "$out" | grep -cE 'pass|fail|skipping')
+  if [ "$total" -gt 0 ] && [ "$settled" -ge "$total" ]; then
+    break
+  fi
+
+  now=$(date +%s)
+  if [ $((now - start_ts)) -ge "$TIMEOUT" ]; then
+    echo "Timed out after ${TIMEOUT}s waiting for ${total} checks (settled=${settled})." >&2
+    echo "$out" >&2
+    exit 1
+  fi
+
+  sleep "$INTERVAL"
+done
+
+# Final state — print table to stdout, exit code reflects pass/fail
+echo "$out"
+
+if echo "$out" | grep -qE '^[^[:space:]].*\bfail\b'; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Two related dev-experience additions extracted from the 2026-04-25 autonomous batch.

## What

1. **`commands/pr-ready.md`** — slash command that drives the project's mandatory pre-commit review loop:
   - `pnpm run lint` + `format:check`
   - `pnpm test`
   - parallel pr-review-toolkit agents on the diff
   - triage (critical/recommended block; minor noted)
   - iterate (re-run only agents with findings) up to 5 passes
   - final lint+test gate after fixes
   - report **READY** with suggested commit / next-step OR **NOT READY** with blockers

   Doesn't auto-commit or auto-push — answers "is the work ready?", not "ship it". Replaces the by-hand sequence that `workflows/pre-commit-review.md` documents.

2. **`scripts/wait-for-ci.sh`** — small bash helper that polls `gh pr checks` until every check has a terminal status. Used in the autonomous-batch workflow because `gh pr checks --watch` exits mid-stream in some terminals.
   - Defaults: `--repo costajohnt/oss-autopilot --interval 25 --timeout 600`
   - Returns 0 on all-pass, 1 on any failure, 2 on usage error.

## Why

Both surface friction points documented in the 2026-04-25 batch retro:
- Pre-commit review loop is mandatory but had to be invoked manually each PR
- `gh pr checks --watch` is unreliable; the until-loop pattern was rewritten in every batch session

## Test plan
- [x] `bash -n scripts/wait-for-ci.sh` (syntax)
- [x] `scripts/wait-for-ci.sh --help` shows usage
- [x] `pnpm run lint`
- [x] `pnpm test`
- [x] No application code touched