### PR TITLE
refactor(core): Zod-validated --json output for search command (#1147)

### DIFF
--- a/packages/core/src/cli-registry.test.ts
+++ b/packages/core/src/cli-registry.test.ts
@@ -25,6 +25,13 @@ vi.mock('./core/errors.js', () => ({
 vi.mock('./formatters/json.js', () => ({
   outputJson: vi.fn(),
   outputJsonError: vi.fn(),
+  outputJsonValidated: vi.fn(),
+  // Schemas referenced by command actions — exported as opaque markers; the
+  // mocked outputJsonValidated above doesn't actually validate.
+  StatusOutputSchema: {},
+  SearchOutputSchema: {},
+  DailyOutputSchema: {},
+  CompactDailyOutputSchema: {},
 }));
 
 // ─── Mock dynamic command-module imports ────────────────────────────────────
@@ -54,10 +61,11 @@ vi.mock('./commands/skip-add.js', () => ({ runSkipAdd: mockRunSkipAdd }));
 // ─── Import after mocks ────────────────────────────────────────────────────
 
 import { commands } from './cli-registry.js';
-import { outputJson, outputJsonError } from './formatters/json.js';
+import { outputJson, outputJsonError, outputJsonValidated } from './formatters/json.js';
 
 const mockOutputJson = vi.mocked(outputJson);
 const mockOutputJsonError = vi.mocked(outputJsonError);
+const mockOutputJsonValidated = vi.mocked(outputJsonValidated);
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 
@@ -150,7 +158,8 @@ describe('search count validation', () => {
     await program.parseAsync(['node', 'cli', 'search', '--json']);
 
     expect(mockRunSearch).toHaveBeenCalledWith({ maxResults: 5 });
-    expect(mockOutputJson).toHaveBeenCalledWith(emptySearchResult);
+    // search routes through outputJsonValidated (#1147); the second arg is the result
+    expect(mockOutputJsonValidated).toHaveBeenCalledWith(expect.anything(), emptySearchResult);
   });
 
   it('should accept a valid positive integer count', async () => {
@@ -160,7 +169,7 @@ describe('search count validation', () => {
     await program.parseAsync(['node', 'cli', 'search', '10', '--json']);
 
     expect(mockRunSearch).toHaveBeenCalledWith({ maxResults: 10 });
-    expect(mockOutputJson).toHaveBeenCalledWith(emptySearchResult);
+    expect(mockOutputJsonValidated).toHaveBeenCalledWith(expect.anything(), emptySearchResult);
   });
 
   it.each(['abc', '1.5', '0', '-3'])('should reject invalid count "%s"', async (count) => {
@@ -183,7 +192,7 @@ describe('search count validation', () => {
 
     expect(consoleWarnSpy).toHaveBeenCalledWith('Capping search to 100 results (requested: 150)');
     expect(mockRunSearch).toHaveBeenCalledWith({ maxResults: 100 });
-    expect(mockOutputJson).toHaveBeenCalledWith(emptySearchResult);
+    expect(mockOutputJsonValidated).toHaveBeenCalledWith(expect.anything(), emptySearchResult);
   });
 });
 

--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -232,8 +232,9 @@ export const commands: CLICommandDef[] = [
         .command('search [count]')
         .description('Search for new issues to work on')
         .option('--json', 'Output as JSON')
-        .action((count, options) =>
-          executeAction(
+        .action(async (count, options) => {
+          const { SearchOutputSchema } = await import('./formatters/json.js');
+          await executeAction(
             options,
             async () => {
               const { runSearch, MAX_SEARCH_RESULTS } = await import('./commands/search.js');
@@ -280,8 +281,9 @@ export const commands: CLICommandDef[] = [
                 console.log('---');
               }
             },
-          ),
-        );
+            SearchOutputSchema,
+          );
+        });
     },
   },
 

--- a/packages/core/src/formatters/json.test.ts
+++ b/packages/core/src/formatters/json.test.ts
@@ -15,6 +15,7 @@ import {
   StatusOutputSchema,
   DailyOutputSchema,
   CompactDailyOutputSchema,
+  SearchOutputSchema,
   toCompactDailyOutput,
   toCompactStartupOutput,
   type DailyOutput,
@@ -459,5 +460,68 @@ describe('CompactDailyOutputSchema (#1146)', () => {
     const compact = toCompactDailyOutput(makeMockDailyOutput());
     const broken = { ...compact, failureCount: '0' } as unknown;
     expect(() => formatJson(CompactDailyOutputSchema, broken)).toThrow(/contract drift.*failureCount/i);
+  });
+});
+
+describe('SearchOutputSchema (#1147)', () => {
+  function makeSearchCandidate() {
+    return {
+      issue: {
+        repo: 'foo/bar',
+        repoUrl: 'https://github.com/foo/bar',
+        number: 42,
+        title: 'fix the thing',
+        url: 'https://github.com/foo/bar/issues/42',
+        labels: ['good first issue'],
+      },
+      recommendation: 'approve' as const,
+      reasonsToApprove: ['active maintainer'],
+      reasonsToSkip: [],
+      searchPriority: 'starred' as const,
+      viabilityScore: 88,
+      grade: { letter: 'A' as const, reason: 'fast merges' },
+      repoScore: {
+        score: 9.2,
+        mergedPRCount: 3,
+        closedWithoutMergeCount: 0,
+        isResponsive: true,
+        lastMergedAt: '2026-04-01T00:00:00Z',
+      },
+    };
+  }
+
+  it('round-trips a fully populated candidate', () => {
+    const data = {
+      candidates: [makeSearchCandidate()],
+      excludedRepos: ['stale/abandoned'],
+      aiPolicyBlocklist: ['anti-ai/repo'],
+    };
+    expect(formatJson(SearchOutputSchema, data).success).toBe(true);
+  });
+
+  it('round-trips an empty result', () => {
+    const data = { candidates: [], excludedRepos: [], aiPolicyBlocklist: [] };
+    expect(formatJson(SearchOutputSchema, data).success).toBe(true);
+  });
+
+  it('rejects drift: invalid grade letter', () => {
+    const candidate = makeSearchCandidate();
+    (candidate.grade as { letter: string; reason: string }).letter = 'D';
+    const data = { candidates: [candidate], excludedRepos: [], aiPolicyBlocklist: [] };
+    expect(() => formatJson(SearchOutputSchema, data)).toThrow(/contract drift.*letter/i);
+  });
+
+  it('rejects drift: missing reasonsToApprove', () => {
+    const candidate = makeSearchCandidate() as unknown as Record<string, unknown>;
+    delete candidate.reasonsToApprove;
+    const data = { candidates: [candidate], excludedRepos: [], aiPolicyBlocklist: [] };
+    expect(() => formatJson(SearchOutputSchema, data)).toThrow(/contract drift.*reasonsToApprove/i);
+  });
+
+  it('accepts a candidate without optional repoScore', () => {
+    const candidate = makeSearchCandidate() as unknown as Record<string, unknown>;
+    delete candidate.repoScore;
+    const data = { candidates: [candidate], excludedRepos: [], aiPolicyBlocklist: [] };
+    expect(formatJson(SearchOutputSchema, data).success).toBe(true);
   });
 });

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -382,6 +382,46 @@ export const CompactDailyOutputSchema = z.object({
   warnings: z.array(DailyWarningSchema),
 });
 
+// ── Search output schema (#1147) ─────────────────────────────────────
+
+const SearchPrioritySchema = z.enum(['merged_pr', 'preferred_org', 'starred', 'normal']);
+
+const SearchCandidateSchema = z.object({
+  issue: z.object({
+    repo: z.string(),
+    repoUrl: z.string(),
+    number: z.number().int(),
+    title: z.string(),
+    url: z.string(),
+    labels: z.array(z.string()),
+  }),
+  recommendation: z.enum(['approve', 'skip', 'needs_review']),
+  reasonsToApprove: z.array(z.string()),
+  reasonsToSkip: z.array(z.string()),
+  searchPriority: SearchPrioritySchema,
+  viabilityScore: z.number(),
+  grade: z.object({
+    letter: z.enum(['A', 'B', 'C', 'F']),
+    reason: z.string(),
+  }),
+  repoScore: z
+    .object({
+      score: z.number(),
+      mergedPRCount: z.number().int().nonnegative(),
+      closedWithoutMergeCount: z.number().int().nonnegative(),
+      isResponsive: z.boolean(),
+      lastMergedAt: z.string().optional(),
+    })
+    .optional(),
+});
+
+export const SearchOutputSchema = z.object({
+  candidates: z.array(SearchCandidateSchema),
+  excludedRepos: z.array(z.string()),
+  aiPolicyBlocklist: z.array(z.string()),
+  rateLimitWarning: z.string().optional(),
+});
+
 export interface SearchOutput {
   candidates: Array<{
     issue: {


### PR DESCRIPTION
Closes #1147.

## Summary
- `SearchOutputSchema` exported from `formatters/json.ts`. Strict on the wrapper and on every nested field (issue / recommendation / grade enum / repoScore optional sub-object).
- `cli-registry.ts` search action uses `outputJsonValidated`.
- 5 new test cases: round-trip full candidate, round-trip empty, drift on invalid grade letter, drift on missing `reasonsToApprove`, candidate without optional `repoScore`.
- `cli-registry.test.ts` mocks updated to include the new schema exports and `outputJsonValidated`.

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm test`
- [x] No application code touched

Follow-up #1148 (rest of CLI) still open.