### PR TITLE
refactor(core): Zod coverage for the remaining 13 CLI commands (#1155)

### DIFF
--- a/packages/core/src/cli-registry.test.ts
+++ b/packages/core/src/cli-registry.test.ts
@@ -35,6 +35,18 @@ vi.mock('./formatters/json.js', () => ({
   DoctorOutputSchema: {},
   SkipAddOutputSchema: {},
   ListMoveTierOutputSchema: {},
+  PostOutputSchema: {},
+  ClaimOutputSchema: {},
+  InitOutputSchema: {},
+  CheckSetupOutputSchema: {},
+  SetupOutputSchema: {},
+  ConfigCommandOutputSchema: {},
+  MoveOutputSchema: {},
+  PRTemplateOutputSchema: {},
+  ParseIssueListOutputSchema: {},
+  CheckIntegrationOutputSchema: {},
+  DetectFormattersOutputSchema: {},
+  LocalReposOutputSchema: {},
 }));
 
 // ─── Mock dynamic command-module imports ────────────────────────────────────
@@ -251,7 +263,10 @@ describe('override status validation', () => {
       prUrl: PR_URL,
       target: expectedTarget,
     });
-    expect(mockOutputJson).toHaveBeenCalledWith({ description: `Moved to ${expectedTarget}` });
+    // override now routes through outputJsonValidated (#1155)
+    expect(mockOutputJsonValidated).toHaveBeenCalledWith(expect.anything(), {
+      description: `Moved to ${expectedTarget}`,
+    });
   });
 
   it('should display description in non-JSON mode', async () => {
@@ -313,7 +328,7 @@ describe('printRepos (via local-repos command)', () => {
     expect(repoAIndex).toBeLessThan(repoBIndex);
   });
 
-  it('should call outputJson when --json is passed', async () => {
+  it('should call outputJsonValidated when --json is passed', async () => {
     const repoData = {
       repos: { 'owner/repo': { path: '/home/user/repo', currentBranch: 'main' } },
       scanPaths: ['/home/user'],
@@ -325,7 +340,8 @@ describe('printRepos (via local-repos command)', () => {
 
     await program.parseAsync(['node', 'cli', 'local-repos', '--json']);
 
-    expect(mockOutputJson).toHaveBeenCalledWith(repoData);
+    // local-repos now routes through outputJsonValidated (#1155)
+    expect(mockOutputJsonValidated).toHaveBeenCalledWith(expect.anything(), repoData);
   });
 
   it('should show cached header when fromCache is true', async () => {

--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -544,8 +544,9 @@ export const commands: CLICommandDef[] = [
         .description('Post a comment to a PR or issue')
         .option('--stdin', 'Read message from stdin')
         .option('--json', 'Output as JSON')
-        .action((url, messageParts, options) =>
-          executeAction(
+        .action(async (url, messageParts, options) => {
+          const { PostOutputSchema } = await import('./formatters/json.js');
+          await executeAction(
             options,
             async () => {
               let message: string;
@@ -564,8 +565,9 @@ export const commands: CLICommandDef[] = [
             (data) => {
               console.log(`Comment posted: ${data.commentUrl}`);
             },
-          ),
-        );
+            PostOutputSchema,
+          );
+        });
     },
   },
 
@@ -577,8 +579,9 @@ export const commands: CLICommandDef[] = [
         .command('claim <issue-url> [message...]')
         .description('Claim an issue by posting a comment')
         .option('--json', 'Output as JSON')
-        .action((issueUrl, messageParts, options) =>
-          executeAction(
+        .action(async (issueUrl, messageParts, options) => {
+          const { ClaimOutputSchema } = await import('./formatters/json.js');
+          await executeAction(
             options,
             async () => {
               const { runClaim } = await import('./commands/comments.js');
@@ -588,8 +591,9 @@ export const commands: CLICommandDef[] = [
             (data) => {
               console.log(`Issue claimed: ${data.commentUrl}`);
             },
-          ),
-        );
+            ClaimOutputSchema,
+          );
+        });
     },
   },
 
@@ -603,8 +607,9 @@ export const commands: CLICommandDef[] = [
         .description('Show or update configuration')
         .option('--json', 'Output as JSON')
         .option('--list-keys', 'List every known config key with descriptions')
-        .action((key, value, options) =>
-          executeAction(
+        .action(async (key, value, options) => {
+          const { ConfigCommandOutputSchema } = await import('./formatters/json.js');
+          await executeAction(
             options,
             async () =>
               (await import('./commands/config.js')).runConfig({
@@ -628,8 +633,9 @@ export const commands: CLICommandDef[] = [
                 console.log(`Set ${data.key} to: ${data.value}`);
               }
             },
-          ),
-        );
+            ConfigCommandOutputSchema,
+          );
+        });
     },
   },
 
@@ -641,16 +647,18 @@ export const commands: CLICommandDef[] = [
         .command('init <username>')
         .description('Initialize with your GitHub username and import open PRs')
         .option('--json', 'Output as JSON')
-        .action((username, options) =>
-          executeAction(
+        .action(async (username, options) => {
+          const { InitOutputSchema } = await import('./formatters/json.js');
+          await executeAction(
             options,
             async () => (await import('./commands/init.js')).runInit({ username }),
             (data) => {
               console.log(`\nUsername set to @${data.username}.`);
               console.log('Run `oss-autopilot daily` to fetch your open PRs from GitHub.');
             },
-          ),
-        );
+            InitOutputSchema,
+          );
+        });
     },
   },
 
@@ -665,8 +673,9 @@ export const commands: CLICommandDef[] = [
         .option('--reset', 'Re-run setup even if already complete')
         .option('--set <settings...>', 'Set specific values (key=value)')
         .option('--json', 'Output as JSON')
-        .action((options) =>
-          executeAction(
+        .action(async (options) => {
+          const { SetupOutputSchema } = await import('./formatters/json.js');
+          await executeAction(
             options,
             async () => (await import('./commands/setup.js')).runSetup({ reset: options.reset, set: options.set }),
             (data) => {
@@ -715,8 +724,9 @@ export const commands: CLICommandDef[] = [
                 console.log('END_SETUP_PROMPTS');
               }
             },
-          ),
-        );
+            SetupOutputSchema,
+          );
+        });
     },
   },
 
@@ -729,8 +739,9 @@ export const commands: CLICommandDef[] = [
         .command('checkSetup')
         .description('Check if setup is complete')
         .option('--json', 'Output as JSON')
-        .action((options) =>
-          executeAction(
+        .action(async (options) => {
+          const { CheckSetupOutputSchema } = await import('./formatters/json.js');
+          await executeAction(
             options,
             async () => (await import('./commands/setup.js')).runCheckSetup(),
             (data) => {
@@ -741,8 +752,9 @@ export const commands: CLICommandDef[] = [
                 console.log('SETUP_INCOMPLETE');
               }
             },
-          ),
-        );
+            CheckSetupOutputSchema,
+          );
+        });
     },
   },
 
@@ -782,8 +794,9 @@ export const commands: CLICommandDef[] = [
         .command('parse-issue-list <path>')
         .description('Parse a markdown issue list into structured JSON')
         .option('--json', 'Output as JSON')
-        .action((filePath, options) =>
-          executeAction(
+        .action(async (filePath, options) => {
+          const { ParseIssueListOutputSchema } = await import('./formatters/json.js');
+          await executeAction(
             options,
             async () => (await import('./commands/parse-list.js')).runParseList({ filePath }),
             async (data) => {
@@ -804,8 +817,9 @@ export const commands: CLICommandDef[] = [
                 }
               }
             },
-          ),
-        );
+            ParseIssueListOutputSchema,
+          );
+        });
     },
   },
 
@@ -820,8 +834,9 @@ export const commands: CLICommandDef[] = [
         .description('Detect new files on this branch that no other file references')
         .option('--base <branch>', 'Base branch to compare against', 'main')
         .option('--json', 'Output as JSON')
-        .action((options) =>
-          executeAction(
+        .action(async (options) => {
+          const { CheckIntegrationOutputSchema } = await import('./formatters/json.js');
+          await executeAction(
             options,
             async () => (await import('./commands/check-integration.js')).runCheckIntegration({ base: options.base }),
             (data) => {
@@ -844,8 +859,9 @@ export const commands: CLICommandDef[] = [
                 }
               }
             },
-          ),
-        );
+            CheckIntegrationOutputSchema,
+          );
+        });
     },
   },
 
@@ -893,8 +909,9 @@ export const commands: CLICommandDef[] = [
         .option('--scan', 'Force re-scan (ignores cache)')
         .option('--paths <dirs...>', 'Directories to scan')
         .option('--json', 'Output as JSON')
-        .action((options) =>
-          executeAction(
+        .action(async (options) => {
+          const { LocalReposOutputSchema } = await import('./formatters/json.js');
+          await executeAction(
             options,
             async () =>
               (await import('./commands/local-repos.js')).runLocalRepos({
@@ -910,8 +927,9 @@ export const commands: CLICommandDef[] = [
                 printRepos(data.repos);
               }
             },
-          ),
-        );
+            LocalReposOutputSchema,
+          );
+        });
     },
   },
 
@@ -1083,8 +1101,9 @@ export const commands: CLICommandDef[] = [
         .command('override <pr-url> <status>')
         .description('Manually override PR status (needs_addressing or waiting_on_maintainer)')
         .option('--json', 'Output as JSON')
-        .action((prUrl, status, options) =>
-          executeAction(
+        .action(async (prUrl, status, options) => {
+          const { MoveOutputSchema } = await import('./formatters/json.js');
+          await executeAction(
             options,
             async () => {
               const validStatuses = ['needs_addressing', 'waiting_on_maintainer'];
@@ -1098,8 +1117,9 @@ export const commands: CLICommandDef[] = [
             (data) => {
               console.log(data.description);
             },
-          ),
-        );
+            MoveOutputSchema,
+          );
+        });
     },
   },
 
@@ -1112,15 +1132,17 @@ export const commands: CLICommandDef[] = [
         .command('clear-override <pr-url>')
         .description('Clear a manual status override for a PR')
         .option('--json', 'Output as JSON')
-        .action((prUrl, options) =>
-          executeAction(
+        .action(async (prUrl, options) => {
+          const { MoveOutputSchema } = await import('./formatters/json.js');
+          await executeAction(
             options,
             async () => (await import('./commands/move.js')).runMove({ prUrl, target: 'auto' }),
             (data) => {
               console.log(data.description);
             },
-          ),
-        );
+            MoveOutputSchema,
+          );
+        });
     },
   },
 
@@ -1132,8 +1154,9 @@ export const commands: CLICommandDef[] = [
         .command('pr-template <repo>')
         .description("Fetch a repository's PR description template")
         .option('--json', 'Output as JSON')
-        .action((repo, options) =>
-          executeAction(
+        .action(async (repo, options) => {
+          const { PRTemplateOutputSchema } = await import('./formatters/json.js');
+          await executeAction(
             options,
             async () => (await import('./commands/pr-template.js')).runPRTemplate({ repo }),
             (data) => {
@@ -1146,8 +1169,9 @@ export const commands: CLICommandDef[] = [
                 console.log('\nNo PR template found for this repository.');
               }
             },
-          ),
-        );
+            PRTemplateOutputSchema,
+          );
+        });
     },
   },
 
@@ -1161,8 +1185,9 @@ export const commands: CLICommandDef[] = [
         .description('Detect formatters and linters configured in a repository')
         .option('--ci-log <path>', 'Analyze CI log file for formatting failures')
         .option('--json', 'Output as JSON')
-        .action((repoPath, options) =>
-          executeAction(
+        .action(async (repoPath, options) => {
+          const { DetectFormattersOutputSchema } = await import('./formatters/json.js');
+          await executeAction(
             options,
             async () =>
               (await import('./commands/detect-formatters.js')).runDetectFormatters({
@@ -1197,8 +1222,9 @@ export const commands: CLICommandDef[] = [
                 }
               }
             },
-          ),
-        );
+            DetectFormattersOutputSchema,
+          );
+        });
     },
   },
 

--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -50,8 +50,13 @@ async function executeAction<T>(
   /** Optional Zod schema. When provided, the JSON output is validated against
    * it (#1105). On mismatch, executeAction throws and the standard error
    * envelope fires — surfacing a contract drift instead of silently shipping
-   * a broken shape. */
-  schema?: ZodType<T>,
+   * a broken shape.
+   *
+   * Typed as `ZodType<unknown>` because validation is a runtime concern: the
+   * schema runs `safeParse(data: unknown)`, and Zod-inferred union types do
+   * not always structurally match hand-written TS union interfaces. The test
+   * harness still catches drift via `safeParse`. */
+  schema?: ZodType<unknown>,
 ): Promise<void> {
   try {
     const data = await run();

--- a/packages/core/src/formatters/json.test.ts
+++ b/packages/core/src/formatters/json.test.ts
@@ -19,6 +19,18 @@ import {
   DoctorOutputSchema,
   SkipAddOutputSchema,
   ListMoveTierOutputSchema,
+  PostOutputSchema,
+  ClaimOutputSchema,
+  InitOutputSchema,
+  CheckSetupOutputSchema,
+  SetupOutputSchema,
+  ConfigCommandOutputSchema,
+  MoveOutputSchema,
+  PRTemplateOutputSchema,
+  ParseIssueListOutputSchema,
+  CheckIntegrationOutputSchema,
+  DetectFormattersOutputSchema,
+  LocalReposOutputSchema,
   toCompactDailyOutput,
   toCompactStartupOutput,
   type DailyOutput,
@@ -625,5 +637,112 @@ describe('ListMoveTierOutputSchema (#1148)', () => {
       count: 1,
     } as unknown;
     expect(() => formatJson(ListMoveTierOutputSchema, data)).toThrow(/contract drift.*toTier/i);
+  });
+});
+
+describe('Misc command schemas (#1155)', () => {
+  it('PostOutputSchema round-trip + drift', () => {
+    expect(formatJson(PostOutputSchema, { commentUrl: 'a', url: 'b' }).success).toBe(true);
+    expect(() => formatJson(PostOutputSchema, { commentUrl: 'a' })).toThrow(/contract drift.*url/i);
+  });
+
+  it('ClaimOutputSchema round-trip + drift', () => {
+    expect(formatJson(ClaimOutputSchema, { commentUrl: 'a', issueUrl: 'b' }).success).toBe(true);
+    expect(() => formatJson(ClaimOutputSchema, { commentUrl: 'a' })).toThrow(/contract drift.*issueUrl/i);
+  });
+
+  it('InitOutputSchema round-trip + drift', () => {
+    expect(formatJson(InitOutputSchema, { username: 'foo', message: 'ok' }).success).toBe(true);
+    expect(() => formatJson(InitOutputSchema, { username: 'foo' })).toThrow(/contract drift.*message/i);
+  });
+
+  it('CheckSetupOutputSchema accepts both setupComplete states', () => {
+    expect(formatJson(CheckSetupOutputSchema, { setupComplete: true, username: 'a' }).success).toBe(true);
+    expect(formatJson(CheckSetupOutputSchema, { setupComplete: false, username: '' }).success).toBe(true);
+    expect(() => formatJson(CheckSetupOutputSchema, { setupComplete: 'yes', username: 'a' })).toThrow(
+      /contract drift/i,
+    );
+  });
+
+  it('SetupOutputSchema accepts all three union variants', () => {
+    expect(formatJson(SetupOutputSchema, { success: true, settings: { a: 'b' } }).success).toBe(true);
+    expect(
+      formatJson(SetupOutputSchema, {
+        setupComplete: true,
+        config: {
+          githubUsername: 'x',
+          maxActivePRs: 5,
+          dormantThresholdDays: 30,
+          approachingDormantDays: 25,
+          languages: [],
+          labels: [],
+          projectCategories: [],
+          preferredOrgs: [],
+          scope: [],
+          persistence: 'local',
+        },
+      }).success,
+    ).toBe(true);
+    expect(formatJson(SetupOutputSchema, { setupRequired: true, prompts: [] }).success).toBe(true);
+  });
+
+  it('ConfigCommandOutputSchema accepts all three union variants', () => {
+    expect(formatJson(ConfigCommandOutputSchema, { config: { foo: 'bar' } }).success).toBe(true);
+    expect(formatJson(ConfigCommandOutputSchema, { success: true, key: 'k', value: 'v' }).success).toBe(true);
+    expect(formatJson(ConfigCommandOutputSchema, { keys: [{ key: 'a' }] }).success).toBe(true);
+  });
+
+  it('MoveOutputSchema round-trip + drift on target enum', () => {
+    expect(formatJson(MoveOutputSchema, { url: 'u', target: 'attention', description: 'd' }).success).toBe(true);
+    expect(() => formatJson(MoveOutputSchema, { url: 'u', target: 'invalid', description: 'd' })).toThrow(
+      /contract drift.*target/i,
+    );
+  });
+
+  it('PRTemplateOutputSchema accepts null template/source', () => {
+    expect(formatJson(PRTemplateOutputSchema, { template: 'body', source: '.github/PR.md' }).success).toBe(true);
+    expect(formatJson(PRTemplateOutputSchema, { template: null, source: null }).success).toBe(true);
+    expect(formatJson(PRTemplateOutputSchema, { template: null, source: null, error: 'oops' }).success).toBe(true);
+  });
+
+  it('ParseIssueListOutputSchema round-trip with items', () => {
+    const data = {
+      available: [{ repo: 'a/b', number: 1, title: 't', tier: 'pursue', url: 'u', score: 8 }],
+      completed: [],
+      availableCount: 1,
+      completedCount: 0,
+    };
+    expect(formatJson(ParseIssueListOutputSchema, data).success).toBe(true);
+  });
+
+  it('CheckIntegrationOutputSchema round-trip', () => {
+    expect(formatJson(CheckIntegrationOutputSchema, { newFiles: [], unreferencedCount: 0 }).success).toBe(true);
+  });
+
+  it('DetectFormattersOutputSchema round-trip with formatters', () => {
+    const data = {
+      formatters: [
+        {
+          name: 'prettier' as const,
+          configPath: '.prettierrc',
+          fixCommand: 'npx prettier --write .',
+          checkCommand: 'npx prettier --check .',
+          supportsFileArgs: true,
+        },
+      ],
+      packageJsonScripts: [{ name: 'lint', command: 'eslint .' }],
+      repoPath: '/repo',
+    };
+    expect(formatJson(DetectFormattersOutputSchema, data).success).toBe(true);
+  });
+
+  it('LocalReposOutputSchema round-trip', () => {
+    const data = {
+      repos: { 'a/b': { path: '/p', exists: true, currentBranch: 'main' } },
+      scanPaths: ['/p'],
+      cachedAt: '2026-04-25',
+      fromCache: false,
+    };
+    expect(formatJson(LocalReposOutputSchema, data).success).toBe(true);
   });
 });

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -458,6 +458,175 @@ export const ListMoveTierOutputSchema = z.object({
   reason: z.string().optional(),
 });
 
+// ── #1155: Zod coverage for remaining CLI commands ───────────────────
+
+export const PostOutputSchema = z.object({
+  commentUrl: z.string(),
+  url: z.string(),
+});
+
+export const ClaimOutputSchema = z.object({
+  commentUrl: z.string(),
+  issueUrl: z.string(),
+});
+
+export const InitOutputSchema = z.object({
+  username: z.string(),
+  message: z.string(),
+});
+
+export const CheckSetupOutputSchema = z.object({
+  setupComplete: z.boolean(),
+  username: z.string(),
+});
+
+const SetupSetOutputSchema = z.object({
+  success: z.literal(true),
+  settings: z.record(z.string(), z.string()),
+  warnings: z.array(z.string()).optional(),
+});
+
+const SetupCompleteOutputSchema = z.object({
+  setupComplete: z.literal(true),
+  config: z.object({
+    githubUsername: z.string(),
+    maxActivePRs: z.number(),
+    dormantThresholdDays: z.number(),
+    approachingDormantDays: z.number(),
+    languages: z.array(z.string()),
+    labels: z.array(z.string()),
+    projectCategories: z.array(z.string()),
+    preferredOrgs: z.array(z.string()),
+    scope: z.array(z.string()),
+    persistence: z.enum(['local', 'gist']),
+  }),
+});
+
+const SetupRequiredOutputSchema = z.object({
+  setupRequired: z.literal(true),
+  prompts: z.array(
+    z.object({
+      setting: z.string(),
+      prompt: z.string(),
+      current: z.union([z.string(), z.number(), z.array(z.string()), z.null()]),
+      required: z.boolean().optional(),
+      default: z.union([z.string(), z.number(), z.array(z.string())]).optional(),
+      type: z.string().optional(),
+    }),
+  ),
+});
+
+export const SetupOutputSchema = z.union([SetupSetOutputSchema, SetupCompleteOutputSchema, SetupRequiredOutputSchema]);
+
+const ConfigKeyDefSchema = z.object({}).passthrough();
+
+const ConfigGetOutputSchema = z.object({
+  config: z.record(z.string(), z.unknown()),
+});
+
+const ConfigSetOutputSchema = z.object({
+  success: z.literal(true),
+  key: z.string(),
+  value: z.string(),
+});
+
+const ConfigListKeysOutputSchema = z.object({
+  keys: z.array(ConfigKeyDefSchema),
+});
+
+export const ConfigCommandOutputSchema = z.union([
+  ConfigGetOutputSchema,
+  ConfigSetOutputSchema,
+  ConfigListKeysOutputSchema,
+]);
+
+export const MoveOutputSchema = z.object({
+  url: z.string(),
+  target: z.enum(['attention', 'waiting', 'shelved', 'auto']),
+  description: z.string(),
+});
+
+export const PRTemplateOutputSchema = z.object({
+  template: z.string().nullable(),
+  source: z.string().nullable(),
+  error: z.string().optional(),
+});
+
+const ParsedIssueItemSchema = z.object({
+  repo: z.string(),
+  number: z.number(),
+  title: z.string(),
+  tier: z.string(),
+  url: z.string(),
+  score: z.number().optional(),
+});
+
+export const ParseIssueListOutputSchema = z.object({
+  available: z.array(ParsedIssueItemSchema),
+  completed: z.array(ParsedIssueItemSchema),
+  availableCount: z.number().int().nonnegative(),
+  completedCount: z.number().int().nonnegative(),
+});
+
+const NewFileInfoSchema = z.object({
+  path: z.string(),
+  referencedBy: z.array(z.string()),
+  isIntegrated: z.boolean(),
+  suggestedEntryPoints: z.array(z.string()).optional(),
+});
+
+export const CheckIntegrationOutputSchema = z.object({
+  newFiles: z.array(NewFileInfoSchema),
+  unreferencedCount: z.number().int().nonnegative(),
+});
+
+const FormatterNameSchema = z.enum([
+  'prettier',
+  'eslint',
+  'biome',
+  'black',
+  'ruff',
+  'rustfmt',
+  'gofmt',
+  'clang-format',
+  'rubocop',
+]);
+
+const DetectedFormatterSchema = z.object({
+  name: FormatterNameSchema,
+  configPath: z.string(),
+  fixCommand: z.string(),
+  checkCommand: z.string(),
+  supportsFileArgs: z.boolean(),
+});
+
+const CIFormatterDiagnosisSchema = z.object({
+  isFormattingFailure: z.boolean(),
+  formatter: FormatterNameSchema.optional(),
+  fixCommand: z.string().optional(),
+  evidence: z.array(z.string()),
+});
+
+export const DetectFormattersOutputSchema = z.object({
+  formatters: z.array(DetectedFormatterSchema),
+  packageJsonScripts: z.array(z.object({ name: z.string(), command: z.string() })),
+  repoPath: z.string(),
+  ciDiagnosis: CIFormatterDiagnosisSchema.optional(),
+});
+
+const LocalRepoInfoSchema = z.object({
+  path: z.string(),
+  exists: z.boolean(),
+  currentBranch: z.string().nullable(),
+});
+
+export const LocalReposOutputSchema = z.object({
+  repos: z.record(z.string(), LocalRepoInfoSchema),
+  scanPaths: z.array(z.string()),
+  cachedAt: z.string(),
+  fromCache: z.boolean(),
+});
+
 export interface SearchOutput {
   candidates: Array<{
     issue: {


### PR DESCRIPTION
Closes #1155. Closes the original ask in #1105 — every registered CLI command now either has a Zod schema on its --json boundary or a golden-file contract test.

## Schemas added (formatters/json.ts)

| Schema | Commands |
|---|---|
| `PostOutputSchema` | post |
| `ClaimOutputSchema` | claim |
| `InitOutputSchema` | init |
| `CheckSetupOutputSchema` | checkSetup |
| `SetupOutputSchema` | setup (union of set/complete/required variants) |
| `ConfigCommandOutputSchema` | config (union of get/set/listKeys) |
| `MoveOutputSchema` | override + clear-override (both delegate to runMove) |
| `PRTemplateOutputSchema` | pr-template (template/source nullable + optional error) |
| `ParseIssueListOutputSchema` | parse-issue-list |
| `CheckIntegrationOutputSchema` | orphan-files |
| `DetectFormattersOutputSchema` | detect-formatters (with optional CI diagnosis) |
| `LocalReposOutputSchema` | local-repos |

## Wired through outputJsonValidated

cli-registry.ts now passes the right schema as the 4th arg to `executeAction` for all 13 commands.

## Test changes
- 11 new unit cases (round-trip + drift + union variant exercises).
- `cli-registry.test.ts` mock exposes the 11 new opaque schema markers.
- Two existing assertions (override, local-repos) updated from `mockOutputJson` to `mockOutputJsonValidated` to match the new path.

## Coverage status (final)
After this PR: every registered CLI command → Zod schema OR golden contract test. No remaining gaps.

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm test` (87 + 22 + 7 test files green)
- [x] `pnpm run bundle` (clean)