### PR TITLE
chore: restrict Dependabot groups to minor + patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,10 @@ updates:
     groups:
       dev-dependencies:
         dependency-type: "development"
+        update-types: ["minor", "patch"]
       production-dependencies:
         dependency-type: "production"
+        update-types: ["minor", "patch"]
     open-pull-requests-limit: 15
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary

- Add `update-types: ["minor", "patch"]` to both Dependabot group filters in `.github/dependabot.yml`.
- Result: major version bumps now get their own individual PRs instead of being silently bundled with patches.

## Why

PR #1126 grouped 12 dev-dep updates including TypeScript 5.9.3 → 6.0.3 (a breaking major) alongside 11 minor/patch bumps. The TS 6.0 bump introduces stricter type checks that need individual evaluation; bundling it with safe patches conflates risk profiles and makes the PR hard to review or revert.

This config keeps the convenience of grouped weekly bumps while ensuring majors land in isolation.

## Test plan

- [x] Config validates against [Dependabot's `update-types` schema](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#update-types).
- [ ] Verify next weekly Dependabot run produces a clean grouped PR (with no major bumps) and a separate PR for any major bumps.

Closes the underlying problem in #1126.