### PR TITLE
feat!: drop Node 20 support, require Node 22+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node-version: [20, 22, 24]
+        node-version: [22, 24]
         include:
           - os: macos-latest
             node-version: 22

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -129,7 +129,7 @@ Debug and warning output goes to stderr via the logger, so it never contaminates
 ### Build
 
 ```
-esbuild src/cli.ts --bundle --platform=node --target=node20 --format=cjs --outfile=dist/cli.bundle.cjs  # run from packages/core/
+esbuild src/cli.ts --bundle --platform=node --target=node22 --format=cjs --outfile=dist/cli.bundle.cjs  # run from packages/core/
 ```
 
 The bundle is a single CommonJS file (gitignored, auto-generated). The `SessionStart` hook rebuilds it if `package.json` is newer than the bundle.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Then follow the steps below.
 ### Step 1: Check prerequisites
 
 ```bash
-node --version  # Need 20+
+node --version  # Need 22+
 gh auth status  # Need GitHub CLI authenticated
 ```
 
@@ -33,7 +33,7 @@ If `gh` is not installed or authenticated:
 
 After restart, `/oss` and `/setup-oss` commands will be available.
 
-The CLI auto-builds on first run (requires Node.js 20+ and npm).
+The CLI auto-builds on first run (requires Node.js 22+ and npm).
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thanks for your interest in contributing! This project helps developers manage t
 
 ### Prerequisites
 
-- Node.js 20+
+- Node.js 22+
 - [pnpm](https://pnpm.io/) (install: `corepack enable && corepack prepare pnpm@latest --activate`)
 - GitHub CLI (`gh`) authenticated: `gh auth login`
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,6 @@ Have an idea? Open a [Discussion](https://github.com/costajohnt/oss-autopilot/di
 
 ## Now (next 1-2 weeks)
 
-- [ ] Node 20 EOL transition — bump engines and CI matrix before April 30, 2026 ([#983](https://github.com/costajohnt/oss-autopilot/issues/983))
 - [ ] Unify skip-list persistence — the `.md` file and `state.skippedIssues` currently drift ([#992](https://github.com/costajohnt/oss-autopilot/issues/992))
 - [ ] Audit-v2 follow-up sprint — close the 15 issues filed by the 2026-04-19 audit ([#993](https://github.com/costajohnt/oss-autopilot/issues/993)–[#1007](https://github.com/costajohnt/oss-autopilot/issues/1007))
 

--- a/commands/setup-oss.md
+++ b/commands/setup-oss.md
@@ -12,7 +12,7 @@ Customize your OSS Autopilot preferences. This is **optional** — the tool work
 
 ## Step 0: Ensure CLI is Built and Available
 
-This flow delegates entirely to the CLI. There is no markdown-only fallback — if the CLI cannot be built, ask the user to install Node 20+ and re-run.
+This flow delegates entirely to the CLI. There is no markdown-only fallback — if the CLI cannot be built, ask the user to install Node 22+ and re-run.
 
 Build the CLI on first run (auto-installs deps):
 
@@ -26,9 +26,9 @@ fi
 
 **If the build succeeded but the bundle file still isn't there**, or **if `node` is unavailable**: Stop the flow and tell the user:
 
-> "OSS Autopilot setup needs the CLI. Install Node.js 20+ from <https://nodejs.org>, then re-run `/setup-oss`. (Alternative: build manually with `cd ${CLAUDE_PLUGIN_ROOT}/packages/core && npm install && npm run bundle`.)"
+> "OSS Autopilot setup needs the CLI. Install Node.js 22+ from <https://nodejs.org>, then re-run `/setup-oss`. (Alternative: build manually with `cd ${CLAUDE_PLUGIN_ROOT}/packages/core && npm install && npm run bundle`.)"
 
-**If output starts with `BUILD_FAILED`**: Show the error lines and the same install/re-run guidance. Common causes: missing Node 20+, stale `node_modules`, no network for `npm install`.
+**If output starts with `BUILD_FAILED`**: Show the error lines and the same install/re-run guidance. Common causes: missing Node 22+, stale `node_modules`, no network for `npm install`.
 
 Then verify the CLI is callable:
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "packageManager": "pnpm@10.27.0",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "pnpm": {
     "overrides": {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -18,7 +18,7 @@ npx @oss-autopilot/core daily --json
 
 ## Requirements
 
-- Node.js 20+
+- Node.js 22+
 - GitHub CLI (`gh`) authenticated, or `GITHUB_TOKEN` environment variable
 
 ## CLI Usage

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "bundle": "esbuild src/cli.ts --bundle --platform=node --target=node20 --format=cjs --minify --sourcemap --outfile=dist/cli.bundle.cjs",
+    "bundle": "esbuild src/cli.ts --bundle --platform=node --target=node22 --format=cjs --minify --sourcemap --outfile=dist/cli.bundle.cjs",
     "start": "tsx src/cli.ts",
     "dev": "tsx watch src/cli.ts",
     "typecheck": "tsc --noEmit",
@@ -62,7 +62,7 @@
     "url": "https://github.com/costajohnt/oss-autopilot/issues"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "dependencies": {
     "@octokit/plugin-throttling": "^11.0.3",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -20,7 +20,7 @@
     "dist/"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -18,7 +18,7 @@ Supports **stdio** (default) and **Streamable HTTP** transports.
 
 ## Prerequisites
 
-- Node.js 20+
+- Node.js 22+
 - [GitHub CLI](https://cli.github.com/) authenticated (`gh auth login`)
 
 ## Quick Start

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "bundle": "esbuild src/index.ts --bundle --platform=node --target=node20 --format=cjs --minify --outfile=dist/mcp-server.bundle.cjs",
+    "bundle": "esbuild src/index.ts --bundle --platform=node --target=node22 --format=cjs --minify --outfile=dist/mcp-server.bundle.cjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
@@ -39,7 +39,7 @@
     "vitest": "^4.1.0"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "license": "MIT",
   "repository": {

--- a/workflows/startup-and-build.md
+++ b/workflows/startup-and-build.md
@@ -90,9 +90,9 @@ The output is a single JSON object with the standard envelope: `{ success: boole
 
 Show any captured error output (from `$BUILD_LOG`, stderr, or the `error` field). Then troubleshoot based on the error type:
 
-- **Build failure** (BUILD_FAILED sentinel): `cd ${CLAUDE_PLUGIN_ROOT}/packages/core && npm install && npm run bundle`. Common causes: missing Node.js 20+, stale `node_modules` (delete and reinstall), npm permission issues.
+- **Build failure** (BUILD_FAILED sentinel): `cd ${CLAUDE_PLUGIN_ROOT}/packages/core && npm install && npm run bundle`. Common causes: missing Node.js 22+, stale `node_modules` (delete and reinstall), npm permission issues.
 - **Auth/network error** (`success: false` with valid JSON): Check `gh auth status` and network connectivity. The CLI built fine — the daily check itself failed.
-- **Invalid output** (empty or non-JSON): Try running manually: `GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" startup --json`. Check `node --version` (need 20+).
+- **Invalid output** (empty or non-JSON): Try running manually: `GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" startup --json`. Check `node --version` (need 22+).
 - **Dashboard not showing or stale**: The dashboard build is non-blocking. Check `/tmp/oss-dashboard-build.log` for build errors. Rebuild manually: `cd ${CLAUDE_PLUGIN_ROOT}/packages/dashboard && npm install && npm run build`.
 
 **Return:** Core router (`commands/oss.md`) — **Summary** section with the parsed startup data.


### PR DESCRIPTION
## Summary

Drops Node 20 from supported runtimes. Node 20 reaches end-of-life on April 30, 2026.

- Bump `engines.node` to `>=22` across all four `package.json` files
- Drop `20` from the CI matrix (now runs on 22 + 24 ubuntu, 22 macOS)
- Update esbuild `--target` from `node20` to `node22` in core and mcp-server bundle scripts
- Update README, CONTRIBUTING, CLAUDE.md, setup-oss command, and architecture docs

## Why

Node 20 EOL is April 30, 2026. The issue's rollout note suggests merging in **early May 2026** rather than day-of, to give the ecosystem a beat to migrate.

## Breaking change

Users on Node 20 will see `npm WARN EBADENGINE` on install. They should upgrade to Node 22 (LTS) or 24 (current).

This will trigger another release-please major bump:
- `@oss-autopilot/core` v2 → v3
- `@oss-autopilot/mcp` v4 → v5

## Suggested merge timing

Hold until **early May 2026** (post Node 20 EOL on April 30) per the issue's rollout note.

## Notes

- The literal string `"Node 20 / ubuntu-latest"` is preserved in test fixtures and golden files — those represent CI check names from *external* PRs we monitor (e.g., projects that still target Node 20). They're realistic test data, not our config.
- Bundle rebuild verified locally: core 733KB, mcp-server 939KB.

## Test plan

- [x] `pnpm install` clean on local Node 22
- [x] `pnpm test` — 2544 tests pass (87 + 22 + 7 files)
- [x] `pnpm run lint` — clean
- [x] `pnpm run bundle` — both bundles build with `--target=node22`
- [x] `tsc --noEmit` — clean
- [ ] CI matrix passes on the PR (Node 22 + 24)

Closes #983.