### PR TITLE
fix: preserve upstream PR templates and checklists

### DIFF
--- a/skills/pr-etiquette/SKILL.md
+++ b/skills/pr-etiquette/SKILL.md
@@ -78,7 +78,17 @@ The tool should NEVER say "PR is ready", "work is complete", or "changes are don
 
 ## Writing Good PR Descriptions
 
-### Structure
+### When the upstream repo has a PR template
+
+If `.github/PULL_REQUEST_TEMPLATE.md` (or a sibling at `.github/pull_request_template.md`, `docs/pull_request_template.md`, or repo root) exists, the template is the **baseline** for your PR body — you merge your summary INTO it, not over it. Use `oss-autopilot pr-template <owner>/<repo>` to fetch it.
+
+- Preserve the template's headings, HTML comments, and checklist items verbatim.
+- Leave every checkbox unchecked (`- [ ]`). Maintainers' bots (DCO, changesets, license headers) rely on those items being actively ticked.
+- Drop your summary under an existing summary/description heading if there is one; otherwise prepend it.
+
+Wiping the template is the most common reason a maintainer flags an autopilot PR as careless.
+
+### Structure (when no template exists)
 
 ```markdown
 ## Summary

--- a/workflows/draft-first-workflow.md
+++ b/workflows/draft-first-workflow.md
@@ -525,7 +525,16 @@ branch=$(git branch --show-current)
 oss-autopilot pr-template {upstream-owner}/{upstream-repo} --json
 ```
 
-If a template is returned (`data.template` is non-null), use it as the structure for the PR body — fill in its sections (e.g., `## Summary`, `## Test Plan`, `## Docs`) with content relevant to your changes. Preserve the template's section headers and formatting. If no template exists or the command fails (network error, API error), use the default format below — template detection is best-effort and must not block PR creation.
+If a template is returned (`data.template` is non-null), the template body is the **baseline** for your PR description. You are merging your generated summary INTO it, not replacing it. Specifically:
+
+1. **Preserve the template verbatim.** Do not delete, reorder, or rewrite sections, headings, HTML comments (`<!-- ... -->`), or checklist items. Maintainers and bots (e.g., DCO checkers, changeset enforcers) rely on these — wiping them often violates the repo's contribution rules and reads as careless.
+2. **Leave every checkbox unchecked** (`- [ ]`, never `- [x]`). The contributor must actively confirm each item, which is the entire point of a checklist. Pre-checking checklist items defeats the safety mechanism.
+3. **Insert your generated summary into the right slot:**
+   - If the template has a labeled summary/description heading (e.g. `## Summary`, `## Description`, `## What does this PR do?`, `## Motivation`), put your summary text directly under that heading, replacing only any placeholder text (e.g. `<!-- Describe your change here -->`).
+   - Otherwise, prepend a `## Summary` block at the very top with your summary text, leaving the template intact below.
+4. **Insert your test plan / verification under any matching template heading** (e.g. `## Testing`, `## How was this tested?`); otherwise append a `## Test plan` block before the template's checklists, again leaving any test-related checklist items in the template untouched.
+
+If no template exists or the command fails (network error, API error), use the default format below — template detection is best-effort and must not block PR creation.
 
 Generate the PR title and body following the target repo's conventions (check `CONTRIBUTING.md`, existing PR formats, and the PR template above). Include:
 - Reference to the issue being fixed (e.g., "Fixes #123")


### PR DESCRIPTION
## Summary

Replaces the vague "fill in its sections" instruction in Step 8 of the draft-first workflow with explicit merge rules so Claude stops wiping upstream PR templates when opening contributions.

## Why

A maintainer recently flagged a PR for missing a changeset and DCO sign-off — both of which were checklist items in the upstream template that got wiped when the workflow generated a fresh PR body. The `pr-template` CLI command already fetches templates correctly; the gap was the workflow guidance to Claude was open to interpretation.

## What changed

**`workflows/draft-first-workflow.md`** Step 8 — the PR-body section now lists explicit rules:
1. Preserve the template verbatim (headings, HTML comments, checklist items).
2. Leave every checkbox unchecked (`- [ ]` never `- [x]`).
3. Insert generated summary under matching headings if present, otherwise prepend.
4. Same for the test plan.

**`skills/pr-etiquette/SKILL.md`** — adds a "When the upstream repo has a PR template" subsection with the same rules so the guidance is reachable from the skill router as well as the workflow.

## Out of scope (deferred)

- The `.github/PULL_REQUEST_TEMPLATE/*.md` directory case (multiple templates with no clear default — GitHub picks via UI chooser). The existing `pr-template` code gracefully skips directories and reports no template; picking a "default" requires repo-specific heuristics. Worth a separate issue if it becomes a pain point.

## Test plan

- [x] `pnpm test` — all 2544 tests pass (existing `pr-template.test.ts` already covers the 4 standard fetch paths + edge cases like 500/429/401/symlinks/empty content)
- [x] `pnpm run lint` — clean
- [x] Manual read of the new wording — concrete imperatives, no "fill in" ambiguity

The merge logic itself runs in Claude's interpretation of the workflow markdown, not in code, so there's no unit test for the merge step. The mitigation is the explicit numbered rules with concrete examples (`- [ ]` not `- [x]`) which leave very little interpretive room.

Closes #1127.