### PR TITLE
feat(vet): surface linkedPRClassification + antiLLMPolicy from scout 0.6.0

### DIFF
--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -64,7 +64,7 @@ GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli
 
 ### Anti-LLM / AI Policy
 
-The CLI auto-filters repos in `aiPolicyBlocklist`. During every vetting, scan CONTRIBUTING.md, CODE_OF_CONDUCT.md, and README for anti-LLM policy language — this is a **hard skip** regardless of score (the whole workflow is AI-assisted). The matcher lives in `packages/core/src/core/anti-llm-policy.ts`; `vet --json` surfaces matches in reasons-to-skip. Categories: `explicit_ban` ("no AI-generated"), `tool_ban` ("no Copilot"), `reject_framing` ("we do not accept AI"). See `docs/anti-llm-policy.md` for the full category definitions and appeal process.
+The CLI auto-filters repos in `aiPolicyBlocklist`. During every vetting, scout scans CONTRIBUTING.md, CODE_OF_CONDUCT.md, and README for anti-LLM policy language — this is a **hard skip** regardless of score (the whole workflow is AI-assisted). The scan lives in `@oss-scout/core` (since v0.6.0) and surfaces as a structured `antiLLMPolicy: { matched, matchedKeywords, sourceFile }` field on `vet --json` output — read that directly rather than parsing reasons-to-skip strings. Categories: `explicit_ban` ("no AI-generated"), `tool_ban` ("no Copilot"), `reject_framing` ("we do not accept AI"). See `docs/anti-llm-policy.md` for the full category definitions and appeal process.
 
 **If matched:** (1) recommendation → `skip` with reason `"anti-LLM policy"`; (2) quote the matching language in the summary so the user can verify the match; (3) do NOT proceed even if score is high.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "@octokit/plugin-throttling": "^11.0.3",
     "@octokit/rest": "^22.0.1",
-    "@oss-scout/core": "^0.5.0",
+    "@oss-scout/core": "^0.6.0",
     "commander": "^14.0.3",
     "zod": "^4.3.6"
   },

--- a/packages/core/src/commands/__golden__/vet-list.mixed.json
+++ b/packages/core/src/commands/__golden__/vet-list.mixed.json
@@ -29,6 +29,7 @@
         "checks": {},
         "notes": []
       },
+      "linkedPRClassification": "none",
       "grade": {
         "letter": "B",
         "reason": "3-day avg response"
@@ -62,6 +63,7 @@
         "checks": {},
         "notes": []
       },
+      "linkedPRClassification": "none",
       "grade": {
         "letter": "B",
         "reason": "3-day avg response"

--- a/packages/core/src/commands/__golden__/vet.approve.json
+++ b/packages/core/src/commands/__golden__/vet.approve.json
@@ -36,6 +36,7 @@
     },
     "notes": []
   },
+  "linkedPRClassification": "none",
   "grade": {
     "letter": "B",
     "reason": "4-day avg response"

--- a/packages/core/src/commands/__golden__/vet.skip.json
+++ b/packages/core/src/commands/__golden__/vet.skip.json
@@ -35,6 +35,7 @@
       "Linked PR already exists"
     ]
   },
+  "linkedPRClassification": "none",
   "grade": {
     "letter": "F",
     "reason": "unknown maintainer responsiveness, merge rate, activity"

--- a/packages/core/src/commands/scout-bridge.ts
+++ b/packages/core/src/commands/scout-bridge.ts
@@ -3,9 +3,27 @@
  * Maps state fields and creates scout instances for search/vet commands.
  */
 
-import { createScout, type OssScout, type ScoutState } from '@oss-scout/core';
+import { createScout, type LinkedPR as ScoutLinkedPR, type OssScout, type ScoutState } from '@oss-scout/core';
 import { getStateManager, requireGitHubToken } from '../core/index.js';
+import type { LinkedPR } from '../core/linked-pr-classification.js';
 import { loadSkippedIssues } from './skip-file-parser.js';
+
+/**
+ * Convert scout 0.6.0's `LinkedPR` (separate `state` + `merged`) into the
+ * shape `classifyLinkedPR` expects (`state` already folded with `merged`).
+ *
+ * Scout exposes the raw GitHub fields verbatim, but the classifier was
+ * written before scout surfaced this data and uses a tri-state
+ * `'open' | 'closed' | 'merged'` enum. Folding `merged` into the state
+ * preserves the function's existing contract + tests.
+ */
+export function adaptScoutLinkedPR(scoutLinkedPR: ScoutLinkedPR | null | undefined): LinkedPR | null {
+  if (!scoutLinkedPR) return null;
+  return {
+    author: { login: scoutLinkedPR.author },
+    state: scoutLinkedPR.merged ? 'merged' : scoutLinkedPR.state,
+  };
+}
 
 /**
  * Build a ScoutState from the current AgentState.

--- a/packages/core/src/commands/vet-list.contract.test.ts
+++ b/packages/core/src/commands/vet-list.contract.test.ts
@@ -18,9 +18,13 @@ const mocks = vi.hoisted(() => ({
   runParseList: vi.fn(),
 }));
 
-vi.mock('./scout-bridge.js', () => ({
-  createAutopilotScout: vi.fn(async () => ({ vetIssue: mocks.vetIssue })),
-}));
+vi.mock('./scout-bridge.js', async () => {
+  const actual = await vi.importActual<typeof import('./scout-bridge.js')>('./scout-bridge.js');
+  return {
+    ...actual,
+    createAutopilotScout: vi.fn(async () => ({ vetIssue: mocks.vetIssue })),
+  };
+});
 
 vi.mock('./startup.js', () => ({ detectIssueList: mocks.detectIssueList }));
 vi.mock('./parse-list.js', () => ({
@@ -32,7 +36,10 @@ vi.mock('../core/index.js', async () => {
   const actual = await vi.importActual<typeof import('../core/index.js')>('../core/index.js');
   return {
     ...actual,
-    getStateManager: () => ({ getRepoScore: mocks.getRepoScore }),
+    getStateManager: () => ({
+      getRepoScore: mocks.getRepoScore,
+      getState: () => ({ config: { githubUsername: 'costajohnt' } }),
+    }),
   };
 });
 

--- a/packages/core/src/commands/vet-list.test.ts
+++ b/packages/core/src/commands/vet-list.test.ts
@@ -7,11 +7,26 @@ import type { VetOutput } from '../formatters/json.js';
 
 const mockVetIssue = vi.fn();
 
-vi.mock('./scout-bridge.js', () => ({
-  createAutopilotScout: vi.fn(async () => ({
-    vetIssue: mockVetIssue,
-  })),
-}));
+vi.mock('./scout-bridge.js', async () => {
+  const actual = await vi.importActual<typeof import('./scout-bridge.js')>('./scout-bridge.js');
+  return {
+    ...actual,
+    createAutopilotScout: vi.fn(async () => ({
+      vetIssue: mockVetIssue,
+    })),
+  };
+});
+
+vi.mock('../core/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../core/index.js')>('../core/index.js');
+  return {
+    ...actual,
+    getStateManager: () => ({
+      getRepoScore: () => undefined,
+      getState: () => ({ config: { githubUsername: 'costajohnt' } }),
+    }),
+  };
+});
 
 vi.mock('./startup.js', () => ({
   detectIssueList: vi.fn(),

--- a/packages/core/src/commands/vet-list.ts
+++ b/packages/core/src/commands/vet-list.ts
@@ -4,12 +4,12 @@
  */
 
 import * as fs from 'fs';
-import { createAutopilotScout } from './scout-bridge.js';
+import { adaptScoutLinkedPR, createAutopilotScout } from './scout-bridge.js';
 import { type VetListOutput, type VetOutput, type VetListItemStatus } from '../formatters/json.js';
 import { runParseList, pruneIssueList } from './parse-list.js';
 import { detectIssueList } from './startup.js';
 import { computeSuccessGrade, gradeFromCandidate } from '../core/issue-grading.js';
-import { getStateManager } from '../core/index.js';
+import { getStateManager, classifyLinkedPR } from '../core/index.js';
 
 const UNKNOWN_GRADE = computeSuccessGrade({ avgResponseDays: null, mergeRate: null, daysSinceLastCommit: null });
 
@@ -153,6 +153,11 @@ export async function runVetList(options: VetListOptions = {}): Promise<VetListO
           projectHealth: candidate.projectHealth,
           getRepoScore: (repo) => getStateManager().getRepoScore(repo),
         });
+        const userLogin = getStateManager().getState().config.githubUsername;
+        const linkedPRClassification = classifyLinkedPR({
+          linkedPR: adaptScoutLinkedPR(candidate.vettingResult.linkedPR),
+          userLogin,
+        });
         const vetResult: VetOutput = {
           issue: {
             repo: candidate.issue.repo,
@@ -166,6 +171,8 @@ export async function runVetList(options: VetListOptions = {}): Promise<VetListO
           reasonsToSkip: candidate.reasonsToSkip,
           projectHealth: candidate.projectHealth,
           vettingResult: candidate.vettingResult,
+          antiLLMPolicy: candidate.antiLLMPolicy,
+          linkedPRClassification,
           grade,
         };
 

--- a/packages/core/src/commands/vet.contract.test.ts
+++ b/packages/core/src/commands/vet.contract.test.ts
@@ -22,15 +22,22 @@ import { describe, it, vi, beforeEach, expect } from 'vitest';
 const mockVetIssue = vi.fn();
 const mockGetRepoScore = vi.fn();
 
-vi.mock('./scout-bridge.js', () => ({
-  createAutopilotScout: vi.fn(async () => ({ vetIssue: mockVetIssue })),
-}));
+vi.mock('./scout-bridge.js', async () => {
+  const actual = await vi.importActual<typeof import('./scout-bridge.js')>('./scout-bridge.js');
+  return {
+    ...actual,
+    createAutopilotScout: vi.fn(async () => ({ vetIssue: mockVetIssue })),
+  };
+});
 
 vi.mock('../core/index.js', async () => {
   const actual = await vi.importActual<typeof import('../core/index.js')>('../core/index.js');
   return {
     ...actual,
-    getStateManager: () => ({ getRepoScore: mockGetRepoScore }),
+    getStateManager: () => ({
+      getRepoScore: mockGetRepoScore,
+      getState: () => ({ config: { githubUsername: 'costajohnt' } }),
+    }),
   };
 });
 

--- a/packages/core/src/commands/vet.test.ts
+++ b/packages/core/src/commands/vet.test.ts
@@ -7,17 +7,24 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const mockVetIssue = vi.fn();
 const mockGetRepoScore = vi.fn();
 
-vi.mock('./scout-bridge.js', () => ({
-  createAutopilotScout: vi.fn(async () => ({
-    vetIssue: mockVetIssue,
-  })),
-}));
+vi.mock('./scout-bridge.js', async () => {
+  const actual = await vi.importActual<typeof import('./scout-bridge.js')>('./scout-bridge.js');
+  return {
+    ...actual,
+    createAutopilotScout: vi.fn(async () => ({
+      vetIssue: mockVetIssue,
+    })),
+  };
+});
 
 vi.mock('../core/index.js', async () => {
   const actual = await vi.importActual<typeof import('../core/index.js')>('../core/index.js');
   return {
     ...actual,
-    getStateManager: () => ({ getRepoScore: mockGetRepoScore }),
+    getStateManager: () => ({
+      getRepoScore: mockGetRepoScore,
+      getState: () => ({ config: { githubUsername: 'costajohnt' } }),
+    }),
   };
 });
 
@@ -53,6 +60,8 @@ describe('runVet', () => {
       reasonsToSkip: [],
       projectHealth: { avgIssueResponseDays: 2, daysSinceLastCommit: 1 },
       vettingResult: { isViable: true },
+      antiLLMPolicy: undefined,
+      linkedPRClassification: 'none',
       grade: { letter: 'A', reason: expect.stringMatching(/respons|merge|commit/i) },
     });
   });

--- a/packages/core/src/commands/vet.ts
+++ b/packages/core/src/commands/vet.ts
@@ -7,7 +7,8 @@ import { createAutopilotScout } from './scout-bridge.js';
 import { type VetOutput } from '../formatters/json.js';
 import { ISSUE_URL_PATTERN, validateGitHubUrl, validateUrl } from './validation.js';
 import { gradeFromCandidate } from '../core/issue-grading.js';
-import { getStateManager } from '../core/index.js';
+import { getStateManager, classifyLinkedPR } from '../core/index.js';
+import { adaptScoutLinkedPR } from './scout-bridge.js';
 
 export { type VetOutput } from '../formatters/json.js';
 
@@ -36,6 +37,12 @@ export async function runVet(options: VetOptions): Promise<VetOutput> {
     getRepoScore: (repo) => getStateManager().getRepoScore(repo),
   });
 
+  const userLogin = getStateManager().getState().config.githubUsername;
+  const linkedPRClassification = classifyLinkedPR({
+    linkedPR: adaptScoutLinkedPR(candidate.vettingResult.linkedPR),
+    userLogin,
+  });
+
   return {
     issue: {
       repo: candidate.issue.repo,
@@ -49,6 +56,8 @@ export async function runVet(options: VetOptions): Promise<VetOutput> {
     reasonsToSkip: candidate.reasonsToSkip,
     projectHealth: candidate.projectHealth,
     vettingResult: candidate.vettingResult,
+    antiLLMPolicy: candidate.antiLLMPolicy,
+    linkedPRClassification,
     grade,
   };
 }

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -811,6 +811,30 @@ export interface VetOutput {
   reasonsToSkip: string[];
   projectHealth: unknown;
   vettingResult: unknown;
+  /**
+   * Result of scout's anti-LLM policy scan over CONTRIBUTING.md /
+   * CODE_OF_CONDUCT.md / README.md (#979). When `matched` is true the issue
+   * should be skipped — the project explicitly disallows AI-generated
+   * contributions.
+   */
+  antiLLMPolicy?: {
+    matched: boolean;
+    matchedKeywords: string[];
+    sourceFile: string | null;
+  };
+  /**
+   * Classification of the issue's first linked PR (#978). `'none'` when
+   * no linked PR exists. The other buckets distinguish whether the user
+   * already has work in flight vs. a competing contributor.
+   */
+  linkedPRClassification?:
+    | 'none'
+    | 'user_open'
+    | 'user_closed'
+    | 'user_merged'
+    | 'other_open'
+    | 'other_closed'
+    | 'other_merged';
   /** Success-likelihood grade (#858): predicts whether a PR will merge. */
   grade: {
     letter: 'A' | 'B' | 'C' | 'F';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@oss-scout/core':
-        specifier: ^0.5.0
-        version: 0.5.0(@octokit/core@7.0.6)
+        specifier: ^0.6.0
+        version: 0.6.0(@octokit/core@7.0.6)
       commander:
         specifier: ^14.0.3
         version: 14.0.3
@@ -816,8 +816,8 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@oss-scout/core@0.5.0':
-    resolution: {integrity: sha512-oq30RyjgOrzSSA2Xl7pt9YPVP7aDWFD0gKAs2+5CkphBKXAPrSTa8pAPaa7QSC5w9reOMfkiqrzvv8JR/Ql/0w==}
+  '@oss-scout/core@0.6.0':
+    resolution: {integrity: sha512-j3BY0hEgEgWxG2/MMctTI86Pknh+AJraOMzFU+CfOnHloY8i1zH9Sgltpm3lEVnyG3hFRGBPRxhX55wg/WwbDQ==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
@@ -3169,7 +3169,7 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@oss-scout/core@0.5.0(@octokit/core@7.0.6)':
+  '@oss-scout/core@0.6.0(@octokit/core@7.0.6)':
     dependencies:
       '@octokit/plugin-throttling': 11.0.3(@octokit/core@7.0.6)
       '@octokit/rest': 22.0.1


### PR DESCRIPTION
## Summary

Bumps `@oss-scout/core` to `^0.6.0` and consumes the new `linkedPR` and `antiLLMPolicy` fields it exposes on every `IssueCandidate`.

## What changed

- **`runVet` / `runVetList`** — call `classifyLinkedPR` (existing pure function) with scout's new `vettingResult.linkedPR` via a small `adaptScoutLinkedPR` bridge that folds scout's `state` + `merged` into the function's expected `'open' | 'closed' | 'merged'` enum.
- **`VetOutput`** — gains optional `linkedPRClassification` and `antiLLMPolicy` fields. Both are documented in the type.
- **`scout-bridge.ts`** — new `adaptScoutLinkedPR` adapter, exported.
- **`agents/issue-scout.md`** — anti-LLM section updated to read the structured `antiLLMPolicy` field directly (was previously parsing reasons-to-skip strings).
- **Tests** — vet/vet-list mocks updated to provide `getState()` (the new code path needs the configured `githubUsername` to compare against PR authors). Golden contract files re-snapshotted.

## Why

Until scout 0.6.0 the linked-PR classification function had to operate on a placeholder type since scout's `IssueCandidate` only exposed `vettingResult.checks.noExistingPR` (a boolean). With scout's new `linkedPR` field carrying author/state/merged/url, autopilot can finally compute the classification structurally instead of duplicating a `gh pr list` round-trip.

The anti-LLM scan move is the same story — scout already fetches CONTRIBUTING/COC/README during vetting, and 0.6.0 surfaces the structured match result rather than only writing it into reasons-to-skip.

## Test plan

- [x] `pnpm run lint` clean
- [x] `npx tsc --noEmit` (packages/core) clean
- [x] `pnpm test` — all 2544 tests pass (including updated unit + contract tests + golden snapshots)
- [x] `pnpm install --frozen-lockfile` aligns with new `^0.6.0` specifier

Closes #978.
Closes #979.