### PR TITLE
feat(vet): consume slmTriage from scout 0.7.1 + add config surface

### DIFF
--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -117,6 +117,17 @@ The `vet` response includes a `linkedPRClassification` when scout exposes the ra
 
 Classification handles case-insensitive logins, ghost authors, and REST/GraphQL state-value casing.
 
+### SLM pre-triage (optional, opt-in)
+
+When the user has configured `slmTriageModel` (e.g. `gemma4:e4b`), the `vet` response includes an `slmTriage: { decision, confidence, reasons, modelVersion }` field. Use it as a *prior*, not a gate:
+
+- `decision: 'pursue'` with `confidence: 'high'` — proceed normally; surface as a strong signal in your summary.
+- `decision: 'investigate'` — read the issue body before recommending; don't auto-approve.
+- `decision: 'skip'` — surface the model's reasons in the skip rationale; still let the user override.
+- `null` — model not configured or unreachable; behave as before.
+
+Never make a recommendation that contradicts the SLM call without saying so explicitly in the summary; users want to see the disagreement, not paper over it.
+
 ### gh fallback vetting
 
 If MCP + CLI both fail, collect the vetting data with `gh` (inform the user first):

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "@octokit/plugin-throttling": "^11.0.3",
     "@octokit/rest": "^22.0.1",
-    "@oss-scout/core": "^0.6.0",
+    "@oss-scout/core": "^0.7.1",
     "commander": "^14.0.3",
     "zod": "^4.3.6"
   },

--- a/packages/core/src/commands/__golden__/vet-list.mixed.json
+++ b/packages/core/src/commands/__golden__/vet-list.mixed.json
@@ -30,6 +30,7 @@
         "notes": []
       },
       "linkedPRClassification": "none",
+      "slmTriage": null,
       "grade": {
         "letter": "B",
         "reason": "3-day avg response"
@@ -64,6 +65,7 @@
         "notes": []
       },
       "linkedPRClassification": "none",
+      "slmTriage": null,
       "grade": {
         "letter": "B",
         "reason": "3-day avg response"

--- a/packages/core/src/commands/__golden__/vet.approve.json
+++ b/packages/core/src/commands/__golden__/vet.approve.json
@@ -37,6 +37,7 @@
     "notes": []
   },
   "linkedPRClassification": "none",
+  "slmTriage": null,
   "grade": {
     "letter": "B",
     "reason": "4-day avg response"

--- a/packages/core/src/commands/__golden__/vet.skip.json
+++ b/packages/core/src/commands/__golden__/vet.skip.json
@@ -36,6 +36,7 @@
     ]
   },
   "linkedPRClassification": "none",
+  "slmTriage": null,
   "grade": {
     "letter": "F",
     "reason": "unknown maintainer responsiveness, merge rate, activity"

--- a/packages/core/src/commands/scout-bridge.ts
+++ b/packages/core/src/commands/scout-bridge.ts
@@ -52,6 +52,8 @@ export function buildScoutState(): ScoutState {
       broadPhaseDelayMs: 90000,
       skipBroadWhenSufficientResults: 15,
       persistence: config.persistence as 'local' | 'gist',
+      slmTriageModel: config.slmTriageModel,
+      slmTriageHost: config.slmTriageHost,
     },
     repoScores: state.repoScores,
     starredRepos: config.starredRepos,

--- a/packages/core/src/commands/vet-list.ts
+++ b/packages/core/src/commands/vet-list.ts
@@ -173,6 +173,7 @@ export async function runVetList(options: VetListOptions = {}): Promise<VetListO
           vettingResult: candidate.vettingResult,
           antiLLMPolicy: candidate.antiLLMPolicy,
           linkedPRClassification,
+          slmTriage: candidate.slmTriage ?? null,
           grade,
         };
 

--- a/packages/core/src/commands/vet.test.ts
+++ b/packages/core/src/commands/vet.test.ts
@@ -62,6 +62,7 @@ describe('runVet', () => {
       vettingResult: { isViable: true },
       antiLLMPolicy: undefined,
       linkedPRClassification: 'none',
+      slmTriage: null,
       grade: { letter: 'A', reason: expect.stringMatching(/respons|merge|commit/i) },
     });
   });

--- a/packages/core/src/commands/vet.ts
+++ b/packages/core/src/commands/vet.ts
@@ -58,6 +58,7 @@ export async function runVet(options: VetOptions): Promise<VetOutput> {
     vettingResult: candidate.vettingResult,
     antiLLMPolicy: candidate.antiLLMPolicy,
     linkedPRClassification,
+    slmTriage: candidate.slmTriage ?? null,
     grade,
   };
 }

--- a/packages/core/src/core/state-schema.ts
+++ b/packages/core/src/core/state-schema.ts
@@ -200,6 +200,21 @@ export const AgentConfigSchema = z.object({
    * the hook does nothing on every push unless the user explicitly enables it.
    */
   autoFormatBeforePush: z.boolean().default(false),
+
+  /**
+   * Optional Ollama model for SLM pre-triage during issue vetting (#1122).
+   * Empty disables the feature. Recommended: `gemma4:e4b` (default for
+   * capable hardware), `gemma4:e2b` or `qwen3:1.7b` for low-RAM machines.
+   * Threaded through to scout via the bridge in `scout-bridge.ts`.
+   */
+  slmTriageModel: z.string().default(''),
+
+  /**
+   * Optional Ollama HTTP host override. Defaults to `http://127.0.0.1:11434`
+   * when empty. Useful when Ollama runs on a different machine on the
+   * local network.
+   */
+  slmTriageHost: z.string().default(''),
 });
 
 // ── 6. Cache schemas ─────────────────────────────────────────────────

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -835,6 +835,17 @@ export interface VetOutput {
     | 'other_open'
     | 'other_closed'
     | 'other_merged';
+  /**
+   * Optional SLM pre-triage classification (#1122). Populated when the
+   * user has set `slmTriageModel` and a local Ollama instance answered
+   * within the timeout. `null` otherwise.
+   */
+  slmTriage?: {
+    decision: 'pursue' | 'investigate' | 'skip';
+    confidence: 'high' | 'medium' | 'low';
+    reasons: string[];
+    modelVersion: string;
+  } | null;
   /** Success-likelihood grade (#858): predicts whether a PR will merge. */
   grade: {
     letter: 'A' | 'B' | 'C' | 'F';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@oss-scout/core':
-        specifier: ^0.6.0
-        version: 0.6.0(@octokit/core@7.0.6)
+        specifier: ^0.7.1
+        version: 0.7.1(@octokit/core@7.0.6)
       commander:
         specifier: ^14.0.3
         version: 14.0.3
@@ -816,8 +816,8 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@oss-scout/core@0.6.0':
-    resolution: {integrity: sha512-j3BY0hEgEgWxG2/MMctTI86Pknh+AJraOMzFU+CfOnHloY8i1zH9Sgltpm3lEVnyG3hFRGBPRxhX55wg/WwbDQ==}
+  '@oss-scout/core@0.7.1':
+    resolution: {integrity: sha512-3a3uQTsJVd6Lsf7q6rxrOwC7JFE3kkdI3Ok+UH1n7S/RHcWNOUUQm+Jh5+FC4dI/b8j1Q912xFOPnbfbQTbR8Q==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
@@ -3169,7 +3169,7 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@oss-scout/core@0.6.0(@octokit/core@7.0.6)':
+  '@oss-scout/core@0.7.1(@octokit/core@7.0.6)':
     dependencies:
       '@octokit/plugin-throttling': 11.0.3(@octokit/core@7.0.6)
       '@octokit/rest': 22.0.1


### PR DESCRIPTION
## Summary

Consumes the new SLM pre-triage feature shipped in `@oss-scout/core@0.7.1` (scout #81 + #83). When the user sets `slmTriageModel`, every `vet` / `vet-list` call optionally classifies the candidate via a local Ollama instance and returns the `decision` / `confidence` / `reasons` on the existing `vet --json` output.

## What changed

- **`packages/core/package.json`** — `@oss-scout/core` `^0.6.0` → `^0.7.1`.
- **`packages/core/src/core/state-schema.ts`** — adds `slmTriageModel` and `slmTriageHost` to AgentState `ConfigSchema`. Empty model disables the feature; empty host falls back to `http://127.0.0.1:11434` inside scout.
- **`packages/core/src/commands/scout-bridge.ts`** — threads both fields into `ScoutPreferences` so `OssScout.getSLMTriageConfig()` reads them.
- **`packages/core/src/commands/vet.ts` + `vet-list.ts`** — surface the candidate's `slmTriage` on `VetOutput` (alongside the existing `linkedPRClassification` + `antiLLMPolicy` fields shipped in #1168).
- **`packages/core/src/formatters/json.ts`** — extends `VetOutput` with the optional `slmTriage` shape.
- **`agents/issue-scout.md`** — new "SLM pre-triage" subsection documenting how to use `decision` / `confidence` / `reasons` as a *prior*, not a gate. Explicit guidance: never make a recommendation that contradicts the SLM call without saying so in the summary.
- **Tests** — vet/vet-list test mocks updated for the new fields; golden contract snapshots regenerated.

## Why

This closes the loop on the local-SLM pre-triage feature requested in #1122. The recommended default model is `gemma4:e4b` (frontier-tier reasoning at edge-device size per Google's release notes); `gemma4:e2b` and `qwen3:1.7b` work for low-RAM machines.

Behavior is fully opt-in:
- Empty `slmTriageModel` → no behavioral change vs. before this PR.
- Configured but Ollama unreachable → scout's fail-open returns `null` for `slmTriage`; vetting proceeds normally.

## Recommended setup

```bash
ollama pull gemma4:e4b
oss-autopilot setup --set slmTriageModel=gemma4:e4b
```

## Test plan

- [x] `pnpm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `pnpm -r test` — 2544 tests pass (2114 core + 256 dashboard + 174 mcp-server)
- [x] `pnpm install --frozen-lockfile` clean against the new `^0.7.1` specifier
- [ ] **Manual smoke test pending**: pull `gemma4:e4b`, set the config, run `vet <issue-url> --json` and verify the `slmTriage` field appears with a `pursue` / `investigate` / `skip` decision

Closes #1122.