### PR TITLE
feat: guidelines-store — Gist freeform document API for per-repo guidelines (#867 PR 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ env:
   #   - **Don't bump for a flaky measurement:** esbuild output is
   #     deterministic. If the threshold trips on a no-op rebuild, it's a
   #     real increase somewhere upstream — not noise.
-  BUNDLE_MAX_CORE: 760000 # ~742 KB (increased for list-move-tier command, #1107)
+  BUNDLE_MAX_CORE: 780000 # ~762 KB (increased for guidelines-store module, #867)
   BUNDLE_MAX_MCP: 2000000 # ~1953 KB
   STARTUP_WARN_MS: 500 # Warn if CLI startup exceeds 500ms
 

--- a/packages/core/src/core/guidelines-store.test.ts
+++ b/packages/core/src/core/guidelines-store.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'vitest';
+import { GistStateStore } from './gist-state-store.js';
+import {
+  getGuidelines,
+  setGuidelines,
+  deleteGuidelines,
+  listGuidelinesRepos,
+  guidelinesFilename,
+  repoFromGuidelinesFilename,
+  GUIDELINES_FILE_PREFIX,
+  GUIDELINES_MAX_BYTES,
+  GuidelinesNotAvailableError,
+  GuidelinesTooLargeError,
+} from './guidelines-store.js';
+
+/**
+ * Build a minimally-valid GistStateStore stub via the public surface — we
+ * only need the in-memory cache + dirty-tracking, not real network calls.
+ *
+ * The store's constructor takes an Octokit-like object; we pass a stub that
+ * never gets called by any of the document operations (which are pure cache
+ * mutations). The cast keeps TypeScript happy without polluting the public
+ * `OctokitLike` shape with test-only fields.
+ */
+function makeStubStore(): GistStateStore {
+  const stubOctokit = {
+    gists: {
+      get: () => Promise.reject(new Error('unused in cache-only tests')),
+      list: () => Promise.reject(new Error('unused in cache-only tests')),
+      create: () => Promise.reject(new Error('unused in cache-only tests')),
+      update: () => Promise.reject(new Error('unused in cache-only tests')),
+    },
+  };
+  return new GistStateStore(stubOctokit as unknown as ConstructorParameters<typeof GistStateStore>[0]);
+}
+
+describe('guidelinesFilename', () => {
+  it('encodes owner/repo as guidelines--owner--repo.md', () => {
+    expect(guidelinesFilename('costajohnt/oss-autopilot')).toBe('guidelines--costajohnt--oss-autopilot.md');
+  });
+
+  it('throws on a string without a slash', () => {
+    expect(() => guidelinesFilename('justanowner')).toThrow(/Invalid repo identifier/);
+  });
+});
+
+describe('repoFromGuidelinesFilename', () => {
+  it('round-trips a standard filename', () => {
+    expect(repoFromGuidelinesFilename('guidelines--costajohnt--oss-autopilot.md')).toBe('costajohnt/oss-autopilot');
+  });
+
+  it('returns null for a filename missing the prefix', () => {
+    expect(repoFromGuidelinesFilename('state.json')).toBeNull();
+  });
+
+  it('returns null for a filename missing the .md suffix', () => {
+    expect(repoFromGuidelinesFilename('guidelines--owner--repo')).toBeNull();
+  });
+
+  it('returns null for a filename with no double-dash separator', () => {
+    expect(repoFromGuidelinesFilename('guidelines--owneronly.md')).toBeNull();
+  });
+
+  it('handles repo names that contain extra hyphens after the separator', () => {
+    expect(repoFromGuidelinesFilename('guidelines--owner--repo-with-hyphens.md')).toBe('owner/repo-with-hyphens');
+  });
+});
+
+describe('getGuidelines / setGuidelines / deleteGuidelines', () => {
+  it('getGuidelines returns null when the store is null (local mode)', () => {
+    expect(getGuidelines(null, 'owner/repo')).toBeNull();
+  });
+
+  it('getGuidelines returns null when the file does not exist in cache', () => {
+    const store = makeStubStore();
+    expect(getGuidelines(store, 'owner/repo')).toBeNull();
+  });
+
+  it('setGuidelines + getGuidelines round-trips content', () => {
+    const store = makeStubStore();
+    setGuidelines(store, 'owner/repo', '# Guidelines\n- rule 1');
+    expect(getGuidelines(store, 'owner/repo')).toBe('# Guidelines\n- rule 1');
+  });
+
+  it('setGuidelines marks the file dirty so the next push includes it', () => {
+    const store = makeStubStore();
+    setGuidelines(store, 'owner/repo', 'x');
+    expect(store.dirtyFiles.has(guidelinesFilename('owner/repo'))).toBe(true);
+  });
+
+  it('setGuidelines throws GuidelinesNotAvailableError when store is null', () => {
+    expect(() => setGuidelines(null, 'owner/repo', 'x')).toThrow(GuidelinesNotAvailableError);
+  });
+
+  it('setGuidelines throws GuidelinesTooLargeError when content exceeds the byte cap', () => {
+    const store = makeStubStore();
+    const oversized = 'x'.repeat(GUIDELINES_MAX_BYTES + 1);
+    expect(() => setGuidelines(store, 'owner/repo', oversized)).toThrow(GuidelinesTooLargeError);
+  });
+
+  it('setGuidelines accepts content exactly at the byte cap', () => {
+    const store = makeStubStore();
+    const max = 'x'.repeat(GUIDELINES_MAX_BYTES);
+    expect(() => setGuidelines(store, 'owner/repo', max)).not.toThrow();
+  });
+
+  it('setGuidelines counts UTF-8 byte length, not character length', () => {
+    const store = makeStubStore();
+    // Each emoji is 4 bytes in UTF-8. 2050 emoji = 8200 bytes, just over the cap.
+    const oversized = '🚀'.repeat(2050);
+    expect(() => setGuidelines(store, 'owner/repo', oversized)).toThrow(GuidelinesTooLargeError);
+  });
+
+  it('deleteGuidelines tombstones the file (empty content)', () => {
+    const store = makeStubStore();
+    setGuidelines(store, 'owner/repo', 'content');
+    deleteGuidelines(store, 'owner/repo');
+    expect(getGuidelines(store, 'owner/repo')).toBeNull();
+  });
+
+  it('getGuidelines returns null for an empty-content (tombstoned) file', () => {
+    const store = makeStubStore();
+    setGuidelines(store, 'owner/repo', 'real content');
+    deleteGuidelines(store, 'owner/repo');
+    // The underlying cached value is empty string, but getGuidelines hides it.
+    expect(store.cachedFiles.get(guidelinesFilename('owner/repo'))).toBe('');
+    expect(getGuidelines(store, 'owner/repo')).toBeNull();
+  });
+
+  it('deleteGuidelines throws GuidelinesNotAvailableError when store is null', () => {
+    expect(() => deleteGuidelines(null, 'owner/repo')).toThrow(GuidelinesNotAvailableError);
+  });
+
+  it('round-trip: set, get, delete, get returns null', () => {
+    const store = makeStubStore();
+    setGuidelines(store, 'owner/repo', 'x');
+    expect(getGuidelines(store, 'owner/repo')).toBe('x');
+    deleteGuidelines(store, 'owner/repo');
+    expect(getGuidelines(store, 'owner/repo')).toBeNull();
+  });
+});
+
+describe('listGuidelinesRepos', () => {
+  it('returns [] when the store is null', () => {
+    expect(listGuidelinesRepos(null)).toEqual([]);
+  });
+
+  it('returns [] when no guidelines files exist', () => {
+    const store = makeStubStore();
+    expect(listGuidelinesRepos(store)).toEqual([]);
+  });
+
+  it('returns a sorted array of repos with stored guidelines', () => {
+    const store = makeStubStore();
+    setGuidelines(store, 'zebra-org/repo-a', 'a');
+    setGuidelines(store, 'apple-org/repo-b', 'b');
+    setGuidelines(store, 'middle-org/repo-c', 'c');
+    expect(listGuidelinesRepos(store)).toEqual(['apple-org/repo-b', 'middle-org/repo-c', 'zebra-org/repo-a']);
+  });
+
+  it('excludes tombstoned (empty-content) files from the result', () => {
+    const store = makeStubStore();
+    setGuidelines(store, 'owner/repo-a', 'real');
+    setGuidelines(store, 'owner/repo-b', 'tombstone');
+    deleteGuidelines(store, 'owner/repo-b');
+    expect(listGuidelinesRepos(store)).toEqual(['owner/repo-a']);
+  });
+
+  it('ignores files that do not match the guidelines naming convention', () => {
+    const store = makeStubStore();
+    // Manually inject a file that uses the prefix but isn't a guidelines file
+    // (e.g. a hand-edited Gist entry from before the convention was finalized).
+    store.cachedFiles.set('guidelines--malformed.md', 'wrong shape');
+    setGuidelines(store, 'owner/real', 'good');
+    expect(listGuidelinesRepos(store)).toEqual(['owner/real']);
+  });
+});
+
+describe('module exports', () => {
+  it('exports the file prefix and byte cap as constants', () => {
+    expect(GUIDELINES_FILE_PREFIX).toBe('guidelines--');
+    expect(GUIDELINES_MAX_BYTES).toBe(8192);
+  });
+});

--- a/packages/core/src/core/guidelines-store.ts
+++ b/packages/core/src/core/guidelines-store.ts
@@ -1,0 +1,151 @@
+/**
+ * Per-repo guidelines persistence on top of the Gist freeform-document API
+ * (#867 PR 2).
+ *
+ * Each repo gets one markdown file named `guidelines--{owner}--{repo}.md`
+ * stored in the user's oss-autopilot Gist alongside `state.json`. The file
+ * holds extracted guidance from past PR review feedback. Reads and writes go
+ * through the in-memory cache that `GistStateStore` already maintains; the
+ * file persists on the next `push()`.
+ *
+ * The byte cap (8 KB) is enforced at write time to keep claim-time context
+ * injection small. Larger guidance should be split across categories or
+ * deferred to a follow-up consolidation pass.
+ */
+import type { GistStateStore } from './gist-state-store.js';
+import { OssAutopilotError } from './errors.js';
+
+/** Filename prefix shared by every guidelines file in the Gist. */
+export const GUIDELINES_FILE_PREFIX = 'guidelines--';
+
+/** Hard byte budget for a single guidelines file (#867 design log §1). */
+export const GUIDELINES_MAX_BYTES = 8_192;
+
+/** Suffix appended to the filename so it renders as markdown in Gist. */
+const GUIDELINES_FILE_SUFFIX = '.md';
+
+/**
+ * Convert an `owner/repo` pair into the filename used inside the Gist.
+ * Slashes are escaped as `--` so the filename is filesystem-safe and
+ * unambiguous when parsing back to a repo string.
+ */
+export function guidelinesFilename(repo: string): string {
+  if (!repo.includes('/')) {
+    throw new OssAutopilotError(`Invalid repo identifier "${repo}". Expected "owner/repo" format.`, 'INVALID_REPO_ID');
+  }
+  // GitHub forbids `/` in owner and repo, so the only `/` is the separator.
+  const [owner, name] = repo.split('/');
+  return `${GUIDELINES_FILE_PREFIX}${owner}--${name}${GUIDELINES_FILE_SUFFIX}`;
+}
+
+/**
+ * Inverse of {@link guidelinesFilename}. Returns null when the filename
+ * doesn't match the guidelines convention.
+ */
+export function repoFromGuidelinesFilename(filename: string): string | null {
+  if (!filename.startsWith(GUIDELINES_FILE_PREFIX)) return null;
+  if (!filename.endsWith(GUIDELINES_FILE_SUFFIX)) return null;
+  const middle = filename.slice(GUIDELINES_FILE_PREFIX.length, filename.length - GUIDELINES_FILE_SUFFIX.length);
+  // Only split on the FIRST `--` separator. Repo names with `--` are rare
+  // but legal; owner names cannot contain `--` per GitHub username rules.
+  const sep = middle.indexOf('--');
+  if (sep === -1) return null;
+  const owner = middle.slice(0, sep);
+  const name = middle.slice(sep + 2);
+  if (!owner || !name) return null;
+  return `${owner}/${name}`;
+}
+
+/**
+ * Thrown by {@link setGuidelines} / {@link deleteGuidelines} when the
+ * StateManager is not in Gist mode. Catch + degrade gracefully when surfacing
+ * to user-facing flows: per-repo guidelines simply aren't available without a
+ * Gist to store them in.
+ */
+export class GuidelinesNotAvailableError extends OssAutopilotError {
+  constructor(message?: string) {
+    super(
+      message ??
+        'Per-repo guidelines require Gist persistence. Run `oss-autopilot setup` to enable Gist sync, then retry.',
+      'GUIDELINES_NOT_AVAILABLE',
+    );
+    this.name = 'GuidelinesNotAvailableError';
+  }
+}
+
+/**
+ * Thrown by {@link setGuidelines} when content exceeds {@link GUIDELINES_MAX_BYTES}.
+ * Surfaced separately from generic validation errors so consumers can prompt the
+ * user with a "trim or split" UX rather than a generic shape rejection.
+ */
+export class GuidelinesTooLargeError extends OssAutopilotError {
+  constructor(byteSize: number, max: number = GUIDELINES_MAX_BYTES) {
+    super(
+      `Guidelines content is ${byteSize} bytes, exceeding the ${max}-byte cap. ` + `Trim or split across categories.`,
+      'GUIDELINES_TOO_LARGE',
+    );
+    this.name = 'GuidelinesTooLargeError';
+  }
+}
+
+/**
+ * Read the guidelines file for a repo from the Gist cache. Returns null when
+ * the store is not in Gist mode, the file does not exist, or the file is
+ * present but empty (treated as a tombstone left by {@link deleteGuidelines}).
+ */
+export function getGuidelines(store: GistStateStore | null, repo: string): string | null {
+  if (!store) return null;
+  const content = store.getDocument(guidelinesFilename(repo));
+  if (content === null || content === '') return null;
+  return content;
+}
+
+/**
+ * Write or replace the guidelines file for a repo. Throws if the store is not
+ * in Gist mode or the content exceeds the byte budget.
+ */
+export function setGuidelines(store: GistStateStore | null, repo: string, content: string): void {
+  if (!store) throw new GuidelinesNotAvailableError();
+  const byteSize = Buffer.byteLength(content, 'utf-8');
+  if (byteSize > GUIDELINES_MAX_BYTES) {
+    throw new GuidelinesTooLargeError(byteSize);
+  }
+  store.setDocument(guidelinesFilename(repo), content);
+}
+
+/**
+ * Delete the guidelines file for a repo. No-op if the file doesn't exist.
+ * Implementation: write an empty string. The Gist API treats files with
+ * empty content as deletions on the next push, matching the existing
+ * single-source-of-truth model.
+ */
+export function deleteGuidelines(store: GistStateStore | null, repo: string): void {
+  if (!store) throw new GuidelinesNotAvailableError();
+  // setDocument('') is interpreted as deletion; the GistStateStore push path
+  // already strips empty-content files before sending to the Gist API.
+  store.setDocument(guidelinesFilename(repo), '');
+}
+
+/**
+ * List every repo (as `owner/repo`) that has a non-empty guidelines file in
+ * the cache. Tombstoned (empty-content) files are excluded so the result
+ * matches what {@link getGuidelines} would actually return.
+ *
+ * Returns an empty array when the store is null or no files exist.
+ */
+export function listGuidelinesRepos(store: GistStateStore | null): string[] {
+  if (!store) return [];
+  const filenames = store.listDocuments(GUIDELINES_FILE_PREFIX);
+  const repos: string[] = [];
+  for (const filename of filenames) {
+    const repo = repoFromGuidelinesFilename(filename);
+    // Skip files we can't decode (e.g. older formats, hand-edited) — better
+    // than throwing and breaking listGuidelinesRepos for everyone.
+    if (!repo) continue;
+    // Skip tombstones — empty content means the user deleted these guidelines.
+    const content = store.getDocument(filename);
+    if (content === null || content === '') continue;
+    repos.push(repo);
+  }
+  return repos.sort();
+}

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -14,6 +14,14 @@ export {
 } from './state.js';
 export { GistStateStore } from './gist-state-store.js';
 export {
+  guidelinesFilename,
+  repoFromGuidelinesFilename,
+  GUIDELINES_FILE_PREFIX,
+  GUIDELINES_MAX_BYTES,
+  GuidelinesNotAvailableError,
+  GuidelinesTooLargeError,
+} from './guidelines-store.js';
+export {
   PRMonitor,
   type PRCheckFailure,
   type FetchPRsResult,

--- a/packages/core/src/core/state.test.ts
+++ b/packages/core/src/core/state.test.ts
@@ -928,4 +928,29 @@ describe('StateManager merged PRs', () => {
       expect(stateManager.getClosedPRs()[0].learningsExtractedAt).toBe('2026-04-26T01:00:00Z');
     });
   });
+
+  describe('per-repo guidelines (#867)', () => {
+    it('isGuidelinesAvailable returns false in local mode', () => {
+      // Default StateManager constructed in this file is local-only.
+      expect(stateManager.isGuidelinesAvailable()).toBe(false);
+    });
+
+    it('getGuidelines returns null in local mode', () => {
+      expect(stateManager.getGuidelines('owner/repo')).toBeNull();
+    });
+
+    it('listGuidelinesRepos returns [] in local mode', () => {
+      expect(stateManager.listGuidelinesRepos()).toEqual([]);
+    });
+
+    it('setGuidelines throws GuidelinesNotAvailableError in local mode', () => {
+      expect(() => stateManager.setGuidelines('owner/repo', 'x')).toThrow(
+        /Per-repo guidelines require Gist persistence/,
+      );
+    });
+
+    it('deleteGuidelines throws GuidelinesNotAvailableError in local mode', () => {
+      expect(() => stateManager.deleteGuidelines('owner/repo')).toThrow(/Per-repo guidelines require Gist persistence/);
+    });
+  });
 });

--- a/packages/core/src/core/state.ts
+++ b/packages/core/src/core/state.ts
@@ -30,6 +30,7 @@ import type { Stats } from './repo-score-manager.js';
 import { debug, warn } from './logger.js';
 import { errorMessage, ConfigurationError, ConcurrencyError } from './errors.js';
 import { GistStateStore, type OctokitLike } from './gist-state-store.js';
+import * as guidelinesStoreModule from './guidelines-store.js';
 import { getStatePath, getStateCachePath } from './paths.js';
 import { parseGitHubUrl } from './urls.js';
 
@@ -314,6 +315,46 @@ export class StateManager {
   /** Whether the Gist is in degraded mode (using local cache fallback). */
   isGistDegraded(): boolean {
     return this.gistDegraded;
+  }
+
+  /**
+   * Whether per-repo guidelines (#867) are available. True iff the Gist store
+   * is initialized — in local-only mode, guidelines are unavailable and
+   * write operations would throw {@link GuidelinesNotAvailableError}.
+   */
+  isGuidelinesAvailable(): boolean {
+    return this.gistStore !== null;
+  }
+
+  /**
+   * Read the per-repo guidelines for `repo` (#867). Returns null when in
+   * local mode, when no file exists, or when the file is empty (tombstoned).
+   */
+  getGuidelines(repo: string): string | null {
+    return guidelinesStoreModule.getGuidelines(this.gistStore, repo);
+  }
+
+  /**
+   * Persist per-repo guidelines for `repo`. Throws when not in Gist mode or
+   * when content exceeds the byte budget.
+   */
+  setGuidelines(repo: string, content: string): void {
+    guidelinesStoreModule.setGuidelines(this.gistStore, repo, content);
+    this.autoSave();
+  }
+
+  /**
+   * Tombstone the guidelines file for `repo` so subsequent reads return null.
+   * Throws when not in Gist mode.
+   */
+  deleteGuidelines(repo: string): void {
+    guidelinesStoreModule.deleteGuidelines(this.gistStore, repo);
+    this.autoSave();
+  }
+
+  /** List repos with non-empty guidelines stored in the Gist. */
+  listGuidelinesRepos(): string[] {
+    return guidelinesStoreModule.listGuidelinesRepos(this.gistStore);
   }
 
   /**


### PR DESCRIPTION
## Summary

Adds the persistence layer for per-repo learning guidelines (#867). Stores each repo's guidelines as a markdown file in the user's oss-autopilot Gist alongside `state.json`, accessed via the existing `GistStateStore.getDocument` / `setDocument` / `listDocuments` cache.

This is **PR 2 of 7** in the #867 sequence — see `docs/design-867-per-repo-learning.md` for the full blueprint. Foundation only: no extraction logic, no claim-time injection, no comment fetching. Subsequent PRs build on this.

## What changed

**`packages/core/src/core/guidelines-store.ts`** (new, 158 lines)
- `guidelinesFilename(repo)` → `guidelines--{owner}--{repo}.md` filename convention.
- `repoFromGuidelinesFilename(filename)` → `'owner/repo'`, with graceful null returns for malformed filenames.
- `getGuidelines(store, repo)` → `string | null`. Returns null for missing files OR empty-content tombstones, so consumers don't need to special-case both.
- `setGuidelines(store, repo, content)` — writes through the cache; throws `GuidelinesNotAvailableError` when not in Gist mode and `GuidelinesTooLargeError` when content exceeds 8 KB. UTF-8 byte length used (not character count) so emoji-heavy content is bounded correctly.
- `deleteGuidelines(store, repo)` — tombstones via empty-string write.
- `listGuidelinesRepos(store)` — sorted `owner/repo` list, excludes tombstones and malformed filenames.
- New error classes `GuidelinesNotAvailableError` (`GUIDELINES_NOT_AVAILABLE`) and `GuidelinesTooLargeError` (`GUIDELINES_TOO_LARGE`).

**`packages/core/src/core/state.ts`** — five new façade methods on `StateManager`:
- `isGuidelinesAvailable()` — true iff backed by a Gist.
- `getGuidelines`, `setGuidelines`, `deleteGuidelines`, `listGuidelinesRepos` — thread the gistStore through. Set/delete call `autoSave()` so the dirty-tracking is persisted on the next save tick.

**`packages/core/src/core/index.ts`** — public exports for the filename helpers, byte cap constant, and typed errors.

## Test plan

- [x] `pnpm test` — 2580 tests pass (2150 core + 256 dashboard + 174 mcp-server)
- [x] `pnpm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] 25 new tests in `guidelines-store.test.ts` cover: filename round-trip, set/get/delete, byte-cap (including UTF-8 multi-byte), tombstone semantics
- [x] 5 new tests in `state.test.ts` cover the StateManager local-mode behavior (returns `false`/`null`/`[]`, throws on writes)

Refs #867. Independent of PR 1 (#1171) — they touch different files and could land in either order.