### PR TITLE
feat: pr-comments-fetcher — fetch raw comment bundles for closed/merged PRs (#867 PR 3)

### DIFF
--- a/packages/core/src/core/pr-comments-fetcher.test.ts
+++ b/packages/core/src/core/pr-comments-fetcher.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Octokit } from '@octokit/rest';
+import { fetchPRCommentBundle, fetchPRCommentBundlesBatch } from './pr-comments-fetcher.js';
+
+// Mock paginateAll so tests don't need to simulate page boundaries; one
+// page is enough to verify the data-shape contract.
+vi.mock('./pagination.js', () => ({
+  paginateAll: async (fetchPage: (page: number) => Promise<{ data: unknown[] }>) => {
+    const r = await fetchPage(1);
+    return r.data;
+  },
+}));
+
+// ── Fixture builders ────────────────────────────────────────────────────────
+
+interface MockComment {
+  user: { login: string; type?: string } | null;
+  author_association?: string;
+  body?: string;
+  path?: string;
+  created_at?: string;
+  submitted_at?: string;
+}
+
+function makePR(overrides: Partial<{ title: string; merged_at: string | null; closed_at: string | null }> = {}) {
+  return {
+    title: 'Add feature X',
+    merged_at: '2026-04-20T12:00:00Z',
+    closed_at: null,
+    ...overrides,
+  };
+}
+
+function makeOctokit(opts: {
+  pr?: ReturnType<typeof makePR>;
+  reviews?: MockComment[];
+  reviewComments?: MockComment[];
+  issueComments?: MockComment[];
+  failPrGet?: boolean;
+}): Octokit {
+  const pr = opts.pr ?? makePR();
+  return {
+    pulls: {
+      get: vi.fn(async () => {
+        if (opts.failPrGet) throw new Error('Not Found');
+        return { data: pr };
+      }),
+      listReviews: vi.fn(async () => ({ data: opts.reviews ?? [] })),
+      listReviewComments: vi.fn(async () => ({ data: opts.reviewComments ?? [] })),
+    },
+    issues: {
+      listComments: vi.fn(async () => ({ data: opts.issueComments ?? [] })),
+    },
+  } as unknown as Octokit;
+}
+
+const PR_URL = 'https://github.com/owner/repo/pull/42';
+
+describe('fetchPRCommentBundle', () => {
+  it('returns a well-formed bundle for a valid PR URL', async () => {
+    const octokit = makeOctokit({
+      reviews: [
+        {
+          user: { login: 'maintainer1' },
+          author_association: 'OWNER',
+          body: 'Looks good with one nit.',
+          submitted_at: '2026-04-20T10:00:00Z',
+        },
+      ],
+      reviewComments: [
+        {
+          user: { login: 'maintainer1' },
+          author_association: 'OWNER',
+          body: 'Use camelCase here.',
+          path: 'src/x.ts',
+          created_at: '2026-04-20T10:01:00Z',
+        },
+      ],
+      issueComments: [
+        {
+          user: { login: 'maintainer2' },
+          author_association: 'COLLABORATOR',
+          body: 'Thanks for the contribution!',
+          created_at: '2026-04-20T11:00:00Z',
+        },
+      ],
+    });
+
+    const bundle = await fetchPRCommentBundle(octokit, PR_URL, 'me');
+
+    expect(bundle.prUrl).toBe(PR_URL);
+    expect(bundle.prTitle).toBe('Add feature X');
+    expect(bundle.repo).toBe('owner/repo');
+    expect(bundle.mergedAt).toBe('2026-04-20T12:00:00Z');
+    expect(bundle.reviews).toHaveLength(1);
+    expect(bundle.reviews[0]).toMatchObject({
+      author: 'maintainer1',
+      authorAssociation: 'OWNER',
+      body: 'Looks good with one nit.',
+    });
+    expect(bundle.reviewComments[0].path).toBe('src/x.ts');
+    expect(bundle.issueComments[0].author).toBe('maintainer2');
+  });
+
+  it('throws ValidationError on a non-PR URL', async () => {
+    const octokit = makeOctokit({});
+    await expect(fetchPRCommentBundle(octokit, 'https://github.com/owner/repo/issues/1', 'me')).rejects.toThrow(
+      /Invalid PR URL/,
+    );
+  });
+
+  it('throws ValidationError on a malformed URL', async () => {
+    const octokit = makeOctokit({});
+    await expect(fetchPRCommentBundle(octokit, 'not-a-url', 'me')).rejects.toThrow(/Invalid PR URL/);
+  });
+
+  it("excludes the authenticated user's own comments", async () => {
+    const octokit = makeOctokit({
+      reviews: [{ user: { login: 'me' }, author_association: 'CONTRIBUTOR', body: 'self review' }],
+      reviewComments: [{ user: { login: 'me' }, author_association: 'CONTRIBUTOR', body: 'my own inline' }],
+      issueComments: [
+        { user: { login: 'me' }, author_association: 'CONTRIBUTOR', body: 'my own thread' },
+        { user: { login: 'maintainer1' }, author_association: 'OWNER', body: 'theirs' },
+      ],
+    });
+    const bundle = await fetchPRCommentBundle(octokit, PR_URL, 'me');
+    expect(bundle.reviews).toHaveLength(0);
+    expect(bundle.reviewComments).toHaveLength(0);
+    expect(bundle.issueComments).toHaveLength(1);
+    expect(bundle.issueComments[0].author).toBe('maintainer1');
+  });
+
+  it('compares the user login case-insensitively', async () => {
+    const octokit = makeOctokit({
+      issueComments: [{ user: { login: 'CostaJohnt' }, author_association: 'CONTRIBUTOR', body: 'mine' }],
+    });
+    const bundle = await fetchPRCommentBundle(octokit, PR_URL, 'costajohnt');
+    expect(bundle.issueComments).toHaveLength(0);
+  });
+
+  it('excludes bot accounts (login containing [bot])', async () => {
+    const octokit = makeOctokit({
+      issueComments: [
+        { user: { login: 'dependabot[bot]' }, author_association: 'NONE', body: 'CI noise' },
+        { user: { login: 'maintainer1' }, author_association: 'OWNER', body: 'real' },
+      ],
+    });
+    const bundle = await fetchPRCommentBundle(octokit, PR_URL, 'me');
+    expect(bundle.issueComments).toHaveLength(1);
+    expect(bundle.issueComments[0].author).toBe('maintainer1');
+  });
+
+  it('excludes entries with no user (deleted account)', async () => {
+    const octokit = makeOctokit({
+      issueComments: [
+        { user: null, body: 'orphaned' },
+        { user: { login: 'maintainer1' }, author_association: 'OWNER', body: 'real' },
+      ],
+    });
+    const bundle = await fetchPRCommentBundle(octokit, PR_URL, 'me');
+    expect(bundle.issueComments).toHaveLength(1);
+    expect(bundle.issueComments[0].author).toBe('maintainer1');
+  });
+
+  it('populates authorAssociation on every comment entry', async () => {
+    const octokit = makeOctokit({
+      reviews: [{ user: { login: 'a' }, author_association: 'MEMBER', body: '' }],
+      reviewComments: [{ user: { login: 'b' }, author_association: 'COLLABORATOR', body: '', path: 'x' }],
+      issueComments: [{ user: { login: 'c' }, author_association: 'NONE', body: '' }],
+    });
+    const bundle = await fetchPRCommentBundle(octokit, PR_URL, 'me');
+    expect(bundle.reviews[0].authorAssociation).toBe('MEMBER');
+    expect(bundle.reviewComments[0].authorAssociation).toBe('COLLABORATOR');
+    expect(bundle.issueComments[0].authorAssociation).toBe('NONE');
+  });
+
+  it("defaults authorAssociation to 'NONE' when GitHub omits it", async () => {
+    const octokit = makeOctokit({
+      issueComments: [{ user: { login: 'a' }, body: 'x' }], // no author_association
+    });
+    const bundle = await fetchPRCommentBundle(octokit, PR_URL, 'me');
+    expect(bundle.issueComments[0].authorAssociation).toBe('NONE');
+  });
+
+  it('uses closed_at when merged_at is null (closed without merge)', async () => {
+    const octokit = makeOctokit({
+      pr: makePR({ merged_at: null, closed_at: '2026-04-19T08:00:00Z' }),
+    });
+    const bundle = await fetchPRCommentBundle(octokit, PR_URL, 'me');
+    expect(bundle.mergedAt).toBe('2026-04-19T08:00:00Z');
+  });
+
+  it('returns mergedAt as empty string when neither timestamp is set (still-open PR edge case)', async () => {
+    const octokit = makeOctokit({
+      pr: makePR({ merged_at: null, closed_at: null }),
+    });
+    const bundle = await fetchPRCommentBundle(octokit, PR_URL, 'me');
+    expect(bundle.mergedAt).toBe('');
+  });
+});
+
+describe('fetchPRCommentBundlesBatch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns a bundle per URL when all calls succeed', async () => {
+    const octokit = makeOctokit({
+      issueComments: [{ user: { login: 'maintainer1' }, author_association: 'OWNER', body: 'feedback' }],
+    });
+    const urls = [
+      'https://github.com/owner/repo/pull/1',
+      'https://github.com/owner/repo/pull/2',
+      'https://github.com/owner/repo/pull/3',
+    ];
+    const bundles = await fetchPRCommentBundlesBatch(octokit, urls, 'me');
+    expect(bundles).toHaveLength(3);
+  });
+
+  it('skips PRs that fail to fetch (404, rate limit) without aborting', async () => {
+    let call = 0;
+    const octokit = {
+      pulls: {
+        get: vi.fn(async () => {
+          call++;
+          if (call === 2) throw new Error('Not Found');
+          return { data: makePR() };
+        }),
+        listReviews: vi.fn(async () => ({ data: [] })),
+        listReviewComments: vi.fn(async () => ({ data: [] })),
+      },
+      issues: {
+        listComments: vi.fn(async () => ({ data: [] })),
+      },
+    } as unknown as Octokit;
+
+    const urls = [
+      'https://github.com/owner/repo/pull/1',
+      'https://github.com/owner/repo/pull/2',
+      'https://github.com/owner/repo/pull/3',
+    ];
+    const bundles = await fetchPRCommentBundlesBatch(octokit, urls, 'me', 1);
+    expect(bundles).toHaveLength(2); // skipped PR 2
+  });
+
+  it('respects the concurrency cap', async () => {
+    let active = 0;
+    let maxActive = 0;
+    const octokit = {
+      pulls: {
+        get: vi.fn(async () => {
+          active++;
+          maxActive = Math.max(maxActive, active);
+          await new Promise((r) => setTimeout(r, 5));
+          active--;
+          return { data: makePR() };
+        }),
+        listReviews: vi.fn(async () => ({ data: [] })),
+        listReviewComments: vi.fn(async () => ({ data: [] })),
+      },
+      issues: {
+        listComments: vi.fn(async () => ({ data: [] })),
+      },
+    } as unknown as Octokit;
+
+    const urls = Array.from({ length: 6 }, (_, i) => `https://github.com/owner/repo/pull/${i + 1}`);
+    await fetchPRCommentBundlesBatch(octokit, urls, 'me', 2);
+    expect(maxActive).toBeLessThanOrEqual(2);
+  });
+
+  it('returns [] when given an empty URL list', async () => {
+    const octokit = makeOctokit({});
+    expect(await fetchPRCommentBundlesBatch(octokit, [], 'me')).toEqual([]);
+  });
+});

--- a/packages/core/src/core/pr-comments-fetcher.ts
+++ b/packages/core/src/core/pr-comments-fetcher.ts
@@ -1,0 +1,204 @@
+/**
+ * Fetch the raw review-comment bundle for a PR (#867 PR 3).
+ *
+ * Returns reviews, inline review comments, and issue-level comments for a
+ * single PR with the contributor's own comments + bots filtered out. The
+ * `authorAssociation` field is preserved on every entry so the host's
+ * extraction prompt can weight maintainer voices (OWNER/MEMBER/COLLABORATOR)
+ * differently from community feedback (CONTRIBUTOR/NONE).
+ *
+ * No LLM calls happen here — this is the data layer feeding the host's
+ * `extract-learnings` prompt. The bundle structure is the contract; the
+ * extraction is the host's responsibility.
+ */
+import type { Octokit } from '@octokit/rest';
+import { paginateAll } from './pagination.js';
+import { isBotAuthor } from './comment-utils.js';
+import { parseGitHubUrl } from './urls.js';
+import { ValidationError, errorMessage } from './errors.js';
+import { debug, warn } from './logger.js';
+
+const MODULE = 'pr-comments-fetcher';
+
+/** Default concurrency for {@link fetchPRCommentBundlesBatch}. */
+const DEFAULT_BATCH_CONCURRENCY = 3;
+
+/** A single review (top-level) on a PR. */
+export interface PRReviewEntry {
+  author: string;
+  authorAssociation: string;
+  body: string;
+  submittedAt: string;
+}
+
+/** An inline review comment (anchored to a file/line) on a PR. */
+export interface PRReviewCommentEntry {
+  author: string;
+  authorAssociation: string;
+  body: string;
+  path: string;
+  createdAt: string;
+}
+
+/** An issue-level comment posted on the PR thread. */
+export interface PRIssueCommentEntry {
+  author: string;
+  authorAssociation: string;
+  body: string;
+  createdAt: string;
+}
+
+/**
+ * The full comment bundle returned for a single PR. Field order matches
+ * the typical narrative arc of a PR review (top-level reviews → inline
+ * comments → general thread chatter), so the host's extraction prompt can
+ * walk the bundle linearly.
+ */
+export interface PRCommentBundle {
+  prUrl: string;
+  prTitle: string;
+  repo: string; // owner/repo
+  /** ISO-8601 timestamp the PR was merged or closed; whichever applies. */
+  mergedAt: string;
+  reviews: PRReviewEntry[];
+  reviewComments: PRReviewCommentEntry[];
+  issueComments: PRIssueCommentEntry[];
+}
+
+/**
+ * Fetch a single PR's comment bundle. Filters out the authenticated user's
+ * own comments and bots. Throws {@link ValidationError} on a non-PR URL.
+ */
+export async function fetchPRCommentBundle(
+  octokit: Octokit,
+  prUrl: string,
+  githubUsername: string,
+): Promise<PRCommentBundle> {
+  const parsed = parseGitHubUrl(prUrl);
+  if (!parsed || parsed.type !== 'pull') {
+    throw new ValidationError(`Invalid PR URL: ${prUrl}`);
+  }
+
+  const { owner, repo, number: pull_number } = parsed;
+  const repoFull = `${owner}/${repo}`;
+
+  // Fetch the PR + all three comment streams in parallel. We always fetch
+  // every page — corpus quality depends on having every reviewer voice, not
+  // just the first 100 comments.
+  const [{ data: pr }, reviews, reviewComments, issueComments] = await Promise.all([
+    octokit.pulls.get({ owner, repo, pull_number }),
+    paginateAll((page) =>
+      octokit.pulls.listReviews({
+        owner,
+        repo,
+        pull_number,
+        per_page: 100,
+        page,
+      }),
+    ),
+    paginateAll((page) =>
+      octokit.pulls.listReviewComments({
+        owner,
+        repo,
+        pull_number,
+        per_page: 100,
+        page,
+      }),
+    ),
+    paginateAll((page) =>
+      octokit.issues.listComments({
+        owner,
+        repo,
+        issue_number: pull_number,
+        per_page: 100,
+        page,
+      }),
+    ),
+  ]);
+
+  const ownLogin = githubUsername.toLowerCase();
+
+  /**
+   * Drop entries that aren't useful corpus: the user's own comments, bots,
+   * and entries with no author at all (deleted accounts surface as null
+   * user from GitHub's REST API).
+   */
+  const isWorthKeeping = (login: string | undefined | null): boolean => {
+    if (!login) return false;
+    if (login.toLowerCase() === ownLogin) return false;
+    if (isBotAuthor(login)) return false;
+    return true;
+  };
+
+  const mergedAt = pr.merged_at ?? pr.closed_at ?? '';
+
+  return {
+    prUrl,
+    prTitle: pr.title,
+    repo: repoFull,
+    mergedAt,
+    reviews: reviews
+      .filter((r) => isWorthKeeping(r.user?.login))
+      .map((r) => ({
+        author: r.user?.login ?? '',
+        authorAssociation: r.author_association ?? 'NONE',
+        body: r.body ?? '',
+        submittedAt: r.submitted_at ?? '',
+      })),
+    reviewComments: reviewComments
+      .filter((c) => isWorthKeeping(c.user?.login))
+      .map((c) => ({
+        author: c.user?.login ?? '',
+        authorAssociation: c.author_association ?? 'NONE',
+        body: c.body ?? '',
+        path: c.path ?? '',
+        createdAt: c.created_at ?? '',
+      })),
+    issueComments: issueComments
+      .filter((c) => isWorthKeeping(c.user?.login))
+      .map((c) => ({
+        author: c.user?.login ?? '',
+        authorAssociation: c.author_association ?? 'NONE',
+        body: c.body ?? '',
+        createdAt: c.created_at ?? '',
+      })),
+  };
+}
+
+/**
+ * Fetch comment bundles for many PRs with a small concurrency cap (default 3).
+ *
+ * Failures on individual PRs are logged and skipped — the batch returns a
+ * shorter array rather than aborting. Rationale: extraction quality is
+ * already a partial-information problem (users contribute to many repos and
+ * many PRs), so a single 404 / rate limit on one PR should not deny the
+ * host the corpus from the other 4.
+ */
+export async function fetchPRCommentBundlesBatch(
+  octokit: Octokit,
+  prUrls: string[],
+  githubUsername: string,
+  concurrency: number = DEFAULT_BATCH_CONCURRENCY,
+): Promise<PRCommentBundle[]> {
+  const results: PRCommentBundle[] = [];
+  const queue = [...prUrls];
+
+  async function worker(): Promise<void> {
+    while (queue.length > 0) {
+      const url = queue.shift();
+      if (!url) return;
+      try {
+        const bundle = await fetchPRCommentBundle(octokit, url, githubUsername);
+        results.push(bundle);
+      } catch (err) {
+        warn(MODULE, `Skipping ${url}: ${errorMessage(err)}`);
+      }
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(concurrency, prUrls.length) }, worker);
+  await Promise.all(workers);
+
+  debug(MODULE, `Fetched ${results.length}/${prUrls.length} comment bundles`);
+  return results;
+}


### PR DESCRIPTION
## Summary

Adds the GitHub data-fetching layer for the per-repo learning feature (#867). Pure data plumbing — calls Octokit, filters authors, returns `PRCommentBundle[]` for the host's `extract-learnings` prompt to consume.

This is **PR 3 of 7** in the #867 sequence. No LLM calls. No state mutations (those land in PR 4 with the `runFetchCorpus` command).

## What changed

**`packages/core/src/core/pr-comments-fetcher.ts`** (new)
- `fetchPRCommentBundle(octokit, prUrl, githubUsername)` — single-PR fetch. Pulls reviews + inline review comments + issue comments via `paginateAll`. Filters out:
  - the user's own comments (case-insensitive match on login)
  - bots (via the existing `isBotAuthor` utility)
  - entries with no user (deleted accounts)
- Preserves `authorAssociation` on every entry — `OWNER` / `MEMBER` / `COLLABORATOR` vs. `CONTRIBUTOR` / `NONE`. The host's extraction prompt uses this to weight maintainer voices, per the design doc's decision §4.
- `fetchPRCommentBundlesBatch(octokit, urls, githubUsername, concurrency=3)` — bounded-concurrency batch. Failures on individual PRs are logged + skipped; the batch returns shorter rather than aborting (one 404 shouldn't deny the host the rest of the corpus).
- `mergedAt` falls back to `closed_at` for closed-without-merge PRs, and empty string when neither is set.
- Exported types: `PRCommentBundle`, `PRReviewEntry`, `PRReviewCommentEntry`, `PRIssueCommentEntry`.

## Test plan

- [x] `pnpm test` — 2596 tests pass (2165 core + 256 dashboard + 174 mcp-server)
- [x] `pnpm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] 15 new tests cover: well-formed bundle shape, ValidationError on non-PR / malformed URLs, exclusion of own comments (case-insensitive), exclusion of bots, exclusion of null users, `authorAssociation` propagation + `'NONE'` default, `mergedAt` fallback to `closed_at` and to empty string.
- [x] 4 new batch tests cover: success path, partial failure (one 404 skipped), concurrency cap actually enforced, empty input → empty output.

Refs #867. Independent of PR 1 (#1171) and PR 2 (#1173) — touches different files.