### PR TITLE
feat: guidelines CLI commands (view/store/reset/fetch-corpus) (#867 PR 4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ env:
   #   - **Don't bump for a flaky measurement:** esbuild output is
   #     deterministic. If the threshold trips on a no-op rebuild, it's a
   #     real increase somewhere upstream — not noise.
-  BUNDLE_MAX_CORE: 780000 # ~762 KB (increased for guidelines-store module, #867)
+  BUNDLE_MAX_CORE: 800000 # ~781 KB (increased for guidelines CLI commands, #867 PR 4)
   BUNDLE_MAX_MCP: 2000000 # ~1953 KB
   STARTUP_WARN_MS: 500 # Warn if CLI startup exceeds 500ms
 

--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -1275,4 +1275,107 @@ export const commands: CLICommandDef[] = [
         });
     },
   },
+
+  // ── Guidelines (#867) ──────────────────────────────────────────────────
+  {
+    name: 'guidelines',
+    register(program) {
+      const group = program
+        .command('guidelines')
+        .description('Manage per-repo learning guidelines extracted from PR feedback (#867)');
+
+      group
+        .command('view')
+        .description('Read the per-repo guidelines file (returns null when none exists or in local mode)')
+        .requiredOption('--repo <owner/repo>', 'Repository identifier')
+        .option('--json', 'Output as JSON')
+        .action(async (options) => {
+          await executeAction(
+            options,
+            async () => (await import('./commands/guidelines.js')).runGuidelinesView({ repo: options.repo }),
+            (data) => {
+              if (data.content === null) {
+                console.log(`No guidelines stored for ${data.repo} (storage: ${data.storageMode}).`);
+              } else {
+                console.log(`# Guidelines for ${data.repo} (${data.byteSize} bytes)\n`);
+                console.log(data.content);
+              }
+            },
+          );
+        });
+
+      group
+        .command('store')
+        .description('Persist per-repo guidelines (overwrites). Reads markdown content from --content or stdin.')
+        .requiredOption('--repo <owner/repo>', 'Repository identifier')
+        .option('--content <markdown>', 'Markdown content. If omitted, reads from stdin.')
+        .option('--json', 'Output as JSON')
+        .action(async (options) => {
+          await executeAction(
+            options,
+            async () => {
+              const content = options.content ?? (await readStdin());
+              return (await import('./commands/guidelines.js')).runGuidelinesStore({ repo: options.repo, content });
+            },
+            (data) => {
+              console.log(`Stored ${data.byteSize} bytes of guidelines for ${data.repo}.`);
+            },
+          );
+        });
+
+      group
+        .command('reset')
+        .description('Tombstone the guidelines file for a repo (subsequent reads return null)')
+        .requiredOption('--repo <owner/repo>', 'Repository identifier')
+        .option('--json', 'Output as JSON')
+        .action(async (options) => {
+          await executeAction(
+            options,
+            async () => (await import('./commands/guidelines.js')).runGuidelinesReset({ repo: options.repo }),
+            (data) => {
+              console.log(
+                data.deleted
+                  ? `Reset guidelines for ${data.repo}.`
+                  : `No guidelines existed for ${data.repo}; nothing to reset.`,
+              );
+            },
+          );
+        });
+
+      group
+        .command('fetch-corpus')
+        .description('Fetch raw PR comment bundles for the host extract-learnings prompt to consume')
+        .requiredOption('--repo <owner/repo>', 'Repository identifier')
+        .option('--limit <n>', 'Max PRs to process (1-10, default 5)', (v: string) => parseInt(v, 10))
+        .option('--force', 'Re-fetch even when commentsFetchedAt is already set')
+        .option('--json', 'Output as JSON')
+        .action(async (options) => {
+          await executeAction(
+            options,
+            async () =>
+              (await import('./commands/guidelines.js')).runFetchCorpus({
+                repo: options.repo,
+                limit: options.limit,
+                forceRefetch: options.force,
+              }),
+            (data) => {
+              console.log(`Fetched ${data.prCount} PR comment bundle(s) for ${data.repo}.`);
+              if (data.skipped > 0) {
+                console.log(`  Skipped ${data.skipped} PR(s) already processed (use --force to re-fetch).`);
+              }
+            },
+          );
+        });
+    },
+  },
 ];
+
+/** Read full stdin content. Used when `guidelines store` content isn't passed inline. */
+async function readStdin(): Promise<string> {
+  if (process.stdin.isTTY) {
+    throw new Error('No --content provided and stdin is a TTY. Pipe content or pass --content "...".');
+  }
+  let data = '';
+  for await (const chunk of process.stdin) data += chunk;
+  return data;
+}

--- a/packages/core/src/cli.test.ts
+++ b/packages/core/src/cli.test.ts
@@ -374,6 +374,7 @@ describe('Command registration', () => {
       'state',
       'skip-add',
       'list-move-tier',
+      'guidelines',
     ];
 
     for (const name of expectedCommands) {
@@ -503,8 +504,13 @@ describe('CLI argument parsing', () => {
     return undefined;
   }
 
-  it('every command should have --json option (except serve)', () => {
+  it('every command should have --json option (except serve and parent groups)', () => {
     const commandNames = commands.map((c) => c.name);
+
+    // Parent command groups (e.g. `guidelines` → `view`/`store`/`reset`) don't
+    // expose --json themselves; their subcommands do. Verify each subcommand
+    // separately rather than expecting the parent to carry the flag.
+    const parentGroups = new Set<string>(['guidelines']);
 
     for (const name of commandNames) {
       const cmd = findCmd(name);
@@ -514,6 +520,12 @@ describe('CLI argument parsing', () => {
         // serve intentionally lacks --json
         const jsonOpt = cmd!.options.find((o) => o.long === '--json');
         expect(jsonOpt, 'serve should NOT have --json').toBeUndefined();
+      } else if (parentGroups.has(name)) {
+        // Parent group: every subcommand must have --json instead.
+        for (const sub of cmd!.commands) {
+          const jsonOpt = sub.options.find((o) => o.long === '--json');
+          expect(jsonOpt, `${name} ${sub.name()} should have --json`).toBeDefined();
+        }
       } else {
         const jsonOpt = cmd!.options.find((o) => o.long === '--json');
         expect(jsonOpt, `command "${name}" should have --json`).toBeDefined();

--- a/packages/core/src/commands/guidelines.test.ts
+++ b/packages/core/src/commands/guidelines.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// vi.mock factories are hoisted; closures over module-level vars don't work.
+// Use vi.hoisted() so the mocks share an identity with the test references.
+const mocks = vi.hoisted(() => ({
+  fetchPRCommentBundlesBatch: vi.fn(),
+  getGuidelines: vi.fn(),
+  setGuidelines: vi.fn(),
+  deleteGuidelines: vi.fn(),
+  isGuidelinesAvailable: vi.fn(),
+  getMergedPRs: vi.fn(),
+  getClosedPRs: vi.fn(),
+  markPRCommentsFetched: vi.fn(),
+  username: vi.fn(() => 'me'),
+}));
+
+vi.mock('../core/pr-comments-fetcher.js', () => ({
+  fetchPRCommentBundlesBatch: mocks.fetchPRCommentBundlesBatch,
+}));
+
+vi.mock('../core/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../core/index.js')>('../core/index.js');
+  return {
+    ...actual,
+    getStateManager: () => ({
+      getGuidelines: mocks.getGuidelines,
+      setGuidelines: mocks.setGuidelines,
+      deleteGuidelines: mocks.deleteGuidelines,
+      isGuidelinesAvailable: mocks.isGuidelinesAvailable,
+      getMergedPRs: mocks.getMergedPRs,
+      getClosedPRs: mocks.getClosedPRs,
+      markPRCommentsFetched: mocks.markPRCommentsFetched,
+      getState: () => ({ config: { githubUsername: mocks.username() } }),
+    }),
+    requireGitHubToken: () => 'ghp_test',
+    getOctokit: () => ({}) as never,
+  };
+});
+
+const mockFetchPRCommentBundlesBatch = mocks.fetchPRCommentBundlesBatch;
+const mockGetGuidelines = mocks.getGuidelines;
+const mockSetGuidelines = mocks.setGuidelines;
+const mockDeleteGuidelines = mocks.deleteGuidelines;
+const mockIsGuidelinesAvailable = mocks.isGuidelinesAvailable;
+const mockGetMergedPRs = mocks.getMergedPRs;
+const mockGetClosedPRs = mocks.getClosedPRs;
+const mockMarkPRCommentsFetched = mocks.markPRCommentsFetched;
+
+import { runGuidelinesView, runGuidelinesStore, runGuidelinesReset, runFetchCorpus } from './guidelines.js';
+import { GuidelinesNotAvailableError } from '../core/index.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetMergedPRs.mockReturnValue([]);
+  mockGetClosedPRs.mockReturnValue([]);
+  mockIsGuidelinesAvailable.mockReturnValue(true);
+});
+
+describe('runGuidelinesView', () => {
+  it('returns content + byteSize when guidelines exist', async () => {
+    mockGetGuidelines.mockReturnValue('# rules\n- be nice');
+    const out = await runGuidelinesView({ repo: 'owner/repo' });
+    expect(out.content).toBe('# rules\n- be nice');
+    expect(out.byteSize).toBe(Buffer.byteLength('# rules\n- be nice', 'utf-8'));
+    expect(out.exists).toBe(true);
+    expect(out.storageMode).toBe('gist');
+  });
+
+  it('returns null content + byteSize 0 when no guidelines exist', async () => {
+    mockGetGuidelines.mockReturnValue(null);
+    const out = await runGuidelinesView({ repo: 'owner/repo' });
+    expect(out.content).toBeNull();
+    expect(out.byteSize).toBe(0);
+    expect(out.exists).toBe(false);
+  });
+
+  it("reports 'local-unavailable' when not in Gist mode", async () => {
+    mockGetGuidelines.mockReturnValue(null);
+    mockIsGuidelinesAvailable.mockReturnValue(false);
+    const out = await runGuidelinesView({ repo: 'owner/repo' });
+    expect(out.storageMode).toBe('local-unavailable');
+  });
+
+  it('throws on a malformed repo identifier', async () => {
+    await expect(runGuidelinesView({ repo: 'not-a-repo' })).rejects.toThrow(/Invalid repo identifier/);
+  });
+});
+
+describe('runGuidelinesStore', () => {
+  it('persists content and returns byte size', async () => {
+    const out = await runGuidelinesStore({ repo: 'owner/repo', content: 'guidelines text' });
+    expect(out.stored).toBe(true);
+    expect(out.byteSize).toBe(Buffer.byteLength('guidelines text', 'utf-8'));
+    expect(mockSetGuidelines).toHaveBeenCalledWith('owner/repo', 'guidelines text');
+  });
+
+  it('throws when content is empty (use reset instead)', async () => {
+    await expect(runGuidelinesStore({ repo: 'owner/repo', content: '' })).rejects.toThrow(/Cannot store empty content/);
+    expect(mockSetGuidelines).not.toHaveBeenCalled();
+  });
+
+  it("propagates GuidelinesNotAvailableError when StateManager isn't in Gist mode", async () => {
+    mockSetGuidelines.mockImplementation(() => {
+      throw new GuidelinesNotAvailableError();
+    });
+    await expect(runGuidelinesStore({ repo: 'owner/repo', content: 'x' })).rejects.toThrow(
+      /Per-repo guidelines require/,
+    );
+  });
+});
+
+describe('runGuidelinesReset', () => {
+  it('returns deleted: true when an existing file was tombstoned', async () => {
+    mockGetGuidelines.mockReturnValue('existing content');
+    const out = await runGuidelinesReset({ repo: 'owner/repo' });
+    expect(out.deleted).toBe(true);
+    expect(mockDeleteGuidelines).toHaveBeenCalledWith('owner/repo');
+  });
+
+  it('returns deleted: false when no file existed', async () => {
+    mockGetGuidelines.mockReturnValue(null);
+    const out = await runGuidelinesReset({ repo: 'owner/repo' });
+    expect(out.deleted).toBe(false);
+    expect(mockDeleteGuidelines).not.toHaveBeenCalled();
+  });
+
+  it('throws GuidelinesNotAvailableError in local mode', async () => {
+    mockIsGuidelinesAvailable.mockReturnValue(false);
+    await expect(runGuidelinesReset({ repo: 'owner/repo' })).rejects.toThrow(/Per-repo guidelines require/);
+  });
+});
+
+describe('runFetchCorpus', () => {
+  const PR_RECENT = 'https://github.com/owner/repo/pull/1';
+  const PR_OLD = 'https://github.com/owner/repo/pull/2';
+  const PR_OTHER_REPO = 'https://github.com/owner/other/pull/1';
+  const PR_FETCHED = 'https://github.com/owner/repo/pull/3';
+
+  function recentTimestamp(): string {
+    return new Date().toISOString();
+  }
+  function oldTimestamp(): string {
+    return new Date(Date.now() - 366 * 24 * 60 * 60 * 1000).toISOString();
+  }
+
+  it('fetches bundles for unprocessed PRs in the requested repo within the recency cliff', async () => {
+    mockGetMergedPRs.mockReturnValue([{ url: PR_RECENT, title: 't', mergedAt: recentTimestamp() }]);
+    mockFetchPRCommentBundlesBatch.mockResolvedValue([
+      {
+        prUrl: PR_RECENT,
+        prTitle: 't',
+        repo: 'owner/repo',
+        mergedAt: recentTimestamp(),
+        reviews: [],
+        reviewComments: [],
+        issueComments: [],
+      },
+    ]);
+
+    const out = await runFetchCorpus({ repo: 'owner/repo' });
+
+    expect(out.prCount).toBe(1);
+    expect(out.bundles).toHaveLength(1);
+    expect(mockMarkPRCommentsFetched).toHaveBeenCalledWith(PR_RECENT, expect.any(String));
+  });
+
+  it('excludes PRs older than 12 months (recency cliff)', async () => {
+    mockGetMergedPRs.mockReturnValue([
+      { url: PR_RECENT, title: 't', mergedAt: recentTimestamp() },
+      { url: PR_OLD, title: 't2', mergedAt: oldTimestamp() },
+    ]);
+    mockFetchPRCommentBundlesBatch.mockImplementation(async (_octokit: unknown, urls: string[]) =>
+      urls.map((url) => ({
+        prUrl: url,
+        prTitle: 't',
+        repo: 'owner/repo',
+        mergedAt: '',
+        reviews: [],
+        reviewComments: [],
+        issueComments: [],
+      })),
+    );
+
+    const out = await runFetchCorpus({ repo: 'owner/repo' });
+
+    expect(out.prCount).toBe(1);
+    expect(mockFetchPRCommentBundlesBatch).toHaveBeenCalledWith(expect.anything(), [PR_RECENT], 'me');
+  });
+
+  it('excludes PRs from other repos', async () => {
+    mockGetMergedPRs.mockReturnValue([
+      { url: PR_OTHER_REPO, title: 'other', mergedAt: recentTimestamp() },
+      { url: PR_RECENT, title: 't', mergedAt: recentTimestamp() },
+    ]);
+    mockFetchPRCommentBundlesBatch.mockResolvedValue([]);
+
+    await runFetchCorpus({ repo: 'owner/repo' });
+
+    expect(mockFetchPRCommentBundlesBatch).toHaveBeenCalledWith(expect.anything(), [PR_RECENT], 'me');
+  });
+
+  it('skips PRs with commentsFetchedAt set unless forceRefetch is true', async () => {
+    mockGetMergedPRs.mockReturnValue([
+      { url: PR_RECENT, title: 't', mergedAt: recentTimestamp() },
+      { url: PR_FETCHED, title: 't3', mergedAt: recentTimestamp(), commentsFetchedAt: '2025-01-01T00:00:00Z' },
+    ]);
+    mockFetchPRCommentBundlesBatch.mockResolvedValue([]);
+
+    const out = await runFetchCorpus({ repo: 'owner/repo' });
+    expect(out.skipped).toBe(1);
+    expect(mockFetchPRCommentBundlesBatch).toHaveBeenCalledWith(expect.anything(), [PR_RECENT], 'me');
+  });
+
+  it('forceRefetch reincludes already-fetched PRs', async () => {
+    mockGetMergedPRs.mockReturnValue([
+      { url: PR_FETCHED, title: 't', mergedAt: recentTimestamp(), commentsFetchedAt: '2025-01-01T00:00:00Z' },
+    ]);
+    mockFetchPRCommentBundlesBatch.mockResolvedValue([]);
+
+    const out = await runFetchCorpus({ repo: 'owner/repo', forceRefetch: true });
+    expect(out.skipped).toBe(0);
+    expect(mockFetchPRCommentBundlesBatch).toHaveBeenCalledWith(expect.anything(), [PR_FETCHED], 'me');
+  });
+
+  it('respects the `limit` parameter and caps it at 10', async () => {
+    const many = Array.from({ length: 20 }, (_, i) => ({
+      url: `https://github.com/owner/repo/pull/${i + 1}`,
+      title: 't',
+      mergedAt: recentTimestamp(),
+    }));
+    mockGetMergedPRs.mockReturnValue(many);
+    mockFetchPRCommentBundlesBatch.mockResolvedValue([]);
+
+    await runFetchCorpus({ repo: 'owner/repo', limit: 100 }); // requesting 100 but capped at 10
+    const call = mockFetchPRCommentBundlesBatch.mock.calls[0];
+    expect(call[1]).toHaveLength(10);
+  });
+
+  it('uses default limit of 5 when limit is omitted', async () => {
+    const many = Array.from({ length: 20 }, (_, i) => ({
+      url: `https://github.com/owner/repo/pull/${i + 1}`,
+      title: 't',
+      mergedAt: recentTimestamp(),
+    }));
+    mockGetMergedPRs.mockReturnValue(many);
+    mockFetchPRCommentBundlesBatch.mockResolvedValue([]);
+
+    await runFetchCorpus({ repo: 'owner/repo' });
+    const call = mockFetchPRCommentBundlesBatch.mock.calls[0];
+    expect(call[1]).toHaveLength(5);
+  });
+
+  it('returns an empty corpus without fetching when no eligible PRs exist', async () => {
+    mockGetMergedPRs.mockReturnValue([]);
+    mockGetClosedPRs.mockReturnValue([]);
+    const out = await runFetchCorpus({ repo: 'owner/repo' });
+    expect(out.bundles).toEqual([]);
+    expect(out.prCount).toBe(0);
+    expect(mockFetchPRCommentBundlesBatch).not.toHaveBeenCalled();
+  });
+
+  it('considers closed-without-merge PRs alongside merged PRs', async () => {
+    mockGetClosedPRs.mockReturnValue([
+      { url: 'https://github.com/owner/repo/pull/9', title: 'closed', closedAt: recentTimestamp() },
+    ]);
+    mockFetchPRCommentBundlesBatch.mockResolvedValue([]);
+
+    await runFetchCorpus({ repo: 'owner/repo' });
+    expect(mockFetchPRCommentBundlesBatch).toHaveBeenCalledWith(
+      expect.anything(),
+      ['https://github.com/owner/repo/pull/9'],
+      'me',
+    );
+  });
+
+  it('throws on a malformed repo identifier', async () => {
+    await expect(runFetchCorpus({ repo: 'just-a-name' })).rejects.toThrow(/Invalid repo identifier/);
+  });
+});

--- a/packages/core/src/commands/guidelines.ts
+++ b/packages/core/src/commands/guidelines.ts
@@ -1,0 +1,216 @@
+/**
+ * Guidelines CLI commands (#867 PR 4).
+ *
+ * `guidelines view`        — read the per-repo guidelines file from the Gist.
+ * `guidelines store`       — overwrite the per-repo guidelines file.
+ * `guidelines reset`       — tombstone the file so subsequent reads return null.
+ * `guidelines fetch-corpus` — pull raw PR comment bundles for the host's
+ *                              extract-learnings prompt to consume.
+ *
+ * The CLI layer is pure data plumbing — extraction is the host's job.
+ * Standalone-mode users see "not available" on store/reset/fetch-corpus
+ * because per-repo guidelines require Gist persistence to be useful.
+ */
+import { getStateManager, requireGitHubToken, getOctokit, GuidelinesNotAvailableError } from '../core/index.js';
+import { fetchPRCommentBundlesBatch, type PRCommentBundle } from '../core/pr-comments-fetcher.js';
+import { warn } from '../core/logger.js';
+
+const MODULE = 'guidelines';
+
+const REPO_ID_PATTERN = /^[^/]+\/[^/]+$/;
+
+const DEFAULT_FETCH_LIMIT = 5;
+const MAX_FETCH_LIMIT = 10;
+
+/**
+ * Cliff at 12 months: PRs older than this are excluded from corpus fetches
+ * (#867 design decision §5). Computed at call time, not module load.
+ */
+const RECENCY_CLIFF_MS = 365 * 24 * 60 * 60 * 1000;
+
+export interface GuidelinesViewOutput {
+  repo: string;
+  /** Markdown content, or null when the repo has no guidelines stored. */
+  content: string | null;
+  /** UTF-8 byte size of `content`, or 0 when content is null. */
+  byteSize: number;
+  /** Whether a guidelines file exists for this repo. */
+  exists: boolean;
+  /** Where the guidelines would be persisted if a write happened now. */
+  storageMode: 'gist' | 'local-unavailable';
+}
+
+export interface GuidelinesStoreOutput {
+  repo: string;
+  byteSize: number;
+  stored: boolean;
+}
+
+export interface GuidelinesResetOutput {
+  repo: string;
+  /** True when an existing file was tombstoned, false when no file existed. */
+  deleted: boolean;
+}
+
+export interface FetchCorpusOutput {
+  repo: string;
+  bundles: PRCommentBundle[];
+  /** How many PRs were considered after recency + already-fetched filtering. */
+  prCount: number;
+  /** PRs skipped because `commentsFetchedAt` is already set (without --force). */
+  skipped: number;
+}
+
+interface RepoOption {
+  repo: string;
+}
+
+interface FetchCorpusOptions extends RepoOption {
+  /** Cap on PRs to process. Defaults to 5; capped at 10 to bound prompt size. */
+  limit?: number;
+  /** Re-fetch even when commentsFetchedAt is already set. */
+  forceRefetch?: boolean;
+}
+
+interface StoreOptions extends RepoOption {
+  content: string;
+}
+
+function validateRepo(repo: string): void {
+  if (!REPO_ID_PATTERN.test(repo)) {
+    throw new Error(`Invalid repo identifier "${repo}". Expected "owner/repo" format.`);
+  }
+}
+
+/** Read the per-repo guidelines for `repo`. Returns a `local-unavailable` envelope in non-Gist mode. */
+export async function runGuidelinesView(options: RepoOption): Promise<GuidelinesViewOutput> {
+  validateRepo(options.repo);
+  const sm = getStateManager();
+  const content = sm.getGuidelines(options.repo);
+  return {
+    repo: options.repo,
+    content,
+    byteSize: content === null ? 0 : Buffer.byteLength(content, 'utf-8'),
+    exists: content !== null,
+    storageMode: sm.isGuidelinesAvailable() ? 'gist' : 'local-unavailable',
+  };
+}
+
+/**
+ * Persist per-repo guidelines for `repo`. Throws when not in Gist mode or
+ * when content exceeds the byte budget — the CLI surface relies on the
+ * outputJson error envelope to surface that to the host cleanly.
+ */
+export async function runGuidelinesStore(options: StoreOptions): Promise<GuidelinesStoreOutput> {
+  validateRepo(options.repo);
+  if (!options.content || options.content.length === 0) {
+    throw new Error('Cannot store empty content. Use `guidelines reset` to delete a guidelines file.');
+  }
+  const sm = getStateManager();
+  // Throws GuidelinesNotAvailableError or GuidelinesTooLargeError on failure.
+  sm.setGuidelines(options.repo, options.content);
+  return {
+    repo: options.repo,
+    byteSize: Buffer.byteLength(options.content, 'utf-8'),
+    stored: true,
+  };
+}
+
+/** Tombstone the guidelines file for `repo`. */
+export async function runGuidelinesReset(options: RepoOption): Promise<GuidelinesResetOutput> {
+  validateRepo(options.repo);
+  const sm = getStateManager();
+  if (!sm.isGuidelinesAvailable()) {
+    throw new GuidelinesNotAvailableError();
+  }
+  const existed = sm.getGuidelines(options.repo) !== null;
+  if (existed) {
+    sm.deleteGuidelines(options.repo);
+  }
+  return { repo: options.repo, deleted: existed };
+}
+
+/**
+ * Fetch raw PR comment bundles for the most recent merged/closed PRs in `repo`
+ * that haven't already been processed. Returns a serializable corpus for the
+ * host's extract-learnings prompt.
+ *
+ * Filters applied at the CLI layer (not the fetcher):
+ * - Only PRs in the requested `repo`
+ * - PRs older than 12 months are dropped (recency cliff)
+ * - PRs with `commentsFetchedAt` already set are skipped unless `forceRefetch`
+ * - Capped at `limit` (default 5, max 10)
+ *
+ * Stamps `commentsFetchedAt` on every PR that was successfully fetched.
+ */
+export async function runFetchCorpus(options: FetchCorpusOptions): Promise<FetchCorpusOutput> {
+  validateRepo(options.repo);
+  const limit = clampLimit(options.limit);
+  const sm = getStateManager();
+
+  const merged = sm.getMergedPRs() ?? [];
+  const closed = sm.getClosedPRs() ?? [];
+  const cutoffMs = Date.now() - RECENCY_CLIFF_MS;
+
+  /** Treat both merged and closed-without-merge PRs as candidates. */
+  const candidates: { url: string; timestamp: string; alreadyFetched: boolean }[] = [
+    ...merged.map((pr) => ({ url: pr.url, timestamp: pr.mergedAt, alreadyFetched: !!pr.commentsFetchedAt })),
+    ...closed.map((pr) => ({ url: pr.url, timestamp: pr.closedAt, alreadyFetched: !!pr.commentsFetchedAt })),
+  ];
+
+  const repoUrlPrefix = `https://github.com/${options.repo}/`;
+
+  const eligible = candidates.filter((c) => {
+    if (!c.url.startsWith(repoUrlPrefix)) return false;
+    if (Date.parse(c.timestamp || '') < cutoffMs) return false;
+    return true;
+  });
+
+  // Skipped count tracks ONLY the eligibility-passing PRs that were excluded
+  // for already-fetched. PRs filtered by repo/recency aren't "skipped" — they
+  // just don't apply to this repo or cutoff.
+  const skipped = options.forceRefetch ? 0 : eligible.filter((c) => c.alreadyFetched).length;
+
+  const toFetch = (options.forceRefetch ? eligible : eligible.filter((c) => !c.alreadyFetched))
+    // Most-recent first so the host always sees the freshest signal in its corpus window.
+    .sort((a, b) => Date.parse(b.timestamp || '') - Date.parse(a.timestamp || ''))
+    .slice(0, limit);
+
+  if (toFetch.length === 0) {
+    return { repo: options.repo, bundles: [], prCount: 0, skipped };
+  }
+
+  const token = requireGitHubToken();
+  const octokit = getOctokit(token);
+  const username = sm.getState().config.githubUsername;
+  if (!username) {
+    warn(MODULE, 'githubUsername is not set; bot/own-comment filtering will be incomplete');
+  }
+
+  const bundles = await fetchPRCommentBundlesBatch(
+    octokit,
+    toFetch.map((c) => c.url),
+    username,
+  );
+
+  // Stamp commentsFetchedAt on each PR we successfully fetched — the bundle
+  // list mirrors the input order until paginateAll fan-out, so we mark on
+  // a per-bundle basis to be safe.
+  const now = new Date().toISOString();
+  for (const bundle of bundles) {
+    sm.markPRCommentsFetched(bundle.prUrl, now);
+  }
+
+  return {
+    repo: options.repo,
+    bundles,
+    prCount: bundles.length,
+    skipped,
+  };
+}
+
+function clampLimit(limit: number | undefined): number {
+  if (limit === undefined) return DEFAULT_FETCH_LIMIT;
+  if (!Number.isFinite(limit) || limit < 1) return DEFAULT_FETCH_LIMIT;
+  return Math.min(limit, MAX_FETCH_LIMIT);
+}

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -65,6 +65,17 @@ export { runSetup } from './setup.js';
 /** Check whether setup has been completed. */
 export { runCheckSetup } from './setup.js';
 
+// ── Per-Repo Guidelines (#867) ──────────────────────────────────────────────
+
+/** Read the guidelines file for a repo. */
+export { runGuidelinesView } from './guidelines.js';
+/** Persist a guidelines file for a repo (overwrites on subsequent calls). */
+export { runGuidelinesStore } from './guidelines.js';
+/** Tombstone a guidelines file so subsequent reads return null. */
+export { runGuidelinesReset } from './guidelines.js';
+/** Fetch raw PR comment bundles for the host's extract-learnings prompt. */
+export { runFetchCorpus } from './guidelines.js';
+
 // ── State Persistence ────────────────────────────────────────────────────────
 
 /** Show current persistence mode, Gist ID, and sync status. */
@@ -124,6 +135,12 @@ export type {
 } from '../formatters/json.js';
 export type { ShelveOutput, UnshelveOutput } from './shelve.js';
 export type { MoveOutput, MoveTarget } from './move.js';
+export type {
+  GuidelinesViewOutput,
+  GuidelinesStoreOutput,
+  GuidelinesResetOutput,
+  FetchCorpusOutput,
+} from './guidelines.js';
 export type { DismissOutput, UndismissOutput } from './dismiss.js';
 export type { InitOutput } from './init.js';
 export type { ConfigSetOutput, ConfigCommandOutput } from './config.js';


### PR DESCRIPTION
## Summary

User-facing CLI surface for per-repo learning guidelines (#867). Pure data plumbing — extraction is the host's job.

This is **PR 4 of 7** in the #867 sequence. Builds on PR 1 (state schema, #1171), PR 2 (guidelines-store API, #1173), and PR 3 (pr-comments-fetcher, #1174).

## What changed

**`packages/core/src/commands/guidelines.ts`** (new) — four commands:
- `guidelines view --repo OWNER/REPO` — read the guidelines file. Returns `'local-unavailable'` storageMode (not an error) when not in Gist mode, so the host can degrade gracefully.
- `guidelines store --repo OWNER/REPO --content MD` — overwrite the guidelines file. Reads from stdin when `--content` is omitted (lets the host pipe in `extract-learnings` output without quoting). Throws `GuidelinesNotAvailableError` in local mode and `GuidelinesTooLargeError` past the 8 KB cap.
- `guidelines reset --repo OWNER/REPO` — tombstone the file. Returns `deleted: false` (not an error) when nothing existed.
- `guidelines fetch-corpus --repo OWNER/REPO [--limit N] [--force]` — pull raw PR comment bundles for the host's `extract-learnings` prompt. Filters: same-repo only, **recency cliff at 12 months**, skips PRs with `commentsFetchedAt` set unless `--force`, default limit 5 capped at 10. Stamps `commentsFetchedAt` on every successfully fetched PR.

**Wiring:**
- `packages/core/src/cli-registry.ts` — parent `guidelines` group with 4 subcommands following the existing `executeAction` pattern. Adds a small `readStdin` helper for the `store --content` ergonomics.
- `packages/core/src/commands/index.ts` — 4 `runX` exports + 4 output type re-exports.
- `packages/core/src/cli.test.ts` — registry expectations updated to include `'guidelines'`. The existing "every command has --json" test now recurses into parent-group subcommands rather than expecting the parent to carry `--json` directly.
- `.github/workflows/ci.yml` — `BUNDLE_MAX_CORE` 780000 → 800000 (~781 KB) for the new commands. Current bundle: 749.3 KB.

## Test plan

- [x] `pnpm test` — 2615 tests pass (2185 core + 256 dashboard + 174 mcp-server)
- [x] `pnpm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `pnpm run bundle` — core 749.3 KB (under the 781 KB cap)
- [x] 20 new tests cover view/store/reset/fetch-corpus across local-mode error paths, recency cliff (excludes >12mo PRs), repo filtering (drops PRs from other repos), already-fetched skip + `--force` re-include, default + max limit clamping, closed-without-merge inclusion alongside merged, malformed repo identifier rejection.

Refs #867. Depends on PR 1 (#1171, schema), PR 2 (#1173, store), PR 3 (#1174, fetcher) — all merged.