### PR TITLE
feat(mcp): add guidelines tools + extract-learnings prompt + repo-guidelines resource (#867 PR 5)

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -135,6 +135,10 @@ The token persists across restarts. To rotate, delete the file and restart — a
 | `state-show` | Show current state persistence mode (local or Gist) and sync status | Yes |
 | `state-sync` | Force push current state to the backing Gist | No |
 | `state-unlink` | Disconnect from Gist persistence and switch to local-only mode | No |
+| `guidelines-get` | Read per-repo learning guidelines extracted from past PR feedback | Yes |
+| `guidelines-store` | Persist per-repo guidelines (8 KB cap; requires Gist mode) | No |
+| `guidelines-reset` | Tombstone the guidelines file for a repo | No |
+| `guidelines-fetch-corpus` | Fetch raw PR comment bundles for the host's `extract-learnings` prompt to consume | No |
 
 ## Resources Reference
 
@@ -145,6 +149,7 @@ The token persists across restarts. To rotate, delete the file and restart — a
 | `oss://prs` | Active open PRs from last daily digest |
 | `oss://prs/shelved` | Shelved PRs |
 | `oss://pr/{owner}/{repo}/{number}` | Detail for a specific PR |
+| `oss://repo/{owner}/{repo}/guidelines` | Per-repo learning guidelines (markdown) |
 
 ## Prompts Reference
 
@@ -153,6 +158,7 @@ The token persists across restarts. To rotate, delete the file and restart — a
 | `triage` | none | Fetches daily digest and builds a prioritized triage list |
 | `respond-to-pr` | `prUrl` | Fetches PR comments and context for drafting a response |
 | `find-issues` | `maxResults?` | Searches for issues ranked by viability score |
+| `extract-learnings` | `repo`, `corpus`, `existingGuidelines?` | Distills durable per-repo guidance from raw PR comment bundles (#867) |
 
 ## Programmatic Usage
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -10,9 +10,9 @@ MCP server for [OSS Autopilot](https://github.com/costajohnt/oss-autopilot) — 
 
 | Feature | Count | Description |
 |---------|-------|-------------|
-| **Tools** | 22 | `daily`, `status`, `search`, `vet`, `vet-list`, `track`, `comments`, `post`, `claim`, `config`, `init`, `setup`, `check-setup`, `startup`, `shelve`, `unshelve`, `dismiss`, `undismiss`, `move`, `state-show`, `state-sync`, `state-unlink` |
-| **Resources** | 5 | `oss://status`, `oss://config`, `oss://prs`, `oss://prs/shelved`, `oss://pr/{owner}/{repo}/{number}` |
-| **Prompts** | 3 | `triage` (PR prioritization), `respond-to-pr` (draft response), `find-issues` (discover issues) |
+| **Tools** | 26 | `daily`, `status`, `search`, `vet`, `vet-list`, `track`, `comments`, `post`, `claim`, `config`, `init`, `setup`, `check-setup`, `startup`, `shelve`, `unshelve`, `dismiss`, `undismiss`, `move`, `state-show`, `state-sync`, `state-unlink`, `guidelines-get`, `guidelines-store`, `guidelines-reset`, `guidelines-fetch-corpus` |
+| **Resources** | 6 | `oss://status`, `oss://config`, `oss://prs`, `oss://prs/shelved`, `oss://pr/{owner}/{repo}/{number}`, `oss://repo/{owner}/{repo}/guidelines` |
+| **Prompts** | 4 | `triage` (PR prioritization), `respond-to-pr` (draft response), `find-issues` (discover issues), `extract-learnings` (distill per-repo guidance from past PR feedback) |
 
 Supports **stdio** (default) and **Streamable HTTP** transports.
 

--- a/packages/mcp-server/src/index.test.ts
+++ b/packages/mcp-server/src/index.test.ts
@@ -161,7 +161,7 @@ describe('MCP server stdio transport', { timeout: 30_000 }, () => {
   it('lists tools via stdio', async () => {
     client = await createStdioClient();
     const { tools } = await client.listTools();
-    expect(tools.length).toBe(22);
+    expect(tools.length).toBe(26);
     expect(tools.some((t) => t.name === 'daily')).toBe(true);
   });
 
@@ -174,7 +174,7 @@ describe('MCP server stdio transport', { timeout: 30_000 }, () => {
   it('lists prompts via stdio', async () => {
     client = await createStdioClient();
     const { prompts } = await client.listPrompts();
-    expect(prompts.length).toBe(3);
+    expect(prompts.length).toBe(4);
   });
 });
 

--- a/packages/mcp-server/src/prompts.test.ts
+++ b/packages/mcp-server/src/prompts.test.ts
@@ -56,6 +56,10 @@ vi.mock('@oss-autopilot/core/commands', () => ({
   runDismiss: vi.fn(),
   runUndismiss: vi.fn(),
   runMove: vi.fn(),
+  runGuidelinesView: vi.fn(),
+  runGuidelinesStore: vi.fn(),
+  runGuidelinesReset: vi.fn(),
+  runFetchCorpus: vi.fn(),
   MAX_SEARCH_RESULTS: 100,
 }));
 
@@ -222,6 +226,99 @@ describe('MCP prompt registrations', () => {
       const text = (result.messages[0].content as { type: 'text'; text: string }).text;
       expect(text).toContain('Failed to search for issues');
       expect(text).toContain('Search quota exceeded');
+    });
+  });
+
+  describe('extract-learnings prompt (#867)', () => {
+    function getText(result: { messages: { content: unknown }[] }): string {
+      return (result.messages[0].content as { type: 'text'; text: string }).text;
+    }
+
+    it('builds a structured prompt from a valid corpus', async () => {
+      const corpus = JSON.stringify([
+        {
+          prUrl: 'https://github.com/owner/repo/pull/1',
+          prTitle: 'Fix sort order',
+          repo: 'owner/repo',
+          mergedAt: '2026-04-20T12:00:00Z',
+          reviews: [{ author: 'maintainer1', authorAssociation: 'OWNER', body: 'Use camelCase' }],
+          reviewComments: [{ author: 'maintainer1', authorAssociation: 'OWNER', body: 'Inline nit', path: 'src/x.ts' }],
+          issueComments: [{ author: 'maintainer2', authorAssociation: 'COLLABORATOR', body: 'Tests please' }],
+        },
+      ]);
+
+      const result = await client.getPrompt({
+        name: 'extract-learnings',
+        arguments: { repo: 'owner/repo', corpus },
+      });
+
+      const text = getText(result);
+      expect(text).toContain('Distill durable contribution guidance for owner/repo');
+      // Categories from the design log §6
+      expect(text).toContain('## Code Style');
+      expect(text).toContain('## Process');
+      expect(text).toContain('## Architecture');
+      expect(text).toContain('## Testing');
+      expect(text).toContain('## Other');
+      // Per-PR section structure
+      expect(text).toContain('### Fix sort order');
+      expect(text).toContain('[REVIEW by maintainer1 (OWNER)]');
+      expect(text).toContain('[INLINE on src/x.ts by maintainer1 (OWNER)]');
+      expect(text).toContain('[COMMENT by maintainer2 (COLLABORATOR)]');
+      // Closing instruction
+      expect(text).toContain('call the `guidelines-store` tool');
+    });
+
+    it('threads existingGuidelines into an incremental update', async () => {
+      const corpus = JSON.stringify([
+        {
+          prUrl: 'https://github.com/owner/repo/pull/2',
+          prTitle: 'Refactor parser',
+          repo: 'owner/repo',
+          mergedAt: '2026-04-21T00:00:00Z',
+          reviews: [],
+          reviewComments: [],
+          issueComments: [{ author: 'm', authorAssociation: 'OWNER', body: 'No new deps' }],
+        },
+      ]);
+
+      const result = await client.getPrompt({
+        name: 'extract-learnings',
+        arguments: { repo: 'owner/repo', corpus, existingGuidelines: '## Code Style\n- Existing rule' },
+      });
+
+      const text = getText(result);
+      expect(text).toContain('EXISTING GUIDELINES');
+      expect(text).toContain('Existing rule');
+      expect(text).toContain('deduplicate');
+    });
+
+    it('returns a friendly error when corpus is not valid JSON', async () => {
+      const result = await client.getPrompt({
+        name: 'extract-learnings',
+        arguments: { repo: 'owner/repo', corpus: '{not valid' },
+      });
+
+      expect(getText(result)).toContain('Invalid corpus JSON');
+    });
+
+    it('returns a friendly error when corpus is JSON but not an array', async () => {
+      const result = await client.getPrompt({
+        name: 'extract-learnings',
+        arguments: { repo: 'owner/repo', corpus: '{"foo":1}' },
+      });
+
+      expect(getText(result)).toContain('expected an array');
+    });
+
+    it('returns a friendly message when the corpus array is empty', async () => {
+      const result = await client.getPrompt({
+        name: 'extract-learnings',
+        arguments: { repo: 'owner/repo', corpus: '[]' },
+      });
+
+      expect(getText(result)).toContain('No PR comment bundles supplied');
+      expect(getText(result)).toContain('guidelines-fetch-corpus');
     });
   });
 });

--- a/packages/mcp-server/src/prompts.test.ts
+++ b/packages/mcp-server/src/prompts.test.ts
@@ -93,15 +93,15 @@ describe('MCP prompt registrations', () => {
   });
 
   describe('prompt listing', () => {
-    it('lists exactly 3 prompts', async () => {
+    it('lists exactly 4 prompts', async () => {
       const result = await client.listPrompts();
-      expect(result.prompts).toHaveLength(3);
+      expect(result.prompts).toHaveLength(4);
     });
 
     it('registers the expected prompt names', async () => {
       const result = await client.listPrompts();
       const names = result.prompts.map((p) => p.name).sort();
-      expect(names).toEqual(['find-issues', 'respond-to-pr', 'triage']);
+      expect(names).toEqual(['extract-learnings', 'find-issues', 'respond-to-pr', 'triage']);
     });
 
     it('each prompt has a name and description', async () => {

--- a/packages/mcp-server/src/prompts.ts
+++ b/packages/mcp-server/src/prompts.ts
@@ -6,11 +6,27 @@
  *   - triage: Daily PR triage and prioritization
  *   - respond-to-pr: Draft responses to maintainer feedback
  *   - find-issues: Discover and rank contributable issues
+ *   - extract-learnings: Distill durable guidance from past PR feedback (#867)
  */
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { runDaily, runComments, runSearch, MAX_SEARCH_RESULTS } from '@oss-autopilot/core/commands';
 import { errorMessage } from '@oss-autopilot/core';
+
+/**
+ * Subset of `PRCommentBundle` from `@oss-autopilot/core` that we render in the
+ * extract-learnings prompt. Inlined as a structural type to avoid pulling in
+ * the full implementation module just for a JSON shape.
+ */
+interface PRCommentBundleShape {
+  prUrl: string;
+  prTitle: string;
+  repo: string;
+  mergedAt: string;
+  reviews: { author: string; authorAssociation: string; body: string }[];
+  reviewComments: { author: string; authorAssociation: string; body: string; path: string }[];
+  issueComments: { author: string; authorAssociation: string; body: string }[];
+}
 
 /** Build a single-message prompt result with a user text message. */
 function userMessage(text: string) {
@@ -101,6 +117,105 @@ export function registerPrompts(server: McpServer): void {
         console.error('[MCP] Prompt error (find-issues):', e);
         return userMessage(`Failed to search for issues: ${errorMessage(e)}`);
       }
+    },
+  );
+
+  // 4. extract-learnings — given a corpus of PR comment bundles, ask the host
+  // LLM to distill durable per-repo guidance (#867 PR 5).
+  server.registerPrompt(
+    'extract-learnings',
+    {
+      title: 'Extract Per-Repo Learnings',
+      description:
+        'Given raw PR comment bundles for a repo, produce a structured guidelines document distilling durable maintainer preferences. Filter PR-specific nitpicks; keep general rules. Optional existingGuidelines argument enables incremental updates.',
+      argsSchema: {
+        repo: z.string().describe('Target repo as owner/repo'),
+        corpus: z.string().describe('JSON-serialized array of PRCommentBundle objects from guidelines-fetch-corpus'),
+        existingGuidelines: z
+          .string()
+          .optional()
+          .describe('Existing guidelines markdown to update incrementally; omit on first extraction'),
+      },
+    },
+    async ({ repo, corpus, existingGuidelines }) => {
+      let bundles: PRCommentBundleShape[];
+      try {
+        const parsed = JSON.parse(corpus);
+        if (!Array.isArray(parsed)) {
+          return userMessage(`Invalid corpus: expected an array of PRCommentBundle objects, got ${typeof parsed}.`);
+        }
+        bundles = parsed as PRCommentBundleShape[];
+      } catch (e) {
+        return userMessage(`Invalid corpus JSON: ${errorMessage(e)}`);
+      }
+
+      if (bundles.length === 0) {
+        return userMessage(
+          `No PR comment bundles supplied for ${repo}. Run guidelines-fetch-corpus first, then re-run this prompt with its output.`,
+        );
+      }
+
+      const prSections = bundles
+        .map((b) => {
+          const reviews = (b.reviews ?? [])
+            .map((r) => `[REVIEW by ${r.author} (${r.authorAssociation})]\n${r.body}`)
+            .join('\n\n');
+          const inline = (b.reviewComments ?? [])
+            .map((c) => `[INLINE on ${c.path} by ${c.author} (${c.authorAssociation})]\n${c.body}`)
+            .join('\n\n');
+          const issue = (b.issueComments ?? [])
+            .map((c) => `[COMMENT by ${c.author} (${c.authorAssociation})]\n${c.body}`)
+            .join('\n\n');
+          const sections = [reviews, inline, issue].filter((s) => s.length > 0).join('\n\n');
+          return `### ${b.prTitle} (${b.prUrl}, merged/closed: ${b.mergedAt})\n${sections}`;
+        })
+        .join('\n\n---\n\n');
+
+      const existing = existingGuidelines
+        ? `\n\nEXISTING GUIDELINES (update incrementally; deduplicate; preserve every rule unless directly contradicted):\n${existingGuidelines}`
+        : '';
+
+      const prompt = [
+        `Distill durable contribution guidance for ${repo} from the PR review feedback below.`,
+        '',
+        'Rules for the extraction:',
+        '1. KEEP only **durable rules** that apply to future PRs — code style preferences, test requirements, architectural conventions, process expectations, dependency constraints, project philosophy.',
+        '2. DISCARD PR-specific nitpicks: "LGTM", "Thanks!", scope-of-this-PR asks, one-time workarounds, status updates, CI flake notes, typo fixes, formatting tweaks on the specific code touched, historical context with no actionable rule.',
+        '3. WEIGHT comments by authorAssociation: OWNER, MEMBER, COLLABORATOR carry strong signal; CONTRIBUTOR/NONE only when they articulate a clear project-wide rule.',
+        '4. FLAG contradictions between maintainer comments rather than silently picking one side.',
+        '5. CAP output at ~6,000 bytes (well under the 8 KB store limit). If the corpus produces more, prefer the rules with strongest signal.',
+        '',
+        'Output format (single markdown document, exactly five fixed categories plus "Other"):',
+        '```markdown',
+        `# Contribution Guidelines: ${repo}`,
+        "_Auto-generated from contribution history. Last updated: <today's date>._",
+        '',
+        '## Code Style',
+        '- ...',
+        '',
+        '## Process',
+        '- ...',
+        '',
+        '## Architecture',
+        '- ...',
+        '',
+        '## Testing',
+        '- ...',
+        '',
+        '## Other',
+        '- ...',
+        '```',
+        '',
+        existing,
+        '',
+        'PR comment corpus:',
+        '',
+        prSections,
+        '',
+        'After producing the guidelines markdown, call the `guidelines-store` tool with `repo` and `content` to persist the result.',
+      ].join('\n');
+
+      return userMessage(prompt);
     },
   );
 }

--- a/packages/mcp-server/src/resources.test.ts
+++ b/packages/mcp-server/src/resources.test.ts
@@ -44,6 +44,8 @@ vi.mock('@oss-autopilot/core', () => ({
   getSetupKeys: () => ['username', 'languages', 'minStars'],
   getConfigKeys: () => ['username', 'add-label', 'remove-label'],
   getStateManager: vi.fn().mockReturnValue({
+    listGuidelinesRepos: vi.fn().mockReturnValue([]),
+    getGuidelines: vi.fn().mockReturnValue(null),
     getState: vi.fn().mockReturnValue({
       lastDigest: {
         generatedAt: '2026-02-28T12:00:00Z',

--- a/packages/mcp-server/src/resources.ts
+++ b/packages/mcp-server/src/resources.ts
@@ -156,4 +156,50 @@ export function registerResources(server: McpServer): void {
       }
     },
   );
+
+  // 6. repo-guidelines — Per-repo learning guidelines extracted from past
+  // PR feedback (#867). Returned as text/markdown so MCP clients can inject
+  // the content directly into a context window without re-parsing JSON.
+  server.registerResource(
+    'repo-guidelines',
+    new ResourceTemplate('oss://repo/{owner}/{repo}/guidelines', {
+      list: async () => {
+        try {
+          const repos = getStateManager().listGuidelinesRepos();
+          return {
+            resources: repos.map((fullRepo) => {
+              const { owner, repo } = splitRepo(fullRepo);
+              return {
+                uri: `oss://repo/${owner}/${repo}/guidelines`,
+                name: `${fullRepo} guidelines`,
+                description: `Per-repo learning guidelines for ${fullRepo}`,
+                mimeType: 'text/markdown' as const,
+              };
+            }),
+          };
+        } catch (e) {
+          console.error('[MCP] Failed to list repo-guidelines resources:', e);
+          throw e;
+        }
+      },
+    }),
+    {
+      title: 'Repo Guidelines',
+      description: 'Per-repo learning guidelines extracted from past PR feedback (#867).',
+      mimeType: 'text/markdown',
+    },
+    async (uri, { owner, repo }) => {
+      try {
+        const fullRepo = `${String(owner)}/${String(repo)}`;
+        const content = getStateManager().getGuidelines(fullRepo);
+        if (!content) {
+          throw new Error(`No guidelines stored for ${fullRepo}`);
+        }
+        return { contents: [{ uri: uri.href, mimeType: 'text/markdown', text: content }] };
+      } catch (e) {
+        console.error('[MCP] repo-guidelines resource error:', e);
+        throw e;
+      }
+    },
+  );
 }

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -27,6 +27,10 @@ const EXPECTED_TOOLS = [
   'state-show',
   'state-sync',
   'state-unlink',
+  'guidelines-get',
+  'guidelines-store',
+  'guidelines-reset',
+  'guidelines-fetch-corpus',
 ] as const;
 
 describe('MCP tool registrations', () => {
@@ -55,8 +59,8 @@ describe('MCP tool registrations', () => {
     await client.close();
   });
 
-  it('registers exactly 22 tools', () => {
-    expect(tools).toHaveLength(22);
+  it('registers exactly 26 tools', () => {
+    expect(tools).toHaveLength(26);
   });
 
   it('registers all expected tool names', () => {

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -26,6 +26,10 @@ import {
   runDismiss,
   runUndismiss,
   runMove,
+  runGuidelinesView,
+  runGuidelinesStore,
+  runGuidelinesReset,
+  runFetchCorpus,
   MAX_SEARCH_RESULTS,
 } from '@oss-autopilot/core/commands';
 import { errorMessage, getSetupKeys, getConfigKeys } from '@oss-autopilot/core';
@@ -450,5 +454,76 @@ export function registerTools(server: McpServer): void {
       const { runStateUnlink } = await import('@oss-autopilot/core/commands');
       return runStateUnlink();
     }),
+  );
+
+  // ── Per-Repo Guidelines (#867) ──────────────────────────────────────
+  // 23. guidelines-get
+  server.registerTool(
+    'guidelines-get',
+    {
+      description:
+        'Read per-repo learning guidelines extracted from past PR feedback. Returns null content when no guidelines exist or when running in local mode without Gist persistence.',
+      inputSchema: {
+        repo: z
+          .string()
+          .regex(/^[^/]+\/[^/]+$/, 'Must be owner/repo format')
+          .describe('Repository identifier in owner/repo form'),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    wrapTool((args: { repo: string }) => runGuidelinesView({ repo: args.repo })),
+  );
+
+  // 24. guidelines-store
+  server.registerTool(
+    'guidelines-store',
+    {
+      description:
+        'Persist per-repo guidelines extracted from PR review feedback. Overwrites any existing guidelines for the repo. Content is capped at 8 KB. Requires Gist persistence — fails with GUIDELINES_NOT_AVAILABLE in local mode.',
+      inputSchema: {
+        repo: z.string().regex(/^[^/]+\/[^/]+$/, 'Must be owner/repo format'),
+        content: z
+          .string()
+          .min(1, 'Cannot store empty content; use guidelines-reset to delete')
+          .max(8192, 'Content exceeds 8 KB cap')
+          .describe('Markdown content extracted from past PR review feedback'),
+      },
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    wrapTool((args: { repo: string; content: string }) =>
+      runGuidelinesStore({ repo: args.repo, content: args.content }),
+    ),
+  );
+
+  // 25. guidelines-reset
+  server.registerTool(
+    'guidelines-reset',
+    {
+      description:
+        'Tombstone the per-repo guidelines file so subsequent reads return null. No-op when no guidelines exist. Requires Gist persistence.',
+      inputSchema: {
+        repo: z.string().regex(/^[^/]+\/[^/]+$/, 'Must be owner/repo format'),
+      },
+      annotations: { readOnlyHint: false, destructiveHint: true },
+    },
+    wrapTool((args: { repo: string }) => runGuidelinesReset({ repo: args.repo })),
+  );
+
+  // 26. guidelines-fetch-corpus
+  server.registerTool(
+    'guidelines-fetch-corpus',
+    {
+      description:
+        "Fetch raw review-comment bundles for a repo's recent merged/closed PRs. Returns the corpus the host's extract-learnings prompt should consume. Does not call any LLM. Filters: same-repo only, recency cliff at 12 months, skips PRs already processed unless forceRefetch is true.",
+      inputSchema: {
+        repo: z.string().regex(/^[^/]+\/[^/]+$/, 'Must be owner/repo format'),
+        limit: z.number().int().min(1).max(10).optional().describe('Max PRs to fetch (default 5, max 10)'),
+        forceRefetch: z.boolean().optional().describe('Re-fetch even when commentsFetchedAt is already set on the PR'),
+      },
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    wrapTool((args: { repo: string; limit?: number; forceRefetch?: boolean }) =>
+      runFetchCorpus({ repo: args.repo, limit: args.limit, forceRefetch: args.forceRefetch }),
+    ),
   );
 }


### PR DESCRIPTION
## Summary

Adds the MCP surface for per-repo learning guidelines (#867). Tools, resource, and prompt all delegate to the existing CLI commands shipped in PR 4 (#1175); no new business logic.

This is **PR 5 of 7** in the #867 sequence.

## What changed

**New MCP tools (22 → 26)** in `packages/mcp-server/src/tools.ts`:
- `guidelines-get(repo)` — read the guidelines file. Returns null content + `'local-unavailable'` storageMode in non-Gist mode.
- `guidelines-store(repo, content)` — overwrite the file. Schema enforces 1-8192 byte content at the boundary so MCP clients see `InvalidParams` instead of `GUIDELINES_TOO_LARGE` on oversized input.
- `guidelines-reset(repo)` — tombstone the file.
- `guidelines-fetch-corpus(repo, limit?, forceRefetch?)` — pull raw PR comment bundles. Same recency cliff (12 months) and limit cap (10) as the CLI.

**New MCP prompt (3 → 4)** in `packages/mcp-server/src/prompts.ts`:
- `extract-learnings(repo, corpus, existingGuidelines?)` — distillation prompt that takes the JSON-serialized output of `guidelines-fetch-corpus` and produces a structured guidelines markdown document. Includes the explicit signal-vs-noise rules from the design log §6, the 5-fixed-category output format, and a closing instruction to call `guidelines-store` with the result. **The prompt is the only LLM surface** — the rest of the feature stays pure data plumbing per the constraint in the design.

**New MCP resource (5 → 6)** in `packages/mcp-server/src/resources.ts`:
- `oss://repo/{owner}/{repo}/guidelines` — `text/markdown` content of the per-repo guidelines file. `listResources` surfaces only repos that actually have non-empty guidelines stored (excludes tombstones). Reading a non-existent repo throws a clear JSON-RPC error.

**README update**: 22 → 26 tools, 5 → 6 resources, 3 → 4 prompts.

**Tests**:
- `packages/mcp-server/src/tools.test.ts` — `EXPECTED_TOOLS` list + count assertion bumped to 26.
- `packages/mcp-server/src/prompts.test.ts` — count + names list bumped to include `extract-learnings`.
- `packages/mcp-server/src/index.test.ts` — stdio listing counts bumped.
- `packages/mcp-server/src/resources.test.ts` — `getStateManager` mock extended with `listGuidelinesRepos` + `getGuidelines` stubs returning empty/null so the new repo-guidelines list callback runs cleanly.

## Test plan

- [x] `pnpm test` — 2623 tests pass (2185 core + 256 dashboard + 182 mcp-server)
- [x] `pnpm run lint` clean
- [x] `npx tsc --noEmit` clean (both packages)
- [x] `pnpm run bundle` — core 749.3 KB, mcp-server 968.7 KB
- [x] All four new tools accessible via stdio + HTTP MCP transports

Refs #867. Depends on PR 4 (#1175, CLI commands) — merged.