### PR TITLE
feat(plugin): inject per-repo guidelines at claim time (#867 PR 6)

### DIFF
--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -128,6 +128,17 @@ When the user has configured `slmTriageModel` (e.g. `gemma4:e4b`), the `vet` res
 
 Never make a recommendation that contradicts the SLM call without saying so explicitly in the summary; users want to see the disagreement, not paper over it.
 
+### Per-repo learning guidelines (#867)
+
+After feasibility analysis but before claiming, the work-through-issues workflow injects any stored per-repo guidelines via `oss-autopilot guidelines view --repo OWNER/REPO --json`. These are extracted from past PR feedback in the user's Gist and encode durable maintainer preferences (code style, process, architecture, testing rules).
+
+When implementing, treat injected guidelines as **strong preferences**, not absolute rules:
+
+- Follow them by default. They reflect what the maintainer has historically wanted.
+- If your proposed approach **contradicts** a stated rule, surface the conflict explicitly in your summary so the user can confirm. Don't silently override.
+- They take precedence over generic CONTRIBUTING.md when the two conflict (the guidelines incorporate CONTRIBUTING.md context already).
+- Absence of guidelines is normal — the user may not have generated them yet for this repo. Fall back to CONTRIBUTING.md and the issue-scout's standard rubric.
+
 ### gh fallback vetting
 
 If MCP + CLI both fail, collect the vetting data with `gh` (inform the user first):

--- a/workflows/work-through-issues.md
+++ b/workflows/work-through-issues.md
@@ -380,7 +380,27 @@ Show the vetting summary, then automatically proceed to investigate the issue. I
 Confidence: {High|Medium|Low — how confident in the diagnosis}
 ```
 
-7. **Post-investigation options:**
+7. **Inject per-repo guidelines (#867).** Before presenting the post-investigation options, fetch any stored guidelines for the target repo. These encode durable maintainer preferences extracted from past PR feedback.
+
+```bash
+GUIDELINES_OUT=$(GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" guidelines view --repo {owner}/{repo} --json 2>/dev/null)
+```
+
+Parse `data.exists` and `data.content`:
+
+- **If `data.exists === true` and `data.content` is non-empty:** Display to the user before offering the options:
+
+  > **Maintainer preferences for {owner}/{repo}** (from past PR feedback):
+  >
+  > {data.content}
+  >
+  > These take precedence over CONTRIBUTING.md when they conflict. When implementing, flag any case where your proposed approach contradicts a stated preference so the user can confirm.
+
+- **If `data.exists === false`** or `data.storageMode === 'local-unavailable'`: skip silently. Per-repo guidelines are opt-in and only available in Gist mode.
+
+- **If the command fails** (network error, malformed output): skip silently. Never block claim on guidelines unavailability — the implementation flow must work even when the guidelines layer is offline.
+
+8. **Post-investigation options:**
 
 ```
 Question: "Investigation complete. How would you like to proceed?"


### PR DESCRIPTION
## Summary

Wires the per-repo guidelines feature into the `work-through-issues` workflow so any guidelines the user has stored for the target repo are surfaced before they confirm "Start implementing". Implementing agents then treat the guidelines as strong preferences rather than rediscovering maintainer rules per-PR.

This is **PR 6 of 7** in the #867 sequence. Builds on PR 4 (#1175, CLI commands).

## What changed

**`workflows/work-through-issues.md`** — new **Step 7** inserted between feasibility analysis and post-investigation options:
- Calls `guidelines view --repo OWNER/REPO --json` after the feasibility report.
- Surfaces `data.content` to the user under a *"Maintainer preferences for {owner}/{repo}"* header.
- **Skip silently** when `data.exists` is false, when in local-mode (`storageMode === 'local-unavailable'`), or when the command fails (network error, malformed output). Guidelines unavailability **never blocks claim** — the implementation flow must work without them.
- Renumbered the existing "Post-investigation options" from Step 7 to Step 8.

**`agents/issue-scout.md`** — new "Per-repo learning guidelines (#867)" subsection in the vetting process:
- Documents how to use guidelines as **strong preferences, not absolute rules**.
- Implementing agents follow them by default but surface contradictions explicitly so the user can confirm.
- Guidelines take precedence over generic CONTRIBUTING.md when the two conflict (since they already incorporate CONTRIBUTING.md context during extraction).
- Absence of guidelines is normal and non-blocking.

## Why "strong preferences, not absolute rules"

Guidelines are LLM-extracted from review feedback, so they have non-zero false-positive risk (the extraction could mischaracterize a one-off nitpick as a general rule). Surfacing contradictions to the user — rather than silently following — keeps the user in the loop on edge cases and lets them correct the guidelines file when extraction got it wrong.

## Test plan

- [x] `pnpm test` — 2628 tests pass (no code changes; markdown-only PR)
- [x] `pnpm run lint` clean
- [x] Manual review: workflow file renders correctly with the new Step 7 inserted before Step 8 (post-investigation options)

Refs #867. Depends on PR 4 (#1175, CLI commands) — merged.