### PR TITLE
chore: enable type-aware lint rules to catch silent-failure bugs

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,7 +9,9 @@ import vitest from '@vitest/eslint-plugin';
 
 export default tseslint.config(
   eslint.configs.recommended,
-  ...tseslint.configs.recommended,
+  // Type-aware preset for source files only (test files are excluded from
+  // per-package tsconfig.json — see scoped block below).
+  ...tseslint.configs.recommendedTypeChecked,
   importX.flatConfigs.recommended,
   // Skip importX.flatConfigs.typescript — typescript-eslint already handles
   // module resolution; the import-x typescript resolver fights it and emits
@@ -19,9 +21,22 @@ export default tseslint.config(
   regexp.configs['flat/recommended'],
   eslintConfigPrettier,
   {
-    ignores: ['packages/*/dist/**', 'packages/*/docs/**', 'node_modules/**', '*.cjs'],
+    ignores: [
+      'packages/*/dist/**',
+      'packages/*/docs/**',
+      'packages/*/coverage/**',
+      'node_modules/**',
+      '*.cjs',
+    ],
   },
   {
+    languageOptions: {
+      parserOptions: {
+        // projectService discovers tsconfig.json per-package automatically.
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
     rules: {
       // Allow unused vars prefixed with _ (common pattern)
       '@typescript-eslint/no-unused-vars': [
@@ -37,6 +52,34 @@ export default tseslint.config(
       '@typescript-eslint/no-explicit-any': 'warn',
       // Allow non-null assertion (used in tests)
       '@typescript-eslint/no-non-null-assertion': 'off',
+
+      // ── Type-aware rules — kept as ERROR (these catch real bugs) ─────
+      // no-floating-promises catches the audit's silent-failure pattern;
+      // no-misused-promises catches passing async fns where sync is expected.
+      '@typescript-eslint/no-floating-promises': 'error',
+      // Allow async functions as React event handlers and as Node http.createServer
+      // callbacks — both APIs handle returned promises fine. Still catches
+      // higher-signal cases like `if (asyncFn())` and conditional checks.
+      '@typescript-eslint/no-misused-promises': [
+        'error',
+        { checksVoidReturn: { arguments: false, attributes: false, properties: false } },
+      ],
+      '@typescript-eslint/no-base-to-string': 'error',
+      '@typescript-eslint/prefer-promise-reject-errors': 'error',
+
+      // ── Type-aware rules — downgraded to WARN ───────────────────────
+      // The unsafe-* family fires heavily on JSON.parse, env vars, third-party
+      // returns. Each one needs hand-review; warn level keeps them visible
+      // without gating CI. Ratchet to error once the warning count is low.
+      '@typescript-eslint/no-unsafe-assignment': 'warn',
+      '@typescript-eslint/no-unsafe-member-access': 'warn',
+      '@typescript-eslint/no-unsafe-call': 'warn',
+      '@typescript-eslint/no-unsafe-argument': 'warn',
+      '@typescript-eslint/no-unsafe-return': 'warn',
+      '@typescript-eslint/restrict-template-expressions': 'warn',
+      '@typescript-eslint/require-await': 'warn',
+      '@typescript-eslint/no-unnecessary-type-assertion': 'warn',
+      '@typescript-eslint/no-redundant-type-constituents': 'warn',
 
       // import-x: dev dependencies are fine in tests + tooling
       'import-x/no-unresolved': 'off', // typescript-eslint handles resolution
@@ -59,10 +102,23 @@ export default tseslint.config(
     },
   },
   {
-    // Test files use `any` extensively for mocking — keep it off there
-    files: ['**/*.test.ts'],
+    // Test files are excluded from per-package tsconfig.json (they don't ship
+    // in dist). Disable type-aware rules for them — vitest already provides
+    // type checking at runtime. The high-value rules (no-floating-promises,
+    // no-misused-promises) primarily catch bugs in production code paths,
+    // not test setup.
+    files: [
+      '**/*.test.ts',
+      '**/*.test.tsx',
+      '**/*.e2e.test.ts',
+      '**/vitest.config.ts',
+      '**/vitest.setup.ts',
+      '**/vite.config.ts',
+    ],
+    ...tseslint.configs.disableTypeChecked,
     plugins: { vitest },
     rules: {
+      ...tseslint.configs.disableTypeChecked.rules,
       '@typescript-eslint/no-explicit-any': 'off',
       ...vitest.configs.recommended.rules,
       // Allow `it.skip` for gated tests; project uses `it.todo` for stubs

--- a/packages/core/src/commands/parse-list.ts
+++ b/packages/core/src/commands/parse-list.ts
@@ -40,7 +40,7 @@ function extractTitle(line: string): string {
   // Remove strikethrough markers
   cleaned = cleaned.replace(/~~/g, '');
   // Remove "Done" markers
-  cleaned = cleaned.replace(/\b(Done|DONE|done)\b/g, '');
+  cleaned = cleaned.replace(/\bdone\b/gi, '');
   // Remove leading/trailing punctuation and whitespace
   cleaned = cleaned.replace(/^[\s\-\u2013\u2014:]+/, '').replace(/[\s\-\u2013\u2014:]+$/, '');
   return cleaned.trim();

--- a/packages/core/src/core/auth.ts
+++ b/packages/core/src/core/auth.ts
@@ -123,7 +123,7 @@ export async function getGitHubTokenAsync(): Promise<string | null> {
     const token = await new Promise<string>((resolve, reject) => {
       execFile('gh', ['auth', 'token'], { encoding: 'utf-8', timeout: 2000 }, (error, stdout) => {
         if (error) {
-          reject(error);
+          reject(error as Error);
         } else {
           resolve(stdout.trim());
         }
@@ -161,7 +161,7 @@ export async function detectGitHubUsername(): Promise<string | null> {
     const login = await new Promise<string>((resolve, reject) => {
       execFile('gh', ['api', 'user', '--jq', '.login'], { encoding: 'utf-8', timeout: 5000 }, (error, stdout) => {
         if (error) {
-          reject(error);
+          reject(error as Error);
         } else {
           resolve(stdout.trim());
         }

--- a/packages/core/src/core/issue-conversation.ts
+++ b/packages/core/src/core/issue-conversation.ts
@@ -204,7 +204,10 @@ export class IssueConversationMonitor {
         body: comment.body || '',
         createdAt: comment.created_at,
         isUser: author.toLowerCase() === username.toLowerCase(),
-        authorAssociation: String((comment as Record<string, unknown>).author_association ?? ''),
+        authorAssociation:
+          typeof (comment as Record<string, unknown>).author_association === 'string'
+            ? ((comment as Record<string, unknown>).author_association as string)
+            : '',
       });
     }
 

--- a/packages/dashboard/src/hooks/use-dashboard.ts
+++ b/packages/dashboard/src/hooks/use-dashboard.ts
@@ -152,8 +152,10 @@ export function useDashboard() {
   );
 
   useEffect(() => {
-    fetchData();
-    const timer = setTimeout(silentRefresh, 5_000);
+    void fetchData();
+    const timer = setTimeout(() => {
+      void silentRefresh();
+    }, 5_000);
     return () => clearTimeout(timer);
   }, [fetchData, silentRefresh]);
 


### PR DESCRIPTION
## Summary

Bumps typescript-eslint config from `recommended` to `recommendedTypeChecked`, enabling type-aware rules that catch the same bug class found in the 2026-04-28 audit (silent floating promises, error swallowing).

This is the structural fix for the audit's silent-failure findings (C2/C3/H3): once `no-floating-promises` is enforced as an error, the next floating-promise bug fails CI before it can merge.

## Configuration

- `projectService` for per-package tsconfig.json discovery
- Test/config files (`*.test.ts`, `vitest.config.ts`, `vite.config.ts`) get `disableTypeChecked` since they're excluded from per-package tsconfig
- Coverage directories added to ignores

## Rule severity

**Error (catch real bugs):**
- `@typescript-eslint/no-floating-promises`
- `@typescript-eslint/no-misused-promises` (with `checksVoidReturn` relaxed for React `onClick` and Node `http.createServer` patterns)
- `@typescript-eslint/no-base-to-string`
- `@typescript-eslint/prefer-promise-reject-errors`

**Warn (visible but non-blocking; ratchet later):**
- `no-unsafe-*` family (211 instances; mostly JSON parse, env vars, third-party returns)
- `require-await`, `restrict-template-expressions`
- `no-unnecessary-type-assertion`, `no-redundant-type-constituents`

## Code fixes (12 errors → 0)

- `auth.ts` — `execFile` reject param cast as Error (ExecException extends Error but the rule doesn't follow the inheritance)
- `issue-conversation.ts` — `authorAssociation` typed-narrow before `String()`
- `use-celebration.ts` — confetti chain given `.catch()` handler
- `use-dashboard.ts` — useEffect awaits prefixed with `void`

## Verification

- `pnpm run lint` — 0 errors, 263 warnings
- `pnpm run typecheck` — clean
- `pnpm test` — 2,628 passing

## Checklist

- [x] Tests pass (`pnpm test`)
- [x] Commits follow conventional format (`feat:`, `fix:`, `chore:`)
- [x] No manual version bumps or CHANGELOG edits (automated via release-please)