### PR TITLE
fix: 3 critical data-loss bugs from audit (#1200, #1201, #1202)

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -3,15 +3,18 @@ project_name: "oss-autopilot"
 
 
 # list of languages for which language servers are started; choose from:
-#   al                  bash                clojure             cpp                 csharp
-#   csharp_omnisharp    dart                elixir              elm                 erlang
-#   fortran             fsharp              go                  groovy              haskell
-#   java                julia               kotlin              lua                 markdown
-#   matlab              nix                 pascal              perl                php
-#   php_phpactor        powershell          python              python_jedi         r
-#   rego                ruby                ruby_solargraph     rust                scala
-#   swift               terraform           toml                typescript          typescript_vts
-#   vue                 yaml                zig
+#   al                  ansible             bash                clojure             cpp
+#   cpp_ccls            crystal             csharp              csharp_omnisharp    dart
+#   elixir              elm                 erlang              fortran             fsharp
+#   go                  groovy              haskell             haxe                hlsl
+#   java                json                julia               kotlin              lean4
+#   lua                 luau                markdown            matlab              msl
+#   nix                 ocaml               pascal              perl                php
+#   php_phpactor        powershell          python              python_jedi         python_ty
+#   r                   rego                ruby                ruby_solargraph     rust
+#   scala               solidity            swift               systemverilog       terraform
+#   toml                typescript          typescript_vts      vue                 yaml
+#   zig
 #   (This list may be outdated. For the current list, see values of Language enum here:
 #   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
 #   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
@@ -45,52 +48,19 @@ ignored_paths: []
 # Added on 2025-04-18
 read_only: false
 
-# list of tool names to exclude. We recommend not excluding any tools, see the readme for more details.
-# Below is the complete list of tools for convenience.
-# To make sure you have the latest list of tools, and to view their descriptions, 
-# execute `uv run scripts/print_tool_overview.py`.
-#
-#  * `activate_project`: Activates a project by name.
-#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
-#  * `create_text_file`: Creates/overwrites a file in the project directory.
-#  * `delete_lines`: Deletes a range of lines within a file.
-#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
-#  * `execute_shell_command`: Executes a shell command.
-#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
-#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
-#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
-#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
-#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
-#  * `initial_instructions`: Gets the initial instructions for the current project.
-#     Should only be used in settings where the system prompt cannot be set,
-#     e.g. in clients you have no control over, like Claude Desktop.
-#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
-#  * `insert_at_line`: Inserts content at a given line in a file.
-#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
-#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
-#  * `list_memories`: Lists memories in Serena's project-specific memory store.
-#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
-#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
-#  * `read_file`: Reads a file within the project directory.
-#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
-#  * `remove_project`: Removes a project from the Serena configuration.
-#  * `replace_lines`: Replaces a range of lines within a file with new content.
-#  * `replace_symbol_body`: Replaces the full definition of a symbol.
-#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
-#  * `search_for_pattern`: Performs a search for a pattern in the project.
-#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
-#  * `switch_modes`: Activates modes by providing a list of their names
-#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
-#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
-#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
-#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 excluded_tools: []
 
-# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default)
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 included_optional_tools: []
 
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
 # This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 fixed_tools: []
 
 # list of mode names to that are always to be included in the set of active modes
@@ -101,19 +71,24 @@ fixed_tools: []
 # Set this to a list of mode names to always include the respective modes for this project.
 base_modes:
 
-# list of mode names that are to be activated by default.
-# The full set of modes to be activated is base_modes + default_modes.
-# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
 # Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
 # This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 default_modes:
 
 # initial prompt for the project. It will always be given to the LLM upon activating the project
 # (contrary to the memories, which are loaded on demand).
 initial_prompt: ""
 
-# override of the corresponding setting in serena_config.yml, see the documentation there.
-# If null or missing, the value from the global config is used.
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
 symbol_info_budget:
 
 # The language backend to use for this project.
@@ -145,3 +120,8 @@ ignored_memory_patterns: []
 # Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
 # No documentation on options means no options are available.
 ls_specific_settings: {}
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:

--- a/packages/core/src/commands/guidelines.test.ts
+++ b/packages/core/src/commands/guidelines.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   getMergedPRs: vi.fn(),
   getClosedPRs: vi.fn(),
   markPRCommentsFetched: vi.fn(),
+  maybeCheckpoint: vi.fn(),
   username: vi.fn(() => 'me'),
 }));
 
@@ -34,6 +35,7 @@ vi.mock('../core/index.js', async () => {
     }),
     requireGitHubToken: () => 'ghp_test',
     getOctokit: () => ({}) as never,
+    maybeCheckpoint: mocks.maybeCheckpoint,
   };
 });
 
@@ -45,6 +47,7 @@ const mockIsGuidelinesAvailable = mocks.isGuidelinesAvailable;
 const mockGetMergedPRs = mocks.getMergedPRs;
 const mockGetClosedPRs = mocks.getClosedPRs;
 const mockMarkPRCommentsFetched = mocks.markPRCommentsFetched;
+const mockMaybeCheckpoint = mocks.maybeCheckpoint;
 
 import { runGuidelinesView, runGuidelinesStore, runGuidelinesReset, runFetchCorpus } from './guidelines.js';
 import { GuidelinesNotAvailableError } from '../core/index.js';
@@ -94,6 +97,19 @@ describe('runGuidelinesStore', () => {
     expect(mockSetGuidelines).toHaveBeenCalledWith('owner/repo', 'guidelines text');
   });
 
+  it('checkpoints to Gist after a successful store (#1200)', async () => {
+    await runGuidelinesStore({ repo: 'owner/repo', content: 'x' });
+    expect(mockMaybeCheckpoint).toHaveBeenCalledOnce();
+  });
+
+  it('does not checkpoint when setGuidelines throws', async () => {
+    mockSetGuidelines.mockImplementation(() => {
+      throw new GuidelinesNotAvailableError();
+    });
+    await expect(runGuidelinesStore({ repo: 'owner/repo', content: 'x' })).rejects.toThrow();
+    expect(mockMaybeCheckpoint).not.toHaveBeenCalled();
+  });
+
   it('throws when content is empty (use reset instead)', async () => {
     await expect(runGuidelinesStore({ repo: 'owner/repo', content: '' })).rejects.toThrow(/Cannot store empty content/);
     expect(mockSetGuidelines).not.toHaveBeenCalled();
@@ -122,6 +138,18 @@ describe('runGuidelinesReset', () => {
     const out = await runGuidelinesReset({ repo: 'owner/repo' });
     expect(out.deleted).toBe(false);
     expect(mockDeleteGuidelines).not.toHaveBeenCalled();
+  });
+
+  it('checkpoints to Gist after a successful reset (#1200)', async () => {
+    mockGetGuidelines.mockReturnValue('existing content');
+    await runGuidelinesReset({ repo: 'owner/repo' });
+    expect(mockMaybeCheckpoint).toHaveBeenCalledOnce();
+  });
+
+  it('does not checkpoint when no file existed', async () => {
+    mockGetGuidelines.mockReturnValue(null);
+    await runGuidelinesReset({ repo: 'owner/repo' });
+    expect(mockMaybeCheckpoint).not.toHaveBeenCalled();
   });
 
   it('throws GuidelinesNotAvailableError in local mode', async () => {
@@ -220,6 +248,32 @@ describe('runFetchCorpus', () => {
     const out = await runFetchCorpus({ repo: 'owner/repo', forceRefetch: true });
     expect(out.skipped).toBe(0);
     expect(mockFetchPRCommentBundlesBatch).toHaveBeenCalledWith(expect.anything(), [PR_FETCHED], 'me');
+  });
+
+  it('checkpoints to Gist after stamping commentsFetchedAt (#1200)', async () => {
+    mockGetMergedPRs.mockReturnValue([{ url: PR_RECENT, title: 't', mergedAt: recentTimestamp() }]);
+    mockFetchPRCommentBundlesBatch.mockResolvedValue([
+      {
+        prUrl: PR_RECENT,
+        prTitle: 't',
+        repo: 'owner/repo',
+        mergedAt: recentTimestamp(),
+        reviews: [],
+        reviewComments: [],
+        issueComments: [],
+      },
+    ]);
+
+    await runFetchCorpus({ repo: 'owner/repo' });
+
+    expect(mockMarkPRCommentsFetched).toHaveBeenCalledWith(PR_RECENT, expect.any(String));
+    expect(mockMaybeCheckpoint).toHaveBeenCalledOnce();
+  });
+
+  it('does not checkpoint when no PRs were fetched', async () => {
+    mockGetMergedPRs.mockReturnValue([]);
+    await runFetchCorpus({ repo: 'owner/repo' });
+    expect(mockMaybeCheckpoint).not.toHaveBeenCalled();
   });
 
   it('respects the `limit` parameter and caps it at 10', async () => {

--- a/packages/core/src/commands/guidelines.ts
+++ b/packages/core/src/commands/guidelines.ts
@@ -11,7 +11,13 @@
  * Standalone-mode users see "not available" on store/reset/fetch-corpus
  * because per-repo guidelines require Gist persistence to be useful.
  */
-import { getStateManager, requireGitHubToken, getOctokit, GuidelinesNotAvailableError } from '../core/index.js';
+import {
+  getStateManager,
+  requireGitHubToken,
+  getOctokit,
+  GuidelinesNotAvailableError,
+  maybeCheckpoint,
+} from '../core/index.js';
 import { fetchPRCommentBundlesBatch, type PRCommentBundle } from '../core/pr-comments-fetcher.js';
 import { warn } from '../core/logger.js';
 
@@ -109,6 +115,10 @@ export async function runGuidelinesStore(options: StoreOptions): Promise<Guideli
   const sm = getStateManager();
   // Throws GuidelinesNotAvailableError or GuidelinesTooLargeError on failure.
   sm.setGuidelines(options.repo, options.content);
+  // Push to Gist — autoSave only writes the local state-cache mirror in Gist
+  // mode, so without this checkpoint the change never propagates across
+  // machines (#1200).
+  await maybeCheckpoint(sm, MODULE);
   return {
     repo: options.repo,
     byteSize: Buffer.byteLength(options.content, 'utf-8'),
@@ -126,6 +136,8 @@ export async function runGuidelinesReset(options: RepoOption): Promise<Guideline
   const existed = sm.getGuidelines(options.repo) !== null;
   if (existed) {
     sm.deleteGuidelines(options.repo);
+    // Push to Gist — see runGuidelinesStore note (#1200).
+    await maybeCheckpoint(sm, MODULE);
   }
   return { repo: options.repo, deleted: existed };
 }
@@ -199,6 +211,12 @@ export async function runFetchCorpus(options: FetchCorpusOptions): Promise<Fetch
   const now = new Date().toISOString();
   for (const bundle of bundles) {
     sm.markPRCommentsFetched(bundle.prUrl, now);
+  }
+  // Push commentsFetchedAt stamps to Gist so other machines don't re-fetch
+  // the same PRs forever. autoSave only writes the local mirror in Gist
+  // mode (#1200).
+  if (bundles.length > 0) {
+    await maybeCheckpoint(sm, MODULE);
   }
 
   return {

--- a/packages/core/src/core/errors.test.ts
+++ b/packages/core/src/core/errors.test.ts
@@ -3,9 +3,11 @@ import {
   OssAutopilotError,
   ConfigurationError,
   ValidationError,
+  GistCorruptError,
   errorMessage,
   getHttpStatusCode,
   resolveErrorCode,
+  isTransientNetworkError,
 } from './errors.js';
 
 describe('Custom Error Hierarchy', () => {
@@ -195,5 +197,71 @@ describe('resolveErrorCode', () => {
     expect(resolveErrorCode('string error')).toBe('UNKNOWN');
     expect(resolveErrorCode(42)).toBe('UNKNOWN');
     expect(resolveErrorCode(null)).toBe('UNKNOWN');
+  });
+});
+
+describe('GistCorruptError (#1201)', () => {
+  it('extends ConfigurationError so callers using existing config-error checks surface it', () => {
+    const err = new GistCorruptError('abc123', '/tmp/state-cache.json.rejected-1', new Error('bad json'));
+    expect(err).toBeInstanceOf(ConfigurationError);
+    expect(err).toBeInstanceOf(OssAutopilotError);
+    expect(err.name).toBe('GistCorruptError');
+  });
+
+  it('embeds the gist id, rejected path, and underlying cause in the message', () => {
+    const cause = new Error('Unexpected token');
+    const err = new GistCorruptError('gist-xyz', '/tmp/cache.rejected-123', cause);
+    expect(err.message).toContain('gist-xyz');
+    expect(err.message).toContain('/tmp/cache.rejected-123');
+    expect(err.message).toContain('Unexpected token');
+    expect(err.cause).toBe(cause);
+  });
+
+  it('warns when content could not be preserved (rejectedPath null)', () => {
+    const err = new GistCorruptError('gist-xyz', null, new Error('bad'));
+    expect(err.message).toContain('Could not preserve');
+  });
+});
+
+describe('isTransientNetworkError (#1202)', () => {
+  it('returns true for Node socket errors', () => {
+    for (const code of ['ECONNRESET', 'ETIMEDOUT', 'ENETUNREACH', 'ENOTFOUND', 'ECONNREFUSED', 'EAI_AGAIN']) {
+      const err = Object.assign(new Error('socket'), { code });
+      expect(isTransientNetworkError(err)).toBe(true);
+    }
+  });
+
+  it('returns true for HTTP 5xx errors', () => {
+    for (const status of [500, 502, 503, 504, 599]) {
+      const err = Object.assign(new Error('server'), { status });
+      expect(isTransientNetworkError(err)).toBe(true);
+    }
+  });
+
+  it('returns true for AbortError and TimeoutError', () => {
+    const abort = Object.assign(new Error('aborted'), { name: 'AbortError' });
+    const timeout = Object.assign(new Error('timed out'), { name: 'TimeoutError' });
+    expect(isTransientNetworkError(abort)).toBe(true);
+    expect(isTransientNetworkError(timeout)).toBe(true);
+  });
+
+  it('returns false for HTTP 4xx errors (auth, permission, not-found)', () => {
+    for (const status of [400, 401, 403, 404, 422, 429]) {
+      const err = Object.assign(new Error('client'), { status });
+      expect(isTransientNetworkError(err)).toBe(false);
+    }
+  });
+
+  it('returns false for plain errors and non-error inputs', () => {
+    expect(isTransientNetworkError(new Error('boom'))).toBe(false);
+    expect(isTransientNetworkError(null)).toBe(false);
+    expect(isTransientNetworkError(undefined)).toBe(false);
+    expect(isTransientNetworkError('string')).toBe(false);
+    expect(isTransientNetworkError(42)).toBe(false);
+  });
+
+  it('returns false for our own custom errors (config, validation)', () => {
+    expect(isTransientNetworkError(new ConfigurationError('bad config'))).toBe(false);
+    expect(isTransientNetworkError(new ValidationError('bad input'))).toBe(false);
   });
 });

--- a/packages/core/src/core/errors.ts
+++ b/packages/core/src/core/errors.ts
@@ -59,6 +59,30 @@ export class GistPermissionError extends ConfigurationError {
 }
 
 /**
+ * Thrown when state.json fetched from a Gist is malformed or fails Zod
+ * validation. The Gist content is preserved as a `.rejected-<ts>.json` file
+ * in the local cache directory so the user can inspect or recover from it
+ * before the next push overwrites the Gist with fresh state.
+ *
+ * See issue #1201.
+ */
+export class GistCorruptError extends ConfigurationError {
+  constructor(
+    public readonly gistId: string,
+    public readonly rejectedPath: string | null,
+    public readonly cause: unknown,
+  ) {
+    const causeMsg = cause instanceof Error ? cause.message : String(cause);
+    const recoverHint = rejectedPath
+      ? `\nCorrupt content preserved at: ${rejectedPath}\n` +
+        'Inspect or restore manually, then re-run. Falling back to a fresh state would overwrite your Gist.'
+      : '\nCould not preserve the rejected content; do not push without inspecting the Gist manually.';
+    super(`Gist ${gistId} state.json is corrupt or fails schema validation: ${causeMsg}${recoverHint}`);
+    this.name = 'GistCorruptError';
+  }
+}
+
+/**
  * Thrown when an optimistic compare-and-swap on state.json detects that
  * another process wrote the file between load and save. See issue #1030.
  *
@@ -142,6 +166,44 @@ export function isRateLimitOrAuthError(err: unknown): boolean {
     const msg = errorMessage(err).toLowerCase();
     return msg.includes('rate limit') || msg.includes('abuse detection');
   }
+  return false;
+}
+
+/**
+ * Check if an error is a transient network/server-side failure that's safe
+ * to retry or fall back from (vs. a permanent error that should surface).
+ *
+ * Returns true for:
+ * - Node socket errors: ECONNRESET, ETIMEDOUT, ENETUNREACH, ENOTFOUND, ECONNREFUSED
+ * - HTTP 5xx (server errors)
+ * - AbortError (timeout)
+ *
+ * Returns false for everything else (including 4xx, schema errors, config errors).
+ *
+ * Used by {@link getStateManagerAsync} to decide whether a Gist init failure
+ * is recoverable enough to silently fall back to local-only mode (#1202).
+ */
+export function isTransientNetworkError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const status = getHttpStatusCode(err);
+  if (typeof status === 'number' && status >= 500 && status < 600) return true;
+  // Node socket-level errors expose `code`
+  const code = (err as { code?: unknown }).code;
+  if (typeof code === 'string') {
+    if (
+      code === 'ECONNRESET' ||
+      code === 'ETIMEDOUT' ||
+      code === 'ENETUNREACH' ||
+      code === 'ENOTFOUND' ||
+      code === 'ECONNREFUSED' ||
+      code === 'EAI_AGAIN'
+    ) {
+      return true;
+    }
+  }
+  // Octokit's RequestError surfaces the underlying name; fetch timeout is AbortError
+  const name = (err as { name?: unknown }).name;
+  if (typeof name === 'string' && (name === 'AbortError' || name === 'TimeoutError')) return true;
   return false;
 }
 

--- a/packages/core/src/core/gist-state-store.test.ts
+++ b/packages/core/src/core/gist-state-store.test.ts
@@ -392,17 +392,31 @@ describe('GistStateStore', () => {
       expect(result.state.config.setupComplete).toBe(false);
     });
 
-    it('should return fresh state when state.json contains invalid JSON', async () => {
+    it('should preserve corrupt content and degrade rather than overwrite Gist (#1201)', async () => {
       const gistId = 'corrupt-gist';
+      const corruptContent = 'not valid json';
 
       fs.writeFileSync(path.join(tmpDir, 'gist-id'), gistId);
-      octokit.gists.get.mockResolvedValue(makeGistResponse(gistId, 'not valid json'));
+      octokit.gists.get.mockResolvedValue(makeGistResponse(gistId, corruptContent));
+      // Force the search fallback to also fail so the bootstrap enters degraded mode
+      octokit.gists.list.mockResolvedValue({ data: [] });
 
       const store = new GistStateStore(octokit);
       const result = await store.bootstrap();
 
+      // Bootstrap recovers in degraded mode (gistId='') so push() can't run
+      // and silently overwrite the Gist with fresh state — that's the data-
+      // loss scenario #1201 was filed for.
+      expect(result.degraded).toBe(true);
+      expect(result.gistId).toBe('');
       expect(result.state.version).toBe(4);
-      expect(result.state.config.setupComplete).toBe(false);
+
+      // The corrupt content should be preserved as `.rejected-<ts>` so the
+      // user can recover it.
+      const rejectedFiles = fs.readdirSync(tmpDir).filter((f) => f.startsWith('state-cache.json.rejected-'));
+      expect(rejectedFiles.length).toBeGreaterThanOrEqual(1);
+      const preservedContent = fs.readFileSync(path.join(tmpDir, rejectedFiles[0]!), 'utf-8');
+      expect(preservedContent).toBe(corruptContent);
     });
   });
 

--- a/packages/core/src/core/gist-state-store.ts
+++ b/packages/core/src/core/gist-state-store.ts
@@ -44,7 +44,7 @@ import {
 } from './state-persistence.js';
 import { getGistIdPath, getStateCachePath } from './paths.js';
 import { debug, warn } from './logger.js';
-import { GistPermissionError, GistConcurrencyError, isRateLimitError } from './errors.js';
+import { GistPermissionError, GistConcurrencyError, GistCorruptError, isRateLimitError } from './errors.js';
 
 const MODULE = 'gist-store';
 
@@ -56,6 +56,27 @@ const MODULE = 'gist-store';
 function extractEtag(headers: Record<string, string | undefined> | undefined): string | null {
   if (!headers) return null;
   return headers.etag ?? headers.ETag ?? null;
+}
+
+/**
+ * Preserve corrupt Gist content for user recovery. Returns the path written,
+ * or null if the preservation itself failed (logged at warn). Mirrors the
+ * pattern in state-persistence.ts:401-407 for the local-state path.
+ *
+ * See {@link GistCorruptError} and issue #1201.
+ */
+function preserveRejectedGistContent(raw: string, gistId: string): string | null {
+  try {
+    const rejectedPath = `${getStateCachePath()}.rejected-${Date.now()}`;
+    fs.writeFileSync(rejectedPath, raw, { encoding: 'utf-8', mode: 0o600 });
+    return rejectedPath;
+  } catch (err) {
+    warn(
+      MODULE,
+      `Could not preserve rejected Gist content for ${gistId}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return null;
+  }
 }
 
 /** Well-known Gist description used for search-based discovery. */
@@ -190,10 +211,12 @@ export class GistStateStore {
       warn(MODULE, 'All Gist API paths failed, entering degraded mode', err);
 
       // Try reading from local cache file
+      const cachePath = getStateCachePath();
+      let cacheRaw: string | null = null;
       try {
-        const cachePath = getStateCachePath();
         if (fs.existsSync(cachePath)) {
-          let obj: unknown = JSON.parse(fs.readFileSync(cachePath, 'utf-8'));
+          cacheRaw = fs.readFileSync(cachePath, 'utf-8');
+          let obj: unknown = JSON.parse(cacheRaw);
 
           // Chain migrations
           if (typeof obj === 'object' && obj !== null) {
@@ -208,7 +231,21 @@ export class GistStateStore {
           return { gistId: '', state: cachedState, created: false, degraded: true };
         }
       } catch (cacheErr) {
-        debug(MODULE, `Failed to read local cache in degraded mode: ${cacheErr}`);
+        // Promote to warn (#1201) and preserve corrupt cache so fresh-state
+        // fallback doesn't silently destroy recoverable data on next push.
+        if (cacheRaw) {
+          const rejectedPath = preserveRejectedGistContent(cacheRaw, 'local-cache');
+          warn(
+            MODULE,
+            `Local state cache failed to parse in degraded mode: ${cacheErr instanceof Error ? cacheErr.message : String(cacheErr)}. ` +
+              `Corrupt cache preserved at: ${rejectedPath ?? '(could not preserve)'}`,
+          );
+        } else {
+          warn(
+            MODULE,
+            `Failed to read local cache in degraded mode: ${cacheErr instanceof Error ? cacheErr.message : String(cacheErr)}`,
+          );
+        }
       }
 
       // No cache either — return fresh state in degraded mode
@@ -264,10 +301,12 @@ export class GistStateStore {
       warn(MODULE, 'bootstrapWithMigration: all Gist API paths failed, entering degraded mode', err);
 
       // Try reading from local cache file
+      const cachePath = getStateCachePath();
+      let cacheRaw: string | null = null;
       try {
-        const cachePath = getStateCachePath();
         if (fs.existsSync(cachePath)) {
-          let obj: unknown = JSON.parse(fs.readFileSync(cachePath, 'utf-8'));
+          cacheRaw = fs.readFileSync(cachePath, 'utf-8');
+          let obj: unknown = JSON.parse(cacheRaw);
 
           // Chain migrations
           if (typeof obj === 'object' && obj !== null) {
@@ -282,7 +321,19 @@ export class GistStateStore {
           return { gistId: '', state: cachedState, created: false, degraded: true, migrated: false };
         }
       } catch (cacheErr) {
-        debug(MODULE, `bootstrapWithMigration: failed to read local cache in degraded mode: ${cacheErr}`);
+        if (cacheRaw) {
+          const rejectedPath = preserveRejectedGistContent(cacheRaw, 'local-cache');
+          warn(
+            MODULE,
+            `bootstrapWithMigration: local cache failed to parse: ${cacheErr instanceof Error ? cacheErr.message : String(cacheErr)}. ` +
+              `Corrupt cache preserved at: ${rejectedPath ?? '(could not preserve)'}`,
+          );
+        } else {
+          warn(
+            MODULE,
+            `bootstrapWithMigration: failed to read local cache: ${cacheErr instanceof Error ? cacheErr.message : String(cacheErr)}`,
+          );
+        }
       }
 
       // No cache either — use the provided existingState in degraded mode
@@ -532,9 +583,17 @@ export class GistStateStore {
   }
 
   /**
-   * Parse `state.json` from the in-memory cache. Handles v2 migration
+   * Parse `state.json` from the in-memory cache. Handles v1→v4 migration
    * by running through the Zod schema (which requires version: 4).
-   * Falls back to fresh state if the file is missing or unparseable.
+   *
+   * Throws {@link GistCorruptError} on parse or schema-validation failure.
+   * The corrupt raw content is preserved as `<state-cache-path>.rejected-<ts>`
+   * so the caller can recover (#1201).
+   *
+   * Returning fresh state on failure (the previous behavior) is unsafe in
+   * Gist mode because the next `push()` would overwrite the Gist with the
+   * empty fallback, silently destroying repoScores, dismissedIssues,
+   * guidelines pointers, and digest history.
    */
   private parseStateFromCache(): AgentState {
     const raw = this.cachedFiles.get(STATE_FILE_NAME);
@@ -556,8 +615,13 @@ export class GistStateStore {
 
       return AgentStateSchema.parse(obj);
     } catch (err) {
-      warn(MODULE, `Failed to parse state.json from Gist: ${err}`);
-      return createFreshState();
+      const rejectedPath = preserveRejectedGistContent(raw, this.gistId ?? 'unknown');
+      warn(
+        MODULE,
+        `Gist state.json failed to parse — refusing to overwrite with fresh state. ` +
+          `Corrupt content preserved at: ${rejectedPath ?? '(could not preserve)'}`,
+      );
+      throw new GistCorruptError(this.gistId ?? 'unknown', rejectedPath, err);
     }
   }
 

--- a/packages/core/src/core/state.ts
+++ b/packages/core/src/core/state.ts
@@ -28,7 +28,7 @@ import {
 import * as repoScoring from './repo-score-manager.js';
 import type { Stats } from './repo-score-manager.js';
 import { debug, warn } from './logger.js';
-import { errorMessage, ConfigurationError, ConcurrencyError } from './errors.js';
+import { errorMessage, ConfigurationError, ConcurrencyError, isTransientNetworkError } from './errors.js';
 import { GistStateStore, type OctokitLike } from './gist-state-store.js';
 import * as guidelinesStoreModule from './guidelines-store.js';
 import { getStatePath, getStateCachePath } from './paths.js';
@@ -1008,10 +1008,18 @@ export async function getStateManagerAsync(token?: string): Promise<StateManager
       })
       .catch((err) => {
         asyncManagerPromise = null;
-        // Configuration errors (e.g. GistPermissionError) must surface to the user
+        // Configuration errors (e.g. GistPermissionError, GistCorruptError)
+        // must surface — falling back to local-only would silently split state
+        // across machines (#1202).
         if (err instanceof ConfigurationError) throw err;
-        warn(MODULE, `Gist initialization failed, falling back to local-only mode: ${err}`);
-        return getStateManager(); // fall back to sync/local for transient errors
+        // Only fall back on actual network/server errors. Other failures
+        // (auth, schema, concurrency conflicts) indicate the Gist mode is
+        // broken in a way the user needs to address — silently falling back
+        // would write subsequent mutations to the local file while the Gist
+        // marker stays in config, causing permanent cross-machine divergence.
+        if (!isTransientNetworkError(err)) throw err;
+        warn(MODULE, `Gist initialization failed (transient network error), falling back to local-only mode: ${err}`);
+        return getStateManager();
       });
     return asyncManagerPromise;
   }


### PR DESCRIPTION
## Summary

Fixes the three critical data-loss bugs the 2026-04-28 audit found in the recently-shipped #867 guidelines feature. All three masked silent state-loss across machines.

Closes #1200, #1201, #1202.

## Changes

### #1200 — guidelines commands now push to Gist

`runGuidelinesStore`, `runGuidelinesReset`, and `runFetchCorpus` called `autoSave()` which only writes the local `state-cache.json` mirror in Gist mode. Other state-mutating commands (shelve, move, comments, dismiss) call `maybeCheckpoint(sm, MODULE)` to push; the new guidelines commands skipped this.

Added `await maybeCheckpoint(sm, MODULE)` after each successful mutation. Skipped on no-op paths (reset of non-existent file, fetch with zero bundles).

### #1201 — parseStateFromCache no longer wipes state on Zod failure

Returning `createFreshState()` on parse failure was unsafe in Gist mode because the next `push()` would overwrite the recoverable Gist with empty state, destroying repoScores, dismissedIssues, guidelines pointers, digest history.

- Added `GistCorruptError` (extends `ConfigurationError` so it surfaces through existing config-error checks)
- `parseStateFromCache` now throws and preserves the corrupt raw content as `state-cache.json.rejected-<ts>` (mirrors the local-state pattern in `state-persistence.ts:401-407`)
- The bootstrap flow catches the error and degrades to local-only mode (`gistId: ''`), making `push()` a no-op so the data-loss path can't trigger
- `bootstrap()` and `bootstrapWithMigration()` cache-parse failure logs promoted from `debug` to `warn` and now preserve the corrupt cache too

### #1202 — getStateManagerAsync only falls back on transient network errors

The catch swallowed every non-`ConfigurationError` (`GistConcurrencyError`, schema failures, 5xx, auth) and silently fell back to local-only mode. Subsequent writes went to the local file while the Gist marker stayed in config — permanent cross-machine state divergence.

Added `isTransientNetworkError` (errors.ts) that matches only Node socket errors (ECONNRESET/ETIMEDOUT/ENETUNREACH/ENOTFOUND/ECONNREFUSED/EAI_AGAIN), `AbortError`/`TimeoutError`, and HTTP 5xx. Narrowed the fallback to that allow-list; everything else surfaces.

## Tests

- 5 new guidelines tests asserting `maybeCheckpoint` is called on the success paths and not called on the no-op paths
- 1 new gist-state-store test asserting corrupt content is preserved as `.rejected-<ts>` and bootstrap degrades safely (gistId='')
- 9 new errors tests covering `GistCorruptError` shape and `isTransientNetworkError` classification across socket codes, HTTP statuses, and abort/timeout names

Existing test suite (2,725 tests) all pass.

## Verification

- `pnpm run lint` — 0 errors / 1,809 warnings
- `pnpm run typecheck` — clean
- `pnpm test` — 2,725 passing across 3 packages

## Checklist

- [x] Tests pass (`pnpm test`)
- [x] Commits follow conventional format
- [x] No manual version bumps or CHANGELOG edits