### PR TITLE
docs: refresh v3→v4 schema chain + ARCHITECTURE.md tables

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -29,6 +29,8 @@ The plugin layer consists of markdown files that Claude Code discovers and execu
 | `setup-oss.md` | `/setup-oss` | First-run configuration wizard |
 | `oss-search.md` | `/oss-search` | Issue discovery with multi-strategy search |
 | `oss-help.md` | `/oss-help` | Quick reference card for commands, agents, and workflows |
+| `oss-dashboard.md` | `/oss-dashboard` | Open the interactive SPA dashboard in the browser |
+| `pr-ready.md` | `/pr-ready` | Run the pre-commit review loop and signal when the branch is ready to push |
 
 Commands invoke the CLI via bash (`node packages/core/dist/cli.bundle.cjs <subcommand> --json`), parse the JSON response, and present results to the user through Claude Code's conversational interface.
 
@@ -44,6 +46,9 @@ Workflows contain delegated logic that commands read on demand. They are not sta
 | `review-issue-replies.md` | "Review issue replies" action | Review and respond to maintainer replies on claimed issues |
 | `pre-commit-review.md` | Before any commit/push | Multi-agent code review gate (existing PR updates) |
 | `draft-first-workflow.md` | New contributions | Create draft PR → iterative review → squash → mark ready |
+| `dispatch-review.md` | On request | Dispatch a multi-specialist review of the current branch |
+| `dormant-pr-follow-up.md` | Dormant PR detected | Polite, escalating follow-up cadence with maintainers |
+| `extract-learnings.md` | After PR merge | Distill maintainer feedback into per-repo guidelines via `guidelines fetch-corpus` + extract-learnings prompt (#867) |
 | `reference.md` | Always loaded | Shared conventions and formatting rules |
 
 ### Agents (`agents/`)
@@ -104,7 +109,7 @@ Debug and warning output goes to stderr via the logger, so it never contaminates
 | `startup` | `startup.ts` | Combined auth + setup + daily + dashboard (single CLI call) |
 | `daily` | `daily.ts` | Fetch all open PRs, compute digest, generate dashboard |
 | `search` | `search.ts` | Multi-strategy issue discovery |
-| `track` / `untrack` | `track.ts` | Add or remove a PR from tracking state |
+| `track` | `track.ts` | Fetch PR metadata for inspection (no longer persists; `untrack` removed in v4 / #1133) |
 | `status` | `status.ts` | Show contribution stats from local state |
 | `config` | `config.ts` | Read/write user configuration |
 | `init` | `init.ts` | Initialize with GitHub username and import open PRs |
@@ -118,11 +123,12 @@ Debug and warning output goes to stderr via the logger, so it never contaminates
 | `dismiss` / `undismiss` | `dismiss.ts` | Dismiss issue reply notifications (auto-resurfaces on new activity) |
 | `comments` / `post` / `claim` | `comments.ts` | Track issue conversations, post comments, claim issues |
 | `local-repos` | `local-repos.ts` | Scan for locally cloned repos |
-| `parse-list` | `parse-list.ts` | Parse a curated issue list file |
+| `parse-issue-list` | `parse-list.ts` | Parse a curated issue list file |
 | `orphan-files` (alias: `check-integration`) | `check-integration.ts` | Audit new files on this branch for cross-references |
 | `doctor` | `doctor.ts` | System-health diagnostic — token, bundle, state, scout, rate limit |
-| `read` | `read.ts` | Mark PR comments as read |
 | `stats` | `stats.ts` | Show contribution statistics (merge rate, PR counts) |
+| `guidelines view/store/reset/fetch-corpus` | `guidelines.ts` | Per-repo guidelines persistence + raw PR comment corpus for the host's extract-learnings prompt (#867) |
+| `manifest` | `cli-registry.ts` | Print the registered command list + version (used by plugin contract tests) |
 | `detect-formatters` | `detect-formatters.ts` | Detect formatters and linters configured in a repository |
 | `pr-template` | `pr-template.ts` | Fetch a repository's PR description template |
 
@@ -141,7 +147,7 @@ The bundle is a single CommonJS file (gitignored, auto-generated). The `SessionS
 `StateManager` is a singleton that reads/writes `~/.oss-autopilot/state.json`. Features:
 - **Advisory file locking** (`wx` flag) with stale lock detection (30s timeout)
 - **Auto-backups** before every write (stored in `~/.oss-autopilot/backups/`)
-- **v1 → v2 → v3 migration chain** built into the load path
+- **v1 → v2 → v3 → v4 migration chain** built into the load path (v4 added `commentsFetchedAt` for the #867 corpus pipeline)
 
 ### PR Monitoring (`pr-monitor.ts`)
 
@@ -255,7 +261,7 @@ The root `AgentState` interface (see `packages/core/src/core/state-schema.ts` fo
 
 ```typescript
 interface AgentState {
-  version: number;                   // Currently 3 (v3 with gist persistence)
+  version: number;                   // Currently 4 (v4 added commentsFetchedAt for the #867 corpus pipeline)
   gistId?: string;                   // Gist ID for cross-machine state sync
   repoScores: Record<string, RepoScore>;
   config: AgentConfig;              // User preferences + shelved/dismissed state

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ The system has three layers:
 
 3. **Core Logic** (`packages/core/src/core/`) — The domain layer. Key modules:
    - `types.ts` — All type definitions. Key PR type: `FetchedPR` (ephemeral, fetched fresh each run in v2). `TrackedPR` was removed in v2.
-   - `state.ts` — `StateManager` singleton. Reads/writes `~/.oss-autopilot/state.json`. Handles v1→v2→v3 migration and auto-backups
+   - `state.ts` — `StateManager` singleton. Reads/writes `~/.oss-autopilot/state.json`. Handles v1→v2→v3→v4 migration and auto-backups
    - `pr-monitor.ts` — `PRMonitor` class. Fetches open PRs from GitHub Search API, enriches each with CI status, review decision, merge conflicts, maintainer comments, and computes `FetchedPRStatus`
    - `github.ts` — Shared Octokit instance with `@octokit/plugin-throttling` for rate limit handling
    - `utils.ts` — GitHub URL parsing, date helpers, token detection (tries `$GITHUB_TOKEN` then `gh auth token`)
@@ -88,7 +88,9 @@ Repo root (also the Claude Code plugin directory):
 │   │   ├── dist/cli.bundle.cjs          # Built bundle (gitignored, auto-generated)
 │   │   ├── package.json                 # Published to npm, has bin + exports
 │   │   └── tsconfig.json
-│   └── dashboard/                       # @oss-autopilot/dashboard (interactive SPA)
+│   ├── dashboard/                       # @oss-autopilot/dashboard (interactive SPA)
+│   │   └── package.json
+│   └── mcp-server/                      # @oss-autopilot/mcp (MCP server bin)
 │       └── package.json
 ├── pnpm-workspace.yaml                  # Workspace definition
 ├── package.json                         # Workspace root (private, not published)

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ A Preact SPA that auto-opens when you run `/oss` — PR management, charts, cont
 
 **Three deployment models** — Claude Code plugin with 7 specialized agents, MCP server for Cursor/Claude Desktop/Codex/Windsurf, and a standalone CLI with `--json` structured output. Same core, different interfaces.
 
-**Deterministic core, AI orchestration layer** — Critical logic (PR status classification, CI failure analysis, state management) lives in tested TypeScript, not in prompts. The CLI returns structured JSON that agents consume. CI failures are categorized into a deterministic taxonomy — actionable vs. fork limitation vs. auth gate vs. infrastructure — rather than asking an LLM each time. 2,250+ tests validate the core independently of any LLM.
+**Deterministic core, AI orchestration layer** — Critical logic (PR status classification, CI failure analysis, state management) lives in tested TypeScript, not in prompts. The CLI returns structured JSON that agents consume. CI failures are categorized into a deterministic taxonomy — actionable vs. fork limitation vs. auth gate vs. infrastructure — rather than asking an LLM each time. 2,700+ tests validate the core independently of any LLM.
 
 **Production-grade GitHub API integration** — ETag-based HTTP caching, automatic rate limit backoff with retries, bounded concurrency pools, and paginated fetching. Handles the full complexity of fork-based contribution workflows: correct diff ranges, squash commit counting, and `--head` flag handling for cross-fork PRs. Designed to run daily without hitting API limits.
 
@@ -187,12 +187,12 @@ All commands return `{ success, data, error, timestamp }` with `--json`.
 
 | Metric | Value |
 |--------|-------|
-| Releases | 189+ changelog versions (core v0.1.0 → v3.2.0; mcp through v5.1.0) |
-| Tests | 2,250+ across 105 files |
-| Issues + PRs | 1,000+ |
+| Releases | 189+ changelog versions (spanning core v0.1 through current v3.x; mcp through current v5.x) |
+| Tests | 2,700+ across 120+ files |
+| Issues + PRs | 1,200+ |
 | Time span | Jan 2025 → present |
 | npm packages | 3 |
-| CLI commands | 34 |
+| CLI commands | 35+ |
 | Agents | 7 |
 
 ---


### PR DESCRIPTION
## Summary

Closes #1206, #1207.

## Changes

### Schema chain (#1206)

- `ARCHITECTURE.md:144` — \`v1 → v2 → v3 migration chain\` → v1→v2→v3→v4
- `ARCHITECTURE.md:258` — code-block comment \`Currently 3\` → \`Currently 4\`
- `CLAUDE.md:54` — \`v1→v2→v3 migration\` → v1→v2→v3→v4

### Removed/renamed CLI commands in ARCHITECTURE.md (#1206)

- Removed \`untrack\` row (deleted in v4 / #1133)
- Removed \`read\` row (deleted in v4 / #1133)
- Renamed \`parse-list\` → \`parse-issue-list\` (matches registry)
- Added \`guidelines\` row (4 subcommands; #867)
- Added \`manifest\` row

### Missing #867 surface in plugin tables (#1206)

- Commands table: added \`oss-dashboard.md\` and \`pr-ready.md\`
- Workflows table: added \`dispatch-review.md\`, \`dormant-pr-follow-up.md\`, \`extract-learnings.md\`

### CLAUDE.md package tree (#1206)

- Added \`packages/mcp-server/\` (was missing from the file-structure block)

### README \"By the Numbers\" (#1207)

Updated stale numbers and rephrased durably so the next release doesn't restale the README:
- Tests: 2,250+/105 files → 2,700+/120+ files (actual: 2,725 / 122)
- Releases: locked upper bound to \"current v3.x / v5.x\"
- CLI commands: 34 → 35+
- Issues + PRs: 1,000+ → 1,200+
- Same update on the in-prose \"2,250+ tests\" claim

## Verification

Docs-only — no code changes. Lint, typecheck, tests unchanged.

## Checklist

- [x] Tests pass (`pnpm test`)
- [x] Commits follow conventional format
- [x] No manual version bumps or CHANGELOG edits