### PR TITLE
chore: prefer node: protocol on all built-in module imports

### DIFF
--- a/packages/core/src/cli-registry.docs.test.ts
+++ b/packages/core/src/cli-registry.docs.test.ts
@@ -8,8 +8,8 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { commands } from './cli-registry.js';
 
 describe('cli-registry ↔ workflows/reference.md parity (#1048)', () => {

--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -841,7 +841,7 @@ export const commands: CLICommandDef[] = [
             options,
             async () => (await import('./commands/parse-list.js')).runParseList({ filePath }),
             async (data) => {
-              const path = await import('path');
+              const path = await import('node:path');
               const resolvedPath = path.resolve(filePath);
               console.log(`\n\ud83d\udccb Issue List: ${resolvedPath}\n`);
               console.log(`Available: ${data.availableCount} | Completed: ${data.completedCount}\n`);

--- a/packages/core/src/cli.test.ts
+++ b/packages/core/src/cli.test.ts
@@ -10,8 +10,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { readFileSync } from 'fs';
-import { join } from 'path';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { Command } from 'commander';
 
 // ─── Mock core imports ───────────────────────────────────────────────────────

--- a/packages/core/src/commands/auth-envelope.e2e.test.ts
+++ b/packages/core/src/commands/auth-envelope.e2e.test.ts
@@ -9,10 +9,10 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { execFile } from 'child_process';
-import { promisify } from 'util';
-import * as fs from 'fs';
-import * as path from 'path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 const execFileAsync = promisify(execFile);
 

--- a/packages/core/src/commands/check-integration.test.ts
+++ b/packages/core/src/commands/check-integration.test.ts
@@ -3,9 +3,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { execFileSync } from 'child_process';
+import { execFileSync } from 'node:child_process';
 
-vi.mock('child_process', () => ({
+vi.mock('node:child_process', () => ({
   execFileSync: vi.fn(),
 }));
 

--- a/packages/core/src/commands/check-integration.ts
+++ b/packages/core/src/commands/check-integration.ts
@@ -3,8 +3,8 @@
  * Detects new files in the current branch that aren't referenced elsewhere
  */
 
-import * as path from 'path';
-import { execFileSync } from 'child_process';
+import * as path from 'node:path';
+import { execFileSync } from 'node:child_process';
 import type { CheckIntegrationOutput, NewFileInfo } from '../formatters/json.js';
 import { debug } from '../core/index.js';
 import { errorMessage } from '../core/errors.js';

--- a/packages/core/src/commands/config.e2e.test.ts
+++ b/packages/core/src/commands/config.e2e.test.ts
@@ -4,10 +4,10 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { execFile } from 'child_process';
-import { promisify } from 'util';
-import * as fs from 'fs';
-import * as path from 'path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 const execFileAsync = promisify(execFile);
 

--- a/packages/core/src/commands/daily.e2e.test.ts
+++ b/packages/core/src/commands/daily.e2e.test.ts
@@ -8,10 +8,10 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { execFile } from 'child_process';
-import { promisify } from 'util';
-import * as fs from 'fs';
-import * as path from 'path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 const execFileAsync = promisify(execFile);
 

--- a/packages/core/src/commands/dashboard-lifecycle.test.ts
+++ b/packages/core/src/commands/dashboard-lifecycle.test.ts
@@ -11,7 +11,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // ── Mocks ────────────────────────────────────────────────────────────
 
 const mockSpawn = vi.fn();
-vi.mock('child_process', () => ({
+vi.mock('node:child_process', () => ({
   spawn: (...args: unknown[]) => mockSpawn(...args),
 }));
 

--- a/packages/core/src/commands/dashboard-lifecycle.ts
+++ b/packages/core/src/commands/dashboard-lifecycle.ts
@@ -4,7 +4,7 @@
  * and detecting whether a server is already running.
  */
 
-import { spawn } from 'child_process';
+import { spawn } from 'node:child_process';
 import {
   findRunningDashboardServer,
   isDashboardServerRunning,

--- a/packages/core/src/commands/dashboard-process.ts
+++ b/packages/core/src/commands/dashboard-process.ts
@@ -3,9 +3,9 @@
  * PID file operations, health probes, and running server detection.
  */
 
-import * as http from 'http';
-import * as fs from 'fs';
-import * as path from 'path';
+import * as http from 'node:http';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { getDataDir } from '../core/index.js';
 import { warn } from '../core/logger.js';
 

--- a/packages/core/src/commands/dashboard-server.test.ts
+++ b/packages/core/src/commands/dashboard-server.test.ts
@@ -12,13 +12,13 @@
  */
 
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
-import { EventEmitter } from 'events';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
+import { EventEmitter } from 'node:events';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
 import type { DailyDigest } from '../core/types.js';
 import { makeAgentState as makeState } from '../core/test-utils.js';
-import type { IncomingMessage, ServerResponse } from 'http';
+import type { IncomingMessage, ServerResponse } from 'node:http';
 
 // ── Captured request handler ──────────────────────────────────────────
 // We'll capture the handler passed to http.createServer() and test it directly.
@@ -39,8 +39,8 @@ const mockServer = {
   once: vi.fn(),
 };
 
-vi.mock('http', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('http')>();
+vi.mock('node:http', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:http')>();
   return {
     ...actual,
     createServer: vi.fn((handler: RequestHandler) => {

--- a/packages/core/src/commands/dashboard-server.ts
+++ b/packages/core/src/commands/dashboard-server.ts
@@ -6,10 +6,10 @@
  * Uses Node's built-in http module — no Express/Fastify.
  */
 
-import * as http from 'http';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as crypto from 'crypto';
+import * as http from 'node:http';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as crypto from 'node:crypto';
 import { getStateManager, getGitHubToken, getCLIVersion, applyStatusOverrides } from '../core/index.js';
 import { errorMessage, ValidationError } from '../core/errors.js';
 import { warn } from '../core/logger.js';

--- a/packages/core/src/commands/dashboard.ts
+++ b/packages/core/src/commands/dashboard.ts
@@ -2,8 +2,8 @@
  * Dashboard command — serves the interactive Preact SPA dashboard.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { getGitHubToken } from '../core/index.js';
 
 // ── Serve (interactive dashboard) ──────────────────────────────────────────

--- a/packages/core/src/commands/detect-formatters.ts
+++ b/packages/core/src/commands/detect-formatters.ts
@@ -4,8 +4,8 @@
  * Optionally diagnoses CI log output for formatting failures.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import type { DetectFormattersOutput } from '../formatters/json.js';
 import { detectFormatters, diagnoseCIFormatterFailure } from '../core/formatter-detection.js';
 import { errorMessage } from '../core/errors.js';

--- a/packages/core/src/commands/doctor.test.ts
+++ b/packages/core/src/commands/doctor.test.ts
@@ -7,13 +7,13 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 // ── Module-level mocks ──────────────────────────────────────────────────
 
-vi.mock('child_process', () => ({
+vi.mock('node:child_process', () => ({
   execFile: vi.fn(),
 }));
 
@@ -27,7 +27,7 @@ vi.mock('../core/index.js', async () => {
   };
 });
 
-import { execFile } from 'child_process';
+import { execFile } from 'node:child_process';
 import { getGitHubTokenAsync, getOctokit, getStatePath } from '../core/index.js';
 import {
   checkBundleUpToDate,

--- a/packages/core/src/commands/doctor.ts
+++ b/packages/core/src/commands/doctor.ts
@@ -10,10 +10,10 @@
  * external dependencies in isolation.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
-import { execFile } from 'child_process';
-import { promisify } from 'util';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 
 import { getGitHubTokenAsync, getOctokit, getStatePath } from '../core/index.js';
 import { AgentStateSchema } from '../core/state-schema.js';

--- a/packages/core/src/commands/list-move-tier.test.ts
+++ b/packages/core/src/commands/list-move-tier.test.ts
@@ -3,9 +3,9 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
 import { moveIssueToTier, runListMoveTier } from './list-move-tier.js';
 
 const URL_A = 'https://github.com/foo/bar/issues/1';

--- a/packages/core/src/commands/list-move-tier.ts
+++ b/packages/core/src/commands/list-move-tier.ts
@@ -11,8 +11,8 @@
  * No GitHub calls — pure read/transform/write of a local file.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { errorMessage } from '../core/errors.js';
 
 export type Tier = 'pursue' | 'maybe' | 'skip';

--- a/packages/core/src/commands/local-repos.test.ts
+++ b/packages/core/src/commands/local-repos.test.ts
@@ -3,9 +3,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { execFileSync } from 'child_process';
+import { execFileSync } from 'node:child_process';
 
-vi.mock('child_process', () => ({
+vi.mock('node:child_process', () => ({
   execFileSync: vi.fn(),
 }));
 
@@ -16,9 +16,9 @@ vi.mock('../core/index.js', () => ({
 
 import { scanForRepos, runLocalRepos } from './local-repos.js';
 import { getStateManager } from '../core/index.js';
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 
-vi.mock('fs', async () => {
+vi.mock('node:fs', async () => {
   const actual = await vi.importActual<typeof fs>('fs');
   return {
     ...actual,

--- a/packages/core/src/commands/local-repos.ts
+++ b/packages/core/src/commands/local-repos.ts
@@ -3,10 +3,10 @@
  * Scans configurable directories for local git clones and caches results
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
-import { execFileSync } from 'child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { execFileSync } from 'node:child_process';
 import { getStateManager, debug } from '../core/index.js';
 import { errorMessage } from '../core/errors.js';
 import type { LocalReposOutput, LocalRepoInfo } from '../formatters/json.js';

--- a/packages/core/src/commands/parse-list.test.ts
+++ b/packages/core/src/commands/parse-list.test.ts
@@ -5,8 +5,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { parseIssueList, pruneIssueList, runParseList } from './parse-list.js';
 
-vi.mock('fs', async () => {
-  const actual = await vi.importActual<typeof import('fs')>('fs');
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
   return {
     ...actual,
     existsSync: vi.fn(),
@@ -14,7 +14,7 @@ vi.mock('fs', async () => {
   };
 });
 
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 
 const mockExistsSync = vi.mocked(fs.existsSync);
 const mockReadFileSync = vi.mocked(fs.readFileSync);

--- a/packages/core/src/commands/parse-list.ts
+++ b/packages/core/src/commands/parse-list.ts
@@ -3,8 +3,8 @@
  * Parses markdown issue lists into structured JSON with tier classification
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import type { ParseIssueListOutput, ParsedIssueItem } from '../formatters/json.js';
 import { errorMessage } from '../core/errors.js';
 

--- a/packages/core/src/commands/search.e2e.test.ts
+++ b/packages/core/src/commands/search.e2e.test.ts
@@ -8,10 +8,10 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { execFile } from 'child_process';
-import { promisify } from 'util';
-import * as fs from 'fs';
-import * as path from 'path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 const execFileAsync = promisify(execFile);
 

--- a/packages/core/src/commands/skip-add.test.ts
+++ b/packages/core/src/commands/skip-add.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
 
 vi.mock('../core/index.js', () => ({
   getStateManager: vi.fn(),

--- a/packages/core/src/commands/skip-add.ts
+++ b/packages/core/src/commands/skip-add.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 import { loadSkippedIssues } from './skip-file-parser.js';
 import { getStateManager } from '../core/index.js';
 

--- a/packages/core/src/commands/skip-file-parser.test.ts
+++ b/packages/core/src/commands/skip-file-parser.test.ts
@@ -4,8 +4,8 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-vi.mock('fs', async () => {
-  const actual = await vi.importActual<typeof import('fs')>('fs');
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
   return {
     ...actual,
     existsSync: vi.fn(),
@@ -17,7 +17,7 @@ vi.mock('../core/logger.js', () => ({
   warn: vi.fn(),
 }));
 
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 import { warn } from '../core/logger.js';
 import { parseSkippedIssuesContent, loadSkippedIssues } from './skip-file-parser.js';
 

--- a/packages/core/src/commands/skip-file-parser.ts
+++ b/packages/core/src/commands/skip-file-parser.ts
@@ -9,7 +9,7 @@
  * so the search engine filters already-skipped URLs out of results.
  */
 
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 import type { SkippedIssue } from '@oss-scout/core';
 import { warn } from '../core/logger.js';
 import { errorMessage } from '../core/errors.js';

--- a/packages/core/src/commands/startup.e2e.test.ts
+++ b/packages/core/src/commands/startup.e2e.test.ts
@@ -4,10 +4,10 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { execFile } from 'child_process';
-import { promisify } from 'util';
-import * as fs from 'fs';
-import * as path from 'path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 const execFileAsync = promisify(execFile);
 

--- a/packages/core/src/commands/startup.test.ts
+++ b/packages/core/src/commands/startup.test.ts
@@ -22,7 +22,7 @@ vi.mock('./daily.js', () => ({
   executeDailyCheck: vi.fn(),
 }));
 
-vi.mock('child_process', () => ({
+vi.mock('node:child_process', () => ({
   execFile: vi.fn(),
 }));
 
@@ -31,8 +31,8 @@ vi.mock('./dashboard-lifecycle.js', () => ({
 }));
 
 // Mock fs so detectIssueList doesn't hit the real filesystem
-vi.mock('fs', async () => {
-  const actual = await vi.importActual<typeof import('fs')>('fs');
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
   return {
     ...actual,
     existsSync: vi.fn(() => false),
@@ -201,7 +201,7 @@ Just some text, no issue list items.
 
 // --- detectIssueList tests ---
 
-import * as fsImport from 'fs';
+import * as fsImport from 'node:fs';
 
 describe('detectIssueList', () => {
   let detectIssueList: typeof import('./startup.js').detectIssueList;
@@ -212,7 +212,7 @@ describe('detectIssueList', () => {
     vi.clearAllMocks();
     const startupMod = await import('./startup.js');
     detectIssueList = startupMod.detectIssueList;
-    const fsMod = await import('fs');
+    const fsMod = await import('node:fs');
     existsSyncMock = fsMod.existsSync as ReturnType<typeof vi.fn>;
     origReadFileSync = (fsImport as any).readFileSync;
   });
@@ -428,7 +428,7 @@ describe('runStartup behavior', () => {
     const dailyMod = await import('./daily.js');
     executeDailyCheck = dailyMod.executeDailyCheck as ReturnType<typeof vi.fn>;
 
-    const cpMod = await import('child_process');
+    const cpMod = await import('node:child_process');
     execFile = cpMod.execFile as unknown as ReturnType<typeof vi.fn>;
 
     const lifecycleMod = await import('./dashboard-lifecycle.js');

--- a/packages/core/src/commands/startup.ts
+++ b/packages/core/src/commands/startup.ts
@@ -7,9 +7,9 @@
  * `node cli.bundle.cjs startup --json` call, reducing UI noise in Claude Code.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
-import { execFile } from 'child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { execFile } from 'node:child_process';
 import { getStateManager, getGitHubTokenAsync, getCLIVersion, detectGitHubUsername } from '../core/index.js';
 import { errorMessage } from '../core/errors.js';
 import { warn } from '../core/logger.js';

--- a/packages/core/src/commands/state-cmd.contract.test.ts
+++ b/packages/core/src/commands/state-cmd.contract.test.ts
@@ -26,8 +26,8 @@ vi.mock('../core/paths.js', async () => {
   };
 });
 
-vi.mock('fs', async () => {
-  const actual = await vi.importActual<typeof import('fs')>('fs');
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
   return { ...actual, existsSync: vi.fn().mockReturnValue(true), unlinkSync: vi.fn() };
 });
 

--- a/packages/core/src/commands/state-cmd.test.ts
+++ b/packages/core/src/commands/state-cmd.test.ts
@@ -29,8 +29,8 @@ vi.mock('../core/logger.js', () => ({
   timed: vi.fn(),
 }));
 
-vi.mock('fs', async () => {
-  const actual = await vi.importActual<typeof import('fs')>('fs');
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
   return {
     ...actual,
     existsSync: vi.fn(),
@@ -42,7 +42,7 @@ import { getStateManager, resetStateManager } from '../core/state.js';
 import { atomicWriteFileSync } from '../core/state-persistence.js';
 import { getStatePath, getGistIdPath } from '../core/paths.js';
 import { warn } from '../core/logger.js';
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 import { runStateShow, runStateSync, runStateUnlink } from './state-cmd.js';
 import { makeStateManagerMock, makeAgentState } from '../core/test-utils.js';
 

--- a/packages/core/src/commands/state-cmd.ts
+++ b/packages/core/src/commands/state-cmd.ts
@@ -3,7 +3,7 @@
  * Provides --show, --sync, and --unlink subcommands for the Gist persistence layer.
  */
 
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 import { getStateManager, resetStateManager } from '../core/state.js';
 import { atomicWriteFileSync } from '../core/state-persistence.js';
 import { getStatePath, getGistIdPath } from '../core/paths.js';

--- a/packages/core/src/commands/status.e2e.test.ts
+++ b/packages/core/src/commands/status.e2e.test.ts
@@ -4,10 +4,10 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { execFile } from 'child_process';
-import { promisify } from 'util';
-import * as fs from 'fs';
-import * as path from 'path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 const execFileAsync = promisify(execFile);
 

--- a/packages/core/src/commands/vet-list.ts
+++ b/packages/core/src/commands/vet-list.ts
@@ -3,7 +3,7 @@
  * Re-vets all available issues in a curated issue list file via @oss-scout/core.
  */
 
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 import { adaptScoutLinkedPR, createAutopilotScout } from './scout-bridge.js';
 import { type VetListOutput, type VetOutput, type VetListItemStatus } from '../formatters/json.js';
 import { runParseList, pruneIssueList } from './parse-list.js';

--- a/packages/core/src/core/auth.ts
+++ b/packages/core/src/core/auth.ts
@@ -7,7 +7,7 @@
  * Extracted from utils.ts under #1116.
  */
 
-import { execFileSync, execFile } from 'child_process';
+import { execFileSync, execFile } from 'node:child_process';
 import { ConfigurationError } from './errors.js';
 import { debug } from './logger.js';
 

--- a/packages/core/src/core/formatter-detection.test.ts
+++ b/packages/core/src/core/formatter-detection.test.ts
@@ -9,9 +9,9 @@ import {
   getPreferredFormatter,
   type FormatterDetectionResult,
 } from './formatter-detection.js';
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 
-vi.mock('fs');
+vi.mock('node:fs');
 
 const mockedFs = vi.mocked(fs);
 

--- a/packages/core/src/core/formatter-detection.ts
+++ b/packages/core/src/core/formatter-detection.ts
@@ -5,8 +5,8 @@
  * and diagnoses CI formatting failures from log output.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { debug } from './logger.js';
 
 const MODULE = 'formatter-detection';

--- a/packages/core/src/core/gist-state-store.concurrency.test.ts
+++ b/packages/core/src/core/gist-state-store.concurrency.test.ts
@@ -23,9 +23,9 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
 import { GistStateStore, GIST_DESCRIPTION, STATE_FILE_NAME, type OctokitLike } from './gist-state-store.js';
 import { GistConcurrencyError } from './errors.js';
 

--- a/packages/core/src/core/gist-state-store.test.ts
+++ b/packages/core/src/core/gist-state-store.test.ts
@@ -3,9 +3,9 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
 import { GistStateStore, GIST_DESCRIPTION, STATE_FILE_NAME, type OctokitLike } from './gist-state-store.js';
 import { AgentStateSchema } from './state-schema.js';
 import { createFreshState } from './state-persistence.js';

--- a/packages/core/src/core/gist-state-store.ts
+++ b/packages/core/src/core/gist-state-store.ts
@@ -32,7 +32,7 @@
  *  oss-autopilot already assumes for state.json.
  */
 
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 import { AgentState } from './types.js';
 import { AgentStateSchema } from './state-schema.js';
 import {

--- a/packages/core/src/core/github-stats.test.ts
+++ b/packages/core/src/core/github-stats.test.ts
@@ -4,9 +4,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
 import { HttpCache } from './http-cache.js';
 import {
   fetchUserMergedPRCounts,

--- a/packages/core/src/core/http-cache.test.ts
+++ b/packages/core/src/core/http-cache.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import * as crypto from 'crypto';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
 import { HttpCache, cachedRequest, type CacheEntry } from './http-cache.js';
 
 /** Create a temporary directory for cache tests. */

--- a/packages/core/src/core/http-cache.ts
+++ b/packages/core/src/core/http-cache.ts
@@ -10,9 +10,9 @@
  * share a single HTTP round-trip.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
-import * as crypto from 'crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as crypto from 'node:crypto';
 import { getCacheDir } from './paths.js';
 import { debug } from './logger.js';
 import { getHttpStatusCode } from './errors.js';

--- a/packages/core/src/core/paths.ts
+++ b/packages/core/src/core/paths.ts
@@ -7,9 +7,9 @@
  * Extracted from utils.ts under #1116.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
 
 /**
  * Returns the oss-autopilot data directory path, creating it if it does not exist.

--- a/packages/core/src/core/state-migration.test.ts
+++ b/packages/core/src/core/state-migration.test.ts
@@ -5,9 +5,9 @@
 
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { StateManager } from './state.js';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
 
 // ─── File-System Persistence Mock Setup ──────────────────────────────────────
 //

--- a/packages/core/src/core/state-persistence.test.ts
+++ b/packages/core/src/core/state-persistence.test.ts
@@ -7,9 +7,9 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { StateManager, acquireLock, releaseLock, atomicWriteFileSync, resetStateManager } from './state.js';
 import { saveState, createFreshState } from './state-persistence.js';
 import { ConcurrencyError } from './errors.js';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
 
 // ─── File-System Persistence Mock Setup ──────────────────────────────────────
 //

--- a/packages/core/src/core/state-persistence.ts
+++ b/packages/core/src/core/state-persistence.ts
@@ -4,8 +4,8 @@
  * No module-level mutable state — functions accept/return AgentState objects.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { AgentState } from './types.js';
 import { AgentStateSchema } from './state-schema.js';
 import { getStatePath, getBackupDir, getDataDir } from './paths.js';

--- a/packages/core/src/core/state-scoring.test.ts
+++ b/packages/core/src/core/state-scoring.test.ts
@@ -5,9 +5,9 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { StateManager } from './state.js';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
 
 // ─── File-System Persistence Mock Setup ──────────────────────────────────────
 //

--- a/packages/core/src/core/state.test.ts
+++ b/packages/core/src/core/state.test.ts
@@ -4,9 +4,9 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { StateManager, getStateManager, resetStateManager } from './state.js';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
 
 // ─── File-System Persistence Mock Setup ──────────────────────────────────────
 //

--- a/packages/core/src/core/state.ts
+++ b/packages/core/src/core/state.ts
@@ -4,7 +4,7 @@
  * and scoring logic to repo-score-manager.ts.
  */
 
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 import {
   AgentState,
   TrackedIssue,

--- a/packages/core/src/core/utils.test.ts
+++ b/packages/core/src/core/utils.test.ts
@@ -18,12 +18,12 @@ import {
   detectGitHubUsername,
 } from './auth.js';
 import { getDataDir, getStatePath, getBackupDir, stateFileExists } from './paths.js';
-import { execFileSync, execFile } from 'child_process';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
+import { execFileSync, execFile } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
 
-vi.mock('child_process', () => ({
+vi.mock('node:child_process', () => ({
   execFileSync: vi.fn(),
   execFile: vi.fn(),
 }));


### PR DESCRIPTION
## Summary

Applies \`unicorn/prefer-node-protocol\` across the codebase. Closes a chunk of the warning backlog from #1182's lint config.

## What changed

53 files modified, 149 insertions / 149 deletions — all single-line import path replacements:

- \`import * as fs from 'fs'\` → \`from 'node:fs'\`
- \`vi.mock('fs', ...)\` → \`vi.mock('node:fs', ...)\`
- \`vi.importActual<typeof import('fs')>('fs')\` → \`'node:fs'\`
- \`await import('fs')\` → \`await import('node:fs')\`

Affected built-in modules: \`fs\`, \`path\`, \`os\`, \`http\`, \`https\`, \`crypto\`, \`child_process\`, \`url\`, \`util\`, \`stream\`, \`buffer\`, \`process\`, \`events\`, \`dns\`, \`zlib\`, \`querystring\`, \`net\`, \`tls\`, \`cluster\`, \`worker_threads\`, \`readline\`, \`repl\`, \`tty\`, \`dgram\`, \`module\`, \`perf_hooks\`, \`async_hooks\`, \`v8\`.

## Why

The \`node:\` prefix is required by Node.js best practices. Without it, an npm package with the same name as a built-in (e.g. \`fs\`) would shadow the built-in import. Adding \`node:\` makes the import unambiguously a built-in.

## Verification

- \`pnpm run lint\` — 135 unicorn/prefer-node-protocol warnings → 0; total 1,809 → 1,674
- \`pnpm run typecheck\` — clean
- \`pnpm test\` — 2,725 passing across 3 packages

## Checklist

- [x] Tests pass (\`pnpm test\`)
- [x] Commits follow conventional format
- [x] No manual version bumps or CHANGELOG edits