### PR TITLE
chore: prefer 'utf8' over 'utf-8' for text encoding identifiers

### DIFF
--- a/packages/core/src/cli-registry.docs.test.ts
+++ b/packages/core/src/cli-registry.docs.test.ts
@@ -20,7 +20,7 @@ describe('cli-registry ↔ workflows/reference.md parity (#1048)', () => {
   });
 
   it('every registered CLI command appears in workflows/reference.md', () => {
-    const doc = fs.readFileSync(referencePath, 'utf-8');
+    const doc = fs.readFileSync(referencePath, 'utf8');
     const missing: string[] = [];
     for (const cmd of commands) {
       // Use word-boundaries so `state` does not match `statement` or `state-sync`,
@@ -52,7 +52,7 @@ describe('cli-registry ↔ .claude-plugin/expected-cli-contract.json parity (#11
   });
 
   it('every command in expectedCommands is registered (no plugin-side dangling references)', () => {
-    const contract: Contract = JSON.parse(fs.readFileSync(contractPath, 'utf-8'));
+    const contract: Contract = JSON.parse(fs.readFileSync(contractPath, 'utf8'));
     const registered = new Set(commands.map((c) => c.name));
     const dangling = contract.expectedCommands.filter((name) => !registered.has(name));
     expect(
@@ -63,7 +63,7 @@ describe('cli-registry ↔ .claude-plugin/expected-cli-contract.json parity (#11
   });
 
   it('every registered command appears in expectedCommands (no silent additions)', () => {
-    const contract: Contract = JSON.parse(fs.readFileSync(contractPath, 'utf-8'));
+    const contract: Contract = JSON.parse(fs.readFileSync(contractPath, 'utf8'));
     const expected = new Set(contract.expectedCommands);
     const unlisted = commands.map((c) => c.name).filter((name) => !expected.has(name));
     expect(
@@ -74,7 +74,7 @@ describe('cli-registry ↔ .claude-plugin/expected-cli-contract.json parity (#11
   });
 
   it('every workflow file referenced by the contract exists on disk', () => {
-    const contract: Contract = JSON.parse(fs.readFileSync(contractPath, 'utf-8'));
+    const contract: Contract = JSON.parse(fs.readFileSync(contractPath, 'utf8'));
     const missing = contract.expectedWorkflowFiles.filter((rel) => !fs.existsSync(path.join(pluginRoot, rel)));
     expect(missing, `Workflow files referenced by the contract are missing: ${missing.join(', ')}`).toEqual([]);
   });

--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -596,7 +596,7 @@ export const commands: CLICommandDef[] = [
                 for await (const chunk of process.stdin) {
                   chunks.push(chunk);
                 }
-                message = Buffer.concat(chunks).toString('utf-8').trim();
+                message = Buffer.concat(chunks).toString('utf8').trim();
               } else {
                 message = messageParts.join(' ');
               }

--- a/packages/core/src/cli.test.ts
+++ b/packages/core/src/cli.test.ts
@@ -286,7 +286,7 @@ describe('Version detection IIFE', () => {
     let version: string;
     try {
       const pkgPath = join(__dirname, '..', 'package.json');
-      version = JSON.parse(readFileSync(pkgPath, 'utf-8')).version;
+      version = JSON.parse(readFileSync(pkgPath, 'utf8')).version;
     } catch {
       version = '0.0.0';
     }
@@ -302,7 +302,7 @@ describe('Version detection IIFE', () => {
     let version: string;
     try {
       // Attempt to read a path that does not exist
-      version = JSON.parse(readFileSync('/nonexistent/path/package.json', 'utf-8')).version;
+      version = JSON.parse(readFileSync('/nonexistent/path/package.json', 'utf8')).version;
       version = 'should-not-reach';
     } catch {
       version = '0.0.0';
@@ -436,7 +436,7 @@ describe('Search maxResults cap', () => {
   });
 
   it('should warn to console when capping maxResults', () => {
-    const src = readFileSync(join(__dirname, 'cli-registry.ts'), 'utf-8');
+    const src = readFileSync(join(__dirname, 'cli-registry.ts'), 'utf8');
     expect(src).toContain('Capping search to');
   });
 });
@@ -446,7 +446,7 @@ describe('Search maxResults cap', () => {
 describe('Lazy imports', () => {
   it('should use dynamic import() in action handlers instead of static imports', () => {
     // Read cli-registry.ts where command definitions now live
-    const src = readFileSync(join(__dirname, 'cli-registry.ts'), 'utf-8');
+    const src = readFileSync(join(__dirname, 'cli-registry.ts'), 'utf8');
 
     // There should be NO static imports from ./commands/* or ./core/index.js
     const staticCommandImports = src.match(/^import .+ from '\.\/(commands\/[^']+)';$/gm);
@@ -461,7 +461,7 @@ describe('Lazy imports', () => {
   });
 
   it('cli.ts should not have static imports from commands/', () => {
-    const src = readFileSync(join(__dirname, 'cli.ts'), 'utf-8');
+    const src = readFileSync(join(__dirname, 'cli.ts'), 'utf8');
 
     // cli.ts should import from cli-registry, not from commands/ directly
     const staticCommandImports = src.match(/^import .+ from '\.\/(commands\/[^']+)';$/gm);
@@ -469,12 +469,12 @@ describe('Lazy imports', () => {
   });
 
   it('cli.ts should import from cli-registry', () => {
-    const src = readFileSync(join(__dirname, 'cli.ts'), 'utf-8');
+    const src = readFileSync(join(__dirname, 'cli.ts'), 'utf8');
     expect(src).toContain("from './cli-registry.js'");
   });
 
   it('should use getGitHubTokenAsync in preAction hook', () => {
-    const src = readFileSync(join(__dirname, 'cli.ts'), 'utf-8');
+    const src = readFileSync(join(__dirname, 'cli.ts'), 'utf8');
 
     // The preAction hook should use the async version
     expect(src).toContain('await getGitHubTokenAsync()');

--- a/packages/core/src/commands/check-integration.ts
+++ b/packages/core/src/commands/check-integration.ts
@@ -88,7 +88,7 @@ export async function runCheckIntegration(options: CheckIntegrationOptions): Pro
   let newFiles: string[];
   try {
     const output = execFileSync('git', ['diff', '--name-only', '--diff-filter=A', `${base}...HEAD`], {
-      encoding: 'utf-8',
+      encoding: 'utf8',
       timeout: 10000,
     }).trim();
     newFiles = output ? output.split('\n').filter(Boolean) : [];
@@ -112,7 +112,7 @@ export async function runCheckIntegration(options: CheckIntegrationOptions): Pro
   let allFiles: string[];
   try {
     allFiles = execFileSync('git', ['ls-files'], {
-      encoding: 'utf-8',
+      encoding: 'utf8',
       timeout: 10000,
     })
       .trim()
@@ -146,7 +146,7 @@ export async function runCheckIntegration(options: CheckIntegrationOptions): Pro
     for (const pattern of patterns) {
       try {
         const grepOutput = execFileSync('git', ['grep', '-l', '--', pattern], {
-          encoding: 'utf-8',
+          encoding: 'utf8',
           timeout: 10000,
         }).trim();
         if (grepOutput) {

--- a/packages/core/src/commands/dashboard-process.ts
+++ b/packages/core/src/commands/dashboard-process.ts
@@ -32,7 +32,7 @@ export function writeDashboardServerInfo(info: DashboardServerInfo): void {
 
 export function readDashboardServerInfo(): DashboardServerInfo | null {
   try {
-    const content = fs.readFileSync(getDashboardPidPath(), 'utf-8');
+    const content = fs.readFileSync(getDashboardPidPath(), 'utf8');
     const parsed = JSON.parse(content);
     if (
       typeof parsed !== 'object' ||

--- a/packages/core/src/commands/dashboard-server.test.ts
+++ b/packages/core/src/commands/dashboard-server.test.ts
@@ -225,7 +225,7 @@ function createMockRes(): { res: ServerResponse; result: Promise<MockResponseRes
       resolve({
         statusCode,
         headers,
-        body: Buffer.concat(chunks).toString('utf-8'),
+        body: Buffer.concat(chunks).toString('utf8'),
       });
     });
   });
@@ -1199,7 +1199,7 @@ describe('dashboard-server', () => {
       writeDashboardServerInfo(info);
 
       const pidPath = getDashboardPidPath();
-      const content = fs.readFileSync(pidPath, 'utf-8');
+      const content = fs.readFileSync(pidPath, 'utf8');
       const parsed = JSON.parse(content);
 
       expect(parsed).toEqual(info);

--- a/packages/core/src/commands/dashboard-server.ts
+++ b/packages/core/src/commands/dashboard-server.ts
@@ -90,7 +90,7 @@ function readVettedIssues(): ParseIssueListOutput | null {
   try {
     const info = detectIssueList();
     if (!info) return null;
-    const content = fs.readFileSync(info.path, 'utf-8');
+    const content = fs.readFileSync(info.path, 'utf8');
     return parseIssueList(content);
   } catch (error) {
     warn(MODULE, `Failed to read vetted issue list: ${errorMessage(error)}`);
@@ -205,7 +205,7 @@ function readBody(req: http.IncomingMessage, maxBytes: number = MAX_BODY_BYTES):
       chunks.push(chunk);
     });
     req.on('end', () => {
-      if (!aborted) resolve(Buffer.concat(chunks).toString('utf-8'));
+      if (!aborted) resolve(Buffer.concat(chunks).toString('utf8'));
     });
     req.on('error', (err) => {
       if (!aborted) reject(err);

--- a/packages/core/src/commands/detect-formatters.ts
+++ b/packages/core/src/commands/detect-formatters.ts
@@ -23,7 +23,7 @@ export async function runDetectFormatters(options: {
   if (options.ciLog) {
     let logContent: string;
     try {
-      logContent = fs.readFileSync(path.resolve(options.ciLog), 'utf-8');
+      logContent = fs.readFileSync(path.resolve(options.ciLog), 'utf8');
     } catch (err) {
       throw new Error(`Failed to read CI log file: ${errorMessage(err)}`, { cause: err });
     }

--- a/packages/core/src/commands/doctor.ts
+++ b/packages/core/src/commands/doctor.ts
@@ -222,7 +222,7 @@ export function checkStateFile(options?: { statePathOverride?: string }): Doctor
     };
   }
   try {
-    const raw = fs.readFileSync(statePath, 'utf-8');
+    const raw = fs.readFileSync(statePath, 'utf8');
     const parsed = JSON.parse(raw);
     const result = AgentStateSchema.safeParse(parsed);
     if (!result.success) {

--- a/packages/core/src/commands/guidelines.test.ts
+++ b/packages/core/src/commands/guidelines.test.ts
@@ -64,7 +64,7 @@ describe('runGuidelinesView', () => {
     mockGetGuidelines.mockReturnValue('# rules\n- be nice');
     const out = await runGuidelinesView({ repo: 'owner/repo' });
     expect(out.content).toBe('# rules\n- be nice');
-    expect(out.byteSize).toBe(Buffer.byteLength('# rules\n- be nice', 'utf-8'));
+    expect(out.byteSize).toBe(Buffer.byteLength('# rules\n- be nice', 'utf8'));
     expect(out.exists).toBe(true);
     expect(out.storageMode).toBe('gist');
   });
@@ -93,7 +93,7 @@ describe('runGuidelinesStore', () => {
   it('persists content and returns byte size', async () => {
     const out = await runGuidelinesStore({ repo: 'owner/repo', content: 'guidelines text' });
     expect(out.stored).toBe(true);
-    expect(out.byteSize).toBe(Buffer.byteLength('guidelines text', 'utf-8'));
+    expect(out.byteSize).toBe(Buffer.byteLength('guidelines text', 'utf8'));
     expect(mockSetGuidelines).toHaveBeenCalledWith('owner/repo', 'guidelines text');
   });
 

--- a/packages/core/src/commands/guidelines.ts
+++ b/packages/core/src/commands/guidelines.ts
@@ -96,7 +96,7 @@ export async function runGuidelinesView(options: RepoOption): Promise<Guidelines
   return {
     repo: options.repo,
     content,
-    byteSize: content === null ? 0 : Buffer.byteLength(content, 'utf-8'),
+    byteSize: content === null ? 0 : Buffer.byteLength(content, 'utf8'),
     exists: content !== null,
     storageMode: sm.isGuidelinesAvailable() ? 'gist' : 'local-unavailable',
   };
@@ -121,7 +121,7 @@ export async function runGuidelinesStore(options: StoreOptions): Promise<Guideli
   await maybeCheckpoint(sm, MODULE);
   return {
     repo: options.repo,
-    byteSize: Buffer.byteLength(options.content, 'utf-8'),
+    byteSize: Buffer.byteLength(options.content, 'utf8'),
     stored: true,
   };
 }

--- a/packages/core/src/commands/list-move-tier.test.ts
+++ b/packages/core/src/commands/list-move-tier.test.ts
@@ -153,7 +153,7 @@ describe('runListMoveTier (filesystem)', () => {
     expect(out.url).toBe(URL_A);
     expect(out.count).toBe(1);
 
-    const after = fs.readFileSync(listPath, 'utf-8');
+    const after = fs.readFileSync(listPath, 'utf8');
     expect(after).toContain('## Skip');
     expect(after.indexOf('## Skip')).toBeLessThan(after.indexOf(URL_A));
   });
@@ -173,6 +173,6 @@ describe('runListMoveTier (filesystem)', () => {
     expect(out.count).toBe(0);
     const after = fs.statSync(listPath).mtimeMs;
     expect(after).toBe(before); // no write happened
-    expect(fs.readFileSync(listPath, 'utf-8')).toBe(original);
+    expect(fs.readFileSync(listPath, 'utf8')).toBe(original);
   });
 });

--- a/packages/core/src/commands/list-move-tier.ts
+++ b/packages/core/src/commands/list-move-tier.ts
@@ -217,7 +217,7 @@ export async function runListMoveTier(options: ListMoveTierOptions): Promise<Lis
 
   let content: string;
   try {
-    content = fs.readFileSync(filePath, 'utf-8');
+    content = fs.readFileSync(filePath, 'utf8');
   } catch (error) {
     throw new Error(`Failed to read file: ${errorMessage(error)}`, { cause: error });
   }
@@ -226,7 +226,7 @@ export async function runListMoveTier(options: ListMoveTierOptions): Promise<Lis
 
   if (result.moved) {
     try {
-      fs.writeFileSync(filePath, result.content, 'utf-8');
+      fs.writeFileSync(filePath, result.content, 'utf8');
     } catch (error) {
       throw new Error(`Failed to write file: ${errorMessage(error)}`, { cause: error });
     }

--- a/packages/core/src/commands/local-repos.ts
+++ b/packages/core/src/commands/local-repos.ts
@@ -32,7 +32,7 @@ const DEFAULT_SCAN_PATHS = [
 function getGitHubRemote(repoPath: string): string | null {
   try {
     const remoteUrl = execFileSync('git', ['-C', repoPath, 'remote', 'get-url', 'origin'], {
-      encoding: 'utf-8',
+      encoding: 'utf8',
       timeout: 5000,
       stdio: ['pipe', 'pipe', 'pipe'],
     }).trim();
@@ -58,7 +58,7 @@ function getCurrentBranch(repoPath: string): string | null {
   try {
     return (
       execFileSync('git', ['-C', repoPath, 'branch', '--show-current'], {
-        encoding: 'utf-8',
+        encoding: 'utf8',
         timeout: 5000,
         stdio: ['pipe', 'pipe', 'pipe'],
       }).trim() || null
@@ -81,7 +81,7 @@ export function scanForRepos(scanPaths: string[]): Record<string, LocalRepoInfo>
     let gitDirs: string[];
     try {
       const output = execFileSync('find', [scanPath, '-maxdepth', '4', '-name', '.git', '-type', 'd'], {
-        encoding: 'utf-8',
+        encoding: 'utf8',
         timeout: 30000,
         stdio: ['pipe', 'pipe', 'pipe'],
       }).trim();

--- a/packages/core/src/commands/parse-list.ts
+++ b/packages/core/src/commands/parse-list.ts
@@ -276,7 +276,7 @@ export async function runParseList(options: ParseListOptions): Promise<ParseIssu
 
   let content: string;
   try {
-    content = fs.readFileSync(filePath, 'utf-8');
+    content = fs.readFileSync(filePath, 'utf8');
   } catch (error) {
     const msg = errorMessage(error);
     throw new Error(`Failed to read file: ${msg}`, { cause: error });

--- a/packages/core/src/commands/skip-add.test.ts
+++ b/packages/core/src/commands/skip-add.test.ts
@@ -39,7 +39,7 @@ describe('runSkipAdd', () => {
       now: new Date('2026-04-19T12:00:00Z'),
     });
 
-    const contents = fs.readFileSync(skipFile, 'utf-8');
+    const contents = fs.readFileSync(skipFile, 'utf8');
     expect(contents).toContain('# Skipped Issues — auto-culled after 90 days');
     expect(contents).toContain('# Format: YYYY-MM-DD URL');
     expect(contents).toContain('2026-04-19 https://github.com/foo/bar/issues/1');
@@ -64,7 +64,7 @@ describe('runSkipAdd', () => {
       now: new Date('2026-04-19T00:00:00Z'),
     });
 
-    const contents = fs.readFileSync(skipFile, 'utf-8');
+    const contents = fs.readFileSync(skipFile, 'utf8');
     const headerOccurrences = contents.split('# Skipped Issues').length - 1;
     expect(headerOccurrences).toBe(1);
     expect(contents).toContain('2026-04-15 https://github.com/owner/repo/issues/99');
@@ -76,7 +76,7 @@ describe('runSkipAdd', () => {
       skipFile,
       '# Skipped Issues — auto-culled after 90 days\n# Format: YYYY-MM-DD URL\n\n2026-04-15 https://github.com/foo/bar/issues/1\n',
     );
-    const before = fs.readFileSync(skipFile, 'utf-8');
+    const before = fs.readFileSync(skipFile, 'utf8');
 
     const result = runSkipAdd({
       issueUrl: 'https://github.com/foo/bar/issues/1',
@@ -84,7 +84,7 @@ describe('runSkipAdd', () => {
       now: new Date('2026-04-19T00:00:00Z'),
     });
 
-    const after = fs.readFileSync(skipFile, 'utf-8');
+    const after = fs.readFileSync(skipFile, 'utf8');
     expect(after).toBe(before);
     expect(result).toEqual({
       added: false,
@@ -102,7 +102,7 @@ describe('runSkipAdd', () => {
     });
 
     expect(result.added).toBe(true);
-    const contents = fs.readFileSync(skipFile, 'utf-8');
+    const contents = fs.readFileSync(skipFile, 'utf8');
     expect(contents).toContain('2026-04-19 https://github.com/foo/bar/pull/42');
   });
 
@@ -135,7 +135,7 @@ describe('runSkipAdd', () => {
 
     expect(result.added).toBe(true);
     expect(result.path).toBe(skipFile);
-    const contents = fs.readFileSync(skipFile, 'utf-8');
+    const contents = fs.readFileSync(skipFile, 'utf8');
     expect(contents).toContain('2026-04-19 https://github.com/foo/bar/issues/7');
   });
 
@@ -156,7 +156,7 @@ describe('runSkipAdd', () => {
       now: new Date('2026-04-20T01:30:00Z'),
     });
 
-    const contents = fs.readFileSync(skipFile, 'utf-8');
+    const contents = fs.readFileSync(skipFile, 'utf8');
     expect(contents).toContain('2026-04-20 https://github.com/foo/bar/issues/1');
     expect(contents).not.toContain('2026-04-19 https://github.com/foo/bar/issues/1');
   });

--- a/packages/core/src/commands/skip-file-parser.test.ts
+++ b/packages/core/src/commands/skip-file-parser.test.ts
@@ -184,7 +184,7 @@ describe('loadSkippedIssues', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].url).toBe('https://github.com/owncast/owncast/issues/4883');
-    expect(mockReadFileSync).toHaveBeenCalledWith('/real/path.md', 'utf-8');
+    expect(mockReadFileSync).toHaveBeenCalledWith('/real/path.md', 'utf8');
   });
 
   it('should return [] and warn if reading the file throws', () => {

--- a/packages/core/src/commands/skip-file-parser.ts
+++ b/packages/core/src/commands/skip-file-parser.ts
@@ -98,7 +98,7 @@ export function loadSkippedIssues(path: string | undefined): SkippedIssue[] {
 
   let content: string;
   try {
-    content = fs.readFileSync(path, 'utf-8');
+    content = fs.readFileSync(path, 'utf8');
   } catch (err) {
     warn('skip-file-parser', `Failed to read skipped-issues file at ${path}: ${errorMessage(err)}`);
     return [];

--- a/packages/core/src/commands/startup.ts
+++ b/packages/core/src/commands/startup.ts
@@ -69,7 +69,7 @@ export function detectIssueList(): IssueListInfo | undefined {
     const configPath = '.claude/oss-autopilot/config.md';
     if (fs.existsSync(configPath)) {
       try {
-        const configContent = fs.readFileSync(configPath, 'utf-8');
+        const configContent = fs.readFileSync(configPath, 'utf8');
         const configuredPath = parseIssueListPathFromConfig(configContent);
         if (configuredPath && fs.existsSync(configuredPath)) {
           issueListPath = configuredPath;
@@ -99,7 +99,7 @@ export function detectIssueList(): IssueListInfo | undefined {
   let availableCount = 0;
   let completedCount = 0;
   try {
-    const content = fs.readFileSync(issueListPath, 'utf-8');
+    const content = fs.readFileSync(issueListPath, 'utf8');
     ({ availableCount, completedCount } = countIssueListItems(content));
   } catch (error) {
     console.error(`[STARTUP] Failed to read issue list at ${issueListPath}:`, errorMessage(error));

--- a/packages/core/src/commands/vet-list.ts
+++ b/packages/core/src/commands/vet-list.ts
@@ -216,10 +216,10 @@ export async function runVetList(options: VetListOptions = {}): Promise<VetListO
   let pruneResult: { removedCount: number } | undefined;
   if (options.prune && issueListPath) {
     try {
-      const content = fs.readFileSync(issueListPath, 'utf-8');
+      const content = fs.readFileSync(issueListPath, 'utf8');
       const { pruned, removedCount } = pruneIssueList(content);
       if (pruned !== content) {
-        fs.writeFileSync(issueListPath, pruned, 'utf-8');
+        fs.writeFileSync(issueListPath, pruned, 'utf8');
       }
       pruneResult = { removedCount };
     } catch (error) {

--- a/packages/core/src/core/auth.ts
+++ b/packages/core/src/core/auth.ts
@@ -44,7 +44,7 @@ export function getGitHubToken(): string | null {
 
   try {
     const token = execFileSync('gh', ['auth', 'token'], {
-      encoding: 'utf-8',
+      encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 2000,
     }).trim();
@@ -121,7 +121,7 @@ export async function getGitHubTokenAsync(): Promise<string | null> {
 
   try {
     const token = await new Promise<string>((resolve, reject) => {
-      execFile('gh', ['auth', 'token'], { encoding: 'utf-8', timeout: 2000 }, (error, stdout) => {
+      execFile('gh', ['auth', 'token'], { encoding: 'utf8', timeout: 2000 }, (error, stdout) => {
         if (error) {
           reject(error as Error);
         } else {
@@ -159,7 +159,7 @@ const GITHUB_USERNAME_RE = /^[a-z0-9](?:[a-z0-9]|-(?=[a-z0-9])){0,38}$/i;
 export async function detectGitHubUsername(): Promise<string | null> {
   try {
     const login = await new Promise<string>((resolve, reject) => {
-      execFile('gh', ['api', 'user', '--jq', '.login'], { encoding: 'utf-8', timeout: 5000 }, (error, stdout) => {
+      execFile('gh', ['api', 'user', '--jq', '.login'], { encoding: 'utf8', timeout: 5000 }, (error, stdout) => {
         if (error) {
           reject(error as Error);
         } else {

--- a/packages/core/src/core/formatter-detection.ts
+++ b/packages/core/src/core/formatter-detection.ts
@@ -129,7 +129,7 @@ const CI_PATTERNS: { formatter: FormatterName; patterns: RegExp[] }[] = [
  */
 function readJsonFile(filePath: string): unknown | undefined {
   try {
-    const content = fs.readFileSync(filePath, 'utf-8');
+    const content = fs.readFileSync(filePath, 'utf8');
     return JSON.parse(content);
   } catch (err) {
     debug(MODULE, `Failed to parse ${filePath}: ${err instanceof Error ? err.message : String(err)}`);
@@ -142,7 +142,7 @@ function readJsonFile(filePath: string): unknown | undefined {
  */
 function readTextFile(filePath: string): string | undefined {
   try {
-    return fs.readFileSync(filePath, 'utf-8');
+    return fs.readFileSync(filePath, 'utf8');
   } catch (err) {
     debug(MODULE, `Failed to read ${filePath}: ${err instanceof Error ? err.message : String(err)}`);
     return undefined;

--- a/packages/core/src/core/gist-state-store.test.ts
+++ b/packages/core/src/core/gist-state-store.test.ts
@@ -186,7 +186,7 @@ describe('GistStateStore', () => {
       const cachePath = path.join(tmpDir, 'state-cache.json');
       expect(fs.existsSync(cachePath)).toBe(true);
 
-      const cached = JSON.parse(fs.readFileSync(cachePath, 'utf-8'));
+      const cached = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
       expect(cached.version).toBe(4);
     });
 
@@ -213,7 +213,7 @@ describe('GistStateStore', () => {
       expect(result.created).toBe(false);
 
       // Local gist-id file should be updated
-      const storedId = fs.readFileSync(path.join(tmpDir, 'gist-id'), 'utf-8');
+      const storedId = fs.readFileSync(path.join(tmpDir, 'gist-id'), 'utf8');
       expect(storedId).toBe(searchId);
     });
   });
@@ -240,7 +240,7 @@ describe('GistStateStore', () => {
       expect(result.state.version).toBe(4);
 
       // Should have written the local gist-id file
-      const storedId = fs.readFileSync(path.join(tmpDir, 'gist-id'), 'utf-8');
+      const storedId = fs.readFileSync(path.join(tmpDir, 'gist-id'), 'utf8');
       expect(storedId).toBe(gistId);
 
       // Should have written local state cache
@@ -315,7 +315,7 @@ describe('GistStateStore', () => {
       });
 
       // Should have written local gist-id file
-      const storedId = fs.readFileSync(path.join(tmpDir, 'gist-id'), 'utf-8');
+      const storedId = fs.readFileSync(path.join(tmpDir, 'gist-id'), 'utf8');
       expect(storedId).toBe(newGistId);
 
       // Should have written local state cache
@@ -415,7 +415,7 @@ describe('GistStateStore', () => {
       // user can recover it.
       const rejectedFiles = fs.readdirSync(tmpDir).filter((f) => f.startsWith('state-cache.json.rejected-'));
       expect(rejectedFiles.length).toBeGreaterThanOrEqual(1);
-      const preservedContent = fs.readFileSync(path.join(tmpDir, rejectedFiles[0]!), 'utf-8');
+      const preservedContent = fs.readFileSync(path.join(tmpDir, rejectedFiles[0]!), 'utf8');
       expect(preservedContent).toBe(corruptContent);
     });
   });
@@ -603,7 +603,7 @@ describe('GistStateStore', () => {
       await store.push();
 
       expect(fs.existsSync(cachePath)).toBe(true);
-      const cached = JSON.parse(fs.readFileSync(cachePath, 'utf-8'));
+      const cached = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
       expect(cached.version).toBe(4);
     });
   });
@@ -811,7 +811,7 @@ describe('GistStateStore', () => {
       await store.bootstrap();
 
       const cachePath = path.join(tmpDir, 'state-cache.json');
-      const raw = JSON.parse(fs.readFileSync(cachePath, 'utf-8'));
+      const raw = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
       const parsed = AgentStateSchema.safeParse(raw);
       expect(parsed.success).toBe(true);
     });
@@ -857,7 +857,7 @@ describe('GistStateStore', () => {
       });
 
       // Local gist-id file should be written
-      const storedId = fs.readFileSync(path.join(tmpDir, 'gist-id'), 'utf-8');
+      const storedId = fs.readFileSync(path.join(tmpDir, 'gist-id'), 'utf8');
       expect(storedId).toBe(newGistId);
     });
 
@@ -1160,7 +1160,7 @@ describe('GistStateStore', () => {
       // ── Step 7: Verify local state cache was updated ───────────────
       const cachePath = path.join(tmpDir, 'state-cache.json');
       expect(fs.existsSync(cachePath)).toBe(true);
-      const cached = JSON.parse(fs.readFileSync(cachePath, 'utf-8'));
+      const cached = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
       expect(cached.version).toBe(4);
       expect(cached.lastRunAt).toBe('2026-03-25T12:00:00.000Z');
 

--- a/packages/core/src/core/gist-state-store.ts
+++ b/packages/core/src/core/gist-state-store.ts
@@ -68,7 +68,7 @@ function extractEtag(headers: Record<string, string | undefined> | undefined): s
 function preserveRejectedGistContent(raw: string, gistId: string): string | null {
   try {
     const rejectedPath = `${getStateCachePath()}.rejected-${Date.now()}`;
-    fs.writeFileSync(rejectedPath, raw, { encoding: 'utf-8', mode: 0o600 });
+    fs.writeFileSync(rejectedPath, raw, { encoding: 'utf8', mode: 0o600 });
     return rejectedPath;
   } catch (err) {
     warn(
@@ -215,7 +215,7 @@ export class GistStateStore {
       let cacheRaw: string | null = null;
       try {
         if (fs.existsSync(cachePath)) {
-          cacheRaw = fs.readFileSync(cachePath, 'utf-8');
+          cacheRaw = fs.readFileSync(cachePath, 'utf8');
           let obj: unknown = JSON.parse(cacheRaw);
 
           // Chain migrations
@@ -305,7 +305,7 @@ export class GistStateStore {
       let cacheRaw: string | null = null;
       try {
         if (fs.existsSync(cachePath)) {
-          cacheRaw = fs.readFileSync(cachePath, 'utf-8');
+          cacheRaw = fs.readFileSync(cachePath, 'utf8');
           let obj: unknown = JSON.parse(cacheRaw);
 
           // Chain migrations
@@ -713,7 +713,7 @@ export class GistStateStore {
     try {
       const gistIdPath = getGistIdPath();
       if (fs.existsSync(gistIdPath)) {
-        const id = fs.readFileSync(gistIdPath, 'utf-8').trim();
+        const id = fs.readFileSync(gistIdPath, 'utf8').trim();
         return id || null;
       }
     } catch (err) {

--- a/packages/core/src/core/github-stats.test.ts
+++ b/packages/core/src/core/github-stats.test.ts
@@ -127,10 +127,10 @@ describe('fetchUserPRCounts caching', () => {
     const cacheFiles = fs.readdirSync(testCacheDir).filter((f) => f.endsWith('.json'));
     for (const file of cacheFiles) {
       const filePath = path.join(testCacheDir, file);
-      const entry = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+      const entry = JSON.parse(fs.readFileSync(filePath, 'utf8'));
       if (entry.url === 'pr-counts:v3:merged:testuser') {
         entry.cachedAt = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
-        fs.writeFileSync(filePath, JSON.stringify(entry), 'utf-8');
+        fs.writeFileSync(filePath, JSON.stringify(entry), 'utf8');
       }
     }
 

--- a/packages/core/src/core/guidelines-store.ts
+++ b/packages/core/src/core/guidelines-store.ts
@@ -106,7 +106,7 @@ export function getGuidelines(store: GistStateStore | null, repo: string): strin
  */
 export function setGuidelines(store: GistStateStore | null, repo: string, content: string): void {
   if (!store) throw new GuidelinesNotAvailableError();
-  const byteSize = Buffer.byteLength(content, 'utf-8');
+  const byteSize = Buffer.byteLength(content, 'utf8');
   if (byteSize > GUIDELINES_MAX_BYTES) {
     throw new GuidelinesTooLargeError(byteSize);
   }

--- a/packages/core/src/core/http-cache.test.ts
+++ b/packages/core/src/core/http-cache.test.ts
@@ -43,7 +43,7 @@ describe('HttpCache', () => {
     it('returns null for a corrupt cache file', () => {
       // Write garbage to the cache file
       const key = crypto.createHash('sha256').update('/repos/bad/data').digest('hex');
-      fs.writeFileSync(path.join(cacheDir, `${key}.json`), 'not valid json', 'utf-8');
+      fs.writeFileSync(path.join(cacheDir, `${key}.json`), 'not valid json', 'utf8');
 
       expect(cache.get('/repos/bad/data')).toBeNull();
     });
@@ -57,7 +57,7 @@ describe('HttpCache', () => {
         body: {},
         cachedAt: new Date().toISOString(),
       };
-      fs.writeFileSync(path.join(cacheDir, `${key}.json`), JSON.stringify(entry), 'utf-8');
+      fs.writeFileSync(path.join(cacheDir, `${key}.json`), JSON.stringify(entry), 'utf8');
 
       expect(cache.get('/repos/a/b')).toBeNull();
     });
@@ -92,7 +92,7 @@ describe('HttpCache', () => {
         body: { count: 1 },
         cachedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(), // 2 hours ago
       };
-      fs.writeFileSync(path.join(cacheDir, `${key}.json`), JSON.stringify(entry), 'utf-8');
+      fs.writeFileSync(path.join(cacheDir, `${key}.json`), JSON.stringify(entry), 'utf8');
 
       expect(cache.getIfFresh('/repos/old', 60 * 60 * 1000)).toBeNull(); // 1 hour TTL
     });
@@ -105,7 +105,7 @@ describe('HttpCache', () => {
         body: { count: 1 },
         cachedAt: 'not-a-valid-date',
       };
-      fs.writeFileSync(path.join(cacheDir, `${key}.json`), JSON.stringify(entry), 'utf-8');
+      fs.writeFileSync(path.join(cacheDir, `${key}.json`), JSON.stringify(entry), 'utf8');
 
       expect(cache.getIfFresh('/repos/bad-date', 60_000)).toBeNull();
     });
@@ -145,7 +145,7 @@ describe('HttpCache', () => {
         body: { stars: 0 },
         cachedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(), // 2 hours ago
       };
-      fs.writeFileSync(path.join(cacheDir, `${key}.json`), JSON.stringify(oldEntry), 'utf-8');
+      fs.writeFileSync(path.join(cacheDir, `${key}.json`), JSON.stringify(oldEntry), 'utf8');
 
       // Write a fresh entry
       cache.set('/repos/fresh/entry', '"new"', { stars: 100 });
@@ -159,7 +159,7 @@ describe('HttpCache', () => {
     });
 
     it('removes corrupt cache files during eviction', () => {
-      fs.writeFileSync(path.join(cacheDir, 'corrupt.json'), 'garbage', 'utf-8');
+      fs.writeFileSync(path.join(cacheDir, 'corrupt.json'), 'garbage', 'utf8');
       const evicted = cache.evictStale(0);
       expect(evicted).toBe(1);
     });

--- a/packages/core/src/core/http-cache.ts
+++ b/packages/core/src/core/http-cache.ts
@@ -93,7 +93,7 @@ export class HttpCache {
   get(url: string): CacheEntry | null {
     const filePath = this.pathFor(url);
     try {
-      const raw = fs.readFileSync(filePath, 'utf-8');
+      const raw = fs.readFileSync(filePath, 'utf8');
       const entry = JSON.parse(raw) as CacheEntry;
       // Sanity-check: the file should contain the URL we asked for
       if (entry.url !== url) {
@@ -117,7 +117,7 @@ export class HttpCache {
       cachedAt: new Date().toISOString(),
     };
     try {
-      fs.writeFileSync(this.pathFor(url), JSON.stringify(entry), { encoding: 'utf-8', mode: 0o600 });
+      fs.writeFileSync(this.pathFor(url), JSON.stringify(entry), { encoding: 'utf8', mode: 0o600 });
       debug(MODULE, `Cached response for ${url}`);
       // Best-effort size cap (#1057 M27). Runs after each write rather than on
       // a schedule so long-lived sessions can't accumulate past the cap.
@@ -208,7 +208,7 @@ export class HttpCache {
         if (!file.endsWith('.json')) continue;
         const filePath = path.join(this.cacheDir, file);
         try {
-          const raw = fs.readFileSync(filePath, 'utf-8');
+          const raw = fs.readFileSync(filePath, 'utf8');
           const entry = JSON.parse(raw) as CacheEntry;
           const age = now - new Date(entry.cachedAt).getTime();
           if (age > maxAgeMs) {

--- a/packages/core/src/core/paths.ts
+++ b/packages/core/src/core/paths.ts
@@ -107,7 +107,7 @@ export function stateFileExists(): boolean {
 export function getCLIVersion(): string {
   try {
     const pkgPath = path.join(path.dirname(process.argv[1]), '..', 'package.json');
-    return JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).version;
+    return JSON.parse(fs.readFileSync(pkgPath, 'utf8')).version;
   } catch {
     return '0.0.0';
   }

--- a/packages/core/src/core/pr-template.ts
+++ b/packages/core/src/core/pr-template.ts
@@ -59,7 +59,7 @@ export async function fetchPRTemplate(octokit: Octokit, owner: string, repo: str
         continue;
       }
 
-      const template = Buffer.from(data.content, 'base64').toString('utf-8');
+      const template = Buffer.from(data.content, 'base64').toString('utf8');
       debug(MODULE, `Found PR template at ${path} (${template.length} chars)`);
       return { template, source: path };
     } catch (err: unknown) {

--- a/packages/core/src/core/state-migration.test.ts
+++ b/packages/core/src/core/state-migration.test.ts
@@ -143,7 +143,7 @@ describe('StateManager v1 → v2 migration', () => {
     expect(state.version).toBe(4);
 
     // Verify migration was persisted to disk
-    const onDisk = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    const onDisk = JSON.parse(fs.readFileSync(statePath, 'utf8'));
     expect(onDisk.version).toBe(4);
   });
 
@@ -321,7 +321,7 @@ describe('StateManager v3 → v4 migration', () => {
     expect(state.closedPRs?.[0].url).toBe('https://github.com/a/b/pull/2');
     expect(state.closedPRs?.[0].commentsFetchedAt).toBeUndefined();
 
-    const onDisk = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    const onDisk = JSON.parse(fs.readFileSync(statePath, 'utf8'));
     expect(onDisk.version).toBe(4);
   });
 });
@@ -354,7 +354,7 @@ describe('legacy state cleanup on load', () => {
 
     // Note: the stale field persists on disk until the next saveState() call.
     // Unlike the old isValidState() cleanup, Zod stripping is in-memory only.
-    const onDisk = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    const onDisk = JSON.parse(fs.readFileSync(statePath, 'utf8'));
     expect(onDisk.config.snoozedPRs).toBeDefined();
   });
 
@@ -400,7 +400,7 @@ describe('legacy state cleanup on load', () => {
     expect(state.config.dismissedIssues['https://github.com/owner/repo/issues/20']).toBe('2025-02-02T00:00:00Z');
 
     // Verify on disk as well
-    const onDisk = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    const onDisk = JSON.parse(fs.readFileSync(statePath, 'utf8'));
     expect(Object.keys(onDisk.config.dismissedIssues)).toHaveLength(2);
     expect(onDisk.config.dismissedIssues['https://github.com/owner/repo/pull/30']).toBeUndefined();
   });

--- a/packages/core/src/core/state-persistence.test.ts
+++ b/packages/core/src/core/state-persistence.test.ts
@@ -107,7 +107,7 @@ describe('Concurrent State Write Protection', () => {
 
       atomicWriteFileSync(filePath, data);
 
-      expect(fs.readFileSync(filePath, 'utf-8')).toBe(data);
+      expect(fs.readFileSync(filePath, 'utf8')).toBe(data);
     });
 
     it('should not leave a .tmp file after successful write', () => {
@@ -126,7 +126,7 @@ describe('Concurrent State Write Protection', () => {
 
       atomicWriteFileSync(filePath, '{"version":3}');
 
-      expect(fs.readFileSync(filePath, 'utf-8')).toBe('{"version":3}');
+      expect(fs.readFileSync(filePath, 'utf8')).toBe('{"version":3}');
     });
 
     it('should apply the specified file mode', () => {
@@ -147,7 +147,7 @@ describe('Concurrent State Write Protection', () => {
       acquireLock(lockPath);
       expect(fs.existsSync(lockPath)).toBe(true);
 
-      const lockData = JSON.parse(fs.readFileSync(lockPath, 'utf-8'));
+      const lockData = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
       expect(lockData.pid).toBe(process.pid);
       expect(typeof lockData.timestamp).toBe('number');
 
@@ -177,7 +177,7 @@ describe('Concurrent State Write Protection', () => {
       acquireLock(lockPath);
       expect(fs.existsSync(lockPath)).toBe(true);
 
-      const newLockData = JSON.parse(fs.readFileSync(lockPath, 'utf-8'));
+      const newLockData = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
       expect(newLockData.pid).toBe(process.pid);
 
       releaseLock(lockPath);
@@ -192,7 +192,7 @@ describe('Concurrent State Write Protection', () => {
       acquireLock(lockPath);
       expect(fs.existsSync(lockPath)).toBe(true);
 
-      const newLockData = JSON.parse(fs.readFileSync(lockPath, 'utf-8'));
+      const newLockData = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
       expect(newLockData.pid).toBe(process.pid);
 
       releaseLock(lockPath);
@@ -237,7 +237,7 @@ describe('StateManager file-system persistence (save / load)', () => {
 
     const statePath = path.join(mockTmpDir, 'state.json');
     expect(fs.existsSync(statePath)).toBe(true);
-    const written = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    const written = JSON.parse(fs.readFileSync(statePath, 'utf8'));
     expect(written.config.githubUsername).toBe('alice');
   });
 
@@ -257,7 +257,7 @@ describe('StateManager file-system persistence (save / load)', () => {
     const after = new Date().toISOString();
 
     const statePath = path.join(mockTmpDir, 'state.json');
-    const written = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    const written = JSON.parse(fs.readFileSync(statePath, 'utf8'));
     expect(written.lastRunAt >= before).toBe(true);
     expect(written.lastRunAt <= after).toBe(true);
   });
@@ -397,7 +397,7 @@ describe('StateManager recovery from corrupt state files', () => {
     new StateManager(false);
 
     // state.json should now contain the restored backup data
-    const restoredOnDisk = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    const restoredOnDisk = JSON.parse(fs.readFileSync(statePath, 'utf8'));
     expect(restoredOnDisk.config.githubUsername).toBe('from-backup');
   });
 
@@ -566,7 +566,7 @@ describe('batch and auto-save', () => {
     sm.updateConfig({ githubUsername: 'alice' });
 
     // auto-save should have persisted the change
-    const written = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    const written = JSON.parse(fs.readFileSync(statePath, 'utf8'));
     expect(written.config.githubUsername).toBe('alice');
   });
 
@@ -583,7 +583,7 @@ describe('batch and auto-save', () => {
       // We test the final result after batch
     });
 
-    const written = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    const written = JSON.parse(fs.readFileSync(statePath, 'utf8'));
     expect(written.config.githubUsername).toBe('bob');
     expect(written.config.maxActivePRs).toBe(3);
     expect(written.config.languages).toEqual(['rust']);
@@ -606,7 +606,7 @@ describe('batch and auto-save', () => {
     // save() should be called exactly once (by the outermost batch)
     expect(saveSpy).toHaveBeenCalledTimes(1);
 
-    const written = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    const written = JSON.parse(fs.readFileSync(statePath, 'utf8'));
     expect(written.config.githubUsername).toBe('carol');
     expect(written.config.maxActivePRs).toBe(7);
     saveSpy.mockRestore();
@@ -764,7 +764,7 @@ describe('save resilience when backup operations fail', () => {
     expect(fs.existsSync(oldestBackup)).toBe(true);
     expect(fs.statSync(oldestBackup).isDirectory()).toBe(true);
 
-    const written = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    const written = JSON.parse(fs.readFileSync(statePath, 'utf8'));
     expect(written.version).toBe(4);
   });
 
@@ -781,7 +781,7 @@ describe('save resilience when backup operations fail', () => {
     expect(() => sm.save()).not.toThrow();
 
     fs.chmodSync(backupDir, 0o700);
-    const written = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    const written = JSON.parse(fs.readFileSync(statePath, 'utf8'));
     expect(written.version).toBe(4);
   });
 
@@ -797,7 +797,7 @@ describe('save resilience when backup operations fail', () => {
 
     sm.save();
 
-    const written = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    const written = JSON.parse(fs.readFileSync(statePath, 'utf8'));
     expect(written.config.githubUsername).toBe('updated-user');
   });
 });
@@ -858,7 +858,7 @@ describe('saveState optimistic compare-and-swap (#1030)', () => {
     expect(() => sm.save()).not.toThrow();
 
     const statePath = path.join(mockTmpDir, 'state.json');
-    const written = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    const written = JSON.parse(fs.readFileSync(statePath, 'utf8'));
     expect(written.config.githubUsername).toBe('bob');
   });
 
@@ -870,7 +870,7 @@ describe('saveState optimistic compare-and-swap (#1030)', () => {
 
     // Simulate another process writing the file.
     const statePath = path.join(mockTmpDir, 'state.json');
-    const raw = fs.readFileSync(statePath, 'utf-8');
+    const raw = fs.readFileSync(statePath, 'utf8');
     const otherProcState = JSON.parse(raw);
     otherProcState.config.githubUsername = 'bob-wrote-this-from-another-process';
     // Sleep briefly so the new mtime is meaningfully different from the
@@ -886,7 +886,7 @@ describe('saveState optimistic compare-and-swap (#1030)', () => {
     expect(() => sm.updateConfig({ githubUsername: 'alice-would-clobber-bob' })).toThrow(ConcurrencyError);
 
     // The on-disk file still has bob's write — alice did NOT clobber it.
-    const final = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    const final = JSON.parse(fs.readFileSync(statePath, 'utf8'));
     expect(final.config.githubUsername).toBe('bob-wrote-this-from-another-process');
   });
 
@@ -924,7 +924,7 @@ describe('saveState optimistic compare-and-swap (#1030)', () => {
 
     // External writer races in.
     const statePath = path.join(mockTmpDir, 'state.json');
-    const other = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    const other = JSON.parse(fs.readFileSync(statePath, 'utf8'));
     other.config.githubUsername = 'carol';
     await new Promise((resolve) => setTimeout(resolve, 50));
     fs.writeFileSync(statePath, JSON.stringify(other, null, 2), { mode: 0o600 });
@@ -946,7 +946,7 @@ describe('saveState optimistic compare-and-swap (#1030)', () => {
 
     // In-memory state now reflects the external write, NOT our stale mutation.
     expect(sm.getState().config.githubUsername).toBe('carol');
-    const onDisk = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    const onDisk = JSON.parse(fs.readFileSync(statePath, 'utf8'));
     expect(onDisk.config.githubUsername).toBe('carol');
   });
 });

--- a/packages/core/src/core/state-persistence.ts
+++ b/packages/core/src/core/state-persistence.ts
@@ -27,7 +27,7 @@ const LEGACY_BACKUP_DIR = path.join(process.cwd(), 'data', 'backups');
  */
 function isLockStale(lockPath: string): boolean {
   try {
-    const existing = JSON.parse(fs.readFileSync(lockPath, 'utf-8'));
+    const existing = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
     return Date.now() - existing.timestamp > LOCK_TIMEOUT_MS;
   } catch (err) {
     // Lock file is unreadable or contains invalid JSON — treat as stale
@@ -78,7 +78,7 @@ export function acquireLock(lockPath: string): void {
  */
 export function releaseLock(lockPath: string): void {
   try {
-    const data = JSON.parse(fs.readFileSync(lockPath, 'utf-8'));
+    const data = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
     if (data.pid === process.pid) {
       fs.unlinkSync(lockPath);
     }
@@ -308,7 +308,7 @@ function tryRestoreFromBackup(): AgentState | null {
   for (const backupFile of backupFiles) {
     const backupPath = path.join(backupDir, backupFile);
     try {
-      const data = fs.readFileSync(backupPath, 'utf-8');
+      const data = fs.readFileSync(backupPath, 'utf8');
       let raw: unknown = JSON.parse(data);
 
       // Chain migrations: v1 → v2 → v3
@@ -369,7 +369,7 @@ export function loadState(): { state: AgentState; mtimeMs: number } {
 
   try {
     if (fs.existsSync(statePath)) {
-      const data = fs.readFileSync(statePath, 'utf-8');
+      const data = fs.readFileSync(statePath, 'utf8');
       let raw: unknown = JSON.parse(data);
 
       // Chain migrations: v1 → v2 → v3 → v4

--- a/packages/core/src/core/state.ts
+++ b/packages/core/src/core/state.ts
@@ -1050,7 +1050,7 @@ export async function ensureGistPersistence(token: string | null): Promise<void>
 
   let persistence: string | undefined;
   try {
-    const raw = fs.readFileSync(getStatePath(), 'utf-8');
+    const raw = fs.readFileSync(getStatePath(), 'utf8');
     persistence = JSON.parse(raw)?.config?.persistence;
   } catch {
     // No state file or unreadable — stay in local mode

--- a/packages/core/src/core/utils.test.ts
+++ b/packages/core/src/core/utils.test.ts
@@ -321,7 +321,7 @@ describe('getGitHubToken', () => {
     const token = getGitHubToken();
     expect(token).toBe('ghp_faketoken');
     expect(mockedExecFileSync).toHaveBeenCalledWith('gh', ['auth', 'token'], {
-      encoding: 'utf-8',
+      encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 2000,
     });
@@ -413,7 +413,7 @@ describe('getGitHubTokenAsync', () => {
     expect(mockedExecFile).toHaveBeenCalledWith(
       'gh',
       ['auth', 'token'],
-      { encoding: 'utf-8', timeout: 2000 },
+      { encoding: 'utf8', timeout: 2000 },
       expect.any(Function),
     );
   });
@@ -539,7 +539,7 @@ describe('detectGitHubUsername', () => {
     expect(mockedExecFile).toHaveBeenCalledWith(
       'gh',
       ['api', 'user', '--jq', '.login'],
-      { encoding: 'utf-8', timeout: 5000 },
+      { encoding: 'utf8', timeout: 5000 },
       expect.any(Function),
     );
   });

--- a/packages/dashboard/index.html
+++ b/packages/dashboard/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="utf8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OSS Autopilot Dashboard</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/packages/mcp-server/src/auth.ts
+++ b/packages/mcp-server/src/auth.ts
@@ -36,7 +36,7 @@ export function resolveTokenPath(): string {
  */
 async function loadToken(tokenPath: string): Promise<string | null> {
   try {
-    const raw = await fs.readFile(tokenPath, 'utf-8');
+    const raw = await fs.readFile(tokenPath, 'utf8');
     const token = raw.trim();
     if (token.length === 0) return null;
     return token;
@@ -86,7 +86,7 @@ export async function ensureHttpToken(tokenPath: string = resolveTokenPath()): P
   // separately on the `loadToken` success branch above.
   const handle = await fs.open(tokenPath, 'w', TOKEN_FILE_MODE);
   try {
-    await handle.writeFile(token + '\n', 'utf-8');
+    await handle.writeFile(token + '\n', 'utf8');
     await handle.chmod(TOKEN_FILE_MODE);
   } finally {
     await handle.close();

--- a/packages/mcp-server/src/index.test.ts
+++ b/packages/mcp-server/src/index.test.ts
@@ -80,7 +80,7 @@ function spawnHttpServer(args: string[], env: Record<string, string> = {}): Prom
       const port = parseInt(match[1], 10);
       // Token file was written synchronously by ensureHttpToken before
       // httpServer.listen, so it must exist by the time the banner prints.
-      const token = fs.readFileSync(tokenPath, 'utf-8').trim();
+      const token = fs.readFileSync(tokenPath, 'utf8').trim();
       resolve({
         port,
         proc,

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -36,7 +36,7 @@ async function readVersion(): Promise<string> {
     const { fileURLToPath } = await import('node:url');
     const { dirname, resolve } = await import('node:path');
     const here = typeof __dirname === 'string' ? __dirname : dirname(fileURLToPath(import.meta.url));
-    const raw = readFileSync(resolve(here, '..', 'package.json'), 'utf-8');
+    const raw = readFileSync(resolve(here, '..', 'package.json'), 'utf8');
     return String(JSON.parse(raw).version ?? 'unknown');
   } catch {
     return 'unknown';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -17,7 +17,7 @@ const version: string = (() => {
     // In CJS bundle: __dirname is defined by esbuild
     // In ESM (dev via tsx): use import.meta.url
     const dir = typeof __dirname !== 'undefined' ? __dirname : dirname(fileURLToPath(import.meta.url));
-    const pkg = JSON.parse(readFileSync(join(dir, '..', 'package.json'), 'utf-8'));
+    const pkg = JSON.parse(readFileSync(join(dir, '..', 'package.json'), 'utf8'));
     return pkg.version;
   } catch (e) {
     console.error('[MCP] Failed to read package version:', e);


### PR DESCRIPTION
Applies `unicorn/text-encoding-identifier-case`. 40 files / 116 single-token replacements in `fs.readFileSync`, `fs.writeFileSync`, `Buffer.byteLength` encoding args. Both 'utf-8' and 'UTF-8' are equivalent to 'utf8' in Node — picking the canonical form removes 115 lint warnings.

Lint: 115 → 0. Tests: 2,725 passing.