### PR TITLE
chore: wrap switch case bodies in braces

### DIFF
--- a/packages/core/src/commands/config.ts
+++ b/packages/core/src/commands/config.ts
@@ -72,20 +72,23 @@ export async function runConfig(options: ConfigOptions): Promise<ConfigCommandOu
 
   // Handle specific config keys
   switch (options.key) {
-    case 'username':
+    case 'username': {
       stateManager.updateConfig({ githubUsername: validateGitHubUsername(value) });
       break;
-    case 'add-language':
+    }
+    case 'add-language': {
       if (!currentConfig.languages.includes(value)) {
         stateManager.updateConfig({ languages: [...currentConfig.languages, value] });
       }
       break;
-    case 'add-label':
+    }
+    case 'add-label': {
       if (!currentConfig.labels.includes(value)) {
         stateManager.updateConfig({ labels: [...currentConfig.labels, value] });
       }
       break;
-    case 'remove-label':
+    }
+    case 'remove-label': {
       if (!currentConfig.labels.includes(value)) {
         throw new Error(
           `Label "${value}" is not currently configured. Current labels: ${currentConfig.labels.join(', ')}`,
@@ -93,6 +96,7 @@ export async function runConfig(options: ConfigOptions): Promise<ConfigCommandOu
       }
       stateManager.updateConfig({ labels: currentConfig.labels.filter((l) => l !== value) });
       break;
+    }
     case 'add-scope': {
       const scope = validateScope(value);
       const currentScopes = currentConfig.scope ?? [];
@@ -145,9 +149,10 @@ export async function runConfig(options: ConfigOptions): Promise<ConfigCommandOu
       }
       break;
     }
-    case 'issueListPath':
+    case 'issueListPath': {
       stateManager.updateConfig({ issueListPath: value || undefined });
       break;
+    }
     case 'diffTool': {
       if (!(DIFF_TOOLS as readonly string[]).includes(value)) {
         throw new Error(`Invalid diffTool "${value}". Valid options: ${DIFF_TOOLS.join(', ')}`);
@@ -155,13 +160,15 @@ export async function runConfig(options: ConfigOptions): Promise<ConfigCommandOu
       stateManager.updateConfig({ diffTool: value as DiffTool });
       break;
     }
-    case 'diffToolCustomCommand':
+    case 'diffToolCustomCommand': {
       stateManager.updateConfig({
         diffToolCustomCommand: value || undefined,
       });
       break;
-    default:
+    }
+    default: {
       throw new ValidationError(formatUnknownKeyError(options.key, 'config'));
+    }
   }
 
   return { success: true, key: options.key, value };

--- a/packages/core/src/commands/daily-render.ts
+++ b/packages/core/src/commands/daily-render.ts
@@ -29,16 +29,21 @@ import type {
  */
 export function formatActionHint(hint: MaintainerActionHint): string {
   switch (hint) {
-    case 'demo_requested':
+    case 'demo_requested': {
       return 'demo/screenshot requested';
-    case 'tests_requested':
+    }
+    case 'tests_requested': {
       return 'tests requested';
-    case 'changes_requested':
+    }
+    case 'changes_requested': {
       return 'code changes requested';
-    case 'docs_requested':
+    }
+    case 'docs_requested': {
       return 'documentation requested';
-    case 'rebase_requested':
+    }
+    case 'rebase_requested': {
       return 'rebase requested';
+    }
   }
 }
 

--- a/packages/core/src/commands/setup.ts
+++ b/packages/core/src/commands/setup.ts
@@ -113,11 +113,12 @@ export async function runSetup(options: SetupOptions): Promise<SetupOutput> {
         const value = valueParts.join('=');
 
         switch (key) {
-          case 'username':
+          case 'username': {
             validateGitHubUsername(value);
             stateManager.updateConfig({ githubUsername: value });
             results[key] = value;
             break;
+          }
           case 'maxActivePRs': {
             const maxPRs = parsePositiveInt(value, 'maxActivePRs');
             stateManager.updateConfig({ maxActivePRs: maxPRs });
@@ -136,15 +137,17 @@ export async function runSetup(options: SetupOptions): Promise<SetupOutput> {
             results[key] = String(approaching);
             break;
           }
-          case 'languages':
+          case 'languages': {
             stateManager.updateConfig({ languages: value.split(',').map((l) => l.trim()) });
             results[key] = value;
             break;
-          case 'labels':
+          }
+          case 'labels': {
             stateManager.updateConfig({ labels: value.split(',').map((l) => l.trim()) });
             results[key] = value;
             break;
-          case 'squashByDefault':
+          }
+          case 'squashByDefault': {
             if (value === 'ask') {
               stateManager.updateConfig({ squashByDefault: 'ask' });
               results[key] = 'ask';
@@ -153,6 +156,7 @@ export async function runSetup(options: SetupOptions): Promise<SetupOutput> {
               results[key] = value !== 'false' ? 'true' : 'false';
             }
             break;
+          }
           case 'minStars': {
             const stars = Number(value);
             if (!Number.isInteger(stars) || stars < 0) {
@@ -179,10 +183,11 @@ export async function runSetup(options: SetupOptions): Promise<SetupOutput> {
             results[key] = String(threshold);
             break;
           }
-          case 'skippedIssuesPath':
+          case 'skippedIssuesPath': {
             stateManager.updateConfig({ skippedIssuesPath: value || undefined });
             results[key] = value || '(cleared)';
             break;
+          }
           case 'autoFormatBeforePush': {
             if (value !== 'true' && value !== 'false') {
               throw new ValidationError(
@@ -194,10 +199,11 @@ export async function runSetup(options: SetupOptions): Promise<SetupOutput> {
             results[key] = String(enabled);
             break;
           }
-          case 'includeDocIssues':
+          case 'includeDocIssues': {
             stateManager.updateConfig({ includeDocIssues: value === 'true' });
             results[key] = value === 'true' ? 'true' : 'false';
             break;
+          }
           case 'aiPolicyBlocklist': {
             const entries = value
               .split(',')
@@ -294,17 +300,19 @@ export async function runSetup(options: SetupOptions): Promise<SetupOutput> {
             results[key] = dedupedScopes.length > 0 ? dedupedScopes.join(', ') : '(empty — using labels only)';
             break;
           }
-          case 'persistence':
+          case 'persistence': {
             if (value !== 'local' && value !== 'gist') {
               throw new ValidationError(`Invalid value for persistence: "${value}". Must be "local" or "gist".`);
             }
             stateManager.updateConfig({ persistence: value as 'local' | 'gist' });
             results[key] = value;
             break;
-          case 'issueListPath':
+          }
+          case 'issueListPath': {
             stateManager.updateConfig({ issueListPath: value || undefined });
             results[key] = value || '(cleared)';
             break;
+          }
           case 'diffTool': {
             if (!(DIFF_TOOLS as readonly string[]).includes(value)) {
               warnings.push(`Invalid diffTool "${value}". Valid: ${DIFF_TOOLS.join(', ')}`);
@@ -314,18 +322,21 @@ export async function runSetup(options: SetupOptions): Promise<SetupOutput> {
             results[key] = value;
             break;
           }
-          case 'diffToolCustomCommand':
+          case 'diffToolCustomCommand': {
             stateManager.updateConfig({ diffToolCustomCommand: value || undefined });
             results[key] = value || '(cleared)';
             break;
-          case 'complete':
+          }
+          case 'complete': {
             if (value === 'true') {
               stateManager.markSetupComplete();
               results[key] = 'true';
             }
             break;
-          default:
+          }
+          default: {
             throw new ValidationError(formatUnknownKeyError(key, 'setup'));
+          }
         }
       }
     });

--- a/packages/core/src/commands/startup.ts
+++ b/packages/core/src/commands/startup.ts
@@ -141,18 +141,21 @@ export function openInBrowser(url: string): void {
   let openCmd: string;
   let args: string[];
   switch (process.platform) {
-    case 'darwin':
+    case 'darwin': {
       openCmd = 'open';
       args = [url];
       break;
-    case 'win32':
+    }
+    case 'win32': {
       openCmd = 'cmd';
       args = ['/c', 'start', '', url];
       break;
-    default:
+    }
+    default: {
       openCmd = 'xdg-open';
       args = [url];
       break;
+    }
   }
   execFile(openCmd, args, (error) => {
     if (error) {

--- a/packages/core/src/commands/vet-list.ts
+++ b/packages/core/src/commands/vet-list.ts
@@ -49,16 +49,20 @@ const KNOWN_SKIP_REASONS: ReadonlySet<ScoutSkipReason> = new Set([
 
 function mapSkipReasonToStatus(reason: ScoutSkipReason): VetListItemStatus | null {
   switch (reason) {
-    case 'issue_closed':
+    case 'issue_closed': {
       return 'closed';
-    case 'claimed':
+    }
+    case 'claimed': {
       return 'claimed';
-    case 'has_linked_pr':
+    }
+    case 'has_linked_pr': {
       return 'has_pr';
+    }
     case 'score_too_low':
     case 'anti_llm_policy':
-    case 'other':
-      return null; // fall through to recommendation / default
+    case 'other': {
+      return null;
+    } // fall through to recommendation / default
   }
 }
 

--- a/packages/core/src/core/daily-logic.ts
+++ b/packages/core/src/core/daily-logic.ts
@@ -276,37 +276,41 @@ export function collectActionableIssues(prs: FetchedPR[], lastDigestAt?: string)
       let label: string;
       let type: ActionableIssueType;
       switch (reason) {
-        case 'needs_response':
+        case 'needs_response': {
           label = '[Needs Response]';
           type = 'needs_response';
           break;
-        case 'needs_changes':
+        }
+        case 'needs_changes': {
           label = '[Needs Changes]';
           type = 'needs_changes';
           break;
+        }
         case 'failing_ci': {
           const checkInfo = pr.failingCheckNames.length > 0 ? ` (${pr.failingCheckNames.join(', ')})` : '';
           label = `[CI Failing${checkInfo}]`;
           type = 'ci_failing';
           break;
         }
-        case 'merge_conflict':
+        case 'merge_conflict': {
           label = '[Merge Conflict]';
           type = 'merge_conflict';
           break;
+        }
         case 'incomplete_checklist': {
           const stats = pr.checklistStats ? ` (${pr.checklistStats.checked}/${pr.checklistStats.total})` : '';
           label = `[Incomplete Checklist${stats}]`;
           type = 'incomplete_checklist';
           break;
         }
-        default:
+        default: {
           // Defensive fallback for ActionReason values not explicitly handled
           // above (e.g. ci_not_running, needs_rebase, missing_required_files).
           // These aren't in reasonOrder today but this guards future additions.
           warn('daily-logic', `Unhandled ActionReason "${reason}" for PR ${pr.url} — falling back to needs_response`);
           label = `[${reason}]`;
           type = 'needs_response';
+        }
       }
 
       // A PR is "new" if it was created after the last daily digest (first time seen).

--- a/packages/dashboard/src/components/merged-pr-list.tsx
+++ b/packages/dashboard/src/components/merged-pr-list.tsx
@@ -28,9 +28,10 @@ export function MergedPRList({ mergedPRs, repoMetadata, onBack }: MergedPRListPr
     return [...mergedPRs].sort((a, b) => {
       let cmp = 0;
       switch (sortKey) {
-        case 'repo':
+        case 'repo': {
           cmp = a.repo.localeCompare(b.repo);
           break;
+        }
         case 'stars': {
           const sa = repoMetadata?.[a.repo]?.stars ?? 0;
           const sb = repoMetadata?.[b.repo]?.stars ?? 0;
@@ -43,9 +44,10 @@ export function MergedPRList({ mergedPRs, repoMetadata, onBack }: MergedPRListPr
           cmp = la.localeCompare(lb);
           break;
         }
-        case 'date':
+        case 'date': {
           cmp = a.mergedAt.localeCompare(b.mergedAt);
           break;
+        }
       }
       return sortDir === 'asc' ? cmp : -cmp;
     });

--- a/packages/dashboard/src/components/pr-detail.tsx
+++ b/packages/dashboard/src/components/pr-detail.tsx
@@ -11,53 +11,69 @@ interface PRDetailProps {
 
 function reviewLabel(decision: string): string {
   switch (decision) {
-    case 'approved':
+    case 'approved': {
       return 'Approved';
-    case 'changes_requested':
+    }
+    case 'changes_requested': {
       return 'Changes Requested';
-    case 'review_required':
+    }
+    case 'review_required': {
       return 'Review Required';
-    default:
+    }
+    default: {
       return 'Unknown';
+    }
   }
 }
 
 function reviewColor(decision: string): string {
   switch (decision) {
-    case 'approved':
+    case 'approved': {
       return 'var(--green)';
-    case 'changes_requested':
+    }
+    case 'changes_requested': {
       return 'var(--red)';
-    case 'review_required':
+    }
+    case 'review_required': {
       return 'var(--amber)';
-    default:
+    }
+    default: {
       return 'var(--text-muted)';
+    }
   }
 }
 
 function ciDotClass(status: string): string {
   switch (status) {
-    case 'passing':
+    case 'passing': {
       return 'green';
-    case 'failing':
+    }
+    case 'failing': {
       return 'red';
-    case 'pending':
+    }
+    case 'pending': {
       return 'amber';
-    default:
+    }
+    default: {
       return '';
+    }
   }
 }
 
 function reviewDotClass(decision: string): string {
   switch (decision) {
-    case 'approved':
+    case 'approved': {
       return 'green';
-    case 'changes_requested':
+    }
+    case 'changes_requested': {
       return 'red';
-    case 'review_required':
+    }
+    case 'review_required': {
       return 'amber';
-    default:
+    }
+    default: {
       return '';
+    }
   }
 }
 
@@ -69,16 +85,21 @@ function activityDotClass(days: number): string {
 
 function categoryBadge(category: string): string {
   switch (category) {
-    case 'actionable':
+    case 'actionable': {
       return 'Actionable';
-    case 'fork_limitation':
+    }
+    case 'fork_limitation': {
       return 'Fork Limitation';
-    case 'auth_gate':
+    }
+    case 'auth_gate': {
       return 'Auth Gate';
-    case 'infrastructure':
+    }
+    case 'infrastructure': {
       return 'Infrastructure';
-    default:
+    }
+    default: {
       return category;
+    }
   }
 }
 

--- a/packages/dashboard/src/components/pr-list.tsx
+++ b/packages/dashboard/src/components/pr-list.tsx
@@ -26,10 +26,12 @@ interface SectionDef {
 /** Maps PR status to a CSS class for status-aware hover borders. */
 export function statusClass(status: FetchedPRStatus): string {
   switch (status) {
-    case 'needs_addressing':
+    case 'needs_addressing': {
       return 'pr-row--need-attention';
-    case 'waiting_on_maintainer':
+    }
+    case 'waiting_on_maintainer': {
       return 'pr-row--waiting';
+    }
     default: {
       const _exhaustive: never = status;
       void _exhaustive;

--- a/packages/dashboard/src/utils.ts
+++ b/packages/dashboard/src/utils.ts
@@ -14,18 +14,22 @@ export function pillColorClass(label: string): string {
     case 'ci failing':
     case 'merge conflict':
     case 'missing files':
-    case 'needs addressing':
+    case 'needs addressing': {
       return 'pill--red';
+    }
     case 'incomplete checklist':
     case 'ci not running':
     case 'needs rebase':
     case 'ci blocked':
-    case 'stale ci failure':
+    case 'stale ci failure': {
       return 'pill--amber';
-    case 'waiting on maintainer':
+    }
+    case 'waiting on maintainer': {
       return 'pill--blue';
-    default:
+    }
+    default: {
       return 'pill--muted';
+    }
   }
 }
 
@@ -49,25 +53,32 @@ export function formatDate(iso: string): string {
 
 export function statusColor(status: FetchedPRStatus | string): string {
   switch (status) {
-    case 'needs_addressing':
+    case 'needs_addressing': {
       return 'var(--red)';
-    case 'waiting_on_maintainer':
+    }
+    case 'waiting_on_maintainer': {
       return 'var(--blue)';
-    default:
+    }
+    default: {
       return 'var(--text-muted)';
+    }
   }
 }
 
 export function ciStatusColor(status: string): string {
   switch (status) {
-    case 'passing':
+    case 'passing': {
       return 'var(--green)';
-    case 'failing':
+    }
+    case 'failing': {
       return 'var(--red)';
-    case 'pending':
+    }
+    case 'pending': {
       return 'var(--amber)';
-    default:
+    }
+    default: {
       return 'var(--text-muted)';
+    }
   }
 }
 


### PR DESCRIPTION
Applies `unicorn/switch-case-braces` — wraps every `case` body in `{ ... }` for explicit lexical scoping.

10 files / +141/-71 lines. Prevents the surprising-fallthrough class of bugs where a `case` declares a `const` visible to subsequent cases.

Lint: 70 → 0 unicorn/switch-case-braces. Tests: 2,725 passing.