### PR TITLE
chore: simplify regex literals via unicorn/better-regex

### DIFF
--- a/packages/core/src/cli-registry.docs.test.ts
+++ b/packages/core/src/cli-registry.docs.test.ts
@@ -27,7 +27,7 @@ describe('cli-registry ↔ workflows/reference.md parity (#1048)', () => {
       // and `setup` does not match `setupComplete`. Hyphens break \b, so build a
       // pattern that tolerates both hyphen and non-hyphen boundaries.
       const pattern = new RegExp(
-        `(^|[^A-Za-z0-9-])${cmd.name.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')}([^A-Za-z0-9-]|$)`,
+        `(^|[^A-Za-z0-9-])${cmd.name.replace(/[$()*+./?[\\\]^{|}-]/g, '\\$&')}([^A-Za-z0-9-]|$)`,
       );
       if (!pattern.test(doc)) {
         missing.push(cmd.name);

--- a/packages/core/src/commands/auth-envelope.e2e.test.ts
+++ b/packages/core/src/commands/auth-envelope.e2e.test.ts
@@ -81,7 +81,7 @@ describe.skipIf(!BUNDLE_EXISTS)('CLI auth-failure envelope (--json)', () => {
     expect(exitCode).not.toBe(0);
     // The interactive path retains the multi-line guidance so `oss-autopilot daily`
     // still tells humans what to do.
-    expect(stderr).toMatch(/GitHub authentication required/i);
+    expect(stderr).toMatch(/github authentication required/i);
     expect(stderr).toMatch(/gh auth login/);
   });
 });

--- a/packages/core/src/commands/list-move-tier.ts
+++ b/packages/core/src/commands/list-move-tier.ts
@@ -83,7 +83,7 @@ function findIssueBlocks(lines: string[], issueUrl: string): IssueBlock[] {
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     // Top-level list item — `- `, `* `, `+ `, or `1.` at the start (with no leading whitespace).
-    const isTopLevelListItem = /^[-*+]\s|^\d+\.\s/.test(line);
+    const isTopLevelListItem = /^[*+-]\s|^\d+\.\s/.test(line);
     if (!isTopLevelListItem || !line.includes(issueUrl)) continue;
 
     // Capture indented sub-bullets that follow this line.

--- a/packages/core/src/commands/local-repos.ts
+++ b/packages/core/src/commands/local-repos.ts
@@ -42,7 +42,7 @@ function getGitHubRemote(repoPath: string): string | null {
     if (httpsMatch) return httpsMatch[1];
 
     // Match SSH: git@github.com:owner/repo.git
-    const sshMatch = remoteUrl.match(/github\.com[:/]([^/]+\/[^/]+?)(?:\.git)?$/);
+    const sshMatch = remoteUrl.match(/github\.com[/:]([^/]+\/[^/]+?)(?:\.git)?$/);
     if (sshMatch) return sshMatch[1];
 
     return null;

--- a/packages/core/src/commands/search.contract.test.ts
+++ b/packages/core/src/commands/search.contract.test.ts
@@ -116,7 +116,7 @@ describe('search --json contract', () => {
       expect(candidate.viabilityScore).toBeGreaterThanOrEqual(0);
       expect(candidate.viabilityScore).toBeLessThanOrEqual(100);
       expect(candidate.issue.url).toMatch(/^https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/\d+$/);
-      expect(candidate.grade.letter).toMatch(/^[ABCF]$/);
+      expect(candidate.grade.letter).toMatch(/^[A-CF]$/);
     }
 
     await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/search.json');

--- a/packages/core/src/commands/setup.ts
+++ b/packages/core/src/commands/setup.ts
@@ -267,7 +267,7 @@ export async function runSetup(options: SetupOptions): Promise<SetupOutput> {
                 warnings.push(
                   `"${org}" looks like a repo path. Use org name only (e.g., "vercel" not "vercel/next.js").`,
                 );
-              } else if (!/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i.test(org)) {
+              } else if (!/^[\da-z](?:[\da-z-]*[\da-z])?$/i.test(org)) {
                 warnings.push(`"${org}" is not a valid GitHub organization name. Skipping.`);
               } else {
                 validOrgs.push(org.toLowerCase());

--- a/packages/core/src/commands/skip-add.ts
+++ b/packages/core/src/commands/skip-add.ts
@@ -6,7 +6,7 @@ import { getStateManager } from '../core/index.js';
 // (despite being unused here) so the regex stays byte-identical to the parser
 // version where the captures are needed.
 // eslint-disable-next-line regexp/no-unused-capturing-group
-const GITHUB_URL_RE = /^https:\/\/github\.com\/([^/]+\/[^/]+)\/(?:issues|pull)\/(\d+)(?:[/?#].*)?$/;
+const GITHUB_URL_RE = /^https:\/\/github\.com\/([^/]+\/[^/]+)\/(?:issues|pull)\/(\d+)(?:[#/?].*)?$/;
 
 const FILE_HEADER = '# Skipped Issues — auto-culled after 90 days\n# Format: YYYY-MM-DD URL\n\n';
 

--- a/packages/core/src/commands/skip-file-parser.ts
+++ b/packages/core/src/commands/skip-file-parser.ts
@@ -15,7 +15,7 @@ import { warn } from '../core/logger.js';
 import { errorMessage } from '../core/errors.js';
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
-const GITHUB_URL_RE = /^https:\/\/github\.com\/([^/]+\/[^/]+)\/(?:issues|pull)\/(\d+)(?:[/?#].*)?$/;
+const GITHUB_URL_RE = /^https:\/\/github\.com\/([^/]+\/[^/]+)\/(?:issues|pull)\/(\d+)(?:[#/?].*)?$/;
 
 /**
  * Parse the raw text of a skipped-issues file into SkippedIssue entries.

--- a/packages/core/src/commands/validation.ts
+++ b/packages/core/src/commands/validation.ts
@@ -83,7 +83,7 @@ export function validateRepoIdentifier(repo: string): string {
 /** Maximum allowed GitHub username length */
 const MAX_USERNAME_LENGTH = 39;
 /** Pattern for valid GitHub username characters (alphanumeric and hyphens) */
-const USERNAME_CHARS_PATTERN = /^[a-z0-9-]+$/i;
+const USERNAME_CHARS_PATTERN = /^[\da-z-]+$/i;
 /** Pattern for consecutive hyphens */
 const CONSECUTIVE_HYPHENS_PATTERN = /--/;
 

--- a/packages/core/src/core/anti-llm-policy.ts
+++ b/packages/core/src/core/anti-llm-policy.ts
@@ -45,7 +45,7 @@ interface Pattern {
 
 const PATTERNS: Pattern[] = [
   // Explicit "no X" bans against AI/LLM nouns.
-  { category: 'explicit_ban', regex: /\bno\s+(ai|llm)[-\s](generated|authored|written|assisted|contributions?)/i },
+  { category: 'explicit_ban', regex: /\bno\s+(ai|llm)[\s-](generated|authored|written|assisted|contributions?)/i },
   { category: 'explicit_ban', regex: /\b(ban|banned|banning)\s+(ai|llm)\b/i },
 
   // Named-tool bans. Optionally match a "-generated/-authored/-…"
@@ -67,7 +67,7 @@ const PATTERNS: Pattern[] = [
   {
     category: 'reject_framing',
     regex:
-      /\b(ai|llm)[-\s](generated|assisted|authored|written)\s+(code|prs?|contributions?)\s+(will\s+be\s+(closed|rejected)|are\s+rejected)/i,
+      /\b(ai|llm)[\s-](generated|assisted|authored|written)\s+(code|prs?|contributions?)\s+(will\s+be\s+(closed|rejected)|are\s+rejected)/i,
   },
   {
     category: 'reject_framing',
@@ -79,7 +79,7 @@ const PATTERNS: Pattern[] = [
   {
     category: 'reject_framing',
     regex:
-      /\b(do|does)(\s+not|n't)\s+accept\s+(ai|llm)[-\s](generated|assisted|authored|written|contributions?|code|prs?)\b/i,
+      /\b(do|does)(\s+not|n't)\s+accept\s+(ai|llm)[\s-](generated|assisted|authored|written|contributions?|code|prs?)\b/i,
   },
   { category: 'reject_framing', regex: /\breject\s+(ai|llm)\s+contributions?\b/i },
 ];
@@ -104,7 +104,7 @@ function normalizeText(text: string): string {
   return text
     .normalize('NFKC')
     .replace(/\u00A0/g, ' ')
-    .replace(/[\u2010\u2011\u2012\u2013\u2014\u2015]/g, '-');
+    .replace(/[\u2010-\u2015]/g, '-');
 }
 
 export function scanForAntiLLMPolicy(text: string): AntiLLMScanResult {

--- a/packages/core/src/core/auth.ts
+++ b/packages/core/src/core/auth.ts
@@ -147,7 +147,7 @@ export async function getGitHubTokenAsync(): Promise<string | null> {
  * Usernames must start with an alphanumeric character, can contain hyphens
  * (but not consecutive ones and not at the end), and be 1-39 characters.
  */
-const GITHUB_USERNAME_RE = /^[a-z0-9](?:[a-z0-9]|-(?=[a-z0-9])){0,38}$/i;
+const GITHUB_USERNAME_RE = /^[\da-z](?:[\da-z]|-(?=[\da-z])){0,38}$/i;
 
 /**
  * Detect the authenticated GitHub username via the `gh` CLI.

--- a/packages/core/src/core/formatter-detection.ts
+++ b/packages/core/src/core/formatter-detection.ts
@@ -88,7 +88,7 @@ const FORMAT_SCRIPT_NAMES = ['lint:fix', 'format', 'fmt', 'lint', 'format:check'
 const CI_PATTERNS: { formatter: FormatterName; patterns: RegExp[] }[] = [
   {
     formatter: 'prettier',
-    patterns: [/Code style issues found/i, /Forgot to run Prettier/i, /prettier --check/i],
+    patterns: [/code style issues found/i, /forgot to run prettier/i, /prettier --check/i],
   },
   {
     formatter: 'ruff',
@@ -96,15 +96,15 @@ const CI_PATTERNS: { formatter: FormatterName; patterns: RegExp[] }[] = [
   },
   {
     formatter: 'black',
-    patterns: [/Oh no! .* files? would be reformatted/i, /black --check/i],
+    patterns: [/oh no! .* files? would be reformatted/i, /black --check/i],
   },
   {
     formatter: 'rustfmt',
-    patterns: [/Diff in .*\.rs/i, /rustfmt --check/i, /cargo fmt.*--check/i],
+    patterns: [/diff in .*\.rs/i, /rustfmt --check/i, /cargo fmt.*--check/i],
   },
   {
     formatter: 'biome',
-    patterns: [/biome check/i, /biome ci/i, /Found \d+ fixable diagnostics?/i],
+    patterns: [/biome check/i, /biome ci/i, /found \d+ fixable diagnostics?/i],
   },
   {
     formatter: 'eslint',

--- a/packages/core/src/core/pr-monitor.test.ts
+++ b/packages/core/src/core/pr-monitor.test.ts
@@ -1972,7 +1972,7 @@ describe('fetchUserOpenPRs auto-repairs known placeholder usernames', () => {
     // breadcrumb to follow.
     expect(result.prs).toEqual([]);
     expect(result.warnings).toBeDefined();
-    expect(result.warnings!.some((w) => /Could not auto-repair/i.test(w))).toBe(true);
+    expect(result.warnings!.some((w) => /could not auto-repair/i.test(w))).toBe(true);
   });
 
   it('rethrows rate-limit / auth errors from viewer lookup', async () => {

--- a/packages/core/src/core/state-persistence.ts
+++ b/packages/core/src/core/state-persistence.ts
@@ -546,7 +546,7 @@ export function saveState(state: Readonly<AgentState>, expectedMtimeMs: number |
     // Create backup of existing state (best-effort, non-fatal)
     try {
       if (fs.existsSync(statePath)) {
-        const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+        const timestamp = new Date().toISOString().replace(/[.:]/g, '-');
         const randomSuffix = Math.random().toString(36).slice(2, 8).padEnd(6, '0');
         const backupFile = path.join(backupDir, `state-${timestamp}-${randomSuffix}.json`);
         fs.copyFileSync(statePath, backupFile);

--- a/packages/core/src/formatters/json.test.ts
+++ b/packages/core/src/formatters/json.test.ts
@@ -392,7 +392,7 @@ describe('formatJson (#1105)', () => {
       },
       lastRunAt: '2026-04-25T00:00:00.000Z',
     };
-    expect(() => formatJson(StatusOutputSchema, data)).toThrow(/contract drift.*stats\.mergeRate/i);
+    expect(() => formatJson(StatusOutputSchema, data)).toThrow(/contract drift.*stats\.mergerate/i);
   });
 });
 
@@ -442,7 +442,7 @@ describe('DailyOutputSchema (#1146)', () => {
       ...fixture,
       digest: { ...fixture.digest, needsAddressingPRs: [{ url: 'x' }] },
     };
-    expect(() => formatJson(DailyOutputSchema, broken)).toThrow(/contract drift.*needsAddressingPRs/i);
+    expect(() => formatJson(DailyOutputSchema, broken)).toThrow(/contract drift.*needsaddressingprs/i);
   });
 
   it('rejects drift: actionMenu missing context flag', () => {
@@ -460,7 +460,7 @@ describe('DailyOutputSchema (#1146)', () => {
         },
       },
     } as unknown;
-    expect(() => formatJson(DailyOutputSchema, broken)).toThrow(/contract drift.*hasIssueResponses/i);
+    expect(() => formatJson(DailyOutputSchema, broken)).toThrow(/contract drift.*hasissueresponses/i);
   });
 });
 
@@ -474,7 +474,7 @@ describe('CompactDailyOutputSchema (#1146)', () => {
   it('rejects drift: failureCount as a string', () => {
     const compact = toCompactDailyOutput(makeMockDailyOutput());
     const broken = { ...compact, failureCount: '0' } as unknown;
-    expect(() => formatJson(CompactDailyOutputSchema, broken)).toThrow(/contract drift.*failureCount/i);
+    expect(() => formatJson(CompactDailyOutputSchema, broken)).toThrow(/contract drift.*failurecount/i);
   });
 });
 
@@ -530,7 +530,7 @@ describe('SearchOutputSchema (#1147)', () => {
     const candidate = makeSearchCandidate() as unknown as Record<string, unknown>;
     delete candidate.reasonsToApprove;
     const data = { candidates: [candidate], excludedRepos: [], aiPolicyBlocklist: [] };
-    expect(() => formatJson(SearchOutputSchema, data)).toThrow(/contract drift.*reasonsToApprove/i);
+    expect(() => formatJson(SearchOutputSchema, data)).toThrow(/contract drift.*reasonstoapprove/i);
   });
 
   it('accepts a candidate without optional repoScore', () => {
@@ -636,7 +636,7 @@ describe('ListMoveTierOutputSchema (#1148)', () => {
       toTier: 'archive',
       count: 1,
     } as unknown;
-    expect(() => formatJson(ListMoveTierOutputSchema, data)).toThrow(/contract drift.*toTier/i);
+    expect(() => formatJson(ListMoveTierOutputSchema, data)).toThrow(/contract drift.*totier/i);
   });
 });
 
@@ -648,7 +648,7 @@ describe('Misc command schemas (#1155)', () => {
 
   it('ClaimOutputSchema round-trip + drift', () => {
     expect(formatJson(ClaimOutputSchema, { commentUrl: 'a', issueUrl: 'b' }).success).toBe(true);
-    expect(() => formatJson(ClaimOutputSchema, { commentUrl: 'a' })).toThrow(/contract drift.*issueUrl/i);
+    expect(() => formatJson(ClaimOutputSchema, { commentUrl: 'a' })).toThrow(/contract drift.*issueurl/i);
   });
 
   it('InitOutputSchema round-trip + drift', () => {

--- a/packages/dashboard/src/app.test.tsx
+++ b/packages/dashboard/src/app.test.tsx
@@ -530,7 +530,7 @@ describe('App', () => {
       window.dispatchEvent(new KeyboardEvent('keydown', { key: 'C', shiftKey: true }));
 
       await waitFor(() => expect(container.querySelector('.celebration-toast')).toBeTruthy());
-      expect(container.querySelector('.celebration-toast')?.textContent).toMatch(/new PRs? merged/i);
+      expect(container.querySelector('.celebration-toast')?.textContent).toMatch(/new prs? merged/i);
     });
 
     it('does NOT fire Shift+C while the user is typing in an input', async () => {

--- a/packages/dashboard/src/components/vetted-issue-list.tsx
+++ b/packages/dashboard/src/components/vetted-issue-list.tsx
@@ -25,7 +25,7 @@ function parseTierMeta(tier: string): { stars?: number; language?: string } {
     stars = starsMatch[2] ? Math.round(num * 1000) : num;
   }
   // Language: last parenthesized text in the heading, e.g., (TypeScript), (Rust), (JS)
-  const langMatches = [...tier.matchAll(/\(([^)★\d][^)]*)\)/g)];
+  const langMatches = [...tier.matchAll(/\(([^\d)★][^)]*)\)/g)];
   const lastMatch = langMatches[langMatches.length - 1];
   const language = lastMatch?.[1]?.trim();
   return { stars, language };

--- a/packages/dashboard/src/error-boundary.test.tsx
+++ b/packages/dashboard/src/error-boundary.test.tsx
@@ -52,10 +52,10 @@ describe('ErrorBoundary', () => {
         <Thrower shouldThrow={() => true} message="boom: someField is undefined" />
       </ErrorBoundary>,
     );
-    expect(screen.getByText(/Dashboard crashed/i)).toBeTruthy();
+    expect(screen.getByText(/dashboard crashed/i)).toBeTruthy();
     // Error details are in a <details> so expand / search the full text for
     // the embedded message.
-    expect(screen.getByText(/boom: someField is undefined/i)).toBeTruthy();
+    expect(screen.getByText(/boom: somefield is undefined/i)).toBeTruthy();
     // Reload / Retry buttons present.
     expect(screen.getByRole('button', { name: /retry/i })).toBeTruthy();
     expect(screen.getByRole('button', { name: /reload/i })).toBeTruthy();
@@ -70,7 +70,7 @@ describe('ErrorBoundary', () => {
         <Thrower shouldThrow={check} message="first render crashed" />
       </ErrorBoundary>,
     );
-    expect(screen.getByText(/Dashboard crashed/i)).toBeTruthy();
+    expect(screen.getByText(/dashboard crashed/i)).toBeTruthy();
 
     shouldThrow = false;
     fireEvent.click(screen.getByRole('button', { name: /retry/i }));
@@ -95,6 +95,6 @@ describe('ErrorBoundary', () => {
     );
 
     expect(screen.getByTestId('custom-msg').textContent).toContain('custom-path');
-    expect(screen.queryByText(/Dashboard crashed/i)).toBeNull();
+    expect(screen.queryByText(/dashboard crashed/i)).toBeNull();
   });
 });

--- a/packages/dashboard/src/hooks/use-dashboard.test.ts
+++ b/packages/dashboard/src/hooks/use-dashboard.test.ts
@@ -406,7 +406,7 @@ describe('useDashboard', () => {
       });
 
       expect(result.current.data).toBe(null);
-      expect(result.current.error).toMatch(/Server response did not match expected shape/i);
+      expect(result.current.error).toMatch(/server response did not match expected shape/i);
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining('schema validation failed'),
         expect.any(String),
@@ -431,7 +431,7 @@ describe('useDashboard', () => {
         await Promise.resolve();
       });
 
-      expect(result.current.error).toMatch(/Server response did not match expected shape/i);
+      expect(result.current.error).toMatch(/server response did not match expected shape/i);
       consoleSpy.mockRestore();
     });
   });

--- a/packages/mcp-server/src/auth.test.ts
+++ b/packages/mcp-server/src/auth.test.ts
@@ -54,7 +54,7 @@ describe('auth.ensureHttpToken', () => {
     const { token, path: p, freshlyGenerated } = await ensureHttpToken(tokenPath);
     expect(p).toBe(tokenPath);
     expect(freshlyGenerated).toBe(true);
-    expect(token).toMatch(/^[0-9a-f]{64}$/);
+    expect(token).toMatch(/^[\da-f]{64}$/);
   });
 
   it('persists the token between calls', async () => {

--- a/packages/mcp-server/src/tools-execution.test.ts
+++ b/packages/mcp-server/src/tools-execution.test.ts
@@ -110,7 +110,7 @@ describe('tool execution', () => {
 
       expect(result.isError).toBe(true);
       const content = result.content[0] as { type: string; text: string };
-      expect(content.text).toMatch(/maxResults/i);
+      expect(content.text).toMatch(/maxresults/i);
     });
 
     it('rejects invalid maxResults (-1) at the schema layer', async () => {
@@ -122,7 +122,7 @@ describe('tool execution', () => {
       expect(result.isError).toBe(true);
       const content = result.content[0] as { type: string; text: string };
       // Zod's structured error payload surfaces the field name.
-      expect(content.text).toMatch(/maxResults/i);
+      expect(content.text).toMatch(/maxresults/i);
     });
 
     it('rejects non-integer maxResults (1.5) at the schema layer', async () => {
@@ -133,7 +133,7 @@ describe('tool execution', () => {
 
       expect(result.isError).toBe(true);
       const content = result.content[0] as { type: string; text: string };
-      expect(content.text).toMatch(/maxResults/i);
+      expect(content.text).toMatch(/maxresults/i);
     });
   });
 


### PR DESCRIPTION
Mechanical regex simplifications across 21 files (39 single-token changes).

Examples:
- `[0-9]` → `\d` (digit shorthand)
- `[a-zA-Z0-9]` → `[\dA-Za-z]` (canonical char-class ordering)

Skipped 3 files (parse-list.ts, checklist-analysis.ts, startup.ts) where unicorn/better-regex's auto-fixes conflicted with the project's stricter `regexp/strict` rule (e.g. unescaping `\]` outside char classes). Those will need manual triage in a follow-up.

Lint: 64 → 21 unicorn/better-regex warnings. Tests: 2,725 passing.