### PR TITLE
chore: medium audit cleanups (M6 + M9 from #1208)

### DIFF
--- a/packages/core/src/core/state-persistence.ts
+++ b/packages/core/src/core/state-persistence.ts
@@ -1,6 +1,6 @@
 /**
  * State persistence layer for the OSS Contribution Agent.
- * Handles file I/O, locking, backup/restore, and schema migration (v1→v2→v3).
+ * Handles file I/O, locking, backup/restore, and schema migration (v1→v2→v3→v4).
  * No module-level mutable state — functions accept/return AgentState objects.
  */
 
@@ -188,7 +188,7 @@ export function migrateV3ToV4(rawState: Record<string, unknown>): Record<string,
 }
 
 /**
- * Create a fresh state (v3).
+ * Create a fresh state (v4).
  * Leverages Zod schema defaults to produce a complete state.
  */
 export function createFreshState(): AgentState {
@@ -311,7 +311,7 @@ function tryRestoreFromBackup(): AgentState | null {
       const data = fs.readFileSync(backupPath, 'utf8');
       let raw: unknown = JSON.parse(data);
 
-      // Chain migrations: v1 → v2 → v3
+      // Chain migrations: v1 → v2 → v3 → v4
       if (typeof raw === 'object' && raw !== null) {
         const rawObj = raw as Record<string, unknown>;
         if (rawObj.version === 1) {

--- a/packages/dashboard/src/test-helpers.ts
+++ b/packages/dashboard/src/test-helpers.ts
@@ -96,6 +96,7 @@ export function makeDashboardData(overrides: Partial<DashboardData> = {}): Dashb
     issueResponses: [],
     allMergedPRs: [],
     allClosedPRs: [],
+    repoMetadata: {},
     ...overrides,
   };
 }

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -58,7 +58,9 @@ export interface DashboardData {
   issueResponses: CommentedIssueWithResponse[];
   allMergedPRs: MergedPR[];
   allClosedPRs: ClosedPR[];
-  repoMetadata?: Record<string, RepoMetadataEntry>;
+  // Required (server always populates, even if empty `{}`); aligns with
+  // DashboardJsonData in @oss-autopilot/core/commands. Closes #1208 M6.
+  repoMetadata: Record<string, RepoMetadataEntry>;
   vettedIssues?: ParseIssueListOutput | null;
   /**
    * Labels of non-critical sub-fetches that degraded to empty fallbacks


### PR DESCRIPTION
Two small cleanups from the audit umbrella #1208:

**M6**: `DashboardData` (SPA) declared `repoMetadata?` as optional while `DashboardJsonData` (core) declared it as required. Server always populates it (even as empty `{}`), so the SPA optional was the drift. Aligned SPA to required; updated test-helpers builder.

**M9**: 3 stale v3 doc-comment references in `state-persistence.ts` (file header, `createFreshState` JSDoc, backup-restore chain comment) updated to v4 (post-#1171 migration).

Lint, typecheck, 2,725 tests pass.