### PR TITLE
chore(mcp): re-export PRCommentBundle from core (#1208 M5)

### DIFF
--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -119,4 +119,15 @@ export {
   validateDashboardData,
   type DashboardDataParsed,
 } from './dashboard-data-schema.js';
+// PR comment bundle types — wire shape consumed by the MCP extract-learnings
+// prompt. Re-exported so MCP doesn't have to redeclare the interface and
+// silently drift (#1208 M5).
+export {
+  fetchPRCommentBundle,
+  fetchPRCommentBundlesBatch,
+  type PRCommentBundle,
+  type PRReviewEntry,
+  type PRReviewCommentEntry,
+  type PRIssueCommentEntry,
+} from './pr-comments-fetcher.js';
 export * from './types.js';

--- a/packages/mcp-server/src/prompts.ts
+++ b/packages/mcp-server/src/prompts.ts
@@ -11,22 +11,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { runDaily, runComments, runSearch, MAX_SEARCH_RESULTS } from '@oss-autopilot/core/commands';
-import { errorMessage } from '@oss-autopilot/core';
-
-/**
- * Subset of `PRCommentBundle` from `@oss-autopilot/core` that we render in the
- * extract-learnings prompt. Inlined as a structural type to avoid pulling in
- * the full implementation module just for a JSON shape.
- */
-interface PRCommentBundleShape {
-  prUrl: string;
-  prTitle: string;
-  repo: string;
-  mergedAt: string;
-  reviews: { author: string; authorAssociation: string; body: string }[];
-  reviewComments: { author: string; authorAssociation: string; body: string; path: string }[];
-  issueComments: { author: string; authorAssociation: string; body: string }[];
-}
+import { errorMessage, type PRCommentBundle } from '@oss-autopilot/core';
 
 /** Build a single-message prompt result with a user text message. */
 function userMessage(text: string) {
@@ -142,7 +127,7 @@ export function registerPrompts(server: McpServer): void {
       },
     },
     async ({ repo, corpus, existingGuidelines }) => {
-      let bundles: PRCommentBundleShape[];
+      let bundles: PRCommentBundle[];
       try {
         const parsed = JSON.parse(corpus);
         if (!Array.isArray(parsed)) {
@@ -150,7 +135,7 @@ export function registerPrompts(server: McpServer): void {
           // surface as proper JSON-RPC errors to the host (#1203).
           throw new Error(`Invalid corpus: expected an array of PRCommentBundle objects, got ${typeof parsed}.`);
         }
-        bundles = parsed as PRCommentBundleShape[];
+        bundles = parsed as PRCommentBundle[];
       } catch (e) {
         throw new Error(`Invalid corpus JSON: ${errorMessage(e)}`, { cause: e });
       }


### PR DESCRIPTION
Re-exports `PRCommentBundle` and 3 sub-types from `@oss-autopilot/core`. Drops the redeclared `PRCommentBundleShape` in `prompts.ts` that was a subset of the canonical type (missing `submittedAt`/`createdAt` fields) and silenced future drift via an `as` cast.

No runtime change. Lint, typecheck, 2,725 tests pass.