### PR TITLE
fix(cli): let leaf subcommands inherit parent group's localOnly flag (#1208 M2)

### DIFF
--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -1315,6 +1315,12 @@ export const commands: CLICommandDef[] = [
   // ── Guidelines (#867) ──────────────────────────────────────────────────
   {
     name: 'guidelines',
+    // Skip the preAction auth gate so `guidelines view` works in local mode
+    // (returns storageMode: 'local-unavailable'). Subcommands that DO need
+    // GitHub auth — `store`/`reset` (Gist) and `fetch-corpus` (PR comment
+    // fetch) — call `requireGitHubToken()` themselves and surface a clear
+    // error. Pairs with the parent-chain walk in cli.ts preAction (#1208 M2).
+    localOnly: true,
     register(program) {
       const group = program
         .command('guidelines')

--- a/packages/core/src/cli.test.ts
+++ b/packages/core/src/cli.test.ts
@@ -55,13 +55,17 @@ function buildTestProgram(localOnlySet: Set<string>) {
   const program = new Command();
   program.name('oss-autopilot').option('--debug', 'Enable debug logging');
 
-  // Register a representative set of commands: two that require a token (daily, search)
-  // and two that are LOCAL_ONLY (status, config). This is sufficient to exercise
-  // preAction hook branching without wiring up all 25 real commands.
+  // Register a representative set of commands: two that require a token (daily, search),
+  // two that are LOCAL_ONLY (status, config), and one subcommand group with
+  // localOnly inheritance (group → leaf) to cover the parent-walk path.
   program.command('daily').description('Run daily check').action(noop);
   program.command('status').description('Show status').action(noop);
   program.command('config').description('Show config').action(noop);
   program.command('search').description('Search').action(noop);
+  // `localGroup view` should inherit `localGroup`'s localOnly flag.
+  const group = program.command('localGroup').description('Group');
+  group.command('view').action(noop);
+  group.command('store').action(noop);
 
   program.hook('preAction', async (thisCommand, actionCommand) => {
     const globalOpts = thisCommand.opts();
@@ -70,8 +74,19 @@ function buildTestProgram(localOnlySet: Set<string>) {
       debug('cli', `Running command: ${actionCommand.name()}`);
     }
 
-    const commandName = actionCommand.name();
-    if (!localOnlySet.has(commandName)) {
+    // Walk parent chain so a localOnly group covers all its leaf subcommands
+    // (#1208 M2). Mirrors the production preAction in cli.ts.
+    let cmd: typeof actionCommand | null = actionCommand;
+    let isLocalOnly = false;
+    while (cmd) {
+      if (localOnlySet.has(cmd.name())) {
+        isLocalOnly = true;
+        break;
+      }
+      cmd = cmd.parent;
+    }
+
+    if (!isLocalOnly) {
       const token = await getGitHubTokenAsync();
       if (!token) {
         console.error('Error: GitHub authentication required.');
@@ -112,6 +127,7 @@ describe('LOCAL_ONLY_COMMANDS (derived from registry)', () => {
     'skip-add',
     'list-move-tier',
     'manifest',
+    'guidelines',
   ];
 
   const expectedTokenRequired = [
@@ -199,6 +215,30 @@ describe('preAction hook', () => {
     await expect(program.parseAsync(['node', 'cli', 'search'])).rejects.toThrow('process.exit called');
 
     expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("should let a leaf subcommand inherit its parent group's localOnly flag (#1208 M2)", async () => {
+    mockGetGitHubTokenAsync.mockResolvedValue(null);
+    // Mark the group (not the leaf) as localOnly — the parent-walk should
+    // pick it up so `localGroup view` skips the auth gate even though
+    // `view` itself isn't in the localOnlySet.
+    const setWithGroup = new Set([...localOnlySet, 'localGroup']);
+    const program = buildTestProgram(setWithGroup);
+
+    await program.parseAsync(['node', 'cli', 'localGroup', 'view']);
+
+    expect(mockGetGitHubTokenAsync).not.toHaveBeenCalled();
+    expect(processExitSpy).not.toHaveBeenCalled();
+  });
+
+  it('should still gate leaf subcommands when the parent group is NOT localOnly', async () => {
+    mockGetGitHubTokenAsync.mockResolvedValue(null);
+    // Group not in localOnlySet → leaf should still hit the auth gate.
+    const program = buildTestProgram(localOnlySet);
+
+    await expect(program.parseAsync(['node', 'cli', 'localGroup', 'view'])).rejects.toThrow('process.exit called');
+
+    expect(mockGetGitHubTokenAsync).toHaveBeenCalledTimes(1);
   });
 
   it('should print a descriptive error message when authentication is missing', async () => {

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -40,10 +40,24 @@ program.hook('preAction', async (thisCommand, actionCommand) => {
     debug('cli', `Running command: ${actionCommand.name()}`);
   }
 
-  // actionCommand is the command being executed (e.g., 'status', 'daily')
-  const commandName = actionCommand.name();
+  // actionCommand is the command being executed (e.g., 'status', 'daily').
+  // For subcommand groups (e.g. `guidelines view`), Commander returns the
+  // leaf name `view` — but the registry sets `localOnly` on the parent
+  // entry `guidelines`. Walk the parent chain so a `localOnly` ancestor
+  // covers all its leaves (#1208 M2). Without this, `guidelines view` —
+  // which works fine in local mode (returns storageMode: 'local-unavailable')
+  // — would still hit the auth gate and fail.
+  let cmd: typeof actionCommand | null = actionCommand;
+  let isLocalOnly = false;
+  while (cmd) {
+    if (localOnlySet.has(cmd.name())) {
+      isLocalOnly = true;
+      break;
+    }
+    cmd = cmd.parent;
+  }
 
-  if (!localOnlySet.has(commandName)) {
+  if (!isLocalOnly) {
     const token = await getGitHubTokenAsync();
     if (!token) {
       // Honor --json at the CLI boundary so machine consumers (plugins, MCP


### PR DESCRIPTION
Closes part of #1208 (M2).

`guidelines view` was hitting the preAction GitHub-token gate even though `runGuidelinesView` is fully local-capable (returns `storageMode: 'local-unavailable'` when no Gist is configured). Local-mode users got `AUTH_REQUIRED` instead of the documented null response.

**Root cause**: Commander's `actionCommand.name()` returns the leaf name `view` for subcommand-group leaves, but the registry's `localOnly` flag is on the parent.

**Fix**:
1. `cli.ts` preAction now walks up the parent chain — any ancestor in `localOnlySet` covers the leaf
2. `cli-registry.ts` marks `guidelines` as `localOnly: true`. The subcommands that DO need auth (`store`/`reset`/`fetch-corpus`) call `requireGitHubToken()` themselves and surface a clear error
3. Two new regression tests cover the inheritance path (leaf inherits / leaf still gates when parent isn't localOnly)

Lint, typecheck, 2,728 tests pass.