### PR TITLE
refactor: move buildStarFilter to core/daily-logic (#1208 M7)

### DIFF
--- a/packages/core/src/commands/daily.ts
+++ b/packages/core/src/commands/daily.ts
@@ -31,8 +31,6 @@ import {
   type CommentedIssueWithResponse,
   type PRCheckFailure,
   type RepoGroup,
-  type AgentState,
-  type StarFilter,
 } from '../core/index.js';
 import { errorMessage, isRateLimitOrAuthError } from '../core/errors.js';
 import { warn } from '../core/logger.js';
@@ -105,25 +103,12 @@ export {
   CRITICAL_STATUSES,
 } from '../core/index.js';
 
-/**
- * Build a star filter from state for use in fetchUserPRCounts.
- * Returns undefined if no star data is available (first run).
- *
- * @param state - Current agent state (read-only)
- * @returns Star filter with minimum threshold and known counts, or undefined on first run
- */
-export function buildStarFilter(state: Readonly<AgentState>): StarFilter | undefined {
-  const minStars = state.config.minStars ?? 50;
-  const knownStarCounts = new Map<string, number>();
-  for (const [repo, score] of Object.entries(state.repoScores)) {
-    if (score.stargazersCount !== undefined) {
-      knownStarCounts.set(repo, score.stargazersCount);
-    }
-  }
-  // Only filter if we have some star data to work with
-  if (knownStarCounts.size === 0) return undefined;
-  return { minStars, knownStarCounts };
-}
+// buildStarFilter moved to core/daily-logic.ts so the dashboard layer can
+// reuse it without crossing the commands → sibling-command boundary
+// (#1208 M7). Re-exported here for backward compatibility with anyone
+// importing from this module.
+import { buildStarFilter } from '../core/daily-logic.js';
+export { buildStarFilter };
 
 /**
  * Internal result of the daily check, using full (non-deduplicated) types.

--- a/packages/core/src/commands/dashboard-data.test.ts
+++ b/packages/core/src/commands/dashboard-data.test.ts
@@ -108,6 +108,12 @@ vi.mock('../core/index.js', async (importOriginal) => {
     getOctokit: mockGetOctokit,
     PRMonitor: MockPRMonitor,
     IssueConversationMonitor: MockIssueConversationMonitor,
+    // dashboard-data.ts now imports these from the core barrel directly
+    // (#1208 M7 moved buildStarFilter from daily.ts → daily-logic.ts).
+    // Override here so the existing mockBuildStarFilter / mockToShelvedPRRef
+    // wiring keeps working.
+    buildStarFilter: (...args: unknown[]) => mockBuildStarFilter(...args),
+    toShelvedPRRef: (...args: unknown[]) => mockToShelvedPRRef(...args),
   };
 });
 

--- a/packages/core/src/commands/dashboard-data.ts
+++ b/packages/core/src/commands/dashboard-data.ts
@@ -24,7 +24,7 @@ import {
   type RepoMetadataEntry,
 } from '../core/types.js';
 import type { ParseIssueListOutput } from '../formatters/json.js';
-import { toShelvedPRRef, buildStarFilter } from './daily.js';
+import { toShelvedPRRef, buildStarFilter } from '../core/index.js';
 
 const MODULE = 'dashboard-data';
 

--- a/packages/core/src/core/daily-logic.ts
+++ b/packages/core/src/core/daily-logic.ts
@@ -34,6 +34,7 @@ import type {
   ActionableIssueType,
   ActionMenu,
   ActionMenuItem,
+  StarFilter,
 } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -158,6 +159,29 @@ export function toShelvedPRRef(pr: ShelvedPRRef): ShelvedPRRef {
     daysSinceActivity: pr.daysSinceActivity,
     status: pr.status,
   };
+}
+
+/**
+ * Build a star filter from state for use in fetchUserPRCounts.
+ *
+ * Returns undefined if no star data is available (first run). Pure logic
+ * over `Readonly<AgentState>` — lives here in core/daily-logic.ts so the
+ * dashboard layer can reuse it without importing from a sibling command
+ * module (#1208 M7).
+ *
+ * @param state - Current agent state (read-only)
+ * @returns Star filter with minimum threshold and known counts, or undefined on first run
+ */
+export function buildStarFilter(state: Readonly<AgentState>): StarFilter | undefined {
+  const minStars = state.config.minStars ?? 50;
+  const knownStarCounts = new Map<string, number>();
+  for (const [repo, score] of Object.entries(state.repoScores)) {
+    if (score.stargazersCount !== undefined) {
+      knownStarCounts.set(repo, score.stargazersCount);
+    }
+  }
+  if (knownStarCounts.size === 0) return undefined;
+  return { minStars, knownStarCounts };
 }
 
 /**

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -74,6 +74,7 @@ export {
   collectActionableIssues,
   computeActionMenu,
   toShelvedPRRef,
+  buildStarFilter,
   formatActionHint,
   formatBriefSummary,
   formatSummary,


### PR DESCRIPTION
Closes part of #1208 (M7).

`dashboard-data.ts` was importing `buildStarFilter` from sibling command module `daily.ts` — a `commands → commands` layering violation. The function is pure logic over `Readonly<AgentState>`, so it belongs in `core/daily-logic.ts` alongside `toShelvedPRRef`.

Changes:
- Moved `buildStarFilter` to `core/daily-logic.ts`
- Re-exported from `core/index.js` barrel
- `commands/daily.ts` re-exports for backward compat
- `dashboard-data.ts` now imports from canonical `../core/index.js`
- Test mock updated to override on the new import path
- Dropped now-unused `AgentState` and `StarFilter` type imports from daily.ts

No runtime change. Lint, typecheck, 2,725 tests pass.