### PR TITLE
chore: low-priority audit cleanups (L3 + L4 + L11 + L12 from #1209)

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ The plugin includes a built-in **pre-commit-reviewer** agent that reviews all co
 | `code-simplifier` | Dead code, unnecessary complexity |
 | `pr-test-analyzer` | Test coverage and assertion quality |
 | `comment-analyzer` | Comment accuracy and maintainability |
+| `type-design-analyzer` | TypeScript type design (encapsulation, invariants, enforcement) |
 
 Without pr-review-toolkit, the built-in pre-commit-reviewer handles all review phases as a single agent with the same fix-and-re-review loop.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -46,7 +46,7 @@ All commands support `--json` for structured output:
 {
   "success": true,
   "data": { ... },
-  "timestamp": "2026-02-28T12:00:00.000Z"
+  "timestamp": "2026-05-04T00:00:00.000Z"
 }
 ```
 

--- a/packages/core/src/core/state-migration.test.ts
+++ b/packages/core/src/core/state-migration.test.ts
@@ -393,13 +393,12 @@ describe('state migration: v4 idempotency (#1208 M8)', () => {
       closedPRs: [],
     };
     fs.writeFileSync(statePath, JSON.stringify(v4State, null, 2), { mode: 0o600 });
-    const mtimeBefore = fs.statSync(statePath).mtimeMs;
 
-    // Wait a tick so mtime would visibly change if the file is rewritten
-    const start = Date.now();
-    while (Date.now() - start < 20) {
-      // busy-wait briefly
-    }
+    // Backdate mtime by 1 second so any rewrite during load is visible
+    // (avoids the CPU-hot busy-wait the original pattern used; #1209 L3).
+    const pastSeconds = Math.floor(Date.now() / 1000) - 1;
+    fs.utimesSync(statePath, pastSeconds, pastSeconds);
+    const mtimeBefore = fs.statSync(statePath).mtimeMs;
 
     new StateManager(false);
 
@@ -557,14 +556,11 @@ describe('legacy state cleanup on load', () => {
     };
     fs.writeFileSync(statePath, JSON.stringify(stateData), { mode: 0o600 });
 
-    // Record file modification time before load
+    // Backdate mtime by 1 second so any rewrite during load is visible
+    // (avoids the CPU-hot busy-wait the original pattern used; #1209 L3).
+    const pastSeconds = Math.floor(Date.now() / 1000) - 1;
+    fs.utimesSync(statePath, pastSeconds, pastSeconds);
     const mtimeBefore = fs.statSync(statePath).mtimeMs;
-
-    // Small delay so any write would be distinguishable by mtime
-    const start = Date.now();
-    while (Date.now() - start < 50) {
-      // busy-wait to ensure mtime would differ if file were rewritten
-    }
 
     const sm = new StateManager(false);
     const state = sm.getState();

--- a/packages/core/src/core/state-schema.test.ts
+++ b/packages/core/src/core/state-schema.test.ts
@@ -132,11 +132,11 @@ describe('AgentStateSchema', () => {
             url: 'https://github.com/o/r/pull/1',
             title: 'Fix bug',
             mergedAt: '2025-01-01',
-            learningsExtractedAt: '2025-02-01',
+            learningsExtractedAt: '2025-02-01T00:00:00Z',
           },
         ],
       });
-      expect(result.mergedPRs![0].learningsExtractedAt).toBe('2025-02-01');
+      expect(result.mergedPRs![0].learningsExtractedAt).toBe('2025-02-01T00:00:00Z');
     });
 
     it('should accept StoredClosedPR with learningsExtractedAt', () => {
@@ -147,11 +147,11 @@ describe('AgentStateSchema', () => {
             url: 'https://github.com/o/r/pull/2',
             title: 'Try fix',
             closedAt: '2025-01-01',
-            learningsExtractedAt: '2025-02-01',
+            learningsExtractedAt: '2025-02-01T00:00:00Z',
           },
         ],
       });
-      expect(result.closedPRs![0].learningsExtractedAt).toBe('2025-02-01');
+      expect(result.closedPRs![0].learningsExtractedAt).toBe('2025-02-01T00:00:00Z');
     });
 
     it('should accept analyzedIssueConversations', () => {

--- a/packages/core/src/core/state-schema.ts
+++ b/packages/core/src/core/state-schema.ts
@@ -55,9 +55,11 @@ export const StoredMergedPRSchema = z.object({
   title: z.string(),
   mergedAt: z.string(),
   /** When the raw review-comment bundle for this PR was last fetched (#867). */
-  commentsFetchedAt: z.string().optional(),
+  // ISO-8601 datetime guards against `markPRCommentsFetched(url, "garbage")`
+  // poisoning state through the stamping API (#1209 L4).
+  commentsFetchedAt: z.string().datetime().optional(),
   /** When the host last ran LLM extraction over this PR's comment bundle (#867). */
-  learningsExtractedAt: z.string().optional(),
+  learningsExtractedAt: z.string().datetime().optional(),
 });
 
 export const StoredClosedPRSchema = z.object({
@@ -65,9 +67,11 @@ export const StoredClosedPRSchema = z.object({
   title: z.string(),
   closedAt: z.string(),
   /** When the raw review-comment bundle for this PR was last fetched (#867). */
-  commentsFetchedAt: z.string().optional(),
+  // ISO-8601 datetime guards against `markPRCommentsFetched(url, "garbage")`
+  // poisoning state through the stamping API (#1209 L4).
+  commentsFetchedAt: z.string().datetime().optional(),
   /** When the host last ran LLM extraction over this PR's comment bundle (#867). */
-  learningsExtractedAt: z.string().optional(),
+  learningsExtractedAt: z.string().datetime().optional(),
 });
 
 export const AnalyzedIssueConversationSchema = z.object({


### PR DESCRIPTION
Four small audit cleanups bundled (each <15 lines):

**L4** — tighten `commentsFetchedAt` / `learningsExtractedAt` to `z.string().datetime()`. Both are stamped via `new Date().toISOString()` in production; the previous `z.string()` allowed malformed inputs to poison state via the `markPRCommentsFetched` API.

**L3** — replace busy-wait (`while (Date.now() - start < N) {}`) with `fs.utimesSync` backdating. Same regression coverage (mtime-unchanged check), no CPU spin, no busy-wait for slow CI runners.

**L11** — add missing `type-design-analyzer` row to README pr-review-toolkit table.

**L12** — refresh stale `'2026-02-28'` example timestamp in `packages/core/README.md`.

Test fixtures updated to match the new datetime requirement (`'2025-02-01'` → `'2025-02-01T00:00:00Z'`).

Lint, typecheck, 2,749 tests pass.