### PR TITLE
test: golden contract fixtures for guidelines commands (#1208 M3)

### DIFF
--- a/packages/core/src/commands/__golden__/guidelines.fetch-corpus-empty.json
+++ b/packages/core/src/commands/__golden__/guidelines.fetch-corpus-empty.json
@@ -1,0 +1,6 @@
+{
+  "repo": "owner/repo",
+  "bundles": [],
+  "prCount": 0,
+  "skipped": 0
+}

--- a/packages/core/src/commands/__golden__/guidelines.fetch-corpus.json
+++ b/packages/core/src/commands/__golden__/guidelines.fetch-corpus.json
@@ -1,0 +1,38 @@
+{
+  "repo": "owner/repo",
+  "bundles": [
+    {
+      "prUrl": "https://github.com/owner/repo/pull/1",
+      "prTitle": "fix: parse edge case",
+      "repo": "owner/repo",
+      "mergedAt": "2026-05-04T00:00:00.000Z",
+      "reviews": [
+        {
+          "author": "maintainer",
+          "authorAssociation": "OWNER",
+          "body": "Looks good but please add a test.",
+          "submittedAt": "2026-05-04T00:00:00.000Z"
+        }
+      ],
+      "reviewComments": [
+        {
+          "author": "maintainer",
+          "authorAssociation": "OWNER",
+          "body": "Use the helper from utils instead.",
+          "path": "src/parse.ts",
+          "createdAt": "2026-05-04T00:00:00.000Z"
+        }
+      ],
+      "issueComments": [
+        {
+          "author": "maintainer",
+          "authorAssociation": "OWNER",
+          "body": "Thanks for the contribution!",
+          "createdAt": "2026-05-04T00:00:00.000Z"
+        }
+      ]
+    }
+  ],
+  "prCount": 1,
+  "skipped": 0
+}

--- a/packages/core/src/commands/__golden__/guidelines.reset-noop.json
+++ b/packages/core/src/commands/__golden__/guidelines.reset-noop.json
@@ -1,0 +1,4 @@
+{
+  "repo": "owner/repo",
+  "deleted": false
+}

--- a/packages/core/src/commands/__golden__/guidelines.reset.json
+++ b/packages/core/src/commands/__golden__/guidelines.reset.json
@@ -1,0 +1,4 @@
+{
+  "repo": "owner/repo",
+  "deleted": true
+}

--- a/packages/core/src/commands/__golden__/guidelines.store.json
+++ b/packages/core/src/commands/__golden__/guidelines.store.json
@@ -1,0 +1,5 @@
+{
+  "repo": "owner/repo",
+  "byteSize": 18,
+  "stored": true
+}

--- a/packages/core/src/commands/__golden__/guidelines.view-empty.json
+++ b/packages/core/src/commands/__golden__/guidelines.view-empty.json
@@ -1,0 +1,7 @@
+{
+  "repo": "owner/repo",
+  "content": null,
+  "byteSize": 0,
+  "exists": false,
+  "storageMode": "gist"
+}

--- a/packages/core/src/commands/__golden__/guidelines.view-local.json
+++ b/packages/core/src/commands/__golden__/guidelines.view-local.json
@@ -1,0 +1,7 @@
+{
+  "repo": "owner/repo",
+  "content": null,
+  "byteSize": 0,
+  "exists": false,
+  "storageMode": "local-unavailable"
+}

--- a/packages/core/src/commands/__golden__/guidelines.view.json
+++ b/packages/core/src/commands/__golden__/guidelines.view.json
@@ -1,0 +1,7 @@
+{
+  "repo": "owner/repo",
+  "content": "# Contribution Guidelines: owner/repo\n\n## Code Style\n- Use 2-space indent.\n",
+  "byteSize": 75,
+  "exists": true,
+  "storageMode": "gist"
+}

--- a/packages/core/src/commands/guidelines.contract.test.ts
+++ b/packages/core/src/commands/guidelines.contract.test.ts
@@ -1,0 +1,157 @@
+/**
+ * --json contract tests for the `guidelines` subcommands (#1208 M3).
+ *
+ * Mocks StateManager + the PR comment fetcher, then snapshots the full
+ * shape that the plugin/MCP consume. Catches schema drift on the four new
+ * mutating + read commands the same way comments.contract.test.ts does
+ * for the `comments` flow.
+ *
+ * Update on intentional shape changes with:
+ *   npx vitest run -u src/commands/guidelines.contract.test.ts
+ */
+
+import { describe, it, vi, expect, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  fetchPRCommentBundlesBatch: vi.fn(),
+  getGuidelines: vi.fn(),
+  setGuidelines: vi.fn(),
+  deleteGuidelines: vi.fn(),
+  isGuidelinesAvailable: vi.fn(),
+  getMergedPRs: vi.fn(),
+  getClosedPRs: vi.fn(),
+  markPRCommentsFetched: vi.fn(),
+  maybeCheckpoint: vi.fn(),
+}));
+
+vi.mock('../core/pr-comments-fetcher.js', () => ({
+  fetchPRCommentBundlesBatch: mocks.fetchPRCommentBundlesBatch,
+}));
+
+vi.mock('../core/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../core/index.js')>('../core/index.js');
+  return {
+    ...actual,
+    getStateManager: () => ({
+      getGuidelines: mocks.getGuidelines,
+      setGuidelines: mocks.setGuidelines,
+      deleteGuidelines: mocks.deleteGuidelines,
+      isGuidelinesAvailable: mocks.isGuidelinesAvailable,
+      getMergedPRs: mocks.getMergedPRs,
+      getClosedPRs: mocks.getClosedPRs,
+      markPRCommentsFetched: mocks.markPRCommentsFetched,
+      getState: () => ({ config: { githubUsername: 'testuser' } }),
+    }),
+    requireGitHubToken: () => 'fake-token',
+    getOctokit: () => ({}) as never,
+    maybeCheckpoint: mocks.maybeCheckpoint,
+  };
+});
+
+import { runGuidelinesView, runGuidelinesStore, runGuidelinesReset, runFetchCorpus } from './guidelines.js';
+
+describe('guidelines --json contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.isGuidelinesAvailable.mockReturnValue(true);
+    mocks.getMergedPRs.mockReturnValue([]);
+    mocks.getClosedPRs.mockReturnValue([]);
+  });
+
+  it('view: existing guidelines matches the golden shape', async () => {
+    mocks.getGuidelines.mockReturnValue(
+      '# Contribution Guidelines: owner/repo\n\n## Code Style\n- Use 2-space indent.\n',
+    );
+    const result = await runGuidelinesView({ repo: 'owner/repo' });
+    await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/guidelines.view.json');
+  });
+
+  it('view: no guidelines stored matches the golden shape', async () => {
+    mocks.getGuidelines.mockReturnValue(null);
+    const result = await runGuidelinesView({ repo: 'owner/repo' });
+    await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/guidelines.view-empty.json');
+  });
+
+  it('view: local-unavailable mode matches the golden shape', async () => {
+    mocks.getGuidelines.mockReturnValue(null);
+    mocks.isGuidelinesAvailable.mockReturnValue(false);
+    const result = await runGuidelinesView({ repo: 'owner/repo' });
+    await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/guidelines.view-local.json');
+  });
+
+  it('store: persisted content matches the golden shape', async () => {
+    const result = await runGuidelinesStore({ repo: 'owner/repo', content: '# Rules\n- be nice\n' });
+    await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/guidelines.store.json');
+  });
+
+  it('reset: tombstoned existing file matches the golden shape', async () => {
+    mocks.getGuidelines.mockReturnValue('# old guidelines');
+    const result = await runGuidelinesReset({ repo: 'owner/repo' });
+    await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/guidelines.reset.json');
+  });
+
+  it('reset: no-op when no guidelines existed matches the golden shape', async () => {
+    mocks.getGuidelines.mockReturnValue(null);
+    const result = await runGuidelinesReset({ repo: 'owner/repo' });
+    await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/guidelines.reset-noop.json');
+  });
+
+  it('fetch-corpus: returns bundles matching the golden shape', async () => {
+    const recentTimestamp = new Date().toISOString();
+    mocks.getMergedPRs.mockReturnValue([
+      {
+        url: 'https://github.com/owner/repo/pull/1',
+        title: 'fix: parse edge case',
+        mergedAt: recentTimestamp,
+      },
+    ]);
+    mocks.fetchPRCommentBundlesBatch.mockResolvedValue([
+      {
+        prUrl: 'https://github.com/owner/repo/pull/1',
+        prTitle: 'fix: parse edge case',
+        repo: 'owner/repo',
+        mergedAt: recentTimestamp,
+        reviews: [
+          {
+            author: 'maintainer',
+            authorAssociation: 'OWNER',
+            body: 'Looks good but please add a test.',
+            submittedAt: recentTimestamp,
+          },
+        ],
+        reviewComments: [
+          {
+            author: 'maintainer',
+            authorAssociation: 'OWNER',
+            body: 'Use the helper from utils instead.',
+            path: 'src/parse.ts',
+            createdAt: recentTimestamp,
+          },
+        ],
+        issueComments: [
+          {
+            author: 'maintainer',
+            authorAssociation: 'OWNER',
+            body: 'Thanks for the contribution!',
+            createdAt: recentTimestamp,
+          },
+        ],
+      },
+    ]);
+
+    const result = await runFetchCorpus({ repo: 'owner/repo', limit: 5 });
+    // Replace the dynamic timestamp in the JSON before snapshotting so the
+    // fixture is stable across test runs.
+    const stable = JSON.stringify(result, null, 2).replaceAll(recentTimestamp, '2026-05-04T00:00:00.000Z');
+    await expect(stable).toMatchFileSnapshot('./__golden__/guidelines.fetch-corpus.json');
+  });
+
+  it('fetch-corpus: empty corpus (no eligible PRs) matches the golden shape', async () => {
+    mocks.getMergedPRs.mockReturnValue([]);
+    mocks.getClosedPRs.mockReturnValue([]);
+    const result = await runFetchCorpus({ repo: 'owner/repo' });
+    await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot(
+      './__golden__/guidelines.fetch-corpus-empty.json',
+    );
+  });
+});


### PR DESCRIPTION
Adds `guidelines.contract.test.ts` + 8 golden JSON fixtures covering all 4 `guidelines` subcommands' `--json` output shapes. Closes part of #1208 (M3) — fills the gap that was the same-pattern remediation #997 did for `track`/`dismiss`/`shelve`/`move`.

Schema drift now fails CI instead of silently breaking the plugin/MCP wire shape.

## 8 fixtures
- guidelines.view.json — content present
- guidelines.view-empty.json — no content stored
- guidelines.view-local.json — local-unavailable mode
- guidelines.store.json — successful store
- guidelines.reset.json — tombstoned existing file
- guidelines.reset-noop.json — no-op when nothing existed
- guidelines.fetch-corpus.json — corpus with one bundle (timestamp normalized to fixed value before snapshot)
- guidelines.fetch-corpus-empty.json — empty corpus

Lint, typecheck, 2,757 tests pass.