### PR TITLE
fix(guidelines): drop PRs with empty/malformed timestamps from recency cliff (#1204)

### DIFF
--- a/packages/core/src/commands/guidelines.test.ts
+++ b/packages/core/src/commands/guidelines.test.ts
@@ -215,6 +215,23 @@ describe('runFetchCorpus', () => {
     expect(mockFetchPRCommentBundlesBatch).toHaveBeenCalledWith(expect.anything(), [PR_RECENT], 'me');
   });
 
+  it('excludes PRs with empty/malformed timestamps (#1204)', async () => {
+    // Date.parse('') is NaN, and `NaN < cutoffMs` is false — the previous
+    // form silently let these PRs through the recency cliff and they could
+    // displace genuinely-recent PRs from the top-N corpus window.
+    mockGetMergedPRs.mockReturnValue([
+      { url: PR_RECENT, title: 'recent', mergedAt: recentTimestamp() },
+      { url: 'https://github.com/owner/repo/pull/100', title: 'no timestamp', mergedAt: '' },
+      { url: 'https://github.com/owner/repo/pull/101', title: 'malformed', mergedAt: 'not-a-date' },
+    ]);
+    mockFetchPRCommentBundlesBatch.mockResolvedValue([]);
+
+    await runFetchCorpus({ repo: 'owner/repo' });
+
+    // Only the recent one survives; the malformed/empty ones are dropped.
+    expect(mockFetchPRCommentBundlesBatch).toHaveBeenCalledWith(expect.anything(), [PR_RECENT], 'me');
+  });
+
   it('excludes PRs from other repos', async () => {
     mockGetMergedPRs.mockReturnValue([
       { url: PR_OTHER_REPO, title: 'other', mergedAt: recentTimestamp() },

--- a/packages/core/src/commands/guidelines.ts
+++ b/packages/core/src/commands/guidelines.ts
@@ -174,7 +174,11 @@ export async function runFetchCorpus(options: FetchCorpusOptions): Promise<Fetch
 
   const eligible = candidates.filter((c) => {
     if (!c.url.startsWith(repoUrlPrefix)) return false;
-    if (Date.parse(c.timestamp || '') < cutoffMs) return false;
+    // Date.parse('') is NaN, and `NaN < cutoffMs` is false — the previous
+    // form silently passed PRs with empty/malformed timestamps through the
+    // recency cliff (#1204). Number.isFinite filters those out explicitly.
+    const ts = Date.parse(c.timestamp || '');
+    if (!Number.isFinite(ts) || ts < cutoffMs) return false;
     return true;
   });
 
@@ -185,6 +189,8 @@ export async function runFetchCorpus(options: FetchCorpusOptions): Promise<Fetch
 
   const toFetch = (options.forceRefetch ? eligible : eligible.filter((c) => !c.alreadyFetched))
     // Most-recent first so the host always sees the freshest signal in its corpus window.
+    // After the eligibility filter (#1204), every entry has a finite Date.parse,
+    // so the comparator is well-defined.
     .sort((a, b) => Date.parse(b.timestamp || '') - Date.parse(a.timestamp || ''))
     .slice(0, limit);
 


### PR DESCRIPTION
Closes #1204.

The recency cliff filter at `packages/core/src/commands/guidelines.ts:177` had a silent bug: `Date.parse(c.timestamp || '') < cutoffMs` evaluated to `NaN < cutoffMs` which is `false`, so PRs with empty `mergedAt`/`closedAt` survived the filter. They could then displace genuinely-recent PRs from the top-N corpus window.

Fixed with `Number.isFinite` guard. One regression test covers both empty-string and malformed-date inputs.

27 guidelines tests pass. Lint, typecheck clean.