### PR TITLE
fix(dashboard): surface background-refresh failure via X-Dashboard-Stale header (#1205)

### DIFF
--- a/packages/core/src/commands/dashboard-server.ts
+++ b/packages/core/src/commands/dashboard-server.ts
@@ -332,6 +332,11 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
   // not disappear when /api/data rebuilds after a state change or after a
   // POST /api/action completes.
   let cachedPartialFailures: string[] | undefined = undefined;
+  // Tracks the last background-refresh failure so /api/data can surface
+  // staleness to the SPA via the X-Dashboard-Stale header (#1205). Cleared
+  // when a refresh succeeds. Without this, token expiry / GitHub outage
+  // produces silent stale data hours old with no client-visible signal.
+  let lastBackgroundRefreshError: string | null = null;
 
   if (!cachedDigest) {
     throw new Error(
@@ -415,6 +420,14 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
             // Signal staleness via response header so clients can detect the degraded mode (#994).
             res.setHeader('X-Dashboard-Stale', '1');
           }
+        }
+        // Surface staleness from a failed background refresh too (#1205) so
+        // token expiry / GitHub outage produces a client-visible signal
+        // rather than silent stale data. Only set the header when a failure
+        // is recorded — successful refreshes clear it.
+        if (lastBackgroundRefreshError !== null) {
+          res.setHeader('X-Dashboard-Stale', '1');
+          res.setHeader('X-Dashboard-Stale-Reason', `background-refresh-failed: ${lastBackgroundRefreshError}`);
         }
         sendJson(res, 200, cachedJsonData);
         return;
@@ -719,11 +732,16 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
           cachedPartialFailures,
         );
         cachedIssueListMtimeMs = getIssueListMtimeMs();
+        // Successful refresh clears any prior failure signal (#1205).
+        lastBackgroundRefreshError = null;
         warn(MODULE, 'Background data refresh complete');
         return;
       })
       .catch((error) => {
-        warn(MODULE, `Background data refresh failed (serving cached data): ${errorMessage(error)}`);
+        // Capture so /api/data can surface staleness via X-Dashboard-Stale
+        // header — previously the catch only logged to stderr (#1205).
+        lastBackgroundRefreshError = errorMessage(error);
+        warn(MODULE, `Background data refresh failed (serving cached data): ${lastBackgroundRefreshError}`);
       });
   }
 


### PR DESCRIPTION
Closes #1205.

The background `fetchDashboardData` call after server startup was fire-and-forget — its catch only logged to stderr. Token expiry / GitHub outage produced silent stale data hours old with no client signal.

## Fix

Mirrors the existing #994 `X-Dashboard-Stale` pattern:

- Module-level `lastBackgroundRefreshError` captures the catch-handler error
- Cleared back to `null` on successful refresh
- `/api/data` sets `X-Dashboard-Stale: 1` + `X-Dashboard-Stale-Reason` headers when `lastBackgroundRefreshError` is non-null

The `X-Dashboard-Stale-Reason` header lets the SPA distinguish background-refresh failure from the rebuild failure that #994 covered.

## Test note

Adding a regression test requires injecting a mocked `fetchDashboardData` rejection into the server's startup-time async, which the current test harness doesn't directly support (`token: null` in beforeAll skips the background path). Worth a follow-up.

Lint, typecheck, 2,758 tests pass.