### PR TITLE
feat(pr-comments-fetcher): return failures list alongside bundles (#1209 L8)

### DIFF
--- a/packages/core/src/commands/__golden__/guidelines.fetch-corpus-empty.json
+++ b/packages/core/src/commands/__golden__/guidelines.fetch-corpus-empty.json
@@ -2,5 +2,6 @@
   "repo": "owner/repo",
   "bundles": [],
   "prCount": 0,
-  "skipped": 0
+  "skipped": 0,
+  "failures": []
 }

--- a/packages/core/src/commands/__golden__/guidelines.fetch-corpus.json
+++ b/packages/core/src/commands/__golden__/guidelines.fetch-corpus.json
@@ -34,5 +34,6 @@
     }
   ],
   "prCount": 1,
-  "skipped": 0
+  "skipped": 0,
+  "failures": []
 }

--- a/packages/core/src/commands/guidelines.contract.test.ts
+++ b/packages/core/src/commands/guidelines.contract.test.ts
@@ -105,39 +105,42 @@ describe('guidelines --json contract', () => {
         mergedAt: recentTimestamp,
       },
     ]);
-    mocks.fetchPRCommentBundlesBatch.mockResolvedValue([
-      {
-        prUrl: 'https://github.com/owner/repo/pull/1',
-        prTitle: 'fix: parse edge case',
-        repo: 'owner/repo',
-        mergedAt: recentTimestamp,
-        reviews: [
-          {
-            author: 'maintainer',
-            authorAssociation: 'OWNER',
-            body: 'Looks good but please add a test.',
-            submittedAt: recentTimestamp,
-          },
-        ],
-        reviewComments: [
-          {
-            author: 'maintainer',
-            authorAssociation: 'OWNER',
-            body: 'Use the helper from utils instead.',
-            path: 'src/parse.ts',
-            createdAt: recentTimestamp,
-          },
-        ],
-        issueComments: [
-          {
-            author: 'maintainer',
-            authorAssociation: 'OWNER',
-            body: 'Thanks for the contribution!',
-            createdAt: recentTimestamp,
-          },
-        ],
-      },
-    ]);
+    mocks.fetchPRCommentBundlesBatch.mockResolvedValue({
+      bundles: [
+        {
+          prUrl: 'https://github.com/owner/repo/pull/1',
+          prTitle: 'fix: parse edge case',
+          repo: 'owner/repo',
+          mergedAt: recentTimestamp,
+          reviews: [
+            {
+              author: 'maintainer',
+              authorAssociation: 'OWNER',
+              body: 'Looks good but please add a test.',
+              submittedAt: recentTimestamp,
+            },
+          ],
+          reviewComments: [
+            {
+              author: 'maintainer',
+              authorAssociation: 'OWNER',
+              body: 'Use the helper from utils instead.',
+              path: 'src/parse.ts',
+              createdAt: recentTimestamp,
+            },
+          ],
+          issueComments: [
+            {
+              author: 'maintainer',
+              authorAssociation: 'OWNER',
+              body: 'Thanks for the contribution!',
+              createdAt: recentTimestamp,
+            },
+          ],
+        },
+      ],
+      failures: [],
+    });
 
     const result = await runFetchCorpus({ repo: 'owner/repo', limit: 5 });
     // Replace the dynamic timestamp in the JSON before snapshotting so the

--- a/packages/core/src/commands/guidelines.test.ts
+++ b/packages/core/src/commands/guidelines.test.ts
@@ -173,17 +173,20 @@ describe('runFetchCorpus', () => {
 
   it('fetches bundles for unprocessed PRs in the requested repo within the recency cliff', async () => {
     mockGetMergedPRs.mockReturnValue([{ url: PR_RECENT, title: 't', mergedAt: recentTimestamp() }]);
-    mockFetchPRCommentBundlesBatch.mockResolvedValue([
-      {
-        prUrl: PR_RECENT,
-        prTitle: 't',
-        repo: 'owner/repo',
-        mergedAt: recentTimestamp(),
-        reviews: [],
-        reviewComments: [],
-        issueComments: [],
-      },
-    ]);
+    mockFetchPRCommentBundlesBatch.mockResolvedValue({
+      bundles: [
+        {
+          prUrl: PR_RECENT,
+          prTitle: 't',
+          repo: 'owner/repo',
+          mergedAt: recentTimestamp(),
+          reviews: [],
+          reviewComments: [],
+          issueComments: [],
+        },
+      ],
+      failures: [],
+    });
 
     const out = await runFetchCorpus({ repo: 'owner/repo' });
 
@@ -197,8 +200,8 @@ describe('runFetchCorpus', () => {
       { url: PR_RECENT, title: 't', mergedAt: recentTimestamp() },
       { url: PR_OLD, title: 't2', mergedAt: oldTimestamp() },
     ]);
-    mockFetchPRCommentBundlesBatch.mockImplementation(async (_octokit: unknown, urls: string[]) =>
-      urls.map((url) => ({
+    mockFetchPRCommentBundlesBatch.mockImplementation(async (_octokit: unknown, urls: string[]) => ({
+      bundles: urls.map((url) => ({
         prUrl: url,
         prTitle: 't',
         repo: 'owner/repo',
@@ -207,7 +210,8 @@ describe('runFetchCorpus', () => {
         reviewComments: [],
         issueComments: [],
       })),
-    );
+      failures: [],
+    }));
 
     const out = await runFetchCorpus({ repo: 'owner/repo' });
 
@@ -224,7 +228,7 @@ describe('runFetchCorpus', () => {
       { url: 'https://github.com/owner/repo/pull/100', title: 'no timestamp', mergedAt: '' },
       { url: 'https://github.com/owner/repo/pull/101', title: 'malformed', mergedAt: 'not-a-date' },
     ]);
-    mockFetchPRCommentBundlesBatch.mockResolvedValue([]);
+    mockFetchPRCommentBundlesBatch.mockResolvedValue({ bundles: [], failures: [] });
 
     await runFetchCorpus({ repo: 'owner/repo' });
 
@@ -237,7 +241,7 @@ describe('runFetchCorpus', () => {
       { url: PR_OTHER_REPO, title: 'other', mergedAt: recentTimestamp() },
       { url: PR_RECENT, title: 't', mergedAt: recentTimestamp() },
     ]);
-    mockFetchPRCommentBundlesBatch.mockResolvedValue([]);
+    mockFetchPRCommentBundlesBatch.mockResolvedValue({ bundles: [], failures: [] });
 
     await runFetchCorpus({ repo: 'owner/repo' });
 
@@ -249,7 +253,7 @@ describe('runFetchCorpus', () => {
       { url: PR_RECENT, title: 't', mergedAt: recentTimestamp() },
       { url: PR_FETCHED, title: 't3', mergedAt: recentTimestamp(), commentsFetchedAt: '2025-01-01T00:00:00Z' },
     ]);
-    mockFetchPRCommentBundlesBatch.mockResolvedValue([]);
+    mockFetchPRCommentBundlesBatch.mockResolvedValue({ bundles: [], failures: [] });
 
     const out = await runFetchCorpus({ repo: 'owner/repo' });
     expect(out.skipped).toBe(1);
@@ -260,7 +264,7 @@ describe('runFetchCorpus', () => {
     mockGetMergedPRs.mockReturnValue([
       { url: PR_FETCHED, title: 't', mergedAt: recentTimestamp(), commentsFetchedAt: '2025-01-01T00:00:00Z' },
     ]);
-    mockFetchPRCommentBundlesBatch.mockResolvedValue([]);
+    mockFetchPRCommentBundlesBatch.mockResolvedValue({ bundles: [], failures: [] });
 
     const out = await runFetchCorpus({ repo: 'owner/repo', forceRefetch: true });
     expect(out.skipped).toBe(0);
@@ -269,17 +273,20 @@ describe('runFetchCorpus', () => {
 
   it('checkpoints to Gist after stamping commentsFetchedAt (#1200)', async () => {
     mockGetMergedPRs.mockReturnValue([{ url: PR_RECENT, title: 't', mergedAt: recentTimestamp() }]);
-    mockFetchPRCommentBundlesBatch.mockResolvedValue([
-      {
-        prUrl: PR_RECENT,
-        prTitle: 't',
-        repo: 'owner/repo',
-        mergedAt: recentTimestamp(),
-        reviews: [],
-        reviewComments: [],
-        issueComments: [],
-      },
-    ]);
+    mockFetchPRCommentBundlesBatch.mockResolvedValue({
+      bundles: [
+        {
+          prUrl: PR_RECENT,
+          prTitle: 't',
+          repo: 'owner/repo',
+          mergedAt: recentTimestamp(),
+          reviews: [],
+          reviewComments: [],
+          issueComments: [],
+        },
+      ],
+      failures: [],
+    });
 
     await runFetchCorpus({ repo: 'owner/repo' });
 
@@ -300,7 +307,7 @@ describe('runFetchCorpus', () => {
       mergedAt: recentTimestamp(),
     }));
     mockGetMergedPRs.mockReturnValue(many);
-    mockFetchPRCommentBundlesBatch.mockResolvedValue([]);
+    mockFetchPRCommentBundlesBatch.mockResolvedValue({ bundles: [], failures: [] });
 
     await runFetchCorpus({ repo: 'owner/repo', limit: 100 }); // requesting 100 but capped at 10
     const call = mockFetchPRCommentBundlesBatch.mock.calls[0];
@@ -314,7 +321,7 @@ describe('runFetchCorpus', () => {
       mergedAt: recentTimestamp(),
     }));
     mockGetMergedPRs.mockReturnValue(many);
-    mockFetchPRCommentBundlesBatch.mockResolvedValue([]);
+    mockFetchPRCommentBundlesBatch.mockResolvedValue({ bundles: [], failures: [] });
 
     await runFetchCorpus({ repo: 'owner/repo' });
     const call = mockFetchPRCommentBundlesBatch.mock.calls[0];
@@ -334,7 +341,7 @@ describe('runFetchCorpus', () => {
     mockGetClosedPRs.mockReturnValue([
       { url: 'https://github.com/owner/repo/pull/9', title: 'closed', closedAt: recentTimestamp() },
     ]);
-    mockFetchPRCommentBundlesBatch.mockResolvedValue([]);
+    mockFetchPRCommentBundlesBatch.mockResolvedValue({ bundles: [], failures: [] });
 
     await runFetchCorpus({ repo: 'owner/repo' });
     expect(mockFetchPRCommentBundlesBatch).toHaveBeenCalledWith(

--- a/packages/core/src/commands/guidelines.ts
+++ b/packages/core/src/commands/guidelines.ts
@@ -65,6 +65,13 @@ export interface FetchCorpusOutput {
   prCount: number;
   /** PRs skipped because `commentsFetchedAt` is already set (without --force). */
   skipped: number;
+  /**
+   * PRs that were attempted but errored (404, rate limit, transient API
+   * failure). Surfaced so the host can decide whether to retry or warn the
+   * user that the corpus is partial. Empty array when all attempted fetches
+   * succeeded. (#1209 L8)
+   */
+  failures: Array<{ prUrl: string; error: string }>;
 }
 
 interface RepoOption {
@@ -195,7 +202,7 @@ export async function runFetchCorpus(options: FetchCorpusOptions): Promise<Fetch
     .slice(0, limit);
 
   if (toFetch.length === 0) {
-    return { repo: options.repo, bundles: [], prCount: 0, skipped };
+    return { repo: options.repo, bundles: [], prCount: 0, skipped, failures: [] };
   }
 
   const token = requireGitHubToken();
@@ -205,7 +212,7 @@ export async function runFetchCorpus(options: FetchCorpusOptions): Promise<Fetch
     warn(MODULE, 'githubUsername is not set; bot/own-comment filtering will be incomplete');
   }
 
-  const bundles = await fetchPRCommentBundlesBatch(
+  const { bundles, failures } = await fetchPRCommentBundlesBatch(
     octokit,
     toFetch.map((c) => c.url),
     username,
@@ -230,6 +237,7 @@ export async function runFetchCorpus(options: FetchCorpusOptions): Promise<Fetch
     bundles,
     prCount: bundles.length,
     skipped,
+    failures,
   };
 }
 

--- a/packages/core/src/core/pr-comments-fetcher.test.ts
+++ b/packages/core/src/core/pr-comments-fetcher.test.ts
@@ -213,7 +213,7 @@ describe('fetchPRCommentBundlesBatch', () => {
       'https://github.com/owner/repo/pull/2',
       'https://github.com/owner/repo/pull/3',
     ];
-    const bundles = await fetchPRCommentBundlesBatch(octokit, urls, 'me');
+    const { bundles } = await fetchPRCommentBundlesBatch(octokit, urls, 'me');
     expect(bundles).toHaveLength(3);
   });
 
@@ -239,7 +239,7 @@ describe('fetchPRCommentBundlesBatch', () => {
       'https://github.com/owner/repo/pull/2',
       'https://github.com/owner/repo/pull/3',
     ];
-    const bundles = await fetchPRCommentBundlesBatch(octokit, urls, 'me', 1);
+    const { bundles } = await fetchPRCommentBundlesBatch(octokit, urls, 'me', 1);
     expect(bundles).toHaveLength(2); // skipped PR 2
   });
 
@@ -281,8 +281,38 @@ describe('fetchPRCommentBundlesBatch', () => {
     expect(maxActive).toBeLessThanOrEqual(2);
   });
 
-  it('returns [] when given an empty URL list', async () => {
+  it('returns empty bundles + failures when given an empty URL list', async () => {
     const octokit = makeOctokit({});
-    expect(await fetchPRCommentBundlesBatch(octokit, [], 'me')).toEqual([]);
+    expect(await fetchPRCommentBundlesBatch(octokit, [], 'me')).toEqual({ bundles: [], failures: [] });
+  });
+
+  it('records per-PR failures alongside successful bundles (#1209 L8)', async () => {
+    // octokit.pulls.get fails for PR 2 only; other PRs succeed.
+    const octokit = {
+      pulls: {
+        get: vi.fn(async ({ pull_number }: { pull_number: number }) => {
+          if (pull_number === 2) throw new Error('Not Found');
+          return { data: makePR() };
+        }),
+        listReviews: vi.fn(async () => ({ data: [] })),
+        listReviewComments: vi.fn(async () => ({ data: [] })),
+      },
+      issues: {
+        listComments: vi.fn(async () => ({ data: [] })),
+      },
+    } as unknown as Octokit;
+
+    const urls = [
+      'https://github.com/owner/repo/pull/1',
+      'https://github.com/owner/repo/pull/2',
+      'https://github.com/owner/repo/pull/3',
+    ];
+    const result = await fetchPRCommentBundlesBatch(octokit, urls, 'me', 1);
+    expect(result.bundles).toHaveLength(2);
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]).toEqual({
+      prUrl: 'https://github.com/owner/repo/pull/2',
+      error: expect.stringContaining('Not Found'),
+    });
   });
 });

--- a/packages/core/src/core/pr-comments-fetcher.ts
+++ b/packages/core/src/core/pr-comments-fetcher.ts
@@ -168,19 +168,26 @@ export async function fetchPRCommentBundle(
 /**
  * Fetch comment bundles for many PRs with a small concurrency cap (default 3).
  *
- * Failures on individual PRs are logged and skipped — the batch returns a
- * shorter array rather than aborting. Rationale: extraction quality is
- * already a partial-information problem (users contribute to many repos and
- * many PRs), so a single 404 / rate limit on one PR should not deny the
- * host the corpus from the other 4.
+ * Failures on individual PRs are logged and recorded — the batch returns
+ * `{ bundles, failures }` so the caller can decide whether to retry, surface
+ * a partial-data banner, or proceed. Rationale: extraction quality is already
+ * a partial-information problem (users contribute to many repos and many PRs),
+ * so a single 404 / rate limit on one PR should not deny the host the corpus
+ * from the other 4 — but the failure should still be visible (#1209 L8).
  */
+export interface PRCommentBundlesBatchResult {
+  bundles: PRCommentBundle[];
+  failures: Array<{ prUrl: string; error: string }>;
+}
+
 export async function fetchPRCommentBundlesBatch(
   octokit: Octokit,
   prUrls: string[],
   githubUsername: string,
   concurrency: number = DEFAULT_BATCH_CONCURRENCY,
-): Promise<PRCommentBundle[]> {
-  const results: PRCommentBundle[] = [];
+): Promise<PRCommentBundlesBatchResult> {
+  const bundles: PRCommentBundle[] = [];
+  const failures: Array<{ prUrl: string; error: string }> = [];
   const queue = [...prUrls];
 
   async function worker(): Promise<void> {
@@ -189,9 +196,11 @@ export async function fetchPRCommentBundlesBatch(
       if (!url) return;
       try {
         const bundle = await fetchPRCommentBundle(octokit, url, githubUsername);
-        results.push(bundle);
+        bundles.push(bundle);
       } catch (err) {
-        warn(MODULE, `Skipping ${url}: ${errorMessage(err)}`);
+        const errorMsg = errorMessage(err);
+        failures.push({ prUrl: url, error: errorMsg });
+        warn(MODULE, `Skipping ${url}: ${errorMsg}`);
       }
     }
   }
@@ -199,6 +208,6 @@ export async function fetchPRCommentBundlesBatch(
   const workers = Array.from({ length: Math.min(concurrency, prUrls.length) }, worker);
   await Promise.all(workers);
 
-  debug(MODULE, `Fetched ${results.length}/${prUrls.length} comment bundles`);
-  return results;
+  debug(MODULE, `Fetched ${bundles.length}/${prUrls.length} comment bundles (${failures.length} failed)`);
+  return { bundles, failures };
 }


### PR DESCRIPTION
Closes part of #1209.

`fetchPRCommentBundlesBatch` previously returned just `PRCommentBundle[]` — callers couldn't distinguish 'this PR was filtered' from 'this PR's fetch failed'. `pr-monitor.ts` already collects `{ prUrl, error }` failures for the same reason; this brings the corpus fetcher in line.

## Breaking-shape changes

`fetchPRCommentBundlesBatch` now returns `{ bundles, failures }`. The single caller (`runFetchCorpus`) is updated to destructure and propagate `failures` into `FetchCorpusOutput` so the plugin/MCP can surface partial failure to the user.

## Tests

- 8 existing test sites updated to destructure `{ bundles, failures }`.
- New regression test verifies per-PR failures are recorded with `prUrl + error`.
- `guidelines.contract.test.ts` fetch-corpus golden fixtures regenerated to include the new `failures: []` field.

Lint, typecheck, 2,759 tests pass.