### PR TITLE
refactor: GistStateStore.refreshFromGist returns discriminated union (#1209 L9)

### DIFF
--- a/packages/core/src/core/gist-state-store.concurrency.test.ts
+++ b/packages/core/src/core/gist-state-store.concurrency.test.ts
@@ -208,7 +208,9 @@ async function tryWriteDocument(
         (store as unknown as { lastRefreshAt: number }).lastRefreshAt = 0;
       }
       const refreshed = await store.refreshFromGist();
-      if (!refreshed) throw new Error('refreshFromGist returned false during retry loop');
+      if (refreshed.status !== 'refreshed') {
+        throw new Error(`refreshFromGist returned ${refreshed.status} during retry loop`);
+      }
     }
     store.setDocument(filename, content);
     try {

--- a/packages/core/src/core/gist-state-store.test.ts
+++ b/packages/core/src/core/gist-state-store.test.ts
@@ -455,6 +455,65 @@ describe('GistStateStore', () => {
     });
   });
 
+  describe('refreshFromGist (#1209 L9)', () => {
+    it('returns { status: "no-gist" } before bootstrap (no gistId)', async () => {
+      const store = new GistStateStore(octokit);
+      const result = await store.refreshFromGist();
+      expect(result).toEqual({ status: 'no-gist' });
+    });
+
+    it('returns { status: "refreshed" } on a successful re-fetch', async () => {
+      const gistId = 'refresh-success';
+      fs.writeFileSync(path.join(tmpDir, 'gist-id'), gistId);
+      octokit.gists.get.mockResolvedValue(makeGistResponse(gistId, makeStateJson()));
+
+      const store = new GistStateStore(octokit);
+      await store.bootstrap();
+      // Reset the throttle so the refresh isn't blocked.
+      (store as unknown as { lastRefreshAt: number }).lastRefreshAt = 0;
+      const result = await store.refreshFromGist();
+      expect(result).toEqual({ status: 'refreshed' });
+    });
+
+    it('returns { status: "throttled", sinceLastMs } when called within 30s of the previous refresh', async () => {
+      const gistId = 'refresh-throttled';
+      fs.writeFileSync(path.join(tmpDir, 'gist-id'), gistId);
+      octokit.gists.get.mockResolvedValue(makeGistResponse(gistId, makeStateJson()));
+
+      const store = new GistStateStore(octokit);
+      await store.bootstrap();
+      // Reset throttle and do a first refresh to stamp lastRefreshAt.
+      (store as unknown as { lastRefreshAt: number }).lastRefreshAt = 0;
+      const first = await store.refreshFromGist();
+      expect(first.status).toBe('refreshed');
+      // Immediate next call is within the 30s throttle window.
+      const result = await store.refreshFromGist();
+      expect(result.status).toBe('throttled');
+      if (result.status === 'throttled') {
+        expect(result.sinceLastMs).toBeGreaterThanOrEqual(0);
+        expect(result.sinceLastMs).toBeLessThan(30_000);
+      }
+    });
+
+    it('returns { status: "error", error } when the API call fails', async () => {
+      const gistId = 'refresh-error';
+      fs.writeFileSync(path.join(tmpDir, 'gist-id'), gistId);
+      octokit.gists.get.mockResolvedValueOnce(makeGistResponse(gistId, makeStateJson()));
+
+      const store = new GistStateStore(octokit);
+      await store.bootstrap();
+      (store as unknown as { lastRefreshAt: number }).lastRefreshAt = 0;
+      // Subsequent fetch fails.
+      octokit.gists.get.mockRejectedValueOnce(new Error('Gist API 500'));
+
+      const result = await store.refreshFromGist();
+      expect(result.status).toBe('error');
+      if (result.status === 'error') {
+        expect(result.error.message).toContain('Gist API 500');
+      }
+    });
+  });
+
   describe('getGistId', () => {
     it('should return null before bootstrap', () => {
       const store = new GistStateStore(octokit);

--- a/packages/core/src/core/gist-state-store.ts
+++ b/packages/core/src/core/gist-state-store.ts
@@ -95,6 +95,17 @@ export interface BootstrapResult {
 }
 
 /**
+ * Discriminated outcome of {@link GistStateStore.refreshFromGist} (#1209 L9).
+ * Lets callers distinguish "got fresh data" from "throttled / no-op / failed"
+ * without conflating them as a single boolean.
+ */
+export type RefreshResult =
+  | { status: 'refreshed' }
+  | { status: 'no-gist' }
+  | { status: 'throttled'; sinceLastMs: number }
+  | { status: 'error'; error: Error };
+
+/**
  * Minimal Octokit-shaped interface for the Gist API methods we use.
  * Accepts the real ThrottledOctokit or a plain mock object in tests.
  *
@@ -516,22 +527,33 @@ export class GistStateStore {
   /**
    * Re-fetch the Gist and update the in-memory cache.
    * Throttled to at most once per 30 seconds.
+   *
+   * Returns a discriminated union so callers can tell apart the four
+   * outcomes that previously collapsed into a single boolean (#1209 L9):
+   *   - `{ status: 'refreshed' }` — fresh data loaded successfully.
+   *   - `{ status: 'no-gist' }` — store not in Gist mode (e.g. degraded).
+   *   - `{ status: 'throttled', sinceLastMs }` — within the 30s throttle.
+   *   - `{ status: 'error', error }` — fetch attempt failed.
    */
-  async refreshFromGist(): Promise<boolean> {
-    if (!this.gistId) return false;
+  async refreshFromGist(): Promise<RefreshResult> {
+    if (!this.gistId) return { status: 'no-gist' };
     const now = Date.now();
+    const sinceLastMs = now - this.lastRefreshAt;
     // Throttle hits are not failures — preserve any previous lastRefreshError
     // for the caller to inspect.
-    if (now - this.lastRefreshAt < GistStateStore.REFRESH_THROTTLE_MS) return false;
+    if (sinceLastMs < GistStateStore.REFRESH_THROTTLE_MS) {
+      return { status: 'throttled', sinceLastMs };
+    }
     try {
       await this.fetchAndCache(this.gistId);
       this.lastRefreshAt = now;
       this.lastRefreshError = null;
-      return true;
+      return { status: 'refreshed' };
     } catch (err) {
-      warn(MODULE, `refreshFromGist failed: ${err}`);
-      this.lastRefreshError = err instanceof Error ? err : new Error(String(err));
-      return false;
+      const error = err instanceof Error ? err : new Error(String(err));
+      warn(MODULE, `refreshFromGist failed: ${error.message}`);
+      this.lastRefreshError = error;
+      return { status: 'error', error };
     }
   }
 

--- a/packages/core/src/core/state.test.ts
+++ b/packages/core/src/core/state.test.ts
@@ -1011,7 +1011,7 @@ describe('StateManager Gist staleness marker (#1193)', () => {
   });
 
   it('sets a staleness marker when refreshFromGist fails', async () => {
-    mockGistStore.refreshFromGist.mockResolvedValue(false);
+    mockGistStore.refreshFromGist.mockResolvedValue({ status: 'error', error: new Error('mocked refresh failure') });
     mockGistStore.lastRefreshError = new Error('GitHub API: rate limited');
 
     await manager.refreshFromGist();
@@ -1026,13 +1026,16 @@ describe('StateManager Gist staleness marker (#1193)', () => {
 
   it('clears the marker on a successful refresh', async () => {
     // Seed with a staleness marker first.
-    mockGistStore.refreshFromGist.mockResolvedValueOnce(false);
+    mockGistStore.refreshFromGist.mockResolvedValueOnce({
+      status: 'error',
+      error: new Error('mocked refresh failure'),
+    });
     mockGistStore.lastRefreshError = new Error('boom');
     await manager.refreshFromGist();
     expect(manager.getStateStaleness()).not.toBeNull();
 
     // Now a successful refresh.
-    mockGistStore.refreshFromGist.mockResolvedValueOnce(true);
+    mockGistStore.refreshFromGist.mockResolvedValueOnce({ status: 'refreshed' });
     mockGistStore.lastRefreshError = null;
     await manager.refreshFromGist();
 
@@ -1040,7 +1043,7 @@ describe('StateManager Gist staleness marker (#1193)', () => {
   });
 
   it('sets a marker when a successful HTTP fetch returns a parse-invalid payload', async () => {
-    mockGistStore.refreshFromGist.mockResolvedValue(true);
+    mockGistStore.refreshFromGist.mockResolvedValue({ status: 'refreshed' });
     mockGistStore.cachedFiles.set('state.json', '{ not valid json');
 
     const refreshed = await manager.refreshFromGist();
@@ -1052,7 +1055,7 @@ describe('StateManager Gist staleness marker (#1193)', () => {
   });
 
   it('sets a marker when refreshFromGist returns true but state.json is missing', async () => {
-    mockGistStore.refreshFromGist.mockResolvedValue(true);
+    mockGistStore.refreshFromGist.mockResolvedValue({ status: 'refreshed' });
     mockGistStore.cachedFiles.delete('state.json');
 
     const refreshed = await manager.refreshFromGist();
@@ -1065,14 +1068,20 @@ describe('StateManager Gist staleness marker (#1193)', () => {
 
   it('preserves an existing marker when the refresh is throttled (no new error)', async () => {
     // First, seed a marker via a real failure.
-    mockGistStore.refreshFromGist.mockResolvedValueOnce(false);
+    mockGistStore.refreshFromGist.mockResolvedValueOnce({
+      status: 'error',
+      error: new Error('mocked refresh failure'),
+    });
     mockGistStore.lastRefreshError = new Error('initial failure');
     await manager.refreshFromGist();
     const before = manager.getStateStaleness();
     expect(before).not.toBeNull();
 
     // Now simulate a throttled refresh (false return, no error).
-    mockGistStore.refreshFromGist.mockResolvedValueOnce(false);
+    mockGistStore.refreshFromGist.mockResolvedValueOnce({
+      status: 'error',
+      error: new Error('mocked refresh failure'),
+    });
     mockGistStore.lastRefreshError = null;
     await manager.refreshFromGist();
 

--- a/packages/core/src/core/state.ts
+++ b/packages/core/src/core/state.ts
@@ -417,7 +417,11 @@ export class StateManager {
    */
   async refreshFromGist(): Promise<boolean> {
     if (!this.gistStore) return false;
-    const refreshed = await this.gistStore.refreshFromGist();
+    const result = await this.gistStore.refreshFromGist();
+    // StateManager keeps its boolean shape (callers rely on truthy-check
+    // semantics) but consults the discriminated union internally to know
+    // whether to reload state.json from the now-fresh cache (#1209 L9).
+    const refreshed = result.status === 'refreshed';
     if (refreshed) {
       const raw = this.gistStore.cachedFiles.get('state.json');
       if (!raw) {


### PR DESCRIPTION
Closes part of #1209.

`refreshFromGist` previously returned a single boolean that collapsed four distinct outcomes (no-gist / throttled / error / success). Callers couldn't distinguish 'no refresh needed' from 'refresh failed silently'.

## Changes

`GistStateStore.refreshFromGist` now returns:
```ts
type RefreshResult =
  | { status: 'refreshed' }
  | { status: 'no-gist' }
  | { status: 'throttled'; sinceLastMs: number }
  | { status: 'error'; error: Error };
```

`StateManager.refreshFromGist` keeps its boolean shape for backward compat (5 callers rely on truthy semantics) but consults the union internally to know whether to reload state.json from the now-fresh cache.

Concurrency-test retry loop updated; state.test.ts mocks updated to return the new shape.

## Tests

4 new `gist-state-store.test.ts` tests verify the four discriminated outcomes are actually distinguishable. Lint, typecheck, 2,764 tests pass.