### PR TITLE
fix(validation): reject octocat and monalisa as placeholder usernames

### DIFF
--- a/packages/core/src/commands/validation.test.ts
+++ b/packages/core/src/commands/validation.test.ts
@@ -186,7 +186,7 @@ describe('validateGitHubUrl', () => {
 describe('validateGitHubUsername', () => {
   describe('valid usernames', () => {
     it('should accept a normal username', () => {
-      expect(validateGitHubUsername('octocat')).toBe('octocat');
+      expect(validateGitHubUsername('alice-dev')).toBe('alice-dev');
     });
 
     it('should accept a username with hyphens', () => {
@@ -211,7 +211,7 @@ describe('validateGitHubUsername', () => {
     });
 
     it('should trim whitespace from the username', () => {
-      expect(validateGitHubUsername('  octocat  ')).toBe('octocat');
+      expect(validateGitHubUsername('  alice-dev  ')).toBe('alice-dev');
     });
   });
 
@@ -258,12 +258,19 @@ describe('validateGitHubUsername', () => {
       expect(() => validateGitHubUsername('octo.cat')).toThrow('alphanumeric characters and hyphens');
     });
 
-    it.each(['example-user', 'your-username', 'your-github-username', 'EXAMPLE-USER', 'Your-Username'])(
-      'should reject placeholder username %s (case-insensitive)',
-      (placeholder) => {
-        expect(() => validateGitHubUsername(placeholder)).toThrow(ValidationError);
-        expect(() => validateGitHubUsername(placeholder)).toThrow('looks like a placeholder');
-      },
-    );
+    it.each([
+      'example-user',
+      'your-username',
+      'your-github-username',
+      'octocat',
+      'monalisa',
+      'EXAMPLE-USER',
+      'Your-Username',
+      'Octocat',
+      'MONALISA',
+    ])('should reject placeholder username %s (case-insensitive)', (placeholder) => {
+      expect(() => validateGitHubUsername(placeholder)).toThrow(ValidationError);
+      expect(() => validateGitHubUsername(placeholder)).toThrow('looks like a placeholder');
+    });
   });
 });

--- a/packages/core/src/core/placeholder-usernames.ts
+++ b/packages/core/src/core/placeholder-usernames.ts
@@ -20,6 +20,13 @@ const PLACEHOLDER_USERNAMES: readonly Lowercase<string>[] = [
   'example-user',
   'your-username',
   'your-github-username',
+  // GitHub's mascot accounts. Real users on github.com but seeded into countless
+  // example configs, READMEs, and SDK docs (Octokit's quickstarts use `octocat`
+  // as the canonical login). Treating them as placeholders keeps a stale example
+  // value from silently swapping a real user's PR feed with the mascot's open
+  // PRs in violet-org/boysenberry-repo (octocat's public test fixtures).
+  'octocat',
+  'monalisa',
 ] as const;
 
 const KNOWN_PLACEHOLDER_USERNAMES: ReadonlySet<string> = new Set(PLACEHOLDER_USERNAMES);

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -238,12 +238,12 @@ describe('MCP tool registrations', () => {
     it('accepts a known config key (via registry)', async () => {
       // We don't actually care about the result — just that the schema
       // doesn't reject. The mocked runConfig is fine with anything.
-      // Use a real-looking login (not a placeholder like "example-user")
-      // so this test stays orthogonal to the write-side placeholder rejection
-      // in `validateGitHubUsername`.
+      // Use a real-looking login (not a placeholder like "example-user" or
+      // a mascot login like "octocat") so this test stays orthogonal to the
+      // write-side placeholder rejection in `validateGitHubUsername`.
       const result = await client.callTool({
         name: 'config',
-        arguments: { key: 'username', value: 'octocat' },
+        arguments: { key: 'username', value: 'alice-dev' },
       });
       expect(result.isError).not.toBe(true);
     });


### PR DESCRIPTION
## Summary

- Adds GitHub's mascot accounts (`octocat`, `monalisa`) to `PLACEHOLDER_USERNAMES`. Both are corporate-owned GitHub accounts that show up constantly in example configs, README snippets, and SDK quickstarts (Octokit's docs use `octocat` as the canonical login).
- Extends the parameterized rejection test in `validation.test.ts` to cover the new entries plus their case variants.
- Swaps two happy-path fixtures in the same test from `'octocat'` to `'alice-dev'` so they keep asserting valid-username behavior.

## Why

A real user's `~/.oss-autopilot/state.json` ended up with `githubUsername: "octocat"` (origin unclear, likely an example value that got persisted). The Search query `is:pr is:open is:public author:octocat` then happily returned 4 of octocat's real-but-not-yours open PRs in `violet-org/boysenberry-repo` (octocat's public test fixtures repo, description literally "Testing"). The dashboard rendered them as if they were the user's own.

Two safety nets failed to catch this:
1. `pr-monitor.ts:155` proactive auto-repair only fires for known placeholders. `octocat` wasn't in the list.
2. `pr-monitor.ts:223` post-fetch zero-results guardrail only fires when `totalCount === 0`. Octocat had 4 open PRs.

Neither net was wrong; the placeholder list was just incomplete. This PR closes the gap on both call sites that consume the list (`validation.ts:136` write-side rejection added in #1226, plus `pr-monitor.ts:155` runtime auto-repair).

## Test plan

- [x] `pnpm test` (94 files, 2312 tests) passes locally
- [x] `pnpm run lint` clean (0 errors)
- [x] `tsc --noEmit` clean
- [x] `pnpm run format:check` clean
- [x] Verified no other test fixtures pass `octocat`/`monalisa` through `validateGitHubUsername` (scout-bridge, pr-monitor, doctor, golden fixtures all use `octocat` only as a non-validated string)