### PR TITLE
fix: state.json fail-loud on 412-conflict merge re-apply (#1235)

### DIFF
--- a/packages/core/src/core/gist-state-store.concurrency.test.ts
+++ b/packages/core/src/core/gist-state-store.concurrency.test.ts
@@ -367,14 +367,14 @@ describe('GistStateStore concurrency (#1191)', () => {
     }
   });
 
-  // Pins the current byte-overwrite-per-file behavior: two writers that
-  // both modify state.json with disjoint fields clobber each other rather
-  // than merge. This is the documented last-write-wins-by-intent model
-  // (gist-state-store.ts:17-32). If a future change introduces field-level
-  // merging on state.json, this test flips green-to-red and the assertion
-  // should become `expect(...).toEqual(expect.arrayContaining(['url-a','url-b']))`
-  // to pin the new (better) behavior.
-  it('two writers modifying state.json with disjoint fields clobber each other (byte-overwrite limit)', async () => {
+  // Pins the per-file conflict policy from #1235: state.json fails loud
+  // when its remote copy moved under the writer (preserving the
+  // StateManager optimistic-concurrency contract documented in
+  // state.ts:285-296). Two writers each modifying state.json on the same
+  // base no longer clobber silently — the second writer's push throws
+  // GistConcurrencyError and leaves the canonical state holding the first
+  // writer's edit.
+  it('two writers modifying state.json on the same base — second push fails loud (#1235)', async () => {
     const mock = makeStatefulGistMock(GIST_ID, makeInitialStateJson());
     const a = new GistStateStore(mock.octokit);
     const b = new GistStateStore(mock.octokit);
@@ -390,11 +390,80 @@ describe('GistStateStore concurrency (#1191)', () => {
     const stateB = JSON.parse(b.cachedFiles.get(STATE_FILE_NAME)!) as Record<string, unknown>;
     (stateB.config as { shelvedPRUrls: string[] }).shelvedPRUrls.push('url-b');
     b.setState(JSON.stringify(stateB, null, 2));
-    // b's first push 412s; the inner retry's "merge" reapplies b's staged
-    // bytes verbatim, dropping url-a.
+    // b's first push 412s. The merge re-fetches and finds the remote
+    // state.json has changed since b's baseline (a's url-a edit), so the
+    // store surfaces GistConcurrencyError instead of clobbering.
+    await expect(b.push()).rejects.toBeInstanceOf(GistConcurrencyError);
+
+    // Canonical state retains a's write.
+    const finalState = mock.readState() as { config: { shelvedPRUrls: string[] } };
+    expect(finalState.config.shelvedPRUrls).toEqual(['url-a']);
+
+    // b's local mutation is preserved in memory so the caller can refresh
+    // and reapply manually if desired.
+    expect(b.dirtyFiles.has(STATE_FILE_NAME)).toBe(true);
+    const bStaged = JSON.parse(b.cachedFiles.get(STATE_FILE_NAME)!) as {
+      config: { shelvedPRUrls: string[] };
+    };
+    expect(bStaged.config.shelvedPRUrls).toEqual(['url-b']);
+  });
+
+  // Companion to the test above: per-file policy means freeform documents
+  // (guidelines, etc.) keep last-write-wins on the same merge re-apply
+  // path (#1235). A writer racing on a guidelines file with no concurrent
+  // state.json change still succeeds via the existing merge-and-retry.
+  it('guidelines writes keep last-write-wins even when a state.json baseline changed (#1235)', async () => {
+    const mock = makeStatefulGistMock(GIST_ID, makeInitialStateJson());
+    const a = new GistStateStore(mock.octokit);
+    const b = new GistStateStore(mock.octokit);
+    await Promise.all([a.bootstrap(), b.bootstrap()]);
+
+    // a writes a guidelines file. Bumps mock ETag so b's lastFetchedEtag
+    // is now stale, but state.json has not changed remotely.
+    await tryWriteDocument(a, 'guidelines--writer-a.md', 'a content');
+
+    // b stages a different guidelines file. Its first push 412s; the
+    // merge refresh sees state.json baseline unchanged (a only touched
+    // a guidelines file), so b's push succeeds on the inner retry.
+    b.setDocument('guidelines--writer-b.md', 'b content');
     await b.push();
 
+    const finalFiles = mock.readAllFiles();
+    expect(finalFiles['guidelines--writer-a.md']).toBe('a content');
+    expect(finalFiles['guidelines--writer-b.md']).toBe('b content');
+  });
+
+  // Concurrent state.json + guidelines writes from a single store: when a
+  // peer writes state.json between the writer's last fetch and its push,
+  // the writer's state.json edit must fail loud even though guidelines
+  // would otherwise be safe to reapply. This pins that the per-file check
+  // gates the whole push, not just the state.json file (#1235).
+  it('mixed dirty set surfaces GistConcurrencyError when state.json conflicted (#1235)', async () => {
+    const mock = makeStatefulGistMock(GIST_ID, makeInitialStateJson());
+    const peer = new GistStateStore(mock.octokit);
+    const writer = new GistStateStore(mock.octokit);
+    await Promise.all([peer.bootstrap(), writer.bootstrap()]);
+
+    // Peer pushes a state.json change, bumping the canonical ETag and
+    // moving state.json off the writer's baseline.
+    const peerState = JSON.parse(peer.cachedFiles.get(STATE_FILE_NAME)!) as Record<string, unknown>;
+    (peerState.config as { shelvedPRUrls: string[] }).shelvedPRUrls.push('peer-url');
+    peer.setState(JSON.stringify(peerState, null, 2));
+    await peer.push();
+
+    // Writer stages BOTH a guidelines file and a state.json edit on the
+    // pre-peer base. The 412 merge refresh sees state.json moved under
+    // it; per #1235 the whole push fails loud.
+    const writerState = JSON.parse(writer.cachedFiles.get(STATE_FILE_NAME)!) as Record<string, unknown>;
+    (writerState.config as { shelvedPRUrls: string[] }).shelvedPRUrls.push('writer-url');
+    writer.setDocument('guidelines--writer.md', 'writer content');
+    writer.setState(JSON.stringify(writerState, null, 2));
+    await expect(writer.push()).rejects.toBeInstanceOf(GistConcurrencyError);
+
+    // Canonical state retains peer's write; writer's guidelines did NOT
+    // land (the failed push aborted the whole batch).
     const finalState = mock.readState() as { config: { shelvedPRUrls: string[] } };
-    expect(finalState.config.shelvedPRUrls).toEqual(['url-b']);
+    expect(finalState.config.shelvedPRUrls).toEqual(['peer-url']);
+    expect(mock.readAllFiles()['guidelines--writer.md']).toBeUndefined();
   });
 });

--- a/packages/core/src/core/gist-state-store.test.ts
+++ b/packages/core/src/core/gist-state-store.test.ts
@@ -1063,28 +1063,32 @@ describe('GistStateStore', () => {
       });
     });
 
-    it('refreshes and retries once on 412, succeeding after merge', async () => {
+    it('refreshes and retries once on 412 when state.json baseline is unchanged', async () => {
+      // The 412 may be triggered by a peer writing a guidelines file (or
+      // any non-state.json file) — state.json's content is byte-identical
+      // before and after the refresh. Per #1235 the per-file fail-loud
+      // check passes and the inner retry proceeds normally.
       const gistId = 'etag-merge';
-      const initialStateJson = makeStateJson({ lastRunAt: '2025-01-01T00:00:00.000Z' });
-      const remoteStateJson = makeStateJson({ lastRunAt: '2025-06-01T00:00:00.000Z' });
+      const stateJson = makeStateJson({ lastRunAt: '2025-01-01T00:00:00.000Z' });
       fs.writeFileSync(path.join(tmpDir, 'gist-id'), gistId);
 
-      // Bootstrap fetch returns the initial state with ETag #1.
+      // Bootstrap fetch returns the state with ETag #1.
       octokit.gists.get.mockResolvedValueOnce({
-        ...makeGistResponse(gistId, initialStateJson),
+        ...makeGistResponse(gistId, stateJson),
         headers: { etag: 'W/"v1"' },
       });
-      // First update: 412 (another machine pushed in between).
+      // First update: 412 (another machine pushed something else).
       const conflictErr = Object.assign(new Error('Precondition failed'), { status: 412 });
       octokit.gists.update.mockRejectedValueOnce(conflictErr);
-      // Refresh fetch returns the remote state with a new ETag.
+      // Refresh fetch returns identical state.json content with a new
+      // ETag — modeling a peer write that didn't touch state.json.
       octokit.gists.get.mockResolvedValueOnce({
-        ...makeGistResponse(gistId, remoteStateJson),
+        ...makeGistResponse(gistId, stateJson),
         headers: { etag: 'W/"v2"' },
       });
       // Second update: succeeds with the new ETag.
       octokit.gists.update.mockResolvedValueOnce({
-        ...makeGistResponse(gistId, initialStateJson),
+        ...makeGistResponse(gistId, stateJson),
         headers: { etag: 'W/"v3"' },
       });
 
@@ -1098,14 +1102,51 @@ describe('GistStateStore', () => {
       expect(octokit.gists.update).toHaveBeenCalledTimes(2);
       expect(octokit.gists.update).toHaveBeenNthCalledWith(1, {
         gist_id: gistId,
-        files: { [STATE_FILE_NAME]: { content: initialStateJson } },
+        files: { [STATE_FILE_NAME]: { content: stateJson } },
         headers: { 'if-match': 'W/"v1"' },
       });
       expect(octokit.gists.update).toHaveBeenNthCalledWith(2, {
         gist_id: gistId,
-        files: { [STATE_FILE_NAME]: { content: initialStateJson } },
+        files: { [STATE_FILE_NAME]: { content: stateJson } },
         headers: { 'if-match': 'W/"v2"' },
       });
+    });
+
+    it('throws GistConcurrencyError when state.json moved remotely (#1235)', async () => {
+      // Same shape as the test above, except the refresh returns a
+      // CHANGED state.json. Per #1235 the per-file fail-loud check fires
+      // before the inner retry, so the writer sees GistConcurrencyError
+      // instead of clobbering the remote edit.
+      const gistId = 'etag-state-changed';
+      const initialStateJson = makeStateJson({ lastRunAt: '2025-01-01T00:00:00.000Z' });
+      const remoteStateJson = makeStateJson({ lastRunAt: '2025-06-01T00:00:00.000Z' });
+      fs.writeFileSync(path.join(tmpDir, 'gist-id'), gistId);
+
+      octokit.gists.get.mockResolvedValueOnce({
+        ...makeGistResponse(gistId, initialStateJson),
+        headers: { etag: 'W/"v1"' },
+      });
+      const conflictErr = Object.assign(new Error('Precondition failed'), { status: 412 });
+      octokit.gists.update.mockRejectedValueOnce(conflictErr);
+      octokit.gists.get.mockResolvedValueOnce({
+        ...makeGistResponse(gistId, remoteStateJson),
+        headers: { etag: 'W/"v2"' },
+      });
+
+      const store = new GistStateStore(octokit);
+      await store.bootstrap();
+      store.markDirty(STATE_FILE_NAME);
+
+      const { GistConcurrencyError } = await import('./errors.js');
+      await expect(store.push()).rejects.toThrow(GistConcurrencyError);
+
+      // The store made exactly one update attempt — the second never
+      // fired because the per-file check threw first.
+      expect(octokit.gists.update).toHaveBeenCalledTimes(1);
+      // Local state.json mutation is preserved in cachedFiles for the
+      // caller to retry against the refreshed baseline.
+      expect(store.dirtyFiles.has(STATE_FILE_NAME)).toBe(true);
+      expect(store.cachedFiles.get(STATE_FILE_NAME)).toBe(initialStateJson);
     });
 
     it('throws GistConcurrencyError when the merged push also returns 412', async () => {
@@ -1152,6 +1193,49 @@ describe('GistStateStore', () => {
 
       const { GistConcurrencyError } = await import('./errors.js');
       await expect(store.push()).rejects.toThrow(GistConcurrencyError);
+    });
+
+    it('on corrupt remote during 412 merge, rolls back ETag/baseline and propagates GistCorruptError (#1235)', async () => {
+      // Models the failure mode where a peer pushes between our last
+      // fetch and our push, AND that peer's state.json fails schema
+      // validation. The merge fetch's parse step throws GistCorruptError
+      // after `cachedFiles`/`lastFetchedEtag` were already mutated
+      // mid-fetchAndCache. The rollback in push() restores the prior
+      // values and re-throws the corrupt error so callers don't retry
+      // against a corrupt remote.
+      const gistId = 'etag-corrupt-mid-merge';
+      const initialStateJson = makeStateJson({ lastRunAt: '2025-01-01T00:00:00.000Z' });
+      fs.writeFileSync(path.join(tmpDir, 'gist-id'), gistId);
+
+      // Bootstrap fetch returns valid state with ETag v1.
+      octokit.gists.get.mockResolvedValueOnce({
+        ...makeGistResponse(gistId, initialStateJson),
+        headers: { etag: 'W/"v1"' },
+      });
+      // First update: 412.
+      const conflictErr = Object.assign(new Error('Precondition failed'), { status: 412 });
+      octokit.gists.update.mockRejectedValueOnce(conflictErr);
+      // Refresh fetch returns corrupt state.json (unparseable JSON) so
+      // parseStateFromCache throws GistCorruptError mid-fetchAndCache,
+      // after the cache and ETag have already been mutated.
+      const corruptStateRaw = '{"unterminated json';
+      octokit.gists.get.mockResolvedValueOnce({
+        ...makeGistResponse(gistId, corruptStateRaw),
+        headers: { etag: 'W/"v2"' },
+      });
+
+      const store = new GistStateStore(octokit);
+      await store.bootstrap();
+      store.markDirty(STATE_FILE_NAME);
+
+      const { GistCorruptError } = await import('./errors.js');
+      await expect(store.push()).rejects.toThrow(GistCorruptError);
+
+      // Rollback invariants: lastFetchedEtag and cached state.json must
+      // be restored to their pre-refresh values so a follow-up push
+      // does not blindly succeed against the corrupt remote.
+      expect((store as unknown as { lastFetchedEtag: string | null }).lastFetchedEtag).toBe('W/"v1"');
+      expect(store.cachedFiles.get(STATE_FILE_NAME)).toBe(initialStateJson);
     });
   });
 

--- a/packages/core/src/core/gist-state-store.ts
+++ b/packages/core/src/core/gist-state-store.ts
@@ -14,7 +14,7 @@
  *  6. Cache all Gist file contents in memory for session-scoped reads
  *  7. Write state to a local cache file for fallback
  *
- * Concurrency model (#1115):
+ * Concurrency model (#1115, #1235):
  *
  *  Each fetch captures the response's `ETag` and stores it as
  *  `lastFetchedEtag`. The next `push()` sends that ETag back as
@@ -24,12 +24,25 @@
  *  On 412, the store attempts a single merge: it re-fetches the Gist
  *  (refreshing the ETag), re-applies the in-memory dirty content on top of
  *  the now-current remote state, and pushes once more. If that second push
- *  also returns 412, `push()` throws {@link GistConcurrencyError} — local
- *  mutations stay in memory so the caller can decide whether to refresh and
- *  retry. The merge step is intentionally cheap (state is a single JSON
- *  blob) and treats local dirty changes as authoritative for conflict
- *  cells, which matches the "last-write-wins by intent" model the rest of
- *  oss-autopilot already assumes for state.json.
+ *  also returns 412, `push()` throws {@link GistConcurrencyError}.
+ *
+ *  Per-file conflict policy on the merge re-apply step:
+ *
+ *   - `state.json` is fail-loud. The `StateManager` contract advertises
+ *     optimistic compare-and-swap (state.ts:285-296), so silently clobbering
+ *     a concurrent remote write would violate it. To detect concurrent
+ *     writes without per-file ETags (the Gist API only exposes one ETag for
+ *     the whole gist), we snapshot each file's content at fetch time. If
+ *     the post-refresh `state.json` differs from the snapshot we held
+ *     before the refresh, another machine wrote it: `push()` throws
+ *     `GistConcurrencyError` instead of overwriting.
+ *   - Freeform documents (e.g. per-repo guidelines) keep last-write-wins.
+ *     The `setDocument` / `setGuidelines` callers' intent on a manual write
+ *     is "overwrite". Local dirty content is reapplied on top of the
+ *     refreshed remote.
+ *
+ *  In both cases, when the second push also 412s, local mutations stay in
+ *  memory so the caller can decide whether to refresh and retry.
  */
 
 import * as fs from 'node:fs';
@@ -153,6 +166,16 @@ export class GistStateStore {
   private gistId: string | null = null;
   readonly cachedFiles: Map<string, string> = new Map();
   readonly dirtyFiles: Set<string> = new Set();
+  /**
+   * Per-file content snapshot captured at fetch time (#1235). The Gist API
+   * exposes a single ETag for the whole gist, so we cannot use `If-Match`
+   * to detect a per-file conflict on the 412 merge re-apply. Holding the
+   * baseline content lets us compare it against the freshly-fetched remote
+   * and decide whether `state.json` changed under us. Updated only by
+   * `fetchAndCache` and successful `push()`; not mutated by `setState` /
+   * `setDocument` so the baseline reflects the remote, not local edits.
+   */
+  private baselineFiles: Map<string, string> = new Map();
   /**
    * ETag captured from the most recent successful Gist fetch (#1115).
    * Sent back as `If-Match` on `update` so concurrent writes from another
@@ -481,16 +504,62 @@ export class GistStateStore {
         const content = this.cachedFiles.get(filename);
         if (content !== undefined) stagedContents[filename] = content;
       }
+      // Snapshot the full cache and baseline before refresh so a partial
+      // failure inside fetchAndCache (e.g. parse throws after the cache
+      // was already cleared and repopulated) can be rolled back without
+      // leaving the store with a stale ETag pointing at corrupt or
+      // half-populated state (#1235).
+      const preRefreshCache = new Map(this.cachedFiles);
+      const preRefreshBaseline = new Map(this.baselineFiles);
+      const preRefreshEtag = this.lastFetchedEtag;
+      const reapplyStaged = (): void => {
+        for (const [filename, content] of Object.entries(stagedContents)) {
+          this.cachedFiles.set(filename, content);
+        }
+      };
       try {
         await this.fetchAndCache(this.gistId);
       } catch (refreshErr) {
         warn(MODULE, `Merge refresh after 412 failed: ${refreshErr}`);
+        // Roll back any partial mutation from fetchAndCache so the
+        // caller's retry path sees the prior state (with local
+        // mutations re-applied on top).
+        this.cachedFiles.clear();
+        for (const [filename, content] of preRefreshCache) {
+          this.cachedFiles.set(filename, content);
+        }
+        this.baselineFiles = preRefreshBaseline;
+        this.lastFetchedEtag = preRefreshEtag;
+        reapplyStaged();
+        // Preserve the GistCorruptError type so callers don't retry
+        // against a corrupt remote (which a CONCURRENCY_ERROR would
+        // invite). Other failure types continue to surface as a
+        // concurrency error — the gist content is still likely fine.
+        if (refreshErr instanceof GistCorruptError) throw refreshErr;
         throw new GistConcurrencyError(expectedEtag, null);
       }
-      // Re-apply our staged dirty contents on top of the refreshed remote.
-      for (const [filename, content] of Object.entries(stagedContents)) {
-        this.cachedFiles.set(filename, content);
+      // Per-file conflict policy (#1235):
+      //  - state.json must fail loud when its remote copy moved under us;
+      //    silently overwriting would violate the StateManager
+      //    optimistic-concurrency contract (state.ts:285-296).
+      //  - Freeform documents (guidelines, etc.) keep last-write-wins —
+      //    `setDocument` callers' intent on a manual write is "overwrite".
+      if (stagedContents[STATE_FILE_NAME] !== undefined) {
+        const baselineBeforeRefresh = preRefreshBaseline.get(STATE_FILE_NAME);
+        const remoteAfterRefresh = this.cachedFiles.get(STATE_FILE_NAME);
+        if (baselineBeforeRefresh !== remoteAfterRefresh) {
+          warn(
+            MODULE,
+            'state.json changed remotely while a push was in flight; surfacing GistConcurrencyError instead of clobbering (#1235)',
+          );
+          // Preserve local state.json (and other staged dirty files) in
+          // memory so the caller can refresh and reapply if appropriate.
+          reapplyStaged();
+          throw new GistConcurrencyError(expectedEtag, this.lastFetchedEtag);
+        }
       }
+      // Re-apply our staged dirty contents on top of the refreshed remote.
+      reapplyStaged();
       result = await attempt(this.lastFetchedEtag);
       if (!result.ok && result.status === 412) {
         warn(MODULE, 'Second push after merge also returned 412; surfacing GistConcurrencyError');
@@ -508,8 +577,11 @@ export class GistStateStore {
       }
     }
 
-    // Success: flush dirty set and write local cache
+    // Success: flush dirty set and write local cache. Refresh the
+    // per-file baseline to reflect what we just wrote — the next 412
+    // merge re-apply check compares against this.
     this.dirtyFiles.clear();
+    this.baselineFiles = new Map(this.cachedFiles);
 
     const raw = this.cachedFiles.get(STATE_FILE_NAME);
     if (raw) {
@@ -594,6 +666,10 @@ export class GistStateStore {
         this.cachedFiles.set(filename, file.content);
       }
     }
+    // Snapshot the just-fetched contents as the per-file baseline (#1235).
+    // The 412 merge path uses this to detect whether a concurrent write
+    // changed `state.json` between this fetch and the next push attempt.
+    this.baselineFiles = new Map(this.cachedFiles);
 
     // Parse state.json
     const state = this.parseStateFromCache();
@@ -693,6 +769,7 @@ export class GistStateStore {
         this.cachedFiles.set(filename, file.content);
       }
     }
+    this.baselineFiles = new Map(this.cachedFiles);
 
     // Write-through to local cache
     this.writeLocalStateCache(freshState);
@@ -723,6 +800,7 @@ export class GistStateStore {
         this.cachedFiles.set(filename, file.content);
       }
     }
+    this.baselineFiles = new Map(this.cachedFiles);
 
     // Write-through to local cache
     this.writeLocalStateCache(seedState);


### PR DESCRIPTION
## Summary

Fixes #1235.

The Gist `push()` 412-conflict merge path was unconditionally re-applying every dirty file on top of the freshly-fetched remote, silently clobbering concurrent writes to `state.json`. That contradicted the optimistic-concurrency contract `StateManager` advertises (state.ts:285-296), which is fail-loud on a concurrent external write.

## Why

A peer machine writing `state.json` between this writer's last fetch and its push got swallowed: the writer would 412 on first attempt, refresh, re-apply its stale staged content over the now-current remote, and push again — silently overwriting the peer's edit. The bug was pinned by an existing test asserting "byte-overwrite limit" as known behavior; per the issue, this is wrong for `state.json` (though intentional for guidelines).

## Approach

- New private field `baselineFiles: Map<string, string>` snapshots each file's content at fetch time (Gist API exposes one ETag per gist, not per file, so we substitute content equality).
- On 412 merge re-apply: if `state.json`'s pre-refresh baseline differs from the post-refresh remote, throw `GistConcurrencyError` instead of overwriting.
- Freeform documents (per-repo guidelines, etc.) keep last-write-wins. `setDocument` callers' explicit intent on a manual write is "overwrite".
- Hardened the merge catch path: snapshot ETag/cache/baseline pre-refresh and roll all three back if `fetchAndCache` throws partway through (e.g. corrupt remote). Propagate `GistCorruptError` unchanged so callers don't retry against a corrupt remote.

## Test plan

- [x] Replaced `'two writers modifying state.json with disjoint fields clobber each other (byte-overwrite limit)'` (which pinned the bug) with `'two writers modifying state.json on the same base — second push fails loud (#1235)'`
- [x] Added `'guidelines writes keep last-write-wins even when a state.json baseline changed (#1235)'` — pins the per-file split: guidelines retry path still works
- [x] Added `'mixed dirty set surfaces GistConcurrencyError when state.json conflicted (#1235)'` — pins atomic push: a state.json conflict aborts the whole batch, no guideline gets through
- [x] Added `'throws GistConcurrencyError when state.json moved remotely (#1235)'` — unit-level fail-loud
- [x] Added `'on corrupt remote during 412 merge, rolls back ETag/baseline and propagates GistCorruptError (#1235)'` — pins the rollback invariant
- [x] Replaced `'refreshes and retries once on 412, succeeding after merge'` to use unchanged-state.json content (the only scenario where retry-and-succeed for state.json is now valid)
- [x] All 2316 tests pass; lint clean