### PR TITLE
fix: parseIssueList dedupe + recognize Hold/Continue watch (#1179)

### DIFF
--- a/packages/core/src/commands/parse-list.test.ts
+++ b/packages/core/src/commands/parse-list.test.ts
@@ -269,6 +269,154 @@ describe('parseIssueList — sub-bullet status detection', () => {
     expect(result.available).toHaveLength(1);
     expect(result.completed).toHaveLength(0);
   });
+
+  // Freshness-sweep vocabulary recognized as terminal (#1179). Curators
+  // use these annotations on a later occurrence of an issue to override
+  // an earlier "pursue" line; the dedupe pass then drops the URL from
+  // `available[]`.
+  it('moves Hold items to completed', () => {
+    const content = `- [#1](https://github.com/owner/repo/issues/1) — Fix bug
+  - **Hold** — Score 6/10. Author has 2 PRs in flight.`;
+    const result = parseIssueList(content);
+    expect(result.available).toHaveLength(0);
+    expect(result.completed).toHaveLength(1);
+    expect(result.completed[0].number).toBe(1);
+  });
+
+  it('moves Continue watch items to completed', () => {
+    const content = `- [#2](https://github.com/owner/repo/issues/2) — Watchlist
+  - **Continue watch** — Maintainer absent for 30d.`;
+    const result = parseIssueList(content);
+    expect(result.available).toHaveLength(0);
+    expect(result.completed).toHaveLength(1);
+  });
+
+  it('moves Downgrade items to completed', () => {
+    const content = `- [#3](https://github.com/owner/repo/issues/3) — Lower priority now
+  - **Downgrade** — 7 → 5/10 after re-vet.`;
+    const result = parseIssueList(content);
+    expect(result.available).toHaveLength(0);
+    expect(result.completed).toHaveLength(1);
+  });
+});
+
+describe('parseIssueList — URL deduplication (#1179)', () => {
+  it('dedupes the same URL appearing in two sections to one available entry', () => {
+    const content = `## Pursue
+- [#123](https://github.com/example/repo/issues/123) — Some bug
+  - **Score 7/10** — Vetted Apr 1.
+
+## Pending Vet
+- [#123](https://github.com/example/repo/issues/123) — Re-checked, still relevant.
+`;
+    const result = parseIssueList(content);
+    expect(result.availableCount).toBe(1);
+    expect(result.completedCount).toBe(0);
+    // First occurrence wins — preserves the original tier ("Pursue").
+    expect(result.available[0].tier).toBe('Pursue');
+  });
+
+  it('terminal classification on second occurrence wins over available on first', () => {
+    const content = `## Pursue
+- [#123](https://github.com/example/repo/issues/123) — Some bug
+  - **Score 7/10** — Vetted Apr 1.
+
+## Pending Vet
+### Freshness sweep
+- [#123](https://github.com/example/repo/issues/123) — re-vetted
+  - **Hold** (7 → 6/10). Author has 2 PRs in this repo already waiting.
+`;
+    const result = parseIssueList(content);
+    expect(result.availableCount).toBe(0);
+    expect(result.completedCount).toBe(1);
+    expect(result.completed[0].url).toBe('https://github.com/example/repo/issues/123');
+  });
+
+  it('dedupes the same URL appearing twice in completed[]', () => {
+    const content = `## Done
+- ~~[#1](https://github.com/owner/repo/issues/1)~~ Fixed in PR #2.
+
+## Archive
+- [#1](https://github.com/owner/repo/issues/1) — Done. Notes preserved.
+`;
+    const result = parseIssueList(content);
+    expect(result.completedCount).toBe(1);
+  });
+});
+
+describe('parseIssueList — first-bold anchoring (#1179)', () => {
+  // The terminal vocabulary now includes common English verbs ("Hold",
+  // "Downgrade"), which means a regex matching anywhere on the line would
+  // mis-classify any sub-bullet whose explanatory tail happens to bold one
+  // of those words. Anchoring to the first bold span on the line keeps the
+  // curator's "first **bold** = the status tag" convention intact.
+  it('does not move items based on bolded keywords in the explanatory tail', () => {
+    const content = `- [#7](https://github.com/owner/repo/issues/7) — Trace bug
+  - **Maybe** — yesterday's **Done** sweep recommended a retry.`;
+    const result = parseIssueList(content);
+    expect(result.available).toHaveLength(1);
+    expect(result.completed).toHaveLength(0);
+  });
+
+  it('does not move items when "hold" appears as bold prose, not as the status tag', () => {
+    const content = `- [#8](https://github.com/owner/repo/issues/8) — Resilience work
+  - **Score 8/10** — author asked us to **hold** off until v3 lands.`;
+    const result = parseIssueList(content);
+    expect(result.available).toHaveLength(1);
+    expect(result.available[0].score).toBe(8);
+  });
+});
+
+describe('pruneIssueList — preserves parked entries (#1179)', () => {
+  // pruneIssueList mutates the markdown file in place. The new
+  // freshness-sweep vocabulary (`**Hold**`, `**Continue watch**`,
+  // `**Downgrade**`) parks issues — the curator's intent is "don't pursue
+  // right now", not "delete from disk". The narrower
+  // `isSubBulletDeletable` predicate keeps these on disk while
+  // parseIssueList's broader `isSubBulletTerminal` still excludes them
+  // from the in-memory `available[]` count.
+  it('preserves Hold items (parked, not deleted)', () => {
+    const content = `### Repo
+- [#1](https://github.com/owner/repo/issues/1) — Held back
+  - **Hold** — Score 8/10. Author has 2 PRs in flight.
+`;
+    const { pruned, removedCount } = pruneIssueList(content);
+    expect(removedCount).toBe(0);
+    expect(pruned).toContain('https://github.com/owner/repo/issues/1');
+  });
+
+  it('preserves Continue watch items', () => {
+    const content = `### Repo
+- [#2](https://github.com/owner/repo/issues/2) — Watchlist
+  - **Continue watch** — Score 7/10. Maintainer absent for 30d.
+`;
+    const { pruned, removedCount } = pruneIssueList(content);
+    expect(removedCount).toBe(0);
+    expect(pruned).toContain('https://github.com/owner/repo/issues/2');
+  });
+
+  it('preserves Downgrade items', () => {
+    const content = `### Repo
+- [#3](https://github.com/owner/repo/issues/3) — Lower priority now
+  - **Downgrade** — Score 6/10. 7 → 6 after re-vet.
+`;
+    const { pruned, removedCount } = pruneIssueList(content);
+    expect(removedCount).toBe(0);
+    expect(pruned).toContain('https://github.com/owner/repo/issues/3');
+  });
+
+  it('still deletes Skip / Done / Dropped / Merged / Closed items', () => {
+    const content = `### Repo
+- [#4](https://github.com/owner/repo/issues/4) — Skipped
+  - **Skip** — Score 3/10. Existing PR.
+- [#5](https://github.com/owner/repo/issues/5) — Done
+  - **Done** — Merged.
+`;
+    const { pruned, removedCount } = pruneIssueList(content);
+    expect(removedCount).toBe(2);
+    expect(pruned).not.toContain('issues/4');
+    expect(pruned).not.toContain('issues/5');
+  });
 });
 
 describe('pruneIssueList', () => {

--- a/packages/core/src/commands/parse-list.ts
+++ b/packages/core/src/commands/parse-list.ts
@@ -63,14 +63,61 @@ function extractScore(line: string): number | undefined {
   return match ? parseFloat(match[1]) : undefined;
 }
 
-/** Check if a sub-bullet indicates the item is terminal (completed/abandoned — safe to prune) */
-function isSubBulletTerminal(line: string): boolean {
-  return /\*\*(?:Skip|Done|Dropped|Merged|Closed)\*\*/i.test(line);
+/**
+ * Extract the first bold span (`**...**`) from a line, trimmed.
+ * Anchoring status detection to the first bold span avoids false positives
+ * from explanatory tails that happen to bold an English verb (`...we should
+ * **hold** off until next quarter...`). Returns null when the line has no
+ * bold markup.
+ */
+function firstBoldSpan(line: string): string | null {
+  const m = line.match(/\*\*([^*]+)\*\*/);
+  return m ? m[1].trim() : null;
 }
 
-/** Check if a sub-bullet indicates the item is in-progress (not available, but NOT safe to prune) */
+/**
+ * Check if a sub-bullet's first bold span is a terminal status — completed,
+ * abandoned, or being held back from pursuit (#1179). Used by
+ * `parseIssueList` for in-memory bucketing.
+ *
+ * Curators' freshness-sweep vocabulary has grown beyond the original five
+ * keywords. `hold`, `continue watch`, and `downgrade` all mean "this is no
+ * longer in the actionable bucket" — different from "completed", but
+ * equivalent for the question `parseIssueList` answers
+ * ("which URLs are still pursuable?").
+ *
+ * `pruneIssueList` uses the stricter {@link isSubBulletDeletable} instead,
+ * since on-disk deletion must not silently remove items the curator
+ * explicitly parked.
+ */
+function isSubBulletTerminal(line: string): boolean {
+  const kw = firstBoldSpan(line);
+  if (!kw) return false;
+  return /^(?:Skip|Done|Dropped|Merged|Closed|Hold|Continue watch|Downgrade)$/i.test(kw);
+}
+
+/**
+ * Check if a sub-bullet's first bold span is a "delete-from-disk" status.
+ * Strictly the original five keywords — `pruneIssueList` mutates the
+ * markdown file in place, and a curator's `**Hold**` annotation means
+ * "park", not "delete" (#1179).
+ */
+function isSubBulletDeletable(line: string): boolean {
+  const kw = firstBoldSpan(line);
+  if (!kw) return false;
+  return /^(?:Skip|Done|Dropped|Merged|Closed)$/i.test(kw);
+}
+
+/**
+ * Check if a sub-bullet's first bold span is in-progress (not available,
+ * but NOT safe to prune). Includes the "decision pending" vocabulary
+ * curators use when an issue is being investigated but not yet bucketed
+ * (#1179).
+ */
 function isSubBulletInProgress(line: string): boolean {
-  return /\*\*(?:In Progress|Wait|Waiting)\*\*/i.test(line);
+  const kw = firstBoldSpan(line);
+  if (!kw) return false;
+  return /^(?:In Progress|Wait|Waiting|Post findings first|Ship now|Viable not urgent)$/i.test(kw);
 }
 
 /** Parse a markdown string into structured issue items */
@@ -139,11 +186,38 @@ export function parseIssueList(content: string): ParseIssueListOutput {
     lastItem = item;
   }
 
+  // Dedupe by URL across both buckets (#1179). Curated lists routinely
+  // mention the same issue in multiple sections (e.g. an item under
+  // "Pursue" plus a freshness-sweep entry under "Pending Vet"), and the
+  // raw per-line counts overstate availability. Rules:
+  //   - If a URL appears in `completed[]` at all, it is filtered out of
+  //     `available[]`. Curators add a terminal annotation (`**hold**`,
+  //     `Done`, etc.) on a later occurrence precisely to override an
+  //     earlier "pursue" line; the terminal classification wins.
+  //   - Within each bucket, the first occurrence is kept (preserves the
+  //     parse order and the tier of the original entry).
+  const completedUrls = new Set(completed.map((item) => item.url));
+  const dedupedAvailable: ParsedIssueItem[] = [];
+  const seenAvailable = new Set<string>();
+  for (const item of available) {
+    if (completedUrls.has(item.url)) continue;
+    if (seenAvailable.has(item.url)) continue;
+    seenAvailable.add(item.url);
+    dedupedAvailable.push(item);
+  }
+  const dedupedCompleted: ParsedIssueItem[] = [];
+  const seenCompleted = new Set<string>();
+  for (const item of completed) {
+    if (seenCompleted.has(item.url)) continue;
+    seenCompleted.add(item.url);
+    dedupedCompleted.push(item);
+  }
+
   return {
-    available,
-    completed,
-    availableCount: available.length,
-    completedCount: completed.length,
+    available: dedupedAvailable,
+    completed: dedupedCompleted,
+    availableCount: dedupedAvailable.length,
+    completedCount: dedupedCompleted.length,
   };
 }
 
@@ -195,7 +269,7 @@ export function pruneIssueList(content: string, minScore: number = 6): { pruned:
       let shouldRemove = false;
       let j = i + 1;
       while (j < lines.length && /^\s{2,}/.test(lines[j])) {
-        if (isSubBulletTerminal(lines[j])) {
+        if (isSubBulletDeletable(lines[j])) {
           shouldRemove = true;
         }
         const score = extractScore(lines[j]);


### PR DESCRIPTION
## Summary

Fixes #1179.

The dashboard's `vettedIssues.availableCount` overstated workload because `parseIssueList` (1) pushed every URL match into `available[]` without deduping across sections, and (2) only recognized five fixed sub-bullet keywords as terminal, missing the freshness-sweep vocabulary (`**hold**`, `**continue watch**`, `**downgrade**`) curators use on real lists.

## Approach

1. **Anchor status detection to the first bold span on the sub-bullet line.** Broadening to include common English verbs (Hold, Downgrade) means the regex's false-positive surface grows — bold prose in the explanatory tail (`...we should **hold** off until v3...`) would silently re-bucket the parent. Anchoring restores the curator's "first **bold** = the status tag" convention.

2. **Split the predicate.** `parseIssueList` uses broadened `isSubBulletTerminal` (8 keywords) for in-memory bucketing. `pruneIssueList` uses stricter `isSubBulletDeletable` (5 keywords) so on-disk deletion never silently removes parked entries. A curator's `**Hold**` means "park", not "delete".

3. **Dedupe by URL after the parse loop.** Any URL appearing in `completed[]` is filtered out of `available[]` (terminal classification wins per the issue's stated rule). Within each bucket the first occurrence is kept.

## Test plan

- [x] Same URL in two sections, no terminal sub-bullet → 1 available (was 2)
- [x] Same URL in two sections, second has `**hold**` → 0 available, 1 completed (the issue's example case)
- [x] Sub-bullet `**hold**`, `**continue watch**`, `**downgrade**` move items to completed in `parseIssueList`
- [x] `pruneIssueList` does NOT delete entries with `**Hold**`, `**Continue watch**`, `**Downgrade**` sub-bullets (preserves curator's parked items)
- [x] `pruneIssueList` still deletes Skip/Done/Dropped/Merged/Closed entries
- [x] Bold prose in the tail (`**Maybe** — yesterday's **Done** sweep recommended retry`) does NOT re-bucket the item to completed
- [x] All 2328 tests pass, 0 lint errors