### PR TITLE
feat: pr-compliance-checker linked-issue verification (#1246 B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ env:
   #   - **Don't bump for a flaky measurement:** esbuild output is
   #     deterministic. If the threshold trips on a no-op rebuild, it's a
   #     real increase somewhere upstream — not noise.
-  BUNDLE_MAX_CORE: 800000 # ~781 KB (increased for guidelines CLI commands, #867 PR 4)
+  BUNDLE_MAX_CORE: 820000 # ~801 KB (increased for compliance-score command + linked-issue verification, #1245/#1246)
   BUNDLE_MAX_MCP: 2000000 # ~1953 KB
   STARTUP_WARN_MS: 500 # Warn if CLI startup exceeds 500ms
 

--- a/packages/core/src/commands/compliance-score.ts
+++ b/packages/core/src/commands/compliance-score.ts
@@ -15,7 +15,12 @@ import { getOctokit, requireGitHubToken } from '../core/index.js';
 import { ValidationError } from '../core/errors.js';
 import { validateUrl, PR_URL_PATTERN, validateGitHubUrl } from './validation.js';
 import { parseGitHubUrl } from '../core/urls.js';
-import { computeComplianceScore, type RepoContext, type PRMetadata } from '../core/compliance-score.js';
+import {
+  computeComplianceScore,
+  type RepoContext,
+  type PRMetadata,
+  type LinkedIssueInfo,
+} from '../core/compliance-score.js';
 import type { ComplianceScoreOutput } from '../formatters/json.js';
 
 /**
@@ -37,6 +42,87 @@ async function detectTestInfrastructure(
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Parse every issue/PR reference out of the PR body into a flat list of
+ * `{ owner, repo, number }` triples (#1246 Improvement B). Handles the
+ * three forms that PR bodies use in practice:
+ *   - Bare same-repo: `#42` (with closing keyword or referencing keyword)
+ *   - Cross-repo shorthand: `owner/repo#42`
+ *   - Direct URL: `https://github.com/owner/repo/issues/42`
+ *
+ * Deduplicates by `(owner, repo, number)` so a body that mentions the
+ * same issue twice (`Closes #42 — see #42`) results in one API call.
+ */
+function parseLinkedIssueReferences(
+  body: string,
+  defaultOwner: string,
+  defaultRepo: string,
+): Array<{ owner: string; repo: string; number: number }> {
+  const out = new Map<string, { owner: string; repo: string; number: number }>();
+  const push = (owner: string, repo: string, number: number) => {
+    const key = `${owner}/${repo}#${number}`;
+    if (!out.has(key)) out.set(key, { owner, repo, number });
+  };
+
+  // Bare `#42` only counts when accompanied by a closing or referencing
+  // verb — random hashtags shouldn't trigger an API call.
+  const BARE_REF = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|relates?\s+to|refs?|references?|see)\s+#(\d+)/gi;
+  for (const match of body.matchAll(BARE_REF)) {
+    push(defaultOwner, defaultRepo, Number.parseInt(match[1], 10));
+  }
+
+  const CROSS_REPO = /\b([\w.-]+)\/([\w.-]+)#(\d+)/g;
+  for (const match of body.matchAll(CROSS_REPO)) {
+    push(match[1], match[2], Number.parseInt(match[3], 10));
+  }
+
+  const ISSUE_OR_PR_URL = /https?:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/(?:issues|pull)\/(\d+)/gi;
+  for (const match of body.matchAll(ISSUE_OR_PR_URL)) {
+    push(match[1], match[2], Number.parseInt(match[3], 10));
+  }
+
+  return [...out.values()];
+}
+
+/**
+ * Fetch each linked issue/PR via the Issues API and classify its
+ * state (#1246 Improvement B). Failures (404 / rate limit / network)
+ * map to `state: 'not_found'` for that single reference rather than
+ * aborting the score — the function falls back to surfacing what it
+ * could verify.
+ */
+async function verifyLinkedIssues(
+  octokit: ReturnType<typeof getOctokit>,
+  prRepo: { owner: string; repo: string },
+  refs: Array<{ owner: string; repo: string; number: number }>,
+  now: Date = new Date(),
+): Promise<LinkedIssueInfo[]> {
+  return Promise.all(
+    refs.map(async ({ owner, repo, number }) => {
+      const crossRepo = owner !== prRepo.owner || repo !== prRepo.repo;
+      const fullRepo = `${owner}/${repo}`;
+      try {
+        const { data } = await octokit.issues.get({ owner, repo, issue_number: number });
+        if (data.state === 'open') {
+          return { number, repo: fullRepo, crossRepo, state: 'open' as const };
+        }
+        const closedAt = data.closed_at ? new Date(data.closed_at) : null;
+        const closedDaysAgo = closedAt ? Math.floor((now.getTime() - closedAt.getTime()) / 86400000) : undefined;
+        return { number, repo: fullRepo, crossRepo, state: 'closed' as const, closedDaysAgo };
+      } catch (err) {
+        const status = (err as { status?: number }).status;
+        if (status === 404) {
+          return { number, repo: fullRepo, crossRepo, state: 'not_found' as const };
+        }
+        // Rate limit / network — surface as not_found so the agent does
+        // not silently pass on an unverified reference. The agent's
+        // recommendation text already tells the user to confirm.
+        return { number, repo: fullRepo, crossRepo, state: 'not_found' as const };
+      }
+    }),
+  );
 }
 
 /**
@@ -74,8 +160,16 @@ export async function runComplianceScore(options: { prUrl: string }): Promise<Co
     deletions: pr.deletions,
     files: filesResponse.data.map((f) => f.filename),
   };
+
+  // Verify every linked issue/PR reference in the body (#1246 B) so
+  // `Closes #999` against a non-existent or stale issue fails loud
+  // instead of passing on the regex match.
+  const issueRefs = parseLinkedIssueReferences(meta.body, owner, repo);
+  const linkedIssues = issueRefs.length > 0 ? await verifyLinkedIssues(octokit, { owner, repo }, issueRefs) : undefined;
+
   const repoContext: RepoContext = {
     hasTestInfrastructure,
+    linkedIssues,
   };
 
   const result = computeComplianceScore(meta, repoContext);

--- a/packages/core/src/core/compliance-score.test.ts
+++ b/packages/core/src/core/compliance-score.test.ts
@@ -41,6 +41,75 @@ describe('computeComplianceScore — happy path', () => {
   });
 });
 
+describe('issueReference check — verified linked issues (#1246 B)', () => {
+  it('passes when the linked issue is open in the same repo', () => {
+    const ctx: RepoContext = {
+      linkedIssues: [{ number: 42, repo: 'owner/repo', crossRepo: false, state: 'open' }],
+    };
+    const result = computeComplianceScore(meta({ body: 'Closes #42' }), ctx);
+    expect(result.checks.issueReference.status).toBe('pass');
+  });
+
+  it('warns on a recently-closed linked issue', () => {
+    const ctx: RepoContext = {
+      linkedIssues: [{ number: 42, repo: 'owner/repo', crossRepo: false, state: 'closed', closedDaysAgo: 7 }],
+    };
+    const result = computeComplianceScore(meta({ body: 'Closes #42' }), ctx);
+    expect(result.checks.issueReference.status).toBe('warn');
+    expect(result.checks.issueReference.detail).toMatch(/7 days ago/);
+  });
+
+  it('fails on a long-stale closed linked issue', () => {
+    const ctx: RepoContext = {
+      linkedIssues: [{ number: 42, repo: 'owner/repo', crossRepo: false, state: 'closed', closedDaysAgo: 365 }],
+    };
+    const result = computeComplianceScore(meta({ body: 'Closes #42' }), ctx);
+    expect(result.checks.issueReference.status).toBe('fail');
+    expect(result.checks.issueReference.detail).toMatch(/stale/);
+  });
+
+  it('fails when the linked issue does not exist', () => {
+    const ctx: RepoContext = {
+      linkedIssues: [{ number: 999, repo: 'owner/repo', crossRepo: false, state: 'not_found' }],
+    };
+    const result = computeComplianceScore(meta({ body: 'Closes #999' }), ctx);
+    expect(result.checks.issueReference.status).toBe('fail');
+    expect(result.checks.issueReference.detail).toMatch(/does not exist/);
+  });
+
+  it('warns on a cross-repo open reference', () => {
+    const ctx: RepoContext = {
+      linkedIssues: [{ number: 5, repo: 'other/repo', crossRepo: true, state: 'open' }],
+    };
+    const result = computeComplianceScore(meta({ body: 'See other/repo#5' }), ctx);
+    expect(result.checks.issueReference.status).toBe('warn');
+    expect(result.checks.issueReference.detail).toMatch(/cross-repo/);
+  });
+
+  it('takes the worst single result when multiple references are listed', () => {
+    const ctx: RepoContext = {
+      linkedIssues: [
+        { number: 1, repo: 'owner/repo', crossRepo: false, state: 'open' },
+        { number: 2, repo: 'owner/repo', crossRepo: false, state: 'not_found' },
+      ],
+    };
+    const result = computeComplianceScore(meta({ body: 'Closes #1, fixes #2' }), ctx);
+    expect(result.checks.issueReference.status).toBe('fail');
+    expect(result.checks.issueReference.detail).toMatch(/#2/);
+  });
+
+  it('falls back to regex-only when no verification data is supplied', () => {
+    const result = computeComplianceScore(meta({ body: 'Closes #999' }));
+    expect(result.checks.issueReference.status).toBe('pass');
+  });
+
+  it('still fails when the body has no reference at all, even with verification context', () => {
+    const ctx: RepoContext = { linkedIssues: [] };
+    const result = computeComplianceScore(meta({ body: 'No reference here.' }), ctx);
+    expect(result.checks.issueReference.status).toBe('fail');
+  });
+});
+
 describe('issueReference check', () => {
   it('passes on a closing keyword', () => {
     expect(computeComplianceScore(meta({ body: 'Closes #42' })).checks.issueReference.status).toBe('pass');

--- a/packages/core/src/core/compliance-score.ts
+++ b/packages/core/src/core/compliance-score.ts
@@ -57,6 +57,29 @@ export interface PRMetadata {
 }
 
 /**
+ * Verified state of an issue referenced from a PR body. Populated by
+ * the compliance-score command (which calls the Issues API per
+ * reference) and consumed by `checkIssueReference` to fail loud on
+ * broken links (#1246 Improvement B).
+ */
+export interface LinkedIssueInfo {
+  /** Issue number parsed from the PR body. */
+  number: number;
+  /** Owner/repo where the issue lives — may differ from the PR's repo
+   * when a cross-repo reference like `owner/other#42` is used. */
+  repo: string;
+  /** True when the reference targeted a different repo than the PR. */
+  crossRepo: boolean;
+  /** Result of the verification API call. `not_found` covers HTTP 404
+   * and missing-repo cases alike. */
+  state: 'open' | 'closed' | 'not_found';
+  /** Whole days since the issue was closed, when state === 'closed'.
+   * Used to distinguish "recently closed, may still apply" from "long
+   * stale, almost certainly the wrong reference." */
+  closedDaysAgo?: number;
+}
+
+/**
  * Optional repo context used to fine-tune individual check thresholds
  * (#1245). All fields are optional; absent fields use safe defaults that
  * match the original in-prompt rules.
@@ -69,7 +92,22 @@ export interface RepoContext {
    * required by the project.
    */
   hasTestInfrastructure?: boolean;
+  /**
+   * Verified state of every issue/PR reference found in the PR body
+   * (#1246 Improvement B). When provided, `checkIssueReference` will
+   * fail-loud on broken or stale references rather than passing on the
+   * regex match alone. Absent / empty array preserves original
+   * regex-only behavior.
+   */
+  linkedIssues?: LinkedIssueInfo[];
 }
+
+/**
+ * After how many days a closed-issue reference flips from "warn"
+ * (probably still relevant) to "fail" (probably stale). Exported so
+ * callers can document the cutoff (#1246).
+ */
+export const CLOSED_ISSUE_RECENT_DAYS = 30;
 
 const WEIGHTS = {
   issueReference: 25,
@@ -113,19 +151,97 @@ const CLOSING_KEYWORDS = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#\d+/i;
 const REFERENCE_KEYWORDS = /\b(?:relates?\s+to|see|refs?|references?)\s+#\d+/i;
 const ISSUE_URL = /https?:\/\/github\.com\/[^/]+\/[^/]+\/issues\/\d+/i;
 
-function checkIssueReference(meta: PRMetadata): ComplianceCheckResult {
-  const weight = WEIGHTS.issueReference;
-  if (CLOSING_KEYWORDS.test(meta.body)) {
-    return { status: 'pass', weight, detail: 'closing keyword present' };
+/**
+ * If verified linked-issue state is available, derive a status from
+ * the worst single reference (#1246 Improvement B). Returns `null` when
+ * no validation data is supplied — the caller falls back to the
+ * regex-only result.
+ *
+ * Failure modes the precedence ranks (worst first):
+ *   1. `not_found` — referenced issue doesn't exist (typo, wrong repo)
+ *   2. `closed` more than {@link CLOSED_ISSUE_RECENT_DAYS} days ago
+ *   3. `closed` recently — probably still relevant but worth confirming
+ *   4. `open` cross-repo — caller should sanity-check the link applies
+ *   5. `open` same-repo — canonical pass.
+ */
+function evaluateLinkedIssues(weight: number, linkedIssues: LinkedIssueInfo[]): ComplianceCheckResult | null {
+  if (linkedIssues.length === 0) return null;
+  const notFound = linkedIssues.find((li) => li.state === 'not_found');
+  if (notFound) {
+    const tag = notFound.crossRepo ? `${notFound.repo}#${notFound.number}` : `#${notFound.number}`;
+    return {
+      status: 'fail',
+      weight,
+      detail: `linked issue ${tag} does not exist — typo or wrong repo?`,
+    };
   }
-  if (REFERENCE_KEYWORDS.test(meta.body) || ISSUE_URL.test(meta.body)) {
+  const staleClosed = linkedIssues.find(
+    (li) => li.state === 'closed' && (li.closedDaysAgo ?? 0) > CLOSED_ISSUE_RECENT_DAYS,
+  );
+  if (staleClosed) {
+    return {
+      status: 'fail',
+      weight,
+      detail:
+        `linked issue #${staleClosed.number} has been closed for ` +
+        `${staleClosed.closedDaysAgo} days — reference is probably stale`,
+    };
+  }
+  const recentClosed = linkedIssues.find((li) => li.state === 'closed');
+  if (recentClosed) {
     return {
       status: 'warn',
       weight,
-      detail: 'issue referenced without a closing keyword',
+      detail:
+        `linked issue #${recentClosed.number} was closed ` +
+        `${recentClosed.closedDaysAgo ?? '?'} days ago — confirm this PR is still relevant`,
     };
   }
-  return { status: 'fail', weight, detail: 'no issue reference' };
+  const crossRepo = linkedIssues.find((li) => li.crossRepo);
+  if (crossRepo) {
+    return {
+      status: 'warn',
+      weight,
+      detail:
+        `cross-repo reference ${crossRepo.repo}#${crossRepo.number} — ` +
+        `verify the linked issue applies to changes in this repo`,
+    };
+  }
+  return {
+    status: 'pass',
+    weight,
+    detail: `linked issue${linkedIssues.length > 1 ? 's' : ''} verified open`,
+  };
+}
+
+function checkIssueReference(meta: PRMetadata, repoContext?: RepoContext): ComplianceCheckResult {
+  const weight = WEIGHTS.issueReference;
+  const hasClosing = CLOSING_KEYWORDS.test(meta.body);
+  // The parser's `linkedIssues` already captures cross-repo (`owner/repo#N`)
+  // and direct-URL references that the same-repo regex misses. Treat any
+  // parsed reference as "a reference exists" so cross-repo links don't
+  // collapse to a fail just because they didn't match the bare-ref regex.
+  const hasReference =
+    hasClosing ||
+    REFERENCE_KEYWORDS.test(meta.body) ||
+    ISSUE_URL.test(meta.body) ||
+    (repoContext?.linkedIssues?.length ?? 0) > 0;
+  if (!hasReference) {
+    return { status: 'fail', weight, detail: 'no issue reference' };
+  }
+  // When the caller pre-fetched the linked issues' state, that
+  // verification supersedes the regex-only signal — a `Closes #999`
+  // pointing at a non-existent issue must not score as pass.
+  const verified = repoContext?.linkedIssues ? evaluateLinkedIssues(weight, repoContext.linkedIssues) : null;
+  if (verified) return verified;
+  if (hasClosing) {
+    return { status: 'pass', weight, detail: 'closing keyword present' };
+  }
+  return {
+    status: 'warn',
+    weight,
+    detail: 'issue referenced without a closing keyword',
+  };
 }
 
 const SECTION_WHAT = /(?:^|\n)#{1,3}\s*(?:summary|overview|what(?:\s+changed)?)\b/i;
@@ -242,7 +358,7 @@ function ratingFor(score: number): { rating: ComplianceRating; emoji: Compliance
  */
 export function computeComplianceScore(meta: PRMetadata, repoContext?: RepoContext): ComplianceScoreResult {
   const checks = {
-    issueReference: checkIssueReference(meta),
+    issueReference: checkIssueReference(meta, repoContext),
     description: checkDescription(meta),
     focusedChanges: checkFocusedChanges(meta),
     tests: checkTests(meta, repoContext),


### PR DESCRIPTION
## Summary

Implements **Improvement B** from #1246 — pre-fetch every issue/PR reference in the PR body and feed verified state into `computeComplianceScore`. Improvements A (size-relative thresholds) and C (AI policy from CONTRIBUTING.md) from the same issue are deferred per the issue's own ordering note (A wants `repo-vet` from #1242, C overlaps with the `oss-scout` scanner).

## Why

The existing `Closes #N` regex passed on the keyword alone. A typo or stale link (`Closes #999` against a non-existent or two-year-stale issue) scored higher than no reference at all because the regex still matched. That's a worse failure mode than no reference: it suggests deliberate-but-wrong linkage rather than oversight.

## Approach

- Parse every issue/PR reference in the PR body — bare `#N` (when accompanied by a closing/referencing verb), cross-repo `owner/repo#N`, and direct GitHub URLs. Dedupe by `(owner, repo, number)`.
- Fetch each reference's state via the Issues API, classify as `open` / `closed` (with `closedDaysAgo`) / `not_found`. Failures (404, rate limit, network) map to `not_found` per-reference rather than aborting the whole score.
- New typed `LinkedIssueInfo[]` field on `RepoContext`. `checkIssueReference` consumes it when present and falls back to regex-only when absent (preserves test-fixture and offline behavior).
- Status precedence (worst-first): not_found → fail; closed >30d ago → fail; closed ≤30d ago → warn; cross-repo open → warn; same-repo open → pass.

## Test plan

- [x] 8 new unit tests covering each precedence branch + multi-reference worst-case + fixture fallback
- [x] Total: 2365 core + 256 dashboard + 203 mcp tests pass; 0 lint errors
- [x] Bare-regex behavior preserved when no `linkedIssues` supplied (existing tests still green)