### PR TITLE
refactor: extract computeStrategy core function (#1243)

### DIFF
--- a/packages/core/src/core/strategy.test.ts
+++ b/packages/core/src/core/strategy.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Tests for `computeStrategy` (#1243).
+ *
+ * Pin the deterministic compute layer (style classification, language
+ * weighting, capacity overextension, trajectory direction). The
+ * interpretive narrative belongs to the agent prompt and is not under
+ * test here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeStrategy, STRATEGY_MIN_PRS } from './strategy.js';
+import { AgentStateSchema } from './state-schema.js';
+import type { AgentState } from './state-schema.js';
+
+function makeMergedPR(repo: string, n: number, opts: { title?: string; mergedAt?: string } = {}) {
+  return {
+    url: `https://github.com/${repo}/pull/${n}`,
+    title: opts.title ?? `feat: PR #${n}`,
+    mergedAt: opts.mergedAt ?? new Date().toISOString(),
+  };
+}
+
+function makeState(overrides: Partial<AgentState> = {}): AgentState {
+  return AgentStateSchema.parse({ version: 4, ...overrides });
+}
+
+describe('computeStrategy — minimum data gate', () => {
+  it('returns null when fewer than STRATEGY_MIN_PRS merged PRs are tracked', () => {
+    const state = makeState({
+      mergedPRs: Array.from({ length: STRATEGY_MIN_PRS - 1 }, (_, i) => makeMergedPR('o/r', i + 1)),
+    });
+    expect(computeStrategy(state)).toBeNull();
+  });
+
+  it('returns a result at exactly STRATEGY_MIN_PRS merged PRs', () => {
+    const state = makeState({
+      mergedPRs: Array.from({ length: STRATEGY_MIN_PRS }, (_, i) => makeMergedPR('o/r', i + 1)),
+    });
+    expect(computeStrategy(state)).not.toBeNull();
+  });
+});
+
+describe('computeStrategy — profile', () => {
+  it('classifies a heavy single-repo contributor as maintainer', () => {
+    const state = makeState({
+      mergedPRs: Array.from({ length: 12 }, (_, i) => makeMergedPR('vercel/next.js', i + 1)),
+    });
+    const result = computeStrategy(state);
+    expect(result?.profile.style).toBe('maintainer');
+    expect(result?.profile.favoriteRepos).toEqual(['vercel/next.js']);
+  });
+
+  it('classifies a 4+ repo contributor as generalist', () => {
+    const state = makeState({
+      mergedPRs: [
+        ...Array.from({ length: 3 }, (_, i) => makeMergedPR('a/r', i + 1)),
+        ...Array.from({ length: 3 }, (_, i) => makeMergedPR('b/r', i + 1)),
+        ...Array.from({ length: 3 }, (_, i) => makeMergedPR('c/r', i + 1)),
+        ...Array.from({ length: 3 }, (_, i) => makeMergedPR('d/r', i + 1)),
+      ],
+    });
+    const result = computeStrategy(state);
+    expect(result?.profile.style).toBe('generalist');
+    expect(result?.profile.favoriteRepos).toHaveLength(4);
+  });
+
+  it('weights primary languages by repo PR count', () => {
+    const repoScore = (language: string) => ({
+      repo: 'placeholder',
+      score: 7,
+      mergedPRCount: 0,
+      closedWithoutMergeCount: 0,
+      avgResponseDays: null,
+      lastEvaluatedAt: new Date().toISOString(),
+      signals: {
+        hasActiveMaintainers: true,
+        isResponsive: true,
+        hasHostileComments: false,
+      },
+      language,
+    });
+    const state = makeState({
+      mergedPRs: [
+        ...Array.from({ length: 5 }, (_, i) => makeMergedPR('a/r', i + 1)),
+        ...Array.from({ length: 5 }, (_, i) => makeMergedPR('b/r', i + 1)),
+      ],
+      repoScores: {
+        'a/r': repoScore('TypeScript'),
+        'b/r': repoScore('Go'),
+      },
+    });
+    const result = computeStrategy(state);
+    expect(result?.profile.primaryLanguages.sort()).toEqual(['Go', 'TypeScript'].sort());
+  });
+
+  it('computes merge rate from merged + closed totals', () => {
+    const state = makeState({
+      mergedPRs: Array.from({ length: 10 }, (_, i) => makeMergedPR('a/r', i + 1)),
+      closedPRs: [
+        { url: 'https://github.com/a/r/pull/100', title: 'closed', closedAt: new Date().toISOString() },
+        { url: 'https://github.com/a/r/pull/101', title: 'closed', closedAt: new Date().toISOString() },
+      ],
+    });
+    const result = computeStrategy(state);
+    expect(result?.profile.totalPRs).toBe(12);
+    expect(result?.profile.mergedCount).toBe(10);
+    expect(result?.profile.mergeRate).toBeCloseTo(10 / 12);
+  });
+});
+
+describe('computeStrategy — pr type distribution', () => {
+  it('classifies titles by Conventional Commits prefix and keyword fallbacks', () => {
+    const recent = new Date().toISOString();
+    const state = makeState({
+      mergedPRs: [
+        makeMergedPR('a/r', 1, { title: 'docs: update README', mergedAt: recent }),
+        makeMergedPR('a/r', 2, { title: 'fix(api): correct timeout', mergedAt: recent }),
+        makeMergedPR('a/r', 3, { title: 'feat: add login', mergedAt: recent }),
+        makeMergedPR('a/r', 4, { title: 'refactor: simplify state machine', mergedAt: recent }),
+        makeMergedPR('a/r', 5, { title: 'test: cover edge case', mergedAt: recent }),
+        makeMergedPR('a/r', 6, { title: 'crash on null payload', mergedAt: recent }),
+        makeMergedPR('a/r', 7, { title: 'add support for foo', mergedAt: recent }),
+        makeMergedPR('a/r', 8, { title: 'something else entirely', mergedAt: recent }),
+        makeMergedPR('a/r', 9, { title: 'docs: another doc fix', mergedAt: recent }),
+        makeMergedPR('a/r', 10, { title: 'feat: another feature', mergedAt: recent }),
+      ],
+    });
+    const dist = computeStrategy(state)?.patterns.prTypeDistribution;
+    // `add support for foo` keyword-falls-through to features (catches
+    // the `add` / `support` heuristic), so 3 features total.
+    expect(dist?.docs).toBe(2);
+    expect(dist?.fixes).toBe(2);
+    expect(dist?.features).toBe(3);
+    expect(dist?.refactors).toBe(1);
+    expect(dist?.tests).toBe(1);
+    expect(dist?.other).toBe(1);
+  });
+
+  it('excludes PRs older than the recent window from distribution', () => {
+    const state = makeState({
+      mergedPRs: [
+        ...Array.from({ length: 9 }, (_, i) =>
+          makeMergedPR('a/r', i + 1, {
+            title: 'feat: recent',
+            mergedAt: new Date().toISOString(),
+          }),
+        ),
+        makeMergedPR('a/r', 10, {
+          title: 'feat: ancient',
+          mergedAt: new Date('2020-01-01').toISOString(),
+        }),
+      ],
+    });
+    const dist = computeStrategy(state)?.patterns.prTypeDistribution;
+    expect(dist?.features).toBe(9);
+  });
+});
+
+describe('computeStrategy — capacity', () => {
+  it('flags overExtended when dormant PRs span 2+ repos', () => {
+    const state = makeState({
+      mergedPRs: Array.from({ length: 10 }, (_, i) => makeMergedPR('a/r', i + 1)),
+      lastDigest: {
+        generatedAt: new Date().toISOString(),
+        openPRs: [],
+        needsAddressingPRs: [],
+        waitingOnMaintainerPRs: [
+          { url: 'https://github.com/x/y/pull/1' },
+          { url: 'https://github.com/m/n/pull/2' },
+        ] as any,
+        recentlyClosedPRs: [],
+        recentlyMergedPRs: [],
+        shelvedPRs: [],
+        autoUnshelvedPRs: [],
+        summary: { totalActivePRs: 5, totalNeedingAttention: 2, totalMergedAllTime: 10, mergeRate: 1 },
+      },
+    });
+    const cap = computeStrategy(state)?.capacity;
+    expect(cap?.overExtended).toBe(true);
+    expect(cap?.suggestedAction).toBe('follow_up_dormant');
+  });
+
+  it('does not flag overExtended when dormant PRs are all in one repo', () => {
+    const state = makeState({
+      mergedPRs: Array.from({ length: 10 }, (_, i) => makeMergedPR('a/r', i + 1)),
+      lastDigest: {
+        generatedAt: new Date().toISOString(),
+        openPRs: [],
+        needsAddressingPRs: [],
+        waitingOnMaintainerPRs: [
+          { url: 'https://github.com/x/y/pull/1' },
+          { url: 'https://github.com/x/y/pull/2' },
+        ] as any,
+        recentlyClosedPRs: [],
+        recentlyMergedPRs: [],
+        shelvedPRs: [],
+        autoUnshelvedPRs: [],
+        summary: { totalActivePRs: 5, totalNeedingAttention: 2, totalMergedAllTime: 10, mergeRate: 1 },
+      },
+    });
+    const cap = computeStrategy(state)?.capacity;
+    expect(cap?.overExtended).toBe(false);
+  });
+
+  it('suggests open_more when no PRs are open and no dormant follow-ups', () => {
+    const state = makeState({
+      mergedPRs: Array.from({ length: 10 }, (_, i) => makeMergedPR('a/r', i + 1)),
+      lastDigest: {
+        generatedAt: new Date().toISOString(),
+        openPRs: [],
+        needsAddressingPRs: [],
+        waitingOnMaintainerPRs: [],
+        recentlyClosedPRs: [],
+        recentlyMergedPRs: [],
+        shelvedPRs: [],
+        autoUnshelvedPRs: [],
+        summary: { totalActivePRs: 0, totalNeedingAttention: 0, totalMergedAllTime: 10, mergeRate: 1 },
+      },
+    });
+    expect(computeStrategy(state)?.capacity.suggestedAction).toBe('open_more');
+  });
+});
+
+describe('computeStrategy — trajectory', () => {
+  it('returns steady when monthly history is too thin', () => {
+    const state = makeState({
+      mergedPRs: Array.from({ length: 10 }, (_, i) => makeMergedPR('a/r', i + 1)),
+    });
+    expect(computeStrategy(state)?.patterns.trajectoryDirection).toBe('steady');
+  });
+
+  it('returns growing when recent 3-month merge count is >=20% above prior 3 months', () => {
+    const state = makeState({
+      mergedPRs: Array.from({ length: 10 }, (_, i) => makeMergedPR('a/r', i + 1)),
+      monthlyMergedCounts: {
+        '2025-09': 1,
+        '2025-10': 2,
+        '2025-11': 1,
+        '2025-12': 4,
+        '2026-01': 5,
+        '2026-02': 6,
+      },
+    });
+    expect(computeStrategy(state)?.patterns.trajectoryDirection).toBe('growing');
+  });
+
+  it('returns declining when recent 3-month merge count is <=20% below prior 3 months', () => {
+    const state = makeState({
+      mergedPRs: Array.from({ length: 10 }, (_, i) => makeMergedPR('a/r', i + 1)),
+      monthlyMergedCounts: {
+        '2025-09': 5,
+        '2025-10': 6,
+        '2025-11': 4,
+        '2025-12': 1,
+        '2026-01': 0,
+        '2026-02': 1,
+      },
+    });
+    expect(computeStrategy(state)?.patterns.trajectoryDirection).toBe('declining');
+  });
+});

--- a/packages/core/src/core/strategy.ts
+++ b/packages/core/src/core/strategy.ts
@@ -1,0 +1,282 @@
+/**
+ * Contribution strategy compute (#1243).
+ *
+ * Extracts the deterministic compute layer from
+ * `agents/contribution-strategist.md` so the categorization,
+ * trajectory detection, and capacity overextension rules are typed,
+ * unit-testable, and consumable both by the agent (synthesis layer)
+ * and a future auto-display in `/oss`.
+ *
+ * Same architectural shape as success-grade (#858), linked-PR
+ * classifier (#910), and compliance-score (#1245). Pure function — no
+ * I/O, no global state, no LLM. The interpretive narrative ("you're
+ * doing X well, here's a growth opportunity") stays in the agent
+ * prompt.
+ */
+
+import type { AgentState } from './state-schema.js';
+
+export type ContributorStyle = 'maintainer' | 'explorer' | 'specialist' | 'generalist';
+export type TrajectoryDirection = 'growing' | 'steady' | 'declining';
+export type CapacityAction = 'open_more' | 'follow_up_dormant' | 'wait_on_maintainers' | null;
+
+export interface StrategyProfile {
+  style: ContributorStyle;
+  totalPRs: number;
+  mergedCount: number;
+  /** Merge rate as a 0-1 fraction. `0` when no PRs are tracked. */
+  mergeRate: number;
+  /** Top languages by repo PR count, descending. Empty when language data
+   * is not available in repoScores. */
+  primaryLanguages: string[];
+  /** Top repos by merged PR count, descending. */
+  favoriteRepos: string[];
+}
+
+export interface StrategyCapacity {
+  openPRCount: number;
+  dormantPRCount: number;
+  /** True when dormant PRs span >=2 distinct repos (a signal that the
+   * contributor is awaiting reviews from multiple maintainers, not just
+   * one slow project). */
+  overExtended: boolean;
+  /** The single highest-priority next action — null when state is too
+   * thin to recommend anything. */
+  suggestedAction: CapacityAction;
+}
+
+export interface StrategyPatterns {
+  prTypeDistribution: {
+    docs: number;
+    fixes: number;
+    features: number;
+    refactors: number;
+    tests: number;
+    other: number;
+  };
+  trajectoryDirection: TrajectoryDirection;
+  averagePRSize: number;
+}
+
+export interface StrategyRecommendations {
+  languages: string[];
+  repos: string[];
+  issueTypes: string[];
+  avoidPatterns: string[];
+}
+
+export interface StrategyResult {
+  profile: StrategyProfile;
+  capacity: StrategyCapacity;
+  patterns: StrategyPatterns;
+  recommendations: StrategyRecommendations;
+}
+
+/** Minimum tracked PR history before strategy output is meaningful (#1243). */
+export const STRATEGY_MIN_PRS = 10;
+
+/** How many top-N items each "primary" / "favorite" list returns. */
+const TOP_N = 5;
+
+/** Days since `mergedAt` after which a PR no longer counts as recent for
+ * the active-now PR-type distribution. 90 days matches the issue's
+ * proposed trajectory window. */
+const RECENT_WINDOW_DAYS = 90;
+
+/** Match repo from a GitHub URL: `https://github.com/owner/repo/pull/N`. */
+const REPO_FROM_URL = /https:\/\/github\.com\/([^/]+)\/([^/]+)\/(?:issues|pull)\/\d+/i;
+
+function parseRepo(url: string): string | null {
+  const m = url.match(REPO_FROM_URL);
+  return m ? `${m[1]}/${m[2]}` : null;
+}
+
+function classifyTitle(title: string): keyof StrategyPatterns['prTypeDistribution'] {
+  const t = title.trim().toLowerCase();
+  // Match Conventional Commits prefix first; fall back to keyword search
+  // in the title body.
+  const prefix = t.match(/^(feat|fix|docs|refactor|test|perf|chore|build|ci|style|revert)(?:\([^)]+\))?!?:/);
+  const tag = prefix?.[1];
+  if (tag === 'docs') return 'docs';
+  if (tag === 'fix' || tag === 'perf') return 'fixes';
+  if (tag === 'feat') return 'features';
+  if (tag === 'refactor') return 'refactors';
+  if (tag === 'test') return 'tests';
+  // Heuristic fallbacks for non-conventional titles.
+  if (/\b(?:doc|readme|comment|typo)\b/i.test(t)) return 'docs';
+  if (/\b(?:fix|bug|crash|regression|broken)\b/i.test(t)) return 'fixes';
+  if (/\b(?:add|implement|introduce|support|new)\b/i.test(t)) return 'features';
+  if (/\b(?:refactor|cleanup|extract|simplify|rename)\b/i.test(t)) return 'refactors';
+  if (/\btest|spec\b/i.test(t)) return 'tests';
+  return 'other';
+}
+
+function topNByCount(counts: Record<string, number>, n: number): string[] {
+  return Object.entries(counts)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, n)
+    .map(([name]) => name);
+}
+
+function determineStyle(totalPRs: number, primaryLanguages: string[], favoriteRepos: string[]): ContributorStyle {
+  if (totalPRs < 5) return 'explorer';
+  // Heavy concentration in 1-2 repos → maintainer; spread across many → generalist.
+  if (favoriteRepos.length === 1) return 'maintainer';
+  if (primaryLanguages.length === 1 && favoriteRepos.length >= 2 && favoriteRepos.length <= 3) {
+    return 'specialist';
+  }
+  if (favoriteRepos.length >= 4) return 'generalist';
+  return 'specialist';
+}
+
+function determineTrajectory(state: AgentState): TrajectoryDirection {
+  // Compare the last three months' merged PR counts against the prior
+  // three months. If each window has at least one merge, ratio >1.2 is
+  // growing, <0.8 is declining, otherwise steady.
+  const counts = state.monthlyMergedCounts ?? {};
+  const months = Object.keys(counts).sort();
+  if (months.length < 6) return 'steady';
+  const recent = months.slice(-3).reduce((sum, m) => sum + (counts[m] ?? 0), 0);
+  const prior = months.slice(-6, -3).reduce((sum, m) => sum + (counts[m] ?? 0), 0);
+  if (prior === 0) return recent > 0 ? 'growing' : 'steady';
+  const ratio = recent / prior;
+  if (ratio >= 1.2) return 'growing';
+  if (ratio <= 0.8) return 'declining';
+  return 'steady';
+}
+
+function recommendForOverExtension(openPRCount: number, dormantPRCount: number, overExtended: boolean): CapacityAction {
+  if (overExtended) return 'follow_up_dormant';
+  if (dormantPRCount > 0 && openPRCount > 5) return 'wait_on_maintainers';
+  if (openPRCount === 0) return 'open_more';
+  return null;
+}
+
+/**
+ * Compute the deterministic strategy signal from agent state. Returns
+ * null when state is thinner than {@link STRATEGY_MIN_PRS} merged PRs —
+ * the auto-display surface uses this null sentinel as the
+ * minimum-data gate (#1243).
+ */
+export function computeStrategy(state: AgentState): StrategyResult | null {
+  const merged = state.mergedPRs ?? [];
+  const closed = state.closedPRs ?? [];
+  const totalPRs = merged.length + closed.length;
+  if (merged.length < STRATEGY_MIN_PRS) return null;
+
+  // Per-repo PR counts (merged). Used both for "favorite repos" and to
+  // back-fill primary languages from `repoScores` entries that overlap.
+  const mergedByRepo: Record<string, number> = {};
+  for (const pr of merged) {
+    const repo = parseRepo(pr.url);
+    if (!repo) continue;
+    mergedByRepo[repo] = (mergedByRepo[repo] ?? 0) + 1;
+  }
+  const favoriteRepos = topNByCount(mergedByRepo, TOP_N);
+
+  // Languages: weight a repo's language by that repo's merged count so
+  // `vercel/next.js` (TypeScript) counts more than a one-off PR to a
+  // Lua project even if both repos are in `repoScores`.
+  const languageCounts: Record<string, number> = {};
+  for (const [repo, count] of Object.entries(mergedByRepo)) {
+    const score = state.repoScores[repo];
+    const lang = score?.language;
+    if (!lang) continue;
+    languageCounts[lang] = (languageCounts[lang] ?? 0) + count;
+  }
+  const primaryLanguages = topNByCount(languageCounts, TOP_N);
+
+  // PR-type distribution over the recent window.
+  const distribution: StrategyPatterns['prTypeDistribution'] = {
+    docs: 0,
+    fixes: 0,
+    features: 0,
+    refactors: 0,
+    tests: 0,
+    other: 0,
+  };
+  const cutoff = Date.now() - RECENT_WINDOW_DAYS * 86400000;
+  for (const pr of merged) {
+    const mergedAt = Date.parse(pr.mergedAt);
+    if (Number.isNaN(mergedAt) || mergedAt < cutoff) continue;
+    distribution[classifyTitle(pr.title)] += 1;
+  }
+
+  // Capacity: read from the last digest. When no digest exists yet,
+  // default to zero (the agent has nothing to recommend without a
+  // digest). The DailyDigest schema does not store a `dormantCount`
+  // directly — derive it from the `waitingOnMaintainerPRs` array,
+  // which is the "PR flagged as awaiting maintainer review" bucket
+  // produced by `pr-monitor`.
+  const summary = state.lastDigest?.summary;
+  const openPRCount = summary?.totalActivePRs ?? 0;
+  const waiting = state.lastDigest?.waitingOnMaintainerPRs ?? [];
+  const dormantPRCount = waiting.length;
+  // Overextended: dormant PRs spread across 2+ repos. Same definition
+  // the issue body uses.
+  const dormantRepos = new Set(
+    waiting
+      .map((pr) => (typeof (pr as { url?: unknown }).url === 'string' ? parseRepo((pr as { url: string }).url) : null))
+      .filter((r): r is string => r !== null),
+  );
+  const overExtended = dormantPRCount >= 2 && dormantRepos.size >= 2;
+
+  const profile: StrategyProfile = {
+    style: determineStyle(totalPRs, primaryLanguages, favoriteRepos),
+    totalPRs,
+    mergedCount: merged.length,
+    mergeRate: totalPRs === 0 ? 0 : merged.length / totalPRs,
+    primaryLanguages,
+    favoriteRepos,
+  };
+
+  const capacity: StrategyCapacity = {
+    openPRCount,
+    dormantPRCount,
+    overExtended,
+    suggestedAction: recommendForOverExtension(openPRCount, dormantPRCount, overExtended),
+  };
+
+  const patterns: StrategyPatterns = {
+    prTypeDistribution: distribution,
+    trajectoryDirection: determineTrajectory(state),
+    // Without per-PR diff size in StoredMergedPR, a true "average PR
+    // size" lookup is out of scope until that data is captured (#1243
+    // explicitly defers this). Surface 0 so downstream callers know the
+    // signal is unavailable rather than fabricating a value.
+    averagePRSize: 0,
+  };
+
+  const recommendations: StrategyRecommendations = {
+    // The deterministic recommendations layer reuses the profile
+    // signals — the agent's coaching prose layers on top of these.
+    languages: primaryLanguages,
+    repos: favoriteRepos,
+    issueTypes: deriveIssueTypePreferences(distribution),
+    avoidPatterns: deriveAvoidPatterns(capacity, patterns),
+  };
+
+  return { profile, capacity, patterns, recommendations };
+}
+
+function deriveIssueTypePreferences(distribution: StrategyPatterns['prTypeDistribution']): string[] {
+  // Recommend the user's two strongest PR types — they have a track
+  // record there, so issues in those buckets are higher-yield.
+  const ranked = Object.entries(distribution)
+    .filter(([type]) => type !== 'other')
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 2)
+    .map(([type]) => type);
+  return ranked;
+}
+
+function deriveAvoidPatterns(capacity: StrategyCapacity, patterns: StrategyPatterns): string[] {
+  const out: string[] = [];
+  if (capacity.overExtended) {
+    out.push('opening new PRs while dormant ones await review across multiple repos');
+  }
+  if (patterns.trajectoryDirection === 'declining') {
+    out.push('drifting away from a previously productive cadence — capacity may be saturated');
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

Implements **Step 1** from #1243 — extract the `contribution-strategist` agent's deterministic compute layer into a typed core function. Steps 2 (auto-display in `/oss`) and 4 (agent prompt update) are deferred per the issue's own implementation order; the issue explicitly says \"Step 1 is the most leveraged.\"

## Why

The agent fires zero times in typical `/oss` sessions (only on explicit user ask) and re-implements categorization rules in markdown prose. Pulling the deterministic compute (style, languages, capacity, trajectory) into a typed function makes those rules unit-testable and unblocks future surfaces (auto-display, scout-bias per #1244) without touching the agent.

## What's in this PR

- `packages/core/src/core/strategy.ts` — `computeStrategy(state) → StrategyResult | null`. Pure function.
- 14 unit tests covering: minimum-data gate, style classification (maintainer / specialist / generalist), language weighting by repo PR count, merge-rate computation, PR-type classification (Conventional Commits prefix + keyword fallbacks), recent-window filtering, capacity overextension across multiple repos, suggested-action precedence, and trajectory direction (growing / steady / declining).

## Out of scope (deferred per issue)

- `data.daily.strategySummary` cadence trigger in `daily.ts`.
- `commands/oss.md` action-menu rendering.
- `agents/contribution-strategist.md` prompt update to consume the new function.
- `averagePRSize` requires per-PR diff size capture in `StoredMergedPR` (returned as 0 for now per issue note).

The issue says \"Each step is independently mergeable\" — this PR ships Step 1 standalone.

## Test plan

- [x] 14 new unit tests in `strategy.test.ts`
- [x] All 2379 core + 256 dashboard + 203 mcp tests pass
- [x] 0 lint errors