### PR TITLE
refactor: extract computeRepoVet core function (#1242)

### DIFF
--- a/packages/core/src/core/repo-vet.test.ts
+++ b/packages/core/src/core/repo-vet.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for `computeRepoVet` (#1242).
+ *
+ * Pin the weighted scoring, sub-factor thresholds, and verdict cutoffs.
+ * Pure-fixture tests — no network. The interpretive recommendation
+ * paragraph belongs to the agent prompt and is not under test here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeRepoVet, type RepoVetInput } from './repo-vet.js';
+
+function input(overrides: Partial<RepoVetInput> = {}): RepoVetInput {
+  return {
+    stars: 1500,
+    forks: 200,
+    openIssues: 30,
+    watchers: 50,
+    isArchived: false,
+    lastPushed: new Date().toISOString(),
+    createdAt: new Date('2020-01-01').toISOString(),
+    commitsLast30Days: 30,
+    prMergeTimesDays: [2, 3, 1, 4, 2],
+    mergedCount90Days: 50,
+    openedCount90Days: 60,
+    lastCommitISO: new Date().toISOString(),
+    contributorsLast90d: 8,
+    lastReleaseISO: new Date(Date.now() - 30 * 86400000).toISOString(),
+    hasContributing: true,
+    hasIssueTemplates: true,
+    hasPRTemplate: true,
+    hasCodeOfConduct: true,
+    ...overrides,
+  };
+}
+
+describe('computeRepoVet — verdicts', () => {
+  it('rates a healthy repo as recommended', () => {
+    const result = computeRepoVet(input());
+    expect(result.rubricVerdict).toBe('recommended');
+    expect(result.rubricScore).toBeGreaterThanOrEqual(7.5);
+  });
+
+  it('marks an archived repo as avoid regardless of other metrics', () => {
+    const result = computeRepoVet(input({ isArchived: true }));
+    expect(result.rubricVerdict).toBe('avoid');
+  });
+
+  it('marks a repo with no commits in 60+ days as avoid (red flag)', () => {
+    const oldCommit = new Date(Date.now() - 90 * 86400000).toISOString();
+    const result = computeRepoVet(input({ lastCommitISO: oldCommit }));
+    expect(result.rubricVerdict).toBe('avoid');
+  });
+
+  it('marks a repo with PRs but zero merges in 90 days as avoid (red flag)', () => {
+    const result = computeRepoVet(input({ openedCount90Days: 20, mergedCount90Days: 0 }));
+    expect(result.rubricVerdict).toBe('avoid');
+  });
+
+  it('rates a struggling-but-not-flagged repo as proceed_with_caution', () => {
+    // No red flags but middling sub-scores: borderline merge rate,
+    // weak guidelines coverage.
+    const result = computeRepoVet(
+      input({
+        commitsLast30Days: 15,
+        prMergeTimesDays: [4, 6, 5],
+        mergedCount90Days: 18,
+        openedCount90Days: 28,
+        hasContributing: false,
+        hasIssueTemplates: false,
+      }),
+    );
+    expect(result.rubricVerdict).toBe('proceed_with_caution');
+    expect(result.rubricScore).toBeGreaterThanOrEqual(5);
+    expect(result.rubricScore).toBeLessThan(7.5);
+  });
+});
+
+describe('computeRepoVet — pr-merge-time stats', () => {
+  it('reports avg and median from supplied durations', () => {
+    const result = computeRepoVet(input({ prMergeTimesDays: [1, 3, 5, 7, 9] }));
+    expect(result.prMergeTime.avgDays).toBe(5);
+    expect(result.prMergeTime.medianDays).toBe(5);
+    expect(result.prMergeTime.sampleSize).toBe(5);
+    expect(result.prMergeTime.sourceWindowDays).toBe(90);
+  });
+
+  it('returns null avg/median when no PRs in the sample', () => {
+    const result = computeRepoVet(input({ prMergeTimesDays: [] }));
+    expect(result.prMergeTime.avgDays).toBeNull();
+    expect(result.prMergeTime.medianDays).toBeNull();
+    expect(result.prMergeTime.sampleSize).toBe(0);
+  });
+
+  it('computes median as the average of two middle values for even-length samples', () => {
+    const result = computeRepoVet(input({ prMergeTimesDays: [1, 2, 3, 10] }));
+    expect(result.prMergeTime.medianDays).toBe(2.5);
+  });
+});
+
+describe('computeRepoVet — merge rate', () => {
+  it('reports raw counts and percent', () => {
+    const result = computeRepoVet(input({ mergedCount90Days: 70, openedCount90Days: 100 }));
+    expect(result.mergeRate.merged).toBe(70);
+    expect(result.mergeRate.opened).toBe(100);
+    expect(result.mergeRate.percent).toBe(70);
+  });
+
+  it('returns null percent when no PRs were opened', () => {
+    const result = computeRepoVet(input({ mergedCount90Days: 0, openedCount90Days: 0 }));
+    // openedCount=0 also clears the red-flag check (which only fires on
+    // opened>0 AND merged=0).
+    expect(result.mergeRate.percent).toBeNull();
+  });
+});
+
+describe('computeRepoVet — community health', () => {
+  it('echoes the four flags into the result verbatim', () => {
+    const result = computeRepoVet(
+      input({
+        hasContributing: true,
+        hasIssueTemplates: false,
+        hasPRTemplate: true,
+        hasCodeOfConduct: false,
+      }),
+    );
+    expect(result.communityHealth).toEqual({
+      contributing: true,
+      issueTemplates: false,
+      prTemplate: true,
+      codeOfConduct: false,
+    });
+  });
+});
+
+describe('computeRepoVet — rubric score weighting', () => {
+  it('places the score on a 1-10 scale with normalization', () => {
+    const result = computeRepoVet(input());
+    expect(result.rubricScore).toBeGreaterThanOrEqual(0);
+    expect(result.rubricScore).toBeLessThanOrEqual(10);
+  });
+
+  it('drops the activity sub-score on archived repos to zero', () => {
+    // Compare archived vs non-archived with otherwise identical inputs.
+    // Archived hits the red-flag path so verdict is avoid; the score
+    // itself should still be lower than the non-archived case.
+    const live = computeRepoVet(input());
+    const archived = computeRepoVet(input({ isArchived: true }));
+    expect(archived.rubricScore).toBeLessThan(live.rubricScore);
+  });
+});

--- a/packages/core/src/core/repo-vet.ts
+++ b/packages/core/src/core/repo-vet.ts
@@ -1,0 +1,248 @@
+/**
+ * Repo health scoring (#1242).
+ *
+ * Extracted from `agents/repo-evaluator.md`'s in-prompt assembly logic
+ * so the rubric weights, sub-factor thresholds, and verdict cutoffs
+ * are deterministic, unit-testable, and tunable without editing
+ * markdown. Same architectural shape as success-grade (#858),
+ * compliance-score (#1245), and strategy (#1243).
+ *
+ * The function is pure — callers (the MCP tool, the CLI command)
+ * supply pre-fetched repo signals so the score is reproducible
+ * against fixture data and offline replays.
+ *
+ * Rubric reference: docs/repo-rubric.md.
+ */
+
+export interface RepoVetInput {
+  /** Star count from the GitHub repo metadata. */
+  stars: number;
+  forks: number;
+  openIssues: number;
+  watchers: number;
+  isArchived: boolean;
+  /** ISO-8601 timestamp of the last push. */
+  lastPushed: string;
+  /** ISO-8601 timestamp of repo creation. */
+  createdAt: string;
+  /** Number of commits to the default branch in the last 30 days. */
+  commitsLast30Days: number;
+  /** Per-PR `createdAt → mergedAt` durations in days, for the last 90
+   * days of merged PRs. Used to derive avg / median merge time. */
+  prMergeTimesDays: number[];
+  /** Count of merges in the last 90 days. */
+  mergedCount90Days: number;
+  /** Count of opened PRs in the last 90 days. Used for merge rate. */
+  openedCount90Days: number;
+  /** ISO-8601 timestamp of the most recent commit on the default branch. */
+  lastCommitISO: string | null;
+  /** Distinct authors who committed in the last 90 days. */
+  contributorsLast90d: number;
+  /** ISO-8601 timestamp of the most recent published release. */
+  lastReleaseISO: string | null;
+  hasContributing: boolean;
+  hasIssueTemplates: boolean;
+  hasPRTemplate: boolean;
+  hasCodeOfConduct: boolean;
+}
+
+export type RepoVetVerdict = 'recommended' | 'proceed_with_caution' | 'avoid';
+
+export interface RepoVetResult {
+  repo: {
+    stars: number;
+    forks: number;
+    openIssues: number;
+    watchers: number;
+    isArchived: boolean;
+    lastPushed: string;
+    createdAt: string;
+  };
+  prMergeTime: {
+    avgDays: number | null;
+    medianDays: number | null;
+    sampleSize: number;
+    sourceWindowDays: 90;
+  };
+  mergeRate: {
+    merged: number;
+    opened: number;
+    percent: number | null;
+    windowDays: 90;
+  };
+  maintainerActivity: {
+    lastCommitISO: string | null;
+    contributorsLast90d: number;
+    lastReleaseISO: string | null;
+  };
+  communityHealth: {
+    contributing: boolean;
+    issueTemplates: boolean;
+    prTemplate: boolean;
+    codeOfConduct: boolean;
+  };
+  /** Weighted 1-10 score per docs/repo-rubric.md. */
+  rubricScore: number;
+  /** Top-line verdict derived from the score and red-flag overrides. */
+  rubricVerdict: RepoVetVerdict;
+}
+
+const WEIGHTS = {
+  activity: 0.25,
+  prSpeed: 0.25,
+  mergeRate: 0.2,
+  guidelines: 0.1,
+  stability: 0.05,
+  /** Responsiveness (15%) is documented in the rubric but the input
+   * shape doesn't surface it — `gh pr list --json` doesn't expose
+   * "time to first review". Per the rubric note, omit it rather than
+   * fabricate it. The remaining weights total 0.85 and are normalized
+   * to a 10-point ceiling at the end. */
+} as const;
+
+const SUM_OF_AVAILABLE_WEIGHTS =
+  WEIGHTS.activity + WEIGHTS.prSpeed + WEIGHTS.mergeRate + WEIGHTS.guidelines + WEIGHTS.stability;
+
+const VERDICT_CUTOFFS = {
+  recommended: 7.5,
+  cautious: 5,
+} as const;
+
+function median(nums: number[]): number {
+  if (nums.length === 0) return 0;
+  const sorted = [...nums].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+function activitySubScore(input: RepoVetInput): number {
+  // 1.0 when commits/30d ≥ 30 (one per day), 0 when 0, linear in between.
+  if (input.isArchived) return 0;
+  return Math.min(1, input.commitsLast30Days / 30);
+}
+
+function prSpeedSubScore(input: RepoVetInput): number {
+  // Rubric: avg PR merge time < 7 days = healthy. Linear: 0d → 1.0,
+  // 14d+ → 0.0. Sample of zero merges = 0 score (no signal of speed).
+  if (input.prMergeTimesDays.length === 0) return 0;
+  const avg = input.prMergeTimesDays.reduce((sum, d) => sum + d, 0) / input.prMergeTimesDays.length;
+  if (avg <= 0) return 1;
+  if (avg >= 14) return 0;
+  return Math.max(0, Math.min(1, (14 - avg) / 14));
+}
+
+function mergeRateSubScore(input: RepoVetInput): number {
+  // Rubric: >70% merged in last 90 days. Linear: 100% → 1.0, 0% → 0.
+  if (input.openedCount90Days === 0) return 0;
+  const rate = input.mergedCount90Days / input.openedCount90Days;
+  return Math.max(0, Math.min(1, rate));
+}
+
+function guidelinesSubScore(input: RepoVetInput): number {
+  // Each of the four community-health flags contributes equally.
+  let score = 0;
+  if (input.hasContributing) score += 0.4;
+  if (input.hasIssueTemplates) score += 0.25;
+  if (input.hasPRTemplate) score += 0.25;
+  if (input.hasCodeOfConduct) score += 0.1;
+  return Math.min(1, score);
+}
+
+function stabilitySubScore(input: RepoVetInput): number {
+  // Rubric: not archived, regular releases. Half-credit for not-archived,
+  // half for a release within the last 6 months.
+  if (input.isArchived) return 0;
+  let score = 0.5;
+  if (input.lastReleaseISO) {
+    const since = Date.now() - new Date(input.lastReleaseISO).getTime();
+    const sixMonths = 1000 * 60 * 60 * 24 * 30 * 6;
+    if (since <= sixMonths) score += 0.5;
+  }
+  return score;
+}
+
+/**
+ * Hard red-flag overrides — when one fires, verdict drops to `avoid`
+ * regardless of the weighted score. Sourced verbatim from the rubric.
+ */
+function hasRedFlags(input: RepoVetInput): boolean {
+  if (input.isArchived) return true;
+  if (input.lastCommitISO) {
+    const sinceCommit = Date.now() - new Date(input.lastCommitISO).getTime();
+    const sixtyDays = 60 * 24 * 60 * 60 * 1000;
+    if (sinceCommit > sixtyDays) return true;
+  }
+  if (input.openedCount90Days > 0 && input.mergedCount90Days === 0) return true;
+  return false;
+}
+
+function deriveVerdict(score: number, redFlags: boolean): RepoVetVerdict {
+  if (redFlags) return 'avoid';
+  if (score >= VERDICT_CUTOFFS.recommended) return 'recommended';
+  if (score >= VERDICT_CUTOFFS.cautious) return 'proceed_with_caution';
+  return 'avoid';
+}
+
+/**
+ * Compute repo-health metrics and an overall rubric score from
+ * pre-fetched signals (#1242). Pure function — no I/O, no global state.
+ */
+export function computeRepoVet(input: RepoVetInput): RepoVetResult {
+  const subScores = {
+    activity: activitySubScore(input),
+    prSpeed: prSpeedSubScore(input),
+    mergeRate: mergeRateSubScore(input),
+    guidelines: guidelinesSubScore(input),
+    stability: stabilitySubScore(input),
+  };
+
+  // Weighted average normalized to the 10-point ceiling.
+  const weightedSum =
+    subScores.activity * WEIGHTS.activity +
+    subScores.prSpeed * WEIGHTS.prSpeed +
+    subScores.mergeRate * WEIGHTS.mergeRate +
+    subScores.guidelines * WEIGHTS.guidelines +
+    subScores.stability * WEIGHTS.stability;
+  const rubricScore = Math.round((weightedSum / SUM_OF_AVAILABLE_WEIGHTS) * 100) / 10;
+
+  const sampleSize = input.prMergeTimesDays.length;
+  const avgDays = sampleSize === 0 ? null : input.prMergeTimesDays.reduce((s, d) => s + d, 0) / sampleSize;
+  const medianDays = sampleSize === 0 ? null : median(input.prMergeTimesDays);
+
+  const mergeRatePercent =
+    input.openedCount90Days === 0 ? null : (input.mergedCount90Days / input.openedCount90Days) * 100;
+
+  const verdict = deriveVerdict(rubricScore, hasRedFlags(input));
+
+  return {
+    repo: {
+      stars: input.stars,
+      forks: input.forks,
+      openIssues: input.openIssues,
+      watchers: input.watchers,
+      isArchived: input.isArchived,
+      lastPushed: input.lastPushed,
+      createdAt: input.createdAt,
+    },
+    prMergeTime: { avgDays, medianDays, sampleSize, sourceWindowDays: 90 },
+    mergeRate: {
+      merged: input.mergedCount90Days,
+      opened: input.openedCount90Days,
+      percent: mergeRatePercent,
+      windowDays: 90,
+    },
+    maintainerActivity: {
+      lastCommitISO: input.lastCommitISO,
+      contributorsLast90d: input.contributorsLast90d,
+      lastReleaseISO: input.lastReleaseISO,
+    },
+    communityHealth: {
+      contributing: input.hasContributing,
+      issueTemplates: input.hasIssueTemplates,
+      prTemplate: input.hasPRTemplate,
+      codeOfConduct: input.hasCodeOfConduct,
+    },
+    rubricScore,
+    rubricVerdict: verdict,
+  };
+}


### PR DESCRIPTION
## Summary

Implements **Step 1** from #1242 — extract the `repo-evaluator` agent's deterministic compute layer (rubric weighting, sub-factor thresholds, red-flag detection) into a typed core function. The MCP tool / CLI command and the agent prompt update are deferred per the issue's own implementation order.

## Why

Same shape as compliance-score (#1245) and strategy (#1243). The agent currently does data plumbing in prose — stitching `gh repo view`, `gh pr list --state merged`, and four other CLI calls into a markdown table. Pulling the rubric scoring into typed code makes the weights and red-flag rules unit-testable and tunable without editing markdown.

## What's in this PR

- `packages/core/src/core/repo-vet.ts` — `computeRepoVet(input) → RepoVetResult`. Pure function. Implements the docs/repo-rubric.md scoring (Activity 25% / PR speed 25% / Merge rate 20% / Guidelines 10% / Stability 5%), with red-flag overrides for archived repos, 60-day commit gaps, and zero-merge windows. Responsiveness (15%) is documented but omitted because `gh pr list` doesn't expose first-review time — per the rubric note, omit rather than fabricate.
- 13 unit tests covering verdicts, PR-merge-time stats, merge rate, community health, and red-flag overrides.

## Out of scope (deferred per issue)

- Adding the MCP tool / CLI command (`repo-vet <owner/repo>`) that fetches inputs from the GitHub API.
- Updating `agents/repo-evaluator.md` to consume the structured output.
- Model bump.

The core function is the most leveraged piece per the issue body; the remaining pieces plumb fetched data into it without changing the rubric semantics. Each ships independently.

## Test plan

- [x] 13 new unit tests in `repo-vet.test.ts`
- [x] All 2392 core + 256 dashboard + 203 mcp tests pass
- [x] 0 lint errors