### PR TITLE
refactor: pr-health-checker reads configured clone paths (#1247 Improvement 1)

### DIFF
--- a/agents/pr-health-checker.md
+++ b/agents/pr-health-checker.md
@@ -76,7 +76,15 @@ Use the MCP / CLI / gh path above.
 
 ### 2. Check Branch Freshness
 
-Locate the local clone (`~/Documents/oss/<repo>`, `~/dev/<repo>`). Check upstream divergence:
+**Locate the local clone** by reading the user's configured scan paths. The default (`~/Documents/oss/<repo>`, `~/dev/<repo>`) is a fallback, NOT a fixed assumption. Check `config.localRepoScanPaths` first via `mcp__plugin_oss-autopilot_oss-autopilot__config` (or `cli.bundle.cjs config --json`); a user with clones in `~/code/` or `~/projects/` configures those paths once and avoids the silent-fallback footgun (#1247 Improvement 1).
+
+```bash
+# Read configured scan paths (run once per session):
+GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" config --json
+# → look at .data.config.localRepoScanPaths; fall back to ~/Documents/oss + ~/dev when unset
+```
+
+Once the clone is located:
 
 ```bash
 cd /path/to/repo
@@ -91,7 +99,7 @@ If behind, check review state first via `gh pr view NUMBER --repo OWNER/REPO --j
 - **Active review:** do NOT auto-rebase. Recommend new commits on top; rebase only on explicit user request.
 - **No active review (Tier 1):** `git rebase upstream/<main>`. If clean: `git branch --set-upstream-to=origin/<branch>`, `git fetch origin <branch>`, `git push --force-with-lease`. If `--force-with-lease` fails, STOP — do NOT fall back to `--force`. If conflicts, `git rebase --abort` and escalate to Tier 2.
 
-If not cloned: `git clone https://github.com/<fork>/<repo>.git ~/Documents/oss/<repo>` then add the upstream remote. For very large repos (bun, chromium), use `--filter=blob:none` partial clone.
+If not cloned: clone into the FIRST configured scan path (or `~/Documents/oss/<repo>` when none configured) — `git clone https://github.com/<fork>/<repo>.git <scan-path>/<repo>` then add the upstream remote. For very large repos (bun, chromium), use `--filter=blob:none` partial clone.
 
 ### 3. Categorize CI Status
 


### PR DESCRIPTION
## Summary

Implements **Improvement 1** from #1247 — replace the hardcoded `~/Documents/oss/<repo>` / `~/dev/<repo>` clone-path assumption with a read of `config.localRepoScanPaths`. Improvements 2-6 from the same issue are deferred per the issue's own framing (\"Each item lands incremental wins; together they reduce... Each is independently mergeable\").

## Why

A user with clones in `~/code/` or `~/projects/` (i.e., not the maintainer's exact filesystem) silently falls through to cloning fresh on every check, which is slow and confusing. The config field (`localRepoScanPaths`) already exists in `AgentConfigSchema` from prior work — this PR just teaches the agent to consult it.

## Out of scope (deferred per #1247 bundle)

- Improvement 2: extract-to-core helpers for `getBranchFreshness`, `categorizeCIStatus`, `classifyBotComments`, `getRebaseStrategy`. Each is comparable in effort to compliance-score (#1245) / repo-vet (#1242).
- Improvement 3: per-session PR-state cache (60s TTL).
- Improvement 4: concurrent fan-out across repos.
- Improvement 5: `/pr-ready` reuse.
- Improvement 6: age-weighted rebase risk.

## Test plan

- [x] No code changes — agent prompt edit only
- [x] CI gate (`agents-contract.test.ts`) validates the new `config` MCP tool reference
- [x] All 2392 core + 256 dashboard + 203 mcp tests pass