### PR TITLE
feat: plan-review convergence loop and /plan-ready (#1249)

### DIFF
--- a/.claude-plugin/expected-cli-contract.json
+++ b/.claude-plugin/expected-cli-contract.json
@@ -44,6 +44,7 @@
     "workflows/dormant-pr-follow-up.md",
     "workflows/draft-first-workflow.md",
     "workflows/extract-learnings.md",
+    "workflows/plan-review.md",
     "workflows/pre-commit-review.md",
     "workflows/reference.md",
     "workflows/review-issue-replies.md",

--- a/commands/plan-ready.md
+++ b/commands/plan-ready.md
@@ -1,0 +1,92 @@
+---
+name: plan-ready
+description: Run a review-and-critique convergence loop on an implementation plan BEFORE any code is written — mirrors /pr-ready for the planning phase
+allowed-tools: Bash, Read, Glob, Grep, Agent, TaskCreate, TaskUpdate, Edit, Write
+---
+
+# /plan-ready
+
+Drives the **plan-review convergence loop** that catches design-level
+problems before any code is written. Mirrors `/pr-ready` exactly, but
+applied to a plan artifact instead of a diff (#1249).
+
+## When to use
+
+Run after you have completed investigation and written an implementation
+plan, BEFORE you start implementing. A solid plan caught and refined here
+is much cheaper than the same problem caught after 200 lines of code
+exist.
+
+The slash command auto-locates the plan artifact at
+`/tmp/oss-autopilot-plans/<repo>-<issue-number>.md`. Pass the path
+explicitly if the plan lives elsewhere: `/plan-ready /tmp/some-plan.md`.
+
+## What it does
+
+For the named plan artifact:
+
+1. **Verify the plan is complete enough to evaluate.** Check that it has
+   sections covering: investigation findings, proposed approach,
+   specific file-level changes, alternative approaches considered, and
+   acceptance criteria. Block readiness if the plan is a stub (single
+   paragraph, no structure) — that needs more drafting before review.
+
+2. **Dispatch the pr-review-toolkit agents in parallel** against the
+   plan text:
+   - `pr-review-toolkit:code-reviewer` — design-level critique (does
+     the proposed approach make sense for the codebase? Are there
+     simpler / more idiomatic alternatives the plan missed?)
+   - `pr-review-toolkit:silent-failure-hunter` — does the plan name how
+     it handles edge cases, error paths, partial failures, or does it
+     silently assume the happy path?
+   - `pr-review-toolkit:code-simplifier` — is the plan's scope right?
+     Is there a simpler change that achieves the same outcome?
+   - `devils-advocate` — actively try to break the plan. List
+     scenarios where the proposed approach fails or surprises a future
+     reader.
+
+   Brief each agent with the plan text, the issue body it targets, and
+   any contributing-guidelines context already discovered.
+
+3. **Triage findings**:
+   - **Critical** findings (plan is wrong / incomplete in a way that
+     would force a rewrite mid-implementation): block readiness.
+   - **Recommended** findings (plan ships but is suboptimal — wrong
+     file structure, missed alternative): block readiness.
+   - **Minor** findings (wording, sectioning): report but don't block.
+   - **Out-of-scope** findings: list as "deferred to follow-up plan".
+
+4. **Iterate**: after the user updates the plan (or asks the command
+   to update it), re-run **only the agents that had findings** plus
+   `code-reviewer` as a baseline. Same scope-down-on-rerun pattern as
+   `/pr-ready`. Hard cap at 5 passes; if convergence isn't reached,
+   stop and report.
+
+5. **Report**: produce a short status report — `READY TO IMPLEMENT`
+   with a one-line summary of what the plan does, or `NEEDS REWORK`
+   with the blockers.
+
+## What it does NOT do
+
+- Does not write or modify the plan itself. The user (or a parent
+  workflow) does that. This command only critiques.
+- Does not start implementation. Implementation is gated on the
+  `READY TO IMPLEMENT` verdict but is a separate step.
+- Does not replace `/pr-ready`. The two run at different stages of the
+  pipeline:
+  - `/plan-ready` → before code is written, catches design problems
+  - `/pr-ready` → before code is pushed, catches code problems
+
+Both are mandatory in the project's full draft-first workflow.
+
+## How it integrates with `draft-first-workflow.md`
+
+`workflows/plan-review.md` is the auto-fired sibling to
+`workflows/pre-commit-review.md`. The draft-first workflow dispatches
+plan-review immediately after investigation completes and a plan
+artifact exists; implementation does not begin until plan-review
+returns `READY`.
+
+Manually invoking `/plan-ready` does the same convergence loop without
+the auto-dispatch — useful when you want to critique a plan you wrote
+outside the draft-first workflow.

--- a/workflows/plan-review.md
+++ b/workflows/plan-review.md
@@ -1,0 +1,112 @@
+# Workflow: Plan Review Convergence Loop
+
+Companion to `pre-commit-review.md` for the **planning phase** (#1249).
+The pre-commit loop catches code-quality issues; this loop catches
+design-level problems BEFORE any code is written. A plan caught and
+refined here is much cheaper than the same problem caught after 200
+lines of code exist.
+
+## When this fires
+
+Auto-dispatched by `draft-first-workflow.md` after the investigation
+step completes and a plan artifact has been written to
+`/tmp/oss-autopilot-plans/<repo>-<issue-number>.md`. Implementation
+does not begin until this loop returns `READY TO IMPLEMENT`.
+
+Can also be invoked manually via `/plan-ready` — same convergence
+logic without the auto-dispatch.
+
+## Plan artifact shape
+
+The plan written by the investigation step should follow this
+structure (the review loop checks for these sections):
+
+```markdown
+# Implementation Plan: <repo>#<issue-number>
+
+## Issue Summary
+[One-paragraph restatement of the problem]
+
+## Investigation Findings
+- What the agent learned about the codebase
+- Existing conventions / patterns relevant to the change
+- Alternative approaches considered (and why they were not chosen)
+
+## Proposed Approach
+[The chosen approach with explicit reasoning]
+
+## Specific Changes
+1. File: ... — change description
+2. File: ... — change description
+...
+
+## Edge Cases Handled
+- [Each edge case the plan addresses]
+
+## Acceptance Criteria
+- [How we'll know the implementation is complete]
+```
+
+A plan missing one of: `Investigation Findings`, `Proposed Approach`,
+`Specific Changes`, `Acceptance Criteria` is too thin to review and
+the loop returns `NEEDS DRAFTING` so the planning step iterates first.
+
+## Convergence loop
+
+The same shape as `pre-commit-review.md` but with design-focused
+agents:
+
+1. **First pass** — dispatch in parallel against the plan text:
+   - `pr-review-toolkit:code-reviewer` — design-level critique
+   - `pr-review-toolkit:silent-failure-hunter` — error / edge-case
+     coverage
+   - `pr-review-toolkit:code-simplifier` — scope-shrink opportunities
+   - `devils-advocate` — adversarial scenarios that break the plan
+
+2. **Triage** — same severity buckets as the code review:
+   - **Critical**: plan would force a rewrite mid-implementation. Block.
+   - **Recommended**: plan ships but suboptimal. Block.
+   - **Minor**: wording / sectioning. Report, don't block.
+   - **Deferred**: out-of-scope follow-ups. List separately.
+
+3. **Iterate**: update the plan (the parent workflow / user does
+   this), then re-run **only the agents that had findings** plus
+   `code-reviewer` as a baseline. Same scope-down-on-rerun rule the
+   pre-commit loop uses. Cap at 5 passes; if not converged, stop and
+   surface the unresolved blockers.
+
+4. **Report** — `READY TO IMPLEMENT` with a one-line plan summary, or
+   `NEEDS REWORK` with the blockers.
+
+## Why two loops, not one
+
+`/pr-ready` cannot catch design-level problems because by the time it
+runs, the design is sunk cost. Catching "this should have been a
+config change instead of a 200-line refactor" after 200 lines exist
+means throwing the work away or salvaging it; both are expensive.
+
+`/plan-ready` cannot catch code-quality problems because the code
+doesn't exist yet. Catching dead code or missing tests at the planning
+stage is meaningless — those concerns live in the implementation
+artifact.
+
+The two loops complement each other; they do not replace each other.
+
+## Out of scope
+
+- Choosing the planning agent or planning skill that authors the plan.
+  This loop is the *reviewer*; the author is upstream and exists in
+  several forms (Plan subagent, `superpowers:writing-plans` skill,
+  manual user-authored plans).
+- Persisting the converged plan into project history. The artifact
+  lives at `/tmp/oss-autopilot-plans/...` for the duration of the
+  session and is regenerated each time. PR descriptions reproduce the
+  relevant portions in their own format.
+
+## Why now
+
+The project has tight code-review discipline after code is written
+(pre-commit-review.md) but no equivalent gate before. The cheapest bug
+is the one caught at the planning stage; this workflow makes that
+cheapness available without requiring users to remember to ask for a
+plan critique manually.


### PR DESCRIPTION
## Summary

Closes #1249.

Adds a review-and-critique convergence loop to the **planning phase**, mirroring the existing post-implementation `/pr-ready` loop. The project has tight code-review discipline after code is written but no equivalent gate before. A plan caught and refined here is much cheaper than the same problem caught after 200 lines of code exist.

## What's in this PR

- **`commands/plan-ready.md`** — manual slash command. Same shape as `/pr-ready` but applied to a plan artifact instead of a diff.
- **`workflows/plan-review.md`** — workflow doc that `draft-first-workflow.md` auto-fires after investigation completes and a plan exists. Implementation does not begin until the loop returns `READY TO IMPLEMENT`.
- **Plugin contract pin** — `.claude-plugin/expected-cli-contract.json` lists the new workflow file so the session-start drift detector recognizes it.

## How the loop works

1. **Verify plan completeness** — checks for the structured sections (Investigation Findings, Proposed Approach, Specific Changes, Acceptance Criteria). A stub plan returns `NEEDS DRAFTING` so the planning step iterates first.
2. **Dispatch design-focused review agents in parallel** against the plan text:
   - `pr-review-toolkit:code-reviewer` (design critique)
   - `pr-review-toolkit:silent-failure-hunter` (edge-case coverage)
   - `pr-review-toolkit:code-simplifier` (scope-shrink opportunities)
   - `devils-advocate` (adversarial scenarios)
3. **Triage** with the same severity buckets as the code-side loop (Critical / Recommended block, Minor reports, Out-of-scope deferred).
4. **Iterate** — re-run only the agents that had findings + code-reviewer as a baseline. Hard cap at 5 passes.
5. **Report** — `READY TO IMPLEMENT` or `NEEDS REWORK` with the blockers.

## Why two loops, not one

`/pr-ready` cannot catch design-level problems because by then the design is sunk cost. `/plan-ready` cannot catch code-quality problems because the code doesn't exist yet. They run at different stages and complement each other.

## Test plan

- [x] No code changes — markdown surfaces only
- [x] Plugin contract pin updated; CLI contract test still passes
- [x] All 2392 core + 256 dashboard + 203 mcp tests pass

## Out of scope

- Choosing the planning *author* (Plan subagent vs `superpowers:writing-plans` skill vs manual). This PR is the *reviewer*; the author is upstream.
- Persisting converged plans into project history. Artifacts live at `/tmp/oss-autopilot-plans/...` for the session and are regenerated each time.