### PR TITLE
refactor: pre-commit-reviewer integrates per-repo guidelines (#1250 Improvement 1)

### DIFF
--- a/agents/pre-commit-reviewer.md
+++ b/agents/pre-commit-reviewer.md
@@ -22,7 +22,7 @@ Post-conflict resolution is a critical moment where bugs can be introduced. Revi
 
 model: sonnet
 color: red
-tools: ["Bash", "Read", "Glob", "Grep"]
+tools: ["Bash", "Read", "Glob", "Grep", "mcp__plugin_oss-autopilot_oss-autopilot__guidelines-get"]
 ---
 
 > **Input validation:** See "AskUserQuestion Validation Protocol" in `workflows/reference.md`.
@@ -59,7 +59,9 @@ If this shows commits, save the working range as `diffRange` (the first of the t
 
 ## Phase 2: Convention Detection
 
-Read the target repo's contribution guidelines and style configuration. Skip missing, track found: `CONTRIBUTING.md`, `.editorconfig`, `.eslintrc*`, `.prettierrc*`, `biome.json*`, `.clang-format`, `.rustfmt.toml`, `pyproject.toml` (check for `[tool.ruff]` / `[tool.black]` / `[tool.isort]`). If nothing found, note in the final report that convention checks are inference-only.
+**First**, call `mcp__plugin_oss-autopilot_oss-autopilot__guidelines-get` with the target repo (#1250 Improvement 1). If per-repo guidelines exist (extracted via #867 from prior PR feedback history), they are AUTHORITATIVE — they override anything inferred from configs or sample files. The Phase 3 finding tiers (Critical / Recommended / Minor) consume the guidelines as project-specific rules: a violation of a documented "this repo wants tests in `__tests__/` not `test/`" rule is Recommended at minimum, even if the agent would otherwise call it Minor.
+
+**Then**, read the target repo's contribution guidelines and style configuration. Skip missing, track found: `CONTRIBUTING.md`, `.editorconfig`, `.eslintrc*`, `.prettierrc*`, `biome.json*`, `.clang-format`, `.rustfmt.toml`, `pyproject.toml` (check for `[tool.ruff]` / `[tool.black]` / `[tool.isort]`). If nothing found AND no per-repo guidelines exist, note in the final report that convention checks are inference-only.
 
 Also look at 2–3 existing files in the same directories as changed files to infer naming, import ordering, comment style, and test file location.
 


### PR DESCRIPTION
## Summary

Implements **Improvement 1** from #1250 — wire `pre-commit-reviewer` into the per-repo `guidelines-get` machinery. Improvements 2 (parallelize phases) and 3 (extract shared helpers to core) are deferred per the issue's \"each independently mergeable\" framing.

## Why

Same gap that #1245 fixed for `pr-compliance-checker` and #1248 fixed for `pr-responder`. The user accumulates per-repo learnings via the existing `#867` extract-learnings flow (\"this repo wants tests in `__tests__/` not `test/`\"), and the pre-commit reviewer ignored them — its Phase 2 convention detection read ESLint and Prettier configs but skipped the richest source.

## What changes

- Adds `mcp__plugin_oss-autopilot_oss-autopilot__guidelines-get` to the agent's tool whitelist.
- Phase 2 now calls `guidelines-get` FIRST. Per-repo guidelines are authoritative — they override anything inferred from configs or sample files.
- Phase 3 finding tiers consume the guidelines as project-specific rules: a documented violation (e.g., test-directory naming) is Recommended at minimum, not Minor.

## Test plan

- [x] No code changes — agent prompt edit only
- [x] CI gate (`agents-contract.test.ts`) validates the new `guidelines-get` MCP tool reference
- [x] All 2392 core + 256 dashboard + 203 mcp tests pass

## Out of scope

- Improvement 2: parallelize Phases 2, 2.5, 4, 4.5 (mutually independent phases that all read the same diff).
- Improvement 3: extract `categorizeCIStatus` / convention / security / API-naming helpers into typed core functions (overlaps with #1247 Improvement 2).