### PR TITLE
fix: gate SessionStart PR health summary on cache freshness (#1255)

### DIFF
--- a/.claude-plugin/scripts/health-check.cjs
+++ b/.claude-plugin/scripts/health-check.cjs
@@ -8,6 +8,9 @@
  * - Reads ~/.oss-autopilot/state.json (cached from last /oss run)
  * - If no state exists, shows a first-run hint to run /oss
  * - If last digest is >7 days old, nudges the user to catch up
+ * - If the cached digest is older than the freshness threshold (default
+ *   30 minutes, configurable via `config.healthCheckFreshnessMinutes`),
+ *   suppress the line entirely so the user only sees it when current (#1255)
  * - Otherwise, outputs a compact one-liner: "OSS: 15 active PRs — 3 need addressing, 12 waiting on maintainer (2h ago)"
  *
  * Error handling: Errors are logged to stderr (visible in debug) but never
@@ -34,6 +37,18 @@ try {
   const ageHours = Math.floor(ageMs / 3600000);
   const ageMinutes = Math.floor(ageMs / 60000);
   const ageLabel = ageDays >= 1 ? ageDays + 'd ago' : ageHours >= 1 ? ageHours + 'h ago' : ageMinutes + 'm ago';
+  // Freshness gate (#1255). The cached digest only refreshes on `/oss`;
+  // SessionStart fires every session, so without this gate the line drifts
+  // arbitrarily stale. Suppress when older than the configured minute
+  // budget (default 30) but younger than the 7-day catch-up nudge.
+  const freshnessMinutes =
+    typeof state.config === 'object' && state.config !== null && Number.isInteger(state.config.healthCheckFreshnessMinutes)
+      ? state.config.healthCheckFreshnessMinutes
+      : 30;
+  const freshThresholdMs = freshnessMinutes * 60 * 1000;
+  if (ageMs > freshThresholdMs && ageDays <= 7) {
+    process.exit(0);
+  }
   if (ageDays > 7) {
     console.log("OSS: Haven't checked your PRs in " + ageDays + ' days. Run /oss to catch up.');
   } else {

--- a/packages/core/src/core/config-registry.ts
+++ b/packages/core/src/core/config-registry.ts
@@ -211,6 +211,13 @@ export const CONFIG_KEY_REGISTRY: readonly ConfigKeyDef[] = [
     settableVia: 'setup',
     valueHint: 'true|false',
   },
+  {
+    key: 'healthCheckFreshnessMinutes',
+    description:
+      'Suppress the SessionStart PR health one-liner when the cached digest is older than this many minutes. The line silently disappears between /oss runs, so what remains is always current. Defaults to 30 minutes (#1255).',
+    settableVia: 'setup',
+    valueHint: 'positive integer',
+  },
 
   // ── Setup-only completion flag ──────────────────────────────────────
   {

--- a/packages/core/src/core/state-schema.ts
+++ b/packages/core/src/core/state-schema.ts
@@ -212,6 +212,16 @@ export const AgentConfigSchema = z.object({
   autoFormatBeforePush: z.boolean().default(false),
 
   /**
+   * Threshold (in minutes) for the SessionStart PR health one-liner (#1255).
+   * The cached digest only refreshes when the user runs `/oss`; SessionStart
+   * fires every session. Without a freshness gate the line drifts arbitrarily
+   * stale between runs. When the cache is older than this many minutes (and
+   * not yet 7 days old, which keeps the existing catch-up nudge), the line is
+   * suppressed entirely. Default 30 minutes.
+   */
+  healthCheckFreshnessMinutes: z.number().int().positive().default(30),
+
+  /**
    * Optional Ollama model for SLM pre-triage during issue vetting (#1122).
    * Empty disables the feature. Recommended: `gemma4:e4b` (default for
    * capable hardware), `gemma4:e2b` or `qwen3:1.7b` for low-RAM machines.


### PR DESCRIPTION
## Summary

Closes #1255.

The SessionStart hook's PR health one-liner read from cache only — the cache refreshes on `/oss` but SessionStart fires every session, so the line drifted arbitrarily stale between runs. \"(6m ago)\" got the same UI weight as \"(3h ago)\", which trains the user to ignore the line.

## Approach

Add a freshness gate in `health-check.cjs`: when the cached digest is older than the configured threshold (default **30 minutes**, configurable via the new `healthCheckFreshnessMinutes` setup key) but younger than 7 days, suppress the line entirely. The 7-day catch-up nudge still fires above that ceiling. The \"no state yet\" first-run hint is unaffected.

The issue called out two options (suppress vs. render-with-staleness-signal). Going with **suppress** for the default — when the line is shown it's current; when hidden, no inference is required.

## Test plan

- [x] All 2392 core + 256 dashboard + 203 mcp tests pass
- [x] 0 lint errors
- [x] New config key registered in `config-registry.ts` (settable via setup) and validated by the AgentConfigSchema (positive integer, default 30)