### PR TITLE
feat: guard-git-operations covers `pull --rebase` and `reset --hard` (#1259)

### DIFF
--- a/hooks/guard-git-operations.sh
+++ b/hooks/guard-git-operations.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
-# PreToolUse hook: prevent unsafe git operations that can overwrite remote work.
+# PreToolUse hook: prevent unsafe git operations that can overwrite remote work
+# or destroy local commits.
 #
 # 1. Blocks bare `git push --force` (must use --force-with-lease)
-# 2. Requires explicit fetch before rebase
+# 2. Requires explicit fetch before rebase (including `git pull --rebase`, #1259)
 # 3. Requires explicit fetch before force-with-lease push
+# 4. Warns before `git reset --hard` (#1259) — discards uncommitted work AND
+#    any local commits not in the target ref.
 #
 # Returns "ask" to prompt user confirmation, or a systemMessage reminder.
 
@@ -46,6 +49,22 @@ EOF
   exit 0
 fi
 
+# Warn before `git pull --rebase` (#1259) — same risk profile as `git rebase`.
+# `git\s+rebase\b` above doesn't match the `pull --rebase` form because the
+# verb is "pull". Local commits silently rebased over remote changes here too.
+if echo "$command" | grep -qE 'git\s+pull\b' && echo "$command" | grep -qE '(\s--rebase\b|\s-r\b)'; then
+  cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "ask",
+    "updatedInput": {}
+  },
+  "systemMessage": "Before pulling with --rebase, you MUST fetch the remote tracking branch first to see what you're rebasing over. `git pull --rebase` rebases your local commits onto the latest remote head; if the remote has commits you didn't expect, this can rewrite history past them. Run `git fetch` and inspect `git log HEAD..@{u}` first."
+}
+EOF
+  exit 0
+fi
+
 # Warn before force-with-lease push: remind to fetch first
 if echo "$command" | grep -qE 'git\s+push\b.*--force-with-lease'; then
   cat <<'EOF'
@@ -55,6 +74,23 @@ if echo "$command" | grep -qE 'git\s+push\b.*--force-with-lease'; then
     "updatedInput": {}
   },
   "systemMessage": "Before force-pushing (even with --force-with-lease), verify you fetched the remote branch and incorporated any new commits. Maintainers may push directly to your PR branch. If you haven't fetched, --force-with-lease may still overwrite their work if your local remote-tracking ref is stale."
+}
+EOF
+  exit 0
+fi
+
+# Warn before `git reset --hard` (#1259). Discards uncommitted work AND any
+# local commits not in the target ref. The hook is opt-in friction; the
+# false-positive case (resetting to where you already are) is fast for the
+# user to confirm.
+if echo "$command" | grep -qE 'git\s+reset\s+--hard\b'; then
+  cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "ask",
+    "updatedInput": {}
+  },
+  "systemMessage": "`git reset --hard` discards uncommitted work AND any local commits not in the target ref. If you have unpushed commits on this branch you want to keep, stash them first (`git stash`) or note them on a recovery branch (`git branch wip-recovery`). Confirm you've reviewed `git status` and `git log @{u}..HEAD` before proceeding."
 }
 EOF
   exit 0


### PR DESCRIPTION
## Summary

Closes #1259.

Two patterns in the same risk class as the existing rebase / force / force-with-lease guards were uncovered:

1. **`git pull --rebase`** — same silent-rebase-over-remote risk as `git rebase`. The existing `git\s+rebase\b` regex doesn't match the pull form because the verb is \"pull\". Now ASKs with a \"fetch and inspect first\" prompt.
2. **`git reset --hard`** — discards uncommitted work AND any local commits not in the target ref. Wipes a feature branch's recent commits when run against `origin/main`. Now ASKs with a prompt to stash or branch first.

## Test plan

- [x] No test files exist for this shell hook (consistent with #1257 / others)
- [x] All 2392 core + 256 dashboard + 203 mcp tests still pass