### PR TITLE
feat: guard-public-posts covers GitHub MCP family + gh subcommands (#1260)

### DIFF
--- a/hooks/guard-public-posts.sh
+++ b/hooks/guard-public-posts.sh
@@ -83,7 +83,7 @@ case "$tool_name" in
         #     The sub-pattern (^|[[:space:]]) ... ([[:space:]]|$) avoids
         #     false-positives on names like `oss-autopilot-post-processor`.
         if printf '%s' "$normalized" | grep -qE \
-            '(gh[[:space:]]+api[^|&;]*(-X[[:space:]]*(POST|PATCH|PUT|DELETE)|--method[[:space:]]+(POST|PATCH|PUT|DELETE)|-XPOST|-XPATCH|-XPUT|-XDELETE))|(gh[[:space:]]+api[^|&;]*([[:space:]]|^)(-f|-F|--field|--raw-field)[[:space:]])|(gh[[:space:]]+pr[[:space:]]+(comment|review|create|close|reopen|ready|merge))|(gh[[:space:]]+issue[[:space:]]+(create|comment|close|reopen))|(gh[[:space:]]+release[[:space:]]+(create|edit|delete))|(hub[[:space:]]+(pull-request|issue|release|api))|(curl[[:space:]][^|&;]*-X[[:space:]]*(POST|PATCH|PUT|DELETE)[^|&;]*api\.github\.com/[^[:space:]|&;]*(comments|issues|pulls|releases|reviews))|((^|[[:space:]])(oss-autopilot|cli\.bundle\.cjs)[[:space:]][^|&;]*[[:space:]](post|claim)([[:space:]]|$))|((^|[[:space:]])(oss-autopilot|cli\.bundle\.cjs)[[:space:]](post|claim)([[:space:]]|$))'; then
+            '(gh[[:space:]]+api[^|&;]*(-X[[:space:]]*(POST|PATCH|PUT|DELETE)|--method[[:space:]]+(POST|PATCH|PUT|DELETE)|-XPOST|-XPATCH|-XPUT|-XDELETE))|(gh[[:space:]]+api[^|&;]*([[:space:]]|^)(-f|-F|--field|--raw-field)[[:space:]])|(gh[[:space:]]+pr[[:space:]]+(comment|review|create|close|reopen|ready|merge|edit))|(gh[[:space:]]+issue[[:space:]]+(create|comment|close|reopen))|(gh[[:space:]]+release[[:space:]]+(create|edit|delete))|(gh[[:space:]]+repo[[:space:]]+(create|delete|fork|edit|transfer))|(gh[[:space:]]+gist[[:space:]]+(create|edit|delete))|(hub[[:space:]]+(pull-request|issue|release|api))|(curl[[:space:]][^|&;]*-X[[:space:]]*(POST|PATCH|PUT|DELETE)[^|&;]*api\.github\.com/[^[:space:]|&;]*(comments|issues|pulls|releases|reviews))|((^|[[:space:]])(oss-autopilot|cli\.bundle\.cjs)[[:space:]][^|&;]*[[:space:]](post|claim)([[:space:]]|$))|((^|[[:space:]])(oss-autopilot|cli\.bundle\.cjs)[[:space:]](post|claim)([[:space:]]|$))'; then
             emit_ask "This command produces a public GitHub event (post / merge / close / create / release). Draft the content and present it to the user before running. The user must explicitly approve each external post per the global CLAUDE.md rule."
             exit 0
         fi
@@ -92,6 +92,16 @@ case "$tool_name" in
     mcp__plugin_oss-autopilot_oss-autopilot__post|mcp__plugin_oss-autopilot_oss-autopilot__claim)
         # These MCP tools always post a public comment — ask unconditionally.
         emit_ask "The '${tool_name}' MCP tool writes a public GitHub comment under the user's identity. Show the user the exact body via the draft-review-post skill and wait for explicit approval before invoking."
+        exit 0
+        ;;
+
+    mcp__github__*)
+        # GitHub MCP server family (#1260). The matcher in hooks.json is an
+        # explicit alternation of mutating tools — every entry here produces
+        # an externally-visible event. Read-only tools (list_issues,
+        # get_pull_request, search_*, etc.) are intentionally NOT in the
+        # matcher and never reach this branch.
+        emit_ask "The '${tool_name}' MCP tool produces a public GitHub event (post / merge / close / create / push / fork / delete) under the user's identity. Show the user what will happen and wait for explicit approval before invoking. See draft-review-post for the canonical approval flow."
         exit 0
         ;;
 

--- a/hooks/guard-public-posts.test.sh
+++ b/hooks/guard-public-posts.test.sh
@@ -96,6 +96,33 @@ expect_ask  "gh release edit is guarded"      "$(bash_payload 'gh release edit v
 expect_ask  "oss-autopilot post is guarded"   "$(bash_payload 'oss-autopilot post https://github.com/o/r/issues/1 hi')"
 expect_ask  "oss-autopilot claim is guarded"  "$(bash_payload 'oss-autopilot claim https://github.com/o/r/issues/1')"
 
+# ── New `gh` subcommand coverage (#1260) ──────────────────────────────
+expect_ask  "gh pr edit is guarded"           "$(bash_payload 'gh pr edit 123 --body new-body')"
+expect_ask  "gh repo create is guarded"       "$(bash_payload 'gh repo create newrepo --public')"
+expect_ask  "gh repo delete is guarded"       "$(bash_payload 'gh repo delete owner/repo --yes')"
+expect_ask  "gh repo fork is guarded"         "$(bash_payload 'gh repo fork owner/repo')"
+expect_ask  "gh repo edit is guarded"         "$(bash_payload 'gh repo edit owner/repo --description X')"
+expect_ask  "gh gist create is guarded"       "$(bash_payload 'gh gist create file.txt --public')"
+expect_ask  "gh gist edit is guarded"         "$(bash_payload 'gh gist edit abc123')"
+expect_ask  "gh gist delete is guarded"       "$(bash_payload 'gh gist delete abc123 --yes')"
+
+expect_allow "gh repo view is not guarded"    "$(bash_payload 'gh repo view owner/repo')"
+expect_allow "gh repo list is not guarded"    "$(bash_payload 'gh repo list owner')"
+expect_allow "gh gist list is not guarded"    "$(bash_payload 'gh gist list')"
+expect_allow "gh gist view is not guarded"    "$(bash_payload 'gh gist view abc123')"
+
+# ── GitHub MCP family (#1260) ─────────────────────────────────────────
+# The matcher in hooks.json filters which mcp__github__* tools reach this
+# script — only mutating ones do. The script's `mcp__github__*` case
+# emits the unconditional ASK as defense-in-depth.
+expect_ask  "MCP github add_issue_comment is guarded"          "$(mcp_payload 'mcp__github__add_issue_comment')"
+expect_ask  "MCP github create_pull_request is guarded"        "$(mcp_payload 'mcp__github__create_pull_request')"
+expect_ask  "MCP github merge_pull_request is guarded"         "$(mcp_payload 'mcp__github__merge_pull_request')"
+expect_ask  "MCP github issue_write is guarded"                "$(mcp_payload 'mcp__github__issue_write')"
+expect_ask  "MCP github push_files is guarded"                 "$(mcp_payload 'mcp__github__push_files')"
+expect_ask  "MCP github fork_repository is guarded"            "$(mcp_payload 'mcp__github__fork_repository')"
+expect_ask  "MCP github delete_file is guarded"                "$(mcp_payload 'mcp__github__delete_file')"
+
 # Silent-failure hunter regression tests — real bypasses addressed in this PR.
 expect_ask  "hub pull-request is guarded"     "$(bash_payload 'hub pull-request -m title')"
 expect_ask  "hub issue is guarded"            "$(bash_payload 'hub issue create -m title')"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -23,7 +23,7 @@
         ]
       },
       {
-        "matcher": "mcp__plugin_oss-autopilot_oss-autopilot__post|mcp__plugin_oss-autopilot_oss-autopilot__claim",
+        "matcher": "mcp__plugin_oss-autopilot_oss-autopilot__post|mcp__plugin_oss-autopilot_oss-autopilot__claim|mcp__github__add_issue_comment|mcp__github__add_pull_request_comment|mcp__github__add_reply_to_pull_request_comment|mcp__github__add_comment_to_pending_review|mcp__github__create_pull_request|mcp__github__update_pull_request|mcp__github__update_pull_request_branch|mcp__github__merge_pull_request|mcp__github__pull_request_review_write|mcp__github__issue_write|mcp__github__sub_issue_write|mcp__github__create_repository|mcp__github__delete_file|mcp__github__fork_repository|mcp__github__create_branch|mcp__github__push_files|mcp__github__create_or_update_file|mcp__github__assign_copilot_to_issue|mcp__github__request_copilot_review",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary

Closes #1260.

Two coverage gaps in `hooks/guard-public-posts.{sh,json}`:

1. **GitHub MCP family (`mcp__github__*`) was unguarded.** Tools like `add_issue_comment`, `create_pull_request`, `merge_pull_request`, `issue_write`, `push_files`, `fork_repository`, `delete_file`, etc. all produce externally-visible events but bypassed the hook because the matcher only listed the oss-autopilot family.
2. **Three `gh` subcommands** in the same risk class as the existing coverage: `gh pr edit`, `gh repo (create|delete|fork|edit|transfer)`, `gh gist (create|edit|delete)`.

## Wire-up

- `hooks.json` matcher grows to an explicit alternation of every mutating `mcp__github__*` tool name. Read-only tools stay outside the matcher so list/view/search calls don't ASK.
- The script's case statement gains an `mcp__github__*` branch as defense-in-depth: if any mutation reaches the script, ASK unconditionally.
- The Bash regex grows three new alternations covering `gh repo`, `gh gist`, and `gh pr edit`.

## Test plan

- [x] 20 new test cases in `guard-public-posts.test.sh`; total now 63 (all passing)
- [x] False-positive checks for `gh repo view`, `gh repo list`, `gh gist list`, `gh gist view`
- [x] All 2392 core + 256 dashboard + 203 mcp tests still pass