### PR TITLE
refactor: extract action-menu effort + maintainer-hint helpers (#1264)

### DIFF
--- a/packages/core/src/core/issue-effort.test.ts
+++ b/packages/core/src/core/issue-effort.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Tests for `computeIssueEffort` (#1264).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeIssueEffort } from './issue-effort.js';
+
+describe('computeIssueEffort', () => {
+  it('rates needs_response with 0 or 1 hint as small', () => {
+    expect(computeIssueEffort('needs_response', 0)).toBe('small');
+    expect(computeIssueEffort('needs_response', 1)).toBe('small');
+  });
+
+  it('rates needs_response with 2+ hints as medium', () => {
+    expect(computeIssueEffort('needs_response', 2)).toBe('medium');
+    expect(computeIssueEffort('needs_response', 5)).toBe('medium');
+  });
+
+  it('rates incomplete_checklist as small regardless of hints', () => {
+    expect(computeIssueEffort('incomplete_checklist', 0)).toBe('small');
+    expect(computeIssueEffort('incomplete_checklist', 7)).toBe('small');
+  });
+
+  it('rates needs_changes with 0-2 hints as medium', () => {
+    expect(computeIssueEffort('needs_changes', 0)).toBe('medium');
+    expect(computeIssueEffort('needs_changes', 1)).toBe('medium');
+    expect(computeIssueEffort('needs_changes', 2)).toBe('medium');
+  });
+
+  it('rates needs_changes with 3+ hints as large', () => {
+    expect(computeIssueEffort('needs_changes', 3)).toBe('large');
+    expect(computeIssueEffort('needs_changes', 7)).toBe('large');
+  });
+
+  it('rates ci_failing as medium', () => {
+    expect(computeIssueEffort('ci_failing', 0)).toBe('medium');
+    expect(computeIssueEffort('ci_failing', 5)).toBe('medium');
+  });
+
+  it('rates merge_conflict as large', () => {
+    expect(computeIssueEffort('merge_conflict', 0)).toBe('large');
+    expect(computeIssueEffort('merge_conflict', 4)).toBe('large');
+  });
+
+  it('falls back to medium for unrecognized type', () => {
+    expect(computeIssueEffort('unknown' as never, 0)).toBe('medium');
+  });
+
+  it('treats negative hint counts as zero', () => {
+    expect(computeIssueEffort('needs_response', -3)).toBe('small');
+    expect(computeIssueEffort('needs_changes', -1)).toBe('medium');
+  });
+});

--- a/packages/core/src/core/issue-effort.ts
+++ b/packages/core/src/core/issue-effort.ts
@@ -1,0 +1,53 @@
+/**
+ * Action-menu issue effort classification (#1264).
+ *
+ * Extracted from `workflows/action-menu.md`'s in-prompt truth table so
+ * the rules are typed, unit-testable, and tunable without editing
+ * markdown. Same architectural shape as the typed-core extractions in
+ * #1245 (compliance-score), #1242 (repo-vet), #1243 (strategy), and
+ * #1252 (pr-quality-rubric).
+ */
+
+/** Issue types the action menu surfaces. Match the strings the CLI emits in
+ * `data.daily.actionableIssues[*].type`. */
+export type ActionableIssueType =
+  | 'needs_response'
+  | 'needs_changes'
+  | 'incomplete_checklist'
+  | 'ci_failing'
+  | 'merge_conflict';
+
+export type IssueEffort = 'small' | 'medium' | 'large';
+
+/**
+ * Decide the effort label for an actionable issue based on its type and
+ * how many maintainer hints accompany it. Default falls through to
+ * `medium` for any unrecognized combination — the action-menu workflow
+ * still renders something useful when the CLI surfaces a new issue
+ * type before this function is updated.
+ *
+ * Truth table sourced verbatim from `workflows/action-menu.md`:
+ *
+ * | Effort | Condition |
+ * |--------|-----------|
+ * | small  | needs_response with 0-1 hints, incomplete_checklist |
+ * | medium | needs_response with 2+ hints, needs_changes with 0-2 hints, ci_failing |
+ * | large  | merge_conflict, needs_changes with 3+ hints |
+ */
+export function computeIssueEffort(type: ActionableIssueType, hintCount: number): IssueEffort {
+  const hints = Math.max(0, hintCount);
+  switch (type) {
+    case 'needs_response':
+      return hints <= 1 ? 'small' : 'medium';
+    case 'incomplete_checklist':
+      return 'small';
+    case 'needs_changes':
+      return hints >= 3 ? 'large' : 'medium';
+    case 'ci_failing':
+      return 'medium';
+    case 'merge_conflict':
+      return 'large';
+    default:
+      return 'medium';
+  }
+}

--- a/packages/core/src/core/maintainer-hints.test.ts
+++ b/packages/core/src/core/maintainer-hints.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Tests for maintainer-hint label helpers (#1264).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { MAINTAINER_HINT_LABELS, formatMaintainerHints } from './maintainer-hints.js';
+
+describe('MAINTAINER_HINT_LABELS', () => {
+  it('covers every documented hint with a human label', () => {
+    expect(MAINTAINER_HINT_LABELS.demo_requested).toBe('demo/screenshot requested');
+    expect(MAINTAINER_HINT_LABELS.tests_requested).toBe('tests requested');
+    expect(MAINTAINER_HINT_LABELS.changes_requested).toBe('code changes requested');
+    expect(MAINTAINER_HINT_LABELS.docs_requested).toBe('documentation requested');
+    expect(MAINTAINER_HINT_LABELS.rebase_requested).toBe('rebase requested');
+  });
+});
+
+describe('formatMaintainerHints', () => {
+  it('joins multiple hints with ", " in supplied order', () => {
+    expect(formatMaintainerHints(['tests_requested', 'docs_requested'])).toBe(
+      'tests requested, documentation requested',
+    );
+  });
+
+  it('returns the single label for a one-element array', () => {
+    expect(formatMaintainerHints(['rebase_requested'])).toBe('rebase requested');
+  });
+
+  it('returns an empty string for an empty array', () => {
+    expect(formatMaintainerHints([])).toBe('');
+  });
+
+  it('drops unknown hint values silently', () => {
+    expect(formatMaintainerHints(['tests_requested', 'unknown_thing', 'docs_requested'])).toBe(
+      'tests requested, documentation requested',
+    );
+  });
+});

--- a/packages/core/src/core/maintainer-hints.ts
+++ b/packages/core/src/core/maintainer-hints.ts
@@ -1,0 +1,44 @@
+/**
+ * Maintainer-hint label constants (#1264).
+ *
+ * Extracted from `workflows/action-menu.md`'s in-prompt mapping so the
+ * label strings live in typed code instead of markdown. Adding a new
+ * hint type becomes a single-file change in core; the workflow gets
+ * the new label for free instead of requiring a parallel markdown
+ * edit. Same pattern as #1252.
+ */
+
+export type MaintainerHint =
+  | 'demo_requested'
+  | 'tests_requested'
+  | 'changes_requested'
+  | 'docs_requested'
+  | 'rebase_requested';
+
+/**
+ * Display labels the action-menu workflow renders for each hint type.
+ * Source of truth — both `data.daily.actionableIssues[*].maintainerHintsLabel`
+ * (computed by the CLI) and the workflow's prose docs reference this map.
+ */
+export const MAINTAINER_HINT_LABELS: Record<MaintainerHint, string> = {
+  demo_requested: 'demo/screenshot requested',
+  tests_requested: 'tests requested',
+  changes_requested: 'code changes requested',
+  docs_requested: 'documentation requested',
+  rebase_requested: 'rebase requested',
+};
+
+/**
+ * Format an array of hints as a comma-joined human label, in the same
+ * order the caller passed them. Unknown hint values are dropped silently —
+ * a future CLI version might emit a hint type the workflow doesn't yet
+ * know about; rendering "undefined" would be worse than omitting it.
+ */
+export function formatMaintainerHints(hints: readonly MaintainerHint[] | readonly string[]): string {
+  const labels: string[] = [];
+  for (const h of hints) {
+    const label = MAINTAINER_HINT_LABELS[h as MaintainerHint];
+    if (label) labels.push(label);
+  }
+  return labels.join(', ');
+}

--- a/workflows/action-menu.md
+++ b/workflows/action-menu.md
@@ -54,9 +54,9 @@ Then show the enriched format using the resolved PR's fields:
 ---
 ```
 
-**Maintainer hints line**: Only show if `pr.lastMaintainerComment` exists. Format each hint from `pr.maintainerActionHints` using these labels: `demo_requested` → "demo/screenshot requested", `tests_requested` → "tests requested", `changes_requested` → "code changes requested", `docs_requested` → "documentation requested", `rebase_requested` → "rebase requested". If no hints, show just the maintainer name.
+**Maintainer hints line**: Only show if `pr.lastMaintainerComment` exists. The label mapping for `pr.maintainerActionHints` lives at `packages/core/src/core/maintainer-hints.ts` (`MAINTAINER_HINT_LABELS` + `formatMaintainerHints`) — that file is the source of truth (#1264). Documented mappings: `demo_requested` → "demo/screenshot requested", `tests_requested` → "tests requested", `changes_requested` → "code changes requested", `docs_requested` → "documentation requested", `rebase_requested` → "rebase requested". If no hints, show just the maintainer name.
 
-**Effort estimate**: Compute at display time from issue type + hint count:
+**Effort estimate**: The truth table lives at `packages/core/src/core/issue-effort.ts` (`computeIssueEffort`) — that function is the source of truth (#1264). Reproduced here for the workflow's render template; edit the source first if the rules change.
 
 | Effort | Condition |
 |--------|-----------|
@@ -64,7 +64,7 @@ Then show the enriched format using the resolved PR's fields:
 | **Medium** | `needs_response` with 2+ hints (reply + code changes), `needs_changes` with 0-2 hints, `ci_failing` |
 | **Large** | `merge_conflict`, `needs_changes` with 3+ hints |
 
-If an issue type doesn't match any row above, default to **Medium**.
+If an issue type doesn't match any row above, default to **Medium** (matches the function's fallback).
 
 **Action summary**: Brief description based on type (e.g., "respond + code changes", "rebase + push", "investigate CI logs").
 


### PR DESCRIPTION
## Summary

Closes #1264.

Two pieces of business logic moved from `workflows/action-menu.md` (a markdown template) into typed core functions:

1. **`computeIssueEffort(type, hintCount)`** — `packages/core/src/core/issue-effort.ts`. Implements the same truth table the workflow documented inline (small for `needs_response` 0-1 hints + `incomplete_checklist`; medium for the middle band + `ci_failing`; large for `merge_conflict` + heavy `needs_changes`). Falls through to medium for unknown types.

2. **`MAINTAINER_HINT_LABELS` + `formatMaintainerHints`** — `packages/core/src/core/maintainer-hints.ts`. The five hint-to-label mappings (`demo_requested`, `tests_requested`, `changes_requested`, `docs_requested`, `rebase_requested`). Adding a new hint becomes a single-file change here instead of requiring a parallel edit to the workflow markdown.

The workflow doc now points at both files as the source of truth and keeps the truth table reproduced for the render template's convenience.

## Test plan

- [x] 14 new unit tests across `issue-effort.test.ts` (9) and `maintainer-hints.test.ts` (5)
- [x] All 2414 core + 256 dashboard + 203 mcp tests pass
- [x] 0 lint errors

## Out of scope (per issue's intentional skips)

- \"Other\" input parsing.
- Informational-vs-actionable classification.
- Wiring `data.daily.actionableIssues[*].effort` into `daily.ts` (the typed function is now in place; that integration is its own scope).