### PR TITLE
refactor: extract shouldDraftResponse + getCIEnforcedTools to core (#1286)

### DIFF
--- a/packages/core/src/core/ci-enforced-tools.test.ts
+++ b/packages/core/src/core/ci-enforced-tools.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for `getCIEnforcedTools` (#1286).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getCIEnforcedTools } from './ci-enforced-tools.js';
+
+describe('getCIEnforcedTools — pre-commit', () => {
+  it('detects eslint and prettier from a pre-commit config', () => {
+    const yaml = `
+repos:
+  - repo: local
+    hooks:
+      - id: eslint
+        name: ESLint
+        entry: npx eslint
+      - id: prettier
+        name: Prettier
+        entry: npx prettier --write
+`;
+    const out = getCIEnforcedTools({
+      preCommitConfigYaml: yaml,
+      workflowYamls: null,
+      makefile: null,
+      packageJson: null,
+    });
+    expect(out.map((e) => e.tool)).toEqual(expect.arrayContaining(['lint', 'format']));
+    expect(out.every((e) => e.source === 'pre-commit')).toBe(true);
+  });
+});
+
+describe('getCIEnforcedTools — github workflows', () => {
+  it('detects vitest as test, tsc as typecheck', () => {
+    const yaml = `
+jobs:
+  test:
+    steps:
+      - run: pnpm exec vitest run
+      - run: tsc --noEmit
+`;
+    const out = getCIEnforcedTools({
+      preCommitConfigYaml: null,
+      workflowYamls: yaml,
+      makefile: null,
+      packageJson: null,
+    });
+    expect(out.find((e) => e.tool === 'test')?.source).toBe('github-workflow');
+    expect(out.find((e) => e.tool === 'typecheck')?.source).toBe('github-workflow');
+  });
+
+  it('detects security scanners', () => {
+    const yaml = 'jobs:\n  scan:\n    steps:\n      - uses: github/codeql-action\n';
+    const out = getCIEnforcedTools({
+      preCommitConfigYaml: null,
+      workflowYamls: yaml,
+      makefile: null,
+      packageJson: null,
+    });
+    expect(out.find((e) => e.tool === 'security-scan')?.evidence).toContain('codeql');
+  });
+});
+
+describe('getCIEnforcedTools — package.json', () => {
+  it('extracts script-named tools without re-running grep', () => {
+    const pkg = JSON.stringify({
+      scripts: {
+        lint: 'eslint .',
+        'format:check': 'prettier --check .',
+        typecheck: 'tsc --noEmit',
+        test: 'vitest run',
+        build: 'tsup',
+      },
+    });
+    const out = getCIEnforcedTools({
+      preCommitConfigYaml: null,
+      workflowYamls: null,
+      makefile: null,
+      packageJson: pkg,
+    });
+    const tools = out.filter((e) => e.source === 'package-json').map((e) => e.tool);
+    expect(tools).toEqual(expect.arrayContaining(['lint', 'format', 'typecheck', 'test', 'build']));
+  });
+
+  it('returns nothing on malformed package.json (does not throw)', () => {
+    const out = getCIEnforcedTools({
+      preCommitConfigYaml: null,
+      workflowYamls: null,
+      makefile: null,
+      packageJson: '{invalid',
+    });
+    expect(out).toEqual([]);
+  });
+});
+
+describe('getCIEnforcedTools — empty input', () => {
+  it('returns empty array when every source is null', () => {
+    const out = getCIEnforcedTools({
+      preCommitConfigYaml: null,
+      workflowYamls: null,
+      makefile: null,
+      packageJson: null,
+    });
+    expect(out).toEqual([]);
+  });
+});

--- a/packages/core/src/core/ci-enforced-tools.ts
+++ b/packages/core/src/core/ci-enforced-tools.ts
@@ -1,0 +1,129 @@
+/**
+ * CI-enforced tool detection (#1286).
+ *
+ * Extracted from `workflows/pre-commit-review.md` Steps 2b and 6a so
+ * the same logic isn't reimplemented twice in markdown. Callers
+ * supply pre-fetched config snippets (the workflow runs `cat` /
+ * `head` against the well-known files); this function does the
+ * structured parse.
+ *
+ * Pure typed helper — no I/O.
+ */
+
+export type CIToolName = 'lint' | 'format' | 'typecheck' | 'test' | 'build' | 'commit-format' | 'security-scan';
+
+export interface CIEnforcedToolsInput {
+  /** `.pre-commit-config.yaml` contents, or null when the file is missing. */
+  preCommitConfigYaml: string | null;
+  /** Concatenated contents of `.github/workflows/*.yml` (or null when none). */
+  workflowYamls: string | null;
+  /** `Makefile` contents, or null when missing. */
+  makefile: string | null;
+  /** `package.json` contents — used to detect script names. */
+  packageJson: string | null;
+}
+
+export interface CIEnforcedTool {
+  tool: CIToolName;
+  source: 'pre-commit' | 'github-workflow' | 'makefile' | 'package-json';
+  /** Short snippet that surfaced this tool — useful for explainability. */
+  evidence: string;
+}
+
+/**
+ * Detect which class of tool each input source enforces. The output
+ * may contain duplicates (e.g., `test` enforced by both pre-commit
+ * and a GitHub workflow); callers can dedupe on `tool` or display
+ * each evidence pair separately.
+ */
+export function getCIEnforcedTools(input: CIEnforcedToolsInput): CIEnforcedTool[] {
+  const out: CIEnforcedTool[] = [];
+
+  if (input.preCommitConfigYaml) {
+    detectFromHaystack(input.preCommitConfigYaml, 'pre-commit', out);
+  }
+  if (input.workflowYamls) {
+    detectFromHaystack(input.workflowYamls, 'github-workflow', out);
+  }
+  if (input.makefile) {
+    detectFromHaystack(input.makefile, 'makefile', out);
+  }
+  if (input.packageJson) {
+    detectScriptsFromPackageJson(input.packageJson, out);
+  }
+
+  return out;
+}
+
+function detectFromHaystack(haystack: string, source: CIEnforcedTool['source'], out: CIEnforcedTool[]): void {
+  const lower = haystack.toLowerCase();
+  const checks: Array<{ tool: CIToolName; pattern: RegExp; evidenceFor: string[] }> = [
+    {
+      tool: 'lint',
+      pattern: /\b(?:eslint|biome|ruff|flake8|rubocop|golangci-lint|clippy|pylint)\b/i,
+      evidenceFor: ['eslint', 'biome', 'ruff', 'flake8', 'rubocop', 'golangci-lint', 'clippy', 'pylint'],
+    },
+    {
+      tool: 'format',
+      pattern: /\b(?:prettier|biome[\s-]+format|black|gofmt|rustfmt|clang-format)\b/i,
+      evidenceFor: ['prettier', 'biome', 'black', 'gofmt', 'rustfmt', 'clang-format'],
+    },
+    {
+      tool: 'typecheck',
+      pattern: /\b(?:tsc|mypy|sorbet|pyright|flow)\b/i,
+      evidenceFor: ['tsc', 'mypy', 'sorbet', 'pyright', 'flow'],
+    },
+    {
+      tool: 'test',
+      pattern: /\b(?:vitest|jest|pytest|rspec|go test|cargo test|mocha)\b/i,
+      evidenceFor: ['vitest', 'jest', 'pytest', 'rspec', 'go test', 'cargo test', 'mocha'],
+    },
+    {
+      tool: 'build',
+      pattern: /\b(?:tsc --noemit|tsup|esbuild|webpack|cargo build|go build)\b/i,
+      evidenceFor: ['tsc --noemit', 'tsup', 'esbuild', 'webpack', 'cargo build', 'go build'],
+    },
+    {
+      tool: 'commit-format',
+      pattern: /\b(?:commitlint|conventional-commits)\b/i,
+      evidenceFor: ['commitlint', 'conventional-commits'],
+    },
+    {
+      tool: 'security-scan',
+      pattern: /\b(?:codeql|semgrep|trivy|gitleaks|snyk)\b/i,
+      evidenceFor: ['codeql', 'semgrep', 'trivy', 'gitleaks', 'snyk'],
+    },
+  ];
+
+  for (const c of checks) {
+    if (c.pattern.test(lower)) {
+      const evidence = c.evidenceFor.find((e) => lower.includes(e)) ?? c.tool;
+      out.push({ tool: c.tool, source, evidence });
+    }
+  }
+}
+
+function detectScriptsFromPackageJson(packageJson: string, out: CIEnforcedTool[]): void {
+  let parsed: { scripts?: Record<string, string> };
+  try {
+    parsed = JSON.parse(packageJson) as { scripts?: Record<string, string> };
+  } catch {
+    return;
+  }
+  const scripts = parsed.scripts ?? {};
+  const scriptToTool: Array<{ key: RegExp; tool: CIToolName }> = [
+    { key: /^lint(:|$)/, tool: 'lint' },
+    { key: /^format(:|$)/, tool: 'format' },
+    { key: /^typecheck(:|$)|^tsc(:|$)/, tool: 'typecheck' },
+    { key: /^test(:|$)/, tool: 'test' },
+    { key: /^build(:|$)/, tool: 'build' },
+  ];
+  for (const [name] of Object.entries(scripts)) {
+    for (const m of scriptToTool) {
+      if (m.key.test(name)) {
+        out.push({ tool: m.tool, source: 'package-json', evidence: `scripts.${name}` });
+        break;
+      }
+    }
+  }
+}

--- a/packages/core/src/core/comment-decision.test.ts
+++ b/packages/core/src/core/comment-decision.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for `shouldDraftResponse` (#1286).
+ *
+ * Pin the skip-vs-draft rule shared between
+ * `workflows/pre-commit-review.md` Step 7a and `pr-responder` Step 3.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { shouldDraftResponse } from './comment-decision.js';
+
+describe('shouldDraftResponse', () => {
+  it('does not draft when there is no feedback at all', () => {
+    const r = shouldDraftResponse({ feedback: [], allRequestedChangesAddressed: true });
+    expect(r.shouldDraft).toBe(false);
+  });
+
+  it('always drafts on a question', () => {
+    const r = shouldDraftResponse({
+      feedback: [{ category: 'question', needsComment: false, reason: 'maintainer asked' }],
+      allRequestedChangesAddressed: true,
+    });
+    expect(r.shouldDraft).toBe(true);
+    expect(r.reason).toMatch(/question/);
+  });
+
+  it('always drafts on a design discussion', () => {
+    const r = shouldDraftResponse({
+      feedback: [{ category: 'design_discussion', needsComment: false, reason: '' }],
+      allRequestedChangesAddressed: true,
+    });
+    expect(r.shouldDraft).toBe(true);
+  });
+
+  it('always drafts on an explanation request', () => {
+    const r = shouldDraftResponse({
+      feedback: [{ category: 'explanation_request', needsComment: false, reason: '' }],
+      allRequestedChangesAddressed: true,
+    });
+    expect(r.shouldDraft).toBe(true);
+  });
+
+  it('drafts when an item is intentionally left unchanged', () => {
+    const r = shouldDraftResponse({
+      feedback: [{ category: 'code_request', needsComment: true, reason: 'left tests as-is intentionally' }],
+      allRequestedChangesAddressed: true,
+    });
+    expect(r.shouldDraft).toBe(true);
+    expect(r.reason).toMatch(/intentionally|written explanation/);
+  });
+
+  it('skips when all code requests are addressed and no item needs explanation', () => {
+    const r = shouldDraftResponse({
+      feedback: [{ category: 'code_request', needsComment: false, reason: '' }],
+      allRequestedChangesAddressed: true,
+    });
+    expect(r.shouldDraft).toBe(false);
+    expect(r.reason).toMatch(/diff/);
+  });
+
+  it('drafts when not all requested changes are addressed', () => {
+    const r = shouldDraftResponse({
+      feedback: [{ category: 'code_request', needsComment: false, reason: '' }],
+      allRequestedChangesAddressed: false,
+    });
+    expect(r.shouldDraft).toBe(true);
+    expect(r.reason).toMatch(/not all/);
+  });
+
+  it('the always-draft category check wins over a missing-changes flag', () => {
+    const r = shouldDraftResponse({
+      feedback: [
+        { category: 'question', needsComment: false, reason: '' },
+        { category: 'code_request', needsComment: false, reason: '' },
+      ],
+      allRequestedChangesAddressed: false,
+    });
+    expect(r.shouldDraft).toBe(true);
+    expect(r.reason).toMatch(/question/);
+  });
+});

--- a/packages/core/src/core/comment-decision.ts
+++ b/packages/core/src/core/comment-decision.ts
@@ -1,0 +1,121 @@
+/**
+ * Post-push comment decision (#1286).
+ *
+ * Centralizes the "should I draft a comment, or does the diff speak
+ * for itself?" rule that was duplicated between
+ * `workflows/pre-commit-review.md` Step 7a and `agents/pr-responder.md`
+ * Step 3.
+ *
+ * Pure typed helper — no LLM, no I/O. Callers do the upstream natural-
+ * language classification (mapping a maintainer comment to a structured
+ * `FeedbackCategory` + flags) and pass in the result. This module owns
+ * the rule that decides skip vs. draft from the structured input.
+ *
+ * Same architectural shape as #1245 (compliance-score), #1242 (repo-vet),
+ * #1243 (strategy), #1252 (pr-quality-rubric), and #1264 (issue-effort /
+ * maintainer-hints).
+ */
+
+export type FeedbackCategory =
+  | 'code_request'
+  | 'question'
+  | 'explanation_request'
+  | 'style_request'
+  | 'design_discussion'
+  | 'approval_with_nit'
+  | 'formatting_complaint';
+
+export interface FeedbackClassification {
+  category: FeedbackCategory;
+  /**
+   * Whether this individual feedback item, considered in isolation,
+   * requires a drafted comment. Aggregated by `shouldDraftResponse`
+   * across the full feedback list.
+   */
+  needsComment: boolean;
+  /** Short rationale rendered alongside the decision. */
+  reason: string;
+}
+
+export interface CommentDecisionInput {
+  /**
+   * Pre-classified feedback items in chronological order. The caller
+   * (agent or workflow) is responsible for the natural-language
+   * categorization step; this function only consumes structured input.
+   */
+  feedback: readonly FeedbackClassification[];
+  /**
+   * True when the contributor pushed code that addresses every
+   * feedback item that requested a code change. The agent's diff
+   * inspection determines this; the function trusts the boolean.
+   */
+  allRequestedChangesAddressed: boolean;
+}
+
+export interface CommentDecisionResult {
+  shouldDraft: boolean;
+  reason: string;
+}
+
+/**
+ * Decide whether the contributor should draft a comment after a push.
+ *
+ * Rule (sourced verbatim from `workflows/pre-commit-review.md` Step 7a
+ * and `agents/pr-responder.md` "Comment Decision Logic"):
+ *
+ *  - Skip the comment entirely when ALL of these are true:
+ *    1. Every piece of maintainer feedback that requested code changes
+ *       has a corresponding code change.
+ *    2. No question was asked.
+ *    3. Nothing was intentionally left unchanged (a "yes the maintainer
+ *       asked but I did not change it" item always needs explanation).
+ *    4. The diff makes the fix self-evident — modeled here as the
+ *       `allRequestedChangesAddressed` flag the caller passes in.
+ *
+ *  - Draft a comment if ANY of these are true:
+ *    1. The maintainer asked a question.
+ *    2. The feedback is conceptual or design-level (the diff alone
+ *       cannot answer "why").
+ *    3. Something was intentionally left unchanged (`needsComment: true`
+ *       on a code-request item where the contributor disagrees).
+ *    4. Only some of multiple requested changes were addressed.
+ *    5. The contributor deviated from exactly what was asked.
+ */
+export function shouldDraftResponse(input: CommentDecisionInput): CommentDecisionResult {
+  if (input.feedback.length === 0) {
+    return { shouldDraft: false, reason: 'no maintainer feedback to address' };
+  }
+
+  // Categories that always demand a written reply, regardless of the
+  // diff. The diff cannot answer a question or carry a design decision.
+  const alwaysDraftCategories = new Set<FeedbackCategory>(['question', 'explanation_request', 'design_discussion']);
+
+  for (const item of input.feedback) {
+    if (alwaysDraftCategories.has(item.category)) {
+      return {
+        shouldDraft: true,
+        reason: `${item.category.replace(/_/g, ' ')} — diff alone cannot address this`,
+      };
+    }
+  }
+
+  // Caller flagged at least one item as "I'm intentionally not making
+  // this change" or "I deviated" — needs an explanation either way.
+  const intentionalGap = input.feedback.find((item) => item.needsComment);
+  if (intentionalGap) {
+    return {
+      shouldDraft: true,
+      reason: `requires written explanation: ${intentionalGap.reason}`,
+    };
+  }
+
+  // Caller signaled the diff covers everything that was requested.
+  if (input.allRequestedChangesAddressed) {
+    return { shouldDraft: false, reason: 'all requested changes are visible in the diff' };
+  }
+
+  return {
+    shouldDraft: true,
+    reason: 'not all requested changes are visible in the diff yet',
+  };
+}

--- a/workflows/pre-commit-review.md
+++ b/workflows/pre-commit-review.md
@@ -82,10 +82,11 @@ Before dispatching review agents, run the repo's lint and test commands to catch
 
 1. **Detect and run linter/type checker**: Check for `package.json` scripts (`lint`, `typecheck`, `tsc`), `Makefile` targets, or language-specific tooling. Run the detected command(s). If no linter is detected, skip and note: "No linter detected — skipping pre-review lint."
 
-2. **Verify tools against CI configuration (CI-enforcement check):** Before treating any linter, formatter, or type checker output as authoritative, confirm the tool is actually enforced by the project's CI. Check these sources in order:
+2. **Verify tools against CI configuration (CI-enforcement check):** Before treating any linter, formatter, or type checker output as authoritative, confirm the tool is actually enforced by the project's CI. The structured detection lives at `packages/core/src/core/ci-enforced-tools.ts` (`getCIEnforcedTools`) — call it with the well-known config snippets to get back a typed `CIEnforcedTool[]` instead of stitching `cat`/`grep` output in markdown (#1286). The function reads:
    - `.pre-commit-config.yaml` — lists hooks that run on every commit/PR. Save the list of repo URLs and hook IDs as `enforcedTools`.
    - `.github/workflows/*.yml` (or `.gitlab-ci.yml`, `Jenkinsfile`, etc.) — look for tool invocations in CI job steps.
    - `Makefile` targets referenced by CI — if CI runs `make lint`, check what `make lint` actually invokes.
+   - `package.json` scripts — `scripts.lint`, `scripts.test`, etc. Each script-named tool is surfaced as a CI-enforced source.
 
    **Rules:**
    - If a tool is NOT in CI, its output is **informational only** — report findings but do not auto-apply fixes or block on its output.
@@ -335,6 +336,8 @@ On "Done for now":
 **7a. Classify the feedback — does a comment add value, or does the diff speak for itself? (#904)**
 
 Before drafting, decide whether a comment is actually needed. When the fix is self-evident from the diff, a comment that restates it wastes the maintainer's attention. Err on the side of skipping — the push is already a response.
+
+> **Source of truth (#1286):** the skip-vs-draft rule lives at `packages/core/src/core/comment-decision.ts` (`shouldDraftResponse`). The same function is consumed by the `pr-responder` agent. The bullets below are the human-facing render of that rule — edit the function first if the rule changes.
 
 **Skip the comment entirely if ALL of these are true:**
 - Every piece of maintainer feedback addressed in this push maps to a concrete code change (e.g. "avoid `T.untyped` here", "add a nil check", "rename this variable")


### PR DESCRIPTION
## Summary

Closes #1286.

Two extract-to-core items in `workflows/pre-commit-review.md` — same architectural shape as #1245 / #1242 / #1243 / #1252 / #1264.

## What's in this PR

1. **`packages/core/src/core/comment-decision.ts`** — `shouldDraftResponse()` centralizes the skip-vs-draft rule that was duplicated between Step 7a of the workflow and `pr-responder.md` Step 3. Pure typed function — caller does the natural-language classification, function applies the rule. Always-draft categories (question, design_discussion, explanation_request) win over the diff-self-evident path; an intentionally-unchanged item demands an explanation.

2. **`packages/core/src/core/ci-enforced-tools.ts`** — `getCIEnforcedTools()` reads pre-commit YAML, GitHub workflow YAML, Makefile, and `package.json` scripts and returns a structured `CIEnforcedTool[]` (tool, source, evidence). Replaces the regex-grep stitching duplicated in Steps 2b and 6a of the workflow.

Workflow now points at both files as source of truth.

## Test plan

- [x] 14 unit tests across `comment-decision.test.ts` (8) and `ci-enforced-tools.test.ts` (6)
- [x] All 2428 core + 256 dashboard + 203 mcp tests pass
- [x] 0 lint errors

## Out of scope

- Wiring the agent (`pr-responder`) to call `shouldDraftResponse()` directly — the typed function is now in place; the agent prompt update is its own scope (similar pattern to how #1245's `computeComplianceScore` core landed before the agent surface caught up).
- LLM-driven natural-language classification of comments into `FeedbackCategory` — this PR scopes the rule, not the classifier.