### PR TITLE
refactor: extract CONTRIBUTING.md requirement parser to core (#1279)

### DIFF
--- a/packages/core/src/core/contributing.test.ts
+++ b/packages/core/src/core/contributing.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for `extractRequirements` (#1279).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { extractRequirements, dedupeByCategory } from './contributing.js';
+
+describe('extractRequirements — categories', () => {
+  it('detects a tests requirement from "add unit tests"', () => {
+    const r = extractRequirements('All PRs must add unit tests covering the change.');
+    expect(r.find((x) => x.category === 'tests')).toBeDefined();
+  });
+
+  it('detects a tests requirement from "tests are required"', () => {
+    const r = extractRequirements('Tests are required for every behavior change.');
+    expect(r.find((x) => x.category === 'tests')).toBeDefined();
+  });
+
+  it('detects a documentation requirement', () => {
+    const r = extractRequirements('Please update the documentation when public API changes.');
+    expect(r.find((x) => x.category === 'documentation')).toBeDefined();
+  });
+
+  it('detects a changelog requirement', () => {
+    const r = extractRequirements('Every PR must include a changelog entry under "Unreleased".');
+    expect(r.find((x) => x.category === 'changelog')).toBeDefined();
+  });
+
+  it('detects a code-style requirement from a formatter mention', () => {
+    const r = extractRequirements('Run prettier before opening a PR.');
+    expect(r.find((x) => x.category === 'code_style')).toBeDefined();
+  });
+
+  it('detects a commit-format requirement from "Conventional Commits"', () => {
+    const r = extractRequirements('We use Conventional Commits for all PR titles.');
+    expect(r.find((x) => x.category === 'commit_format')).toBeDefined();
+  });
+
+  it('detects a CLA / DCO requirement', () => {
+    const r = extractRequirements('All commits must include a Signed-off-by line (DCO).');
+    expect(r.find((x) => x.category === 'cla_dco')).toBeDefined();
+  });
+
+  it('detects a branch-target requirement', () => {
+    const r = extractRequirements('Submit pull requests against the develop branch.');
+    expect(r.find((x) => x.category === 'branch_target')).toBeDefined();
+  });
+
+  it('detects a scope requirement', () => {
+    const r = extractRequirements('Keep PRs focused on one logical change.');
+    expect(r.find((x) => x.category === 'scope')).toBeDefined();
+  });
+});
+
+describe('extractRequirements — behavior', () => {
+  it('returns an empty array for empty input', () => {
+    expect(extractRequirements('')).toEqual([]);
+    expect(extractRequirements('   \n\n   ')).toEqual([]);
+  });
+
+  it('preserves the matching line as evidence', () => {
+    const r = extractRequirements('Add unit tests for every change.');
+    expect(r[0].evidence).toContain('Add unit tests');
+  });
+
+  it('truncates very long evidence to 200 chars', () => {
+    const long = 'Every PR ' + 'must add unit tests '.repeat(40);
+    const r = extractRequirements(long);
+    expect(r[0].evidence.length).toBeLessThanOrEqual(201);
+    expect(r[0].evidence.endsWith('…')).toBe(true);
+  });
+
+  it('fires a given rule at most once even if the document repeats the phrase', () => {
+    const content = 'Add unit tests.\n\nAll PRs must add unit tests.\n\nMust add tests.';
+    const r = extractRequirements(content);
+    expect(r.filter((x) => x.category === 'tests')).toHaveLength(1);
+  });
+
+  it('handles a multi-requirement document', () => {
+    const content = `
+# Contributing
+
+All PRs must add unit tests covering the change.
+Update the documentation when public API changes.
+Add a changelog entry under "Unreleased".
+We use Conventional Commits for all PR titles.
+All commits must include a Signed-off-by line.
+Submit pull requests against the main branch.
+Keep PRs focused on one logical change.
+`;
+    const cats = extractRequirements(content).map((x) => x.category);
+    expect(new Set(cats)).toEqual(
+      new Set(['tests', 'documentation', 'changelog', 'commit_format', 'cla_dco', 'branch_target', 'scope']),
+    );
+  });
+});
+
+describe('dedupeByCategory', () => {
+  it('keeps the first entry per category', () => {
+    const reqs = [
+      { category: 'tests' as const, description: 'A', evidence: 'first' },
+      { category: 'tests' as const, description: 'B', evidence: 'second' },
+      { category: 'documentation' as const, description: 'C', evidence: 'third' },
+    ];
+    const r = dedupeByCategory(reqs);
+    expect(r).toHaveLength(2);
+    expect(r[0].evidence).toBe('first');
+  });
+});

--- a/packages/core/src/core/contributing.ts
+++ b/packages/core/src/core/contributing.ts
@@ -1,0 +1,171 @@
+/**
+ * CONTRIBUTING.md requirement extraction (#1279).
+ *
+ * Extracted from `workflows/draft-first-workflow.md` Step 1d so the
+ * heuristic that pulls actionable requirements out of a project's
+ * CONTRIBUTING file lives in typed code instead of workflow prose.
+ * Same architectural shape as compliance-score (#1245), repo-vet
+ * (#1242), strategy (#1243), and the recent #1252 / #1264 / #1286
+ * extractions.
+ *
+ * Pure typed helper — no I/O. Callers (the workflow runner, the
+ * `pr-compliance-checker` agent) read the file themselves and pass
+ * the contents in. The extraction step is heuristic regex matching
+ * over headings + bullet phrases; it intentionally over-recalls
+ * (some false positives) rather than under-recalling.
+ *
+ * Out of scope (deferred per #1279):
+ *  - `findContributingFile(repoPath)` — file-system search for the
+ *    guidelines file at one of seven well-known locations.
+ *  - `verifyRequirements(...)` — diff-aware satisfaction check per
+ *    requirement.
+ *  - `checkContributingCompliance(...)` — convenience wrapper that
+ *    calls all three.
+ *
+ * The remaining pieces plumb `extractRequirements()` into specific
+ * surfaces; each ships independently.
+ */
+
+export type ContributingCategory =
+  | 'tests'
+  | 'documentation'
+  | 'changelog'
+  | 'code_style'
+  | 'commit_format'
+  | 'cla_dco'
+  | 'branch_target'
+  | 'scope';
+
+export interface ContributingRequirement {
+  category: ContributingCategory;
+  /** One-line description of what the project asks for. */
+  description: string;
+  /**
+   * The line that surfaced the requirement, lightly trimmed. Useful
+   * for explainability in agent output ("the project's CONTRIBUTING
+   * says: …").
+   */
+  evidence: string;
+}
+
+interface CategoryRule {
+  category: ContributingCategory;
+  /** Match against a single line; case-insensitive. */
+  pattern: RegExp;
+  /** Friendly description rendered when the rule matches. */
+  description: string;
+}
+
+/**
+ * Heuristic patterns. Each rule fires once if any line in the
+ * document matches its pattern. Rules are ordered by specificity:
+ * commit-format and CLA matchers are precise; the broader
+ * documentation/scope rules sit at the end so they don't shadow
+ * narrower categories.
+ */
+const RULES: readonly CategoryRule[] = [
+  {
+    category: 'tests',
+    pattern: /\b(?:add|include|write|provide|cover\s+with)\s+(?:unit\s+)?tests?\b/i,
+    description: 'Add tests covering the change',
+  },
+  {
+    category: 'tests',
+    pattern: /\btest(?:s|ing)?\s+(?:are|is)\s+required\b/i,
+    description: 'Tests are required',
+  },
+  {
+    category: 'documentation',
+    pattern: /\b(?:update|add|provide)\s+(?:the\s+)?(?:docs?|documentation)\b/i,
+    description: 'Update documentation when behavior changes',
+  },
+  {
+    category: 'changelog',
+    pattern:
+      /\b(?:add|include|update)\s+(?:an?\s+)?(?:entry\s+(?:to|in)\s+)?(?:the\s+)?(?:changelog|CHANGELOG\.md|changeset)\b/i,
+    description: 'Add a changelog entry / changeset',
+  },
+  {
+    category: 'changelog',
+    pattern: /\bchange(?:log|set)\s+(?:entry|file)\s+(?:is\s+)?required\b/i,
+    description: 'Changelog entry / changeset is required',
+  },
+  {
+    category: 'code_style',
+    pattern:
+      /\b(?:run|use)\s+(?:the\s+)?(?:linter|formatter|prettier|eslint|biome|black|ruff|gofmt|rustfmt|clang-format)\b/i,
+    description: 'Run the project formatter / linter before submitting',
+  },
+  {
+    category: 'commit_format',
+    pattern: /\bconventional\s+commits?\b/i,
+    description: 'Use Conventional Commits format',
+  },
+  {
+    category: 'commit_format',
+    pattern: /\bcommit\s+messages?\s+(?:must|should|need)\b/i,
+    description: 'Project enforces a commit-message convention',
+  },
+  {
+    category: 'cla_dco',
+    pattern: /\b(?:CLA|contributor\s+license\s+agreement|DCO|sign(?:ed)?-off-by|signoff)\b/i,
+    description: 'Contributor license / DCO sign-off required',
+  },
+  {
+    category: 'branch_target',
+    pattern:
+      /\b(?:open|submit|target)\s+(?:a\s+)?(?:PR|pull\s+request).*?(?:against|to|targeting)\s+(?:the\s+)?(\S+)\s+branch\b/i,
+    description: 'PR must target a specific branch',
+  },
+  {
+    category: 'scope',
+    pattern: /\b(?:one\s+(?:logical\s+)?change|focused\s+PR|atomic\s+commits?)\b/i,
+    description: 'Keep PRs focused / atomic',
+  },
+];
+
+/**
+ * Extract structured requirements from a CONTRIBUTING.md (or
+ * similar) text. Each rule fires at most once per document — a
+ * project that says "tests are required" twice still surfaces a
+ * single tests requirement.
+ */
+export function extractRequirements(content: string): ContributingRequirement[] {
+  if (!content || content.trim().length === 0) return [];
+  const lines = content.split(/\r?\n/);
+  const out: ContributingRequirement[] = [];
+  const seenCategoriesPerRule = new Set<string>();
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    for (const rule of RULES) {
+      const ruleKey = `${rule.category}::${rule.pattern.source}`;
+      if (seenCategoriesPerRule.has(ruleKey)) continue;
+      if (rule.pattern.test(trimmed)) {
+        out.push({
+          category: rule.category,
+          description: rule.description,
+          evidence: trimmed.length > 200 ? trimmed.slice(0, 200) + '…' : trimmed,
+        });
+        seenCategoriesPerRule.add(ruleKey);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Convenience: dedupe a requirement list down to one entry per
+ * category. Useful for top-line summaries where the agent doesn't
+ * need to render every matched rule.
+ */
+export function dedupeByCategory(requirements: readonly ContributingRequirement[]): ContributingRequirement[] {
+  const seen = new Set<ContributingCategory>();
+  const out: ContributingRequirement[] = [];
+  for (const r of requirements) {
+    if (seen.has(r.category)) continue;
+    seen.add(r.category);
+    out.push(r);
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

Implements the **most leveraged piece** of #1279 — a typed `extractRequirements()` parser. Out-of-scope per the issue: `findContributingFile`, `verifyRequirements`, and the `checkContributingCompliance` wrapper.

## What's in this PR

- **`packages/core/src/core/contributing.ts`** — `extractRequirements(content)` returns structured `ContributingRequirement[]` across 8 categories (tests, documentation, changelog, code_style, commit_format, cla_dco, branch_target, scope). Pure typed function. Heuristic regex matching over single lines; intentionally over-recalls (false positives are fine, missed obligations are not).
- **`dedupeByCategory`** convenience helper for top-line summaries.

Same architectural shape as #1245 (compliance-score), #1242 (repo-vet), #1264 (issue-effort), #1286 (comment-decision).

## Test plan

- [x] 15 unit tests cover each category, the multi-requirement happy path, evidence truncation, and dedupe
- [x] All 2443 core + 256 dashboard + 203 mcp tests pass
- [x] 0 lint errors

## Out of scope (deferred per issue)

- `findContributingFile(repoPath)` — file-system search for the guidelines file at one of seven well-known locations.
- `verifyRequirements(...)` — diff-aware satisfaction check per requirement.
- `checkContributingCompliance(...)` — convenience wrapper that calls all three.

The parser is what `workflows/draft-first-workflow.md` Step 1d and `pr-compliance-checker` currently re-implement in prose. Wiring them to this module is a follow-up that doesn't change the parser's contract.