### PR TITLE
feat: persist PR follow-up history in state.json (#1277 Change 2)

### DIFF
--- a/packages/core/src/core/follow-up-history.test.ts
+++ b/packages/core/src/core/follow-up-history.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for follow-up history helpers (#1277).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  getFollowUpHistory,
+  lastFollowUp,
+  isWithinTierWindow,
+  recordFollowUp,
+  TIER_WINDOW_DAYS,
+} from './follow-up-history.js';
+import { AgentStateSchema } from './state-schema.js';
+import type { AgentState } from './state-schema.js';
+
+function emptyState(): AgentState {
+  return AgentStateSchema.parse({ version: 4 });
+}
+
+const PR = 'https://github.com/owner/repo/pull/123';
+
+describe('getFollowUpHistory', () => {
+  it('returns empty array for unset state field', () => {
+    expect(getFollowUpHistory(emptyState(), PR)).toEqual([]);
+  });
+
+  it('returns empty array for unknown PR url', () => {
+    const s = recordFollowUp(emptyState(), 'https://other/url', {
+      tier: 'light_check_in',
+      timestamp: new Date().toISOString(),
+    });
+    expect(getFollowUpHistory(s, PR)).toEqual([]);
+  });
+
+  it('returns the recorded entries for a known url', () => {
+    const ts = new Date().toISOString();
+    const s = recordFollowUp(emptyState(), PR, { tier: 'light_check_in', timestamp: ts });
+    expect(getFollowUpHistory(s, PR)).toEqual([{ tier: 'light_check_in', timestamp: ts }]);
+  });
+});
+
+describe('recordFollowUp', () => {
+  it('appends across multiple calls without losing prior entries', () => {
+    const t1 = '2026-04-01T00:00:00.000Z';
+    const t2 = '2026-04-15T00:00:00.000Z';
+    let s = recordFollowUp(emptyState(), PR, { tier: 'light_check_in', timestamp: t1 });
+    s = recordFollowUp(s, PR, { tier: 'direct_check_in', timestamp: t2 });
+    expect(getFollowUpHistory(s, PR)).toHaveLength(2);
+  });
+
+  it('does not mutate the input state', () => {
+    const before = emptyState();
+    const after = recordFollowUp(before, PR, {
+      tier: 'light_check_in',
+      timestamp: new Date().toISOString(),
+    });
+    expect(before.prFollowUpHistory).toBeUndefined();
+    expect(after.prFollowUpHistory?.[PR]).toBeDefined();
+  });
+});
+
+describe('lastFollowUp', () => {
+  it('returns null when no entries exist', () => {
+    expect(lastFollowUp(emptyState(), PR)).toBeNull();
+  });
+
+  it('returns the newest entry by timestamp', () => {
+    const older = '2026-03-01T00:00:00.000Z';
+    const newer = '2026-04-01T00:00:00.000Z';
+    let s = recordFollowUp(emptyState(), PR, { tier: 'light_check_in', timestamp: newer });
+    s = recordFollowUp(s, PR, { tier: 'direct_check_in', timestamp: older });
+    expect(lastFollowUp(s, PR)?.timestamp).toBe(newer);
+  });
+});
+
+describe('isWithinTierWindow', () => {
+  it('returns false when there are no prior follow-ups', () => {
+    expect(isWithinTierWindow(emptyState(), PR, 'light_check_in')).toBe(false);
+  });
+
+  it('returns true when the same-tier follow-up is within the window', () => {
+    const now = new Date('2026-04-10T00:00:00.000Z');
+    const recent = new Date('2026-04-08T00:00:00.000Z').toISOString();
+    const s = recordFollowUp(emptyState(), PR, { tier: 'light_check_in', timestamp: recent });
+    expect(isWithinTierWindow(s, PR, 'light_check_in', now)).toBe(true);
+  });
+
+  it('returns false when the same-tier follow-up is outside the window', () => {
+    const now = new Date('2026-04-10T00:00:00.000Z');
+    const oldEntry = new Date('2026-03-01T00:00:00.000Z').toISOString();
+    const s = recordFollowUp(emptyState(), PR, { tier: 'light_check_in', timestamp: oldEntry });
+    expect(isWithinTierWindow(s, PR, 'light_check_in', now)).toBe(false);
+  });
+
+  it('returns false when the prior follow-up was a different tier', () => {
+    const now = new Date('2026-04-10T00:00:00.000Z');
+    const recent = new Date('2026-04-08T00:00:00.000Z').toISOString();
+    const s = recordFollowUp(emptyState(), PR, { tier: 'light_check_in', timestamp: recent });
+    expect(isWithinTierWindow(s, PR, 'direct_check_in', now)).toBe(false);
+  });
+
+  it('uses the documented tier window per tier', () => {
+    expect(TIER_WINDOW_DAYS.light_check_in).toBe(7);
+    expect(TIER_WINDOW_DAYS.direct_check_in).toBe(14);
+    expect(TIER_WINDOW_DAYS.final_check_in).toBe(30);
+  });
+});

--- a/packages/core/src/core/follow-up-history.ts
+++ b/packages/core/src/core/follow-up-history.ts
@@ -1,0 +1,82 @@
+/**
+ * PR follow-up history helpers (#1277).
+ *
+ * Centralizes the read/write logic for `state.prFollowUpHistory`.
+ * Used by `workflows/dormant-pr-follow-up.md` to enforce the
+ * one-follow-up-per-timeframe rule documented in
+ * `skills/pr-etiquette/SKILL.md`.
+ *
+ * Pure functions — callers manage state I/O.
+ */
+
+import type { AgentState } from './state-schema.js';
+import type { FollowUpEntry } from './state-schema.js';
+
+export type FollowUpTier = 'light_check_in' | 'direct_check_in' | 'final_check_in';
+
+/**
+ * Tier window in days. The "no second ping in the same window" rule
+ * uses this to decide whether a recent follow-up still locks out the
+ * next draft. Sourced from `skills/pr-etiquette/SKILL.md`.
+ */
+export const TIER_WINDOW_DAYS: Record<FollowUpTier, number> = {
+  light_check_in: 7,
+  direct_check_in: 14,
+  final_check_in: 30,
+};
+
+/**
+ * Read the existing follow-up entries for a PR. Returns an empty
+ * array when no entries exist or when the state field is unset.
+ */
+export function getFollowUpHistory(state: AgentState, prUrl: string): FollowUpEntry[] {
+  return state.prFollowUpHistory?.[prUrl] ?? [];
+}
+
+/**
+ * Find the most recent entry, or null when there are none. Used by
+ * the workflow's pre-draft gate.
+ */
+export function lastFollowUp(state: AgentState, prUrl: string): FollowUpEntry | null {
+  const entries = getFollowUpHistory(state, prUrl);
+  if (entries.length === 0) return null;
+  // Newest by timestamp wins. Defensive sort because the persistence
+  // path doesn't guarantee insertion order across machines.
+  return [...entries].sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp))[0];
+}
+
+/**
+ * Whether a follow-up of the given tier was drafted within the
+ * tier's own window. The workflow uses this to surface a warning
+ * before the user drafts a second ping in the same window. Different
+ * tiers are always allowed (escalating light → direct → final).
+ */
+export function isWithinTierWindow(
+  state: AgentState,
+  prUrl: string,
+  tier: FollowUpTier,
+  now: Date = new Date(),
+): boolean {
+  const last = lastFollowUp(state, prUrl);
+  if (!last) return false;
+  if (last.tier !== tier) return false;
+  const ageMs = now.getTime() - Date.parse(last.timestamp);
+  if (Number.isNaN(ageMs)) return false;
+  const windowMs = TIER_WINDOW_DAYS[tier] * 86400000;
+  return ageMs < windowMs;
+}
+
+/**
+ * Record a new follow-up entry. Returns the next state; callers
+ * decide when to persist.
+ */
+export function recordFollowUp(state: AgentState, prUrl: string, entry: FollowUpEntry): AgentState {
+  const next: AgentState = {
+    ...state,
+    prFollowUpHistory: { ...(state.prFollowUpHistory ?? {}) },
+  };
+  const list = next.prFollowUpHistory![prUrl] ? [...next.prFollowUpHistory![prUrl]] : [];
+  list.push(entry);
+  next.prFollowUpHistory![prUrl] = list;
+  return next;
+}

--- a/packages/core/src/core/state-schema.ts
+++ b/packages/core/src/core/state-schema.ts
@@ -80,6 +80,20 @@ export const AnalyzedIssueConversationSchema = z.object({
   analyzedAt: z.string(),
 });
 
+/**
+ * One entry in a PR's follow-up history (#1277). Tier matches the
+ * cadence labels in `skills/pr-etiquette/SKILL.md` (light_check_in
+ * for 7-13 days, direct_check_in for 14-29 days, final_check_in for
+ * 30+ days). The `draftPath` is optional so an entry recorded from a
+ * direct `gh pr comment` (no draft) still validates.
+ */
+export const FollowUpEntrySchema = z.object({
+  tier: z.enum(['light_check_in', 'direct_check_in', 'final_check_in']),
+  timestamp: z.string().datetime(),
+  draftPath: z.string().optional(),
+});
+export type FollowUpEntry = z.infer<typeof FollowUpEntrySchema>;
+
 // ── 3. Contribution schemas ──────────────────────────────────────────
 
 export const ContributionGuidelinesSchema = z.object({
@@ -334,6 +348,16 @@ export const AgentStateSchema = z.object({
   analyzedIssueConversations: z.array(AnalyzedIssueConversationSchema).optional(),
 
   activeIssues: z.array(TrackedIssueSchema).default([]),
+
+  /**
+   * Per-PR follow-up history (#1277). Keyed by PR URL. Each entry
+   * records a tier-bucketed follow-up that the user drafted (and
+   * presumably posted via `draft-review-post`). The dormant-pr
+   * workflow reads this before drafting to enforce the
+   * one-follow-up-per-timeframe rule documented in
+   * `skills/pr-etiquette/SKILL.md`.
+   */
+  prFollowUpHistory: z.record(z.string(), z.array(FollowUpEntrySchema)).optional(),
 });
 
 // ── Inferred types ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements **Change 2** from #1277 — the persistence half. The dormant-pr-follow-up workflow can now enforce the one-follow-up-per-timeframe rule (documented in `skills/pr-etiquette/SKILL.md`) without relying on the user remembering. **Change 1** (data-layer comment scanning that detects prior follow-ups visible in the PR thread) is deferred — it's a `daily.ts` pipeline change that wants its own scope.

## What's in this PR

- **New state field** `state.prFollowUpHistory: Record<url, FollowUpEntry[]>`. `z.optional()` so existing state files don't break the migration check. Each entry records a tier (`light_check_in` / `direct_check_in` / `final_check_in`), ISO timestamp, and optional draft path.

- **New core module** `packages/core/src/core/follow-up-history.ts`:
  - `getFollowUpHistory(state, prUrl)` — returns entries (or `[]`)
  - `lastFollowUp(state, prUrl)` — newest entry by timestamp
  - `isWithinTierWindow(state, prUrl, tier)` — same-tier guard; different-tier escalations always allowed
  - `recordFollowUp(state, prUrl, entry)` — pure function returning next state; caller persists
  - `TIER_WINDOW_DAYS` pinned to 7 / 14 / 30 (matches pr-etiquette skill)

- **12 unit tests** covering the helpers, ordering, multi-entry persistence, immutability, and the tier-window decision.

## Out of scope

- **Change 1**: comment scanning that detects prior follow-ups visible in the PR thread (`gh pr view --json comments`). Separate daily.ts pipeline edit.
- **Workflow integration** in `workflows/dormant-pr-follow-up.md` to call `isWithinTierWindow()` before drafting and `recordFollowUp()` after posting. Trivial wiring once the helpers ship.

## Test plan

- [x] All 2455 core + 256 dashboard + 203 mcp tests pass
- [x] 0 lint errors