### PR TITLE
feat: /oss-guidelines slash command + edit-guidelines workflow (#1283)

### DIFF
--- a/.claude-plugin/expected-cli-contract.json
+++ b/.claude-plugin/expected-cli-contract.json
@@ -43,6 +43,7 @@
     "workflows/dispatch-review.md",
     "workflows/dormant-pr-follow-up.md",
     "workflows/draft-first-workflow.md",
+    "workflows/edit-guidelines.md",
     "workflows/extract-learnings.md",
     "workflows/plan-review.md",
     "workflows/pre-commit-review.md",

--- a/commands/oss-guidelines.md
+++ b/commands/oss-guidelines.md
@@ -1,0 +1,79 @@
+---
+name: oss-guidelines
+description: View / edit / reset per-repo contribution guidelines stored from prior extract-learnings runs
+allowed-tools: Bash, Read, Write, Edit, Agent, AskUserQuestion
+---
+
+# /oss-guidelines [repo]
+
+Surface for the per-repo guidelines machinery (#867 / #1283). Most users
+land here after the `extract-learnings` workflow has run at least once
+and want to read, edit, or reset what was stored — without re-running
+the full extraction.
+
+## Inputs
+
+- `[repo]` — optional. `owner/repo` shorthand. When omitted, this
+  command lists every repo with stored guidelines and asks which one
+  the user wants to operate on.
+
+## What it does
+
+1. **Resolve the target repo.**
+   - If an argument was passed, use it verbatim.
+   - Otherwise, run `cli.bundle.cjs guidelines list --json` (or the
+     equivalent `mcp__plugin_oss-autopilot_oss-autopilot__guidelines-get`
+     enumeration path) and present the list of repos with stored
+     guidelines via `AskUserQuestion`.
+   - If no guidelines exist for any repo, surface a one-line nudge
+     toward `extract-learnings` and exit.
+
+2. **Render the current guidelines.**
+
+   ```
+   ## Guidelines for {owner}/{repo}
+   Stored: {byteSize} bytes, last updated {timestamp}
+
+   {markdown content}
+   ```
+
+   Read via `mcp__plugin_oss-autopilot_oss-autopilot__guidelines-get`
+   when available; fall back to
+   `cli.bundle.cjs guidelines view --repo OWNER/REPO --json` otherwise.
+
+3. **Offer follow-up actions.** Use `AskUserQuestion`:
+   - **Re-extract from recent PRs** — dispatches the
+     `extract-learnings.md` workflow scoped to this repo.
+   - **Edit guidelines** — invokes the `edit-guidelines.md`
+     workflow (load → user edit → store, no extraction step).
+   - **Reset (delete)** — calls `cli.bundle.cjs guidelines reset --repo
+     OWNER/REPO` after a confirm prompt. Tombstones the entry in
+     the gist (#867 semantics).
+   - **Done** — exit cleanly.
+
+## What it does NOT do
+
+- Does not run the LLM extraction step itself. That belongs to
+  `extract-learnings.md`.
+- Does not fetch or analyze new PR comments. Read-only over what is
+  already stored.
+- Does not modify multiple repos in one invocation. Re-run with a
+  different `[repo]` arg or pick another from the list.
+
+## Errors
+
+- **No gist persistence configured** — guidelines storage requires
+  Gist mode. Surface the standard "this requires Gist persistence;
+  run `oss-autopilot setup --set persistence=gist`" message and exit.
+- **Repo argument is malformed** — must match `owner/repo`. Validate
+  before any CLI call.
+- **CLI / MCP failure** — surface the underlying error message and
+  exit; do not fabricate a fallback view of the data.
+
+## Why this command exists
+
+The per-repo guidelines machinery has been "data plumbing without a
+user surface" since #867 — the only way to interact with stored
+guidelines was via the extract-learnings workflow's storage step or
+raw CLI. `/oss-guidelines` makes them a first-class object the user
+can read and curate.

--- a/workflows/edit-guidelines.md
+++ b/workflows/edit-guidelines.md
@@ -1,0 +1,95 @@
+# Workflow: Edit Existing Guidelines
+
+Companion to `extract-learnings.md` for the **manual edit path** —
+load existing per-repo guidelines, let the user edit them, store the
+result. No corpus fetch, no LLM extraction step (#1283).
+
+Auto-fired by the `/oss-guidelines` slash command when the user picks
+"Edit guidelines" from the action menu. Can also be invoked manually
+when the user wants to update guidelines without waiting for fresh
+PR comments.
+
+## Why this is its own workflow
+
+The `extract-learnings.md` flow defaults to "fetch fresh corpus → run
+extraction → propose update → user edits/stores". That's the right
+default when the user wants the system to surface new conventions.
+
+But sometimes the user just wants to:
+
+- Add a rule the corpus didn't capture (a convention they've seen in
+  reviews but the extractor missed).
+- Remove a stale entry (a convention that's no longer followed).
+- Reorder / re-section the guidelines for readability.
+
+For all three, the corpus fetch + extraction is wasted work. This
+workflow is the lightweight load → edit → store path.
+
+## Preconditions
+
+- Gist persistence is configured. Guidelines storage requires Gist
+  mode (#867 semantics). If `config.persistence` is `local`, surface
+  the standard "this requires Gist persistence" message and exit.
+- A `repo` argument is provided (`owner/repo`). The slash command
+  passes this through; manual invocations must supply it.
+
+## Steps
+
+1. **Load the current guidelines** for `repo` via
+   `cli.bundle.cjs guidelines view --repo OWNER/REPO --json` (or the
+   `mcp__plugin_oss-autopilot_oss-autopilot__guidelines-get` MCP tool
+   when available).
+
+   - If no guidelines exist, surface a one-line nudge to run
+     `extract-learnings` first and exit. This workflow is for editing
+     existing entries, not bootstrapping new ones.
+
+2. **Write the current content to a temp draft file** at
+   `/tmp/oss-autopilot-guidelines/<owner>-<repo>-<timestamp>.md`.
+   This mirrors the `draft-review-post` skill's convention (#1248) so
+   the user has a stable path to inspect.
+
+3. **Show the rendered content to the user** and offer:
+   - "Open in default editor" — call `${EDITOR:-vi} <path>` for the
+     user.
+   - "Paste replacement here" — accept the new markdown via
+     `AskUserQuestion`'s textarea. Use this when the user has an
+     edited copy on the clipboard already.
+   - "Cancel" — exit without saving.
+
+4. **Validate the edited content** before storing:
+   - Non-empty (a zero-length file is treated as "I want to delete";
+     redirect to `guidelines reset` instead, which has the right
+     tombstone semantics).
+   - Under the 8 KB byte budget (the Gist storage cap from #867).
+   - No raw secrets pattern matches (the same regex set
+     `guard-public-posts.sh` uses; defense-in-depth, not authoritative).
+
+5. **Store via the CLI** —
+   `cat <draft-path> | cli.bundle.cjs guidelines store --repo OWNER/REPO`.
+
+   - On success, print a one-line confirmation with the new byte size
+     and timestamp.
+   - On failure, surface the error and offer to retry, save the draft
+     for later, or cancel.
+
+6. **Show a diff summary** between the prior content and the stored
+   content for the user's audit trail. The draft path stays around
+   until the user runs `/oss-guidelines` again (or manually deletes
+   it).
+
+## What this workflow does NOT do
+
+- Does not fetch fresh PR comments. Use `extract-learnings.md` for
+  that.
+- Does not run an LLM extraction step. The user is the editor here.
+- Does not modify multiple repos. One invocation, one repo.
+
+## Out of scope (deferred follow-ups)
+
+- A side-by-side diff renderer for Step 6. Today's "show before / show
+  after" prose works; a diff view is nicer but not load-bearing.
+- A "compare with the corpus's current state" view that re-runs
+  extraction and shows what new rules the corpus would surface
+  without storing them. That's an `extract-learnings.md` enhancement,
+  not this workflow's concern.


### PR DESCRIPTION
## Summary

Closes #1283.

The per-repo guidelines machinery (#867) has been data plumbing without a user surface. This PR adds two surfaces:

1. **`commands/oss-guidelines.md`** — slash command. Loads stored guidelines for a repo (or lists repos with stored guidelines if no arg), renders the markdown, and offers Re-extract / Edit / Reset / Done.
2. **`workflows/edit-guidelines.md`** — sibling to `extract-learnings.md` for the manual-edit path. Load → user edit → store, no corpus fetch / no LLM step. Validates non-empty, under the 8 KB cap, and does a defense-in-depth secrets check.

The existing `extract-learnings.md` flow is unchanged — it remains the right surface when the user wants the system to surface new conventions from fresh corpus.

## Test plan

- [x] No code changes — markdown surfaces only
- [x] Plugin contract pin updated; CLI contract test still passes
- [x] All 2455 core + 256 dashboard + 203 mcp tests pass