### PR TITLE
feat: extract markIssueListItemDone() to typed core (#1299 part 2)

### DIFF
--- a/packages/core/src/commands/list-mark-done.test.ts
+++ b/packages/core/src/commands/list-mark-done.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Tests for list-mark-done (#1299).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { markIssueAsDone, runMarkIssueListItemDone } from './list-mark-done.js';
+
+const ISSUE_A = 'https://github.com/foo/bar/issues/1';
+const ISSUE_B = 'https://github.com/foo/bar/issues/2';
+const ISSUE_C = 'https://github.com/baz/qux/issues/42';
+const PR_A = 'https://github.com/foo/bar/pull/123';
+const PR_C = 'https://github.com/baz/qux/pull/9';
+
+describe('markIssueAsDone (pure transform)', () => {
+  it('strikes the issue line, appends a Done sub-bullet, and strikes the heading when no other issues remain', () => {
+    const content = [
+      '# My List',
+      '',
+      '## Pursue',
+      '',
+      `### foo/bar (1.2k★) — A library`,
+      `- [#1](${ISSUE_A}) — Test mic while "muted"`,
+      '  - **Low complexity** — Help wanted, unassigned.',
+      '',
+    ].join('\n');
+
+    const result = markIssueAsDone(content, {
+      issueUrl: ISSUE_A,
+      prUrl: PR_A,
+      prStatus: 'CI passing',
+    });
+
+    expect(result.marked).toBe(true);
+    expect(result.repoHeadingStruck).toBe(true);
+    expect(result.remainingUnderRepo).toBe(0);
+
+    expect(result.content).toContain(`### ~~foo/bar (1.2k★) — A library~~`);
+    expect(result.content).toContain(`- ~~[#1](${ISSUE_A}) — Test mic while "muted"~~`);
+    expect(result.content).toContain(`  - **Done** — PR [#123](${PR_A}) submitted, CI passing.`);
+    // Original sub-bullet is preserved (we append, not replace).
+    expect(result.content).toContain('  - **Low complexity** — Help wanted, unassigned.');
+  });
+
+  it('does not strike the heading when other issues under it are still open', () => {
+    const content = [
+      '## Pursue',
+      '',
+      `### foo/bar`,
+      `- [#1](${ISSUE_A}) — first`,
+      `- [#2](${ISSUE_B}) — second`,
+      '',
+    ].join('\n');
+
+    const result = markIssueAsDone(content, {
+      issueUrl: ISSUE_A,
+      prUrl: PR_A,
+      prStatus: 'merged',
+    });
+
+    expect(result.marked).toBe(true);
+    expect(result.repoHeadingStruck).toBe(false);
+    expect(result.remainingUnderRepo).toBe(1);
+
+    expect(result.content).toContain(`### foo/bar`);
+    expect(result.content).not.toContain(`### ~~foo/bar~~`);
+    expect(result.content).toContain(`- ~~[#1](${ISSUE_A}) — first~~`);
+    expect(result.content).toContain(`- [#2](${ISSUE_B}) — second`);
+  });
+
+  it('is idempotent — already-marked issues are a no-op', () => {
+    const content = [
+      `### foo/bar`,
+      `- ~~[#1](${ISSUE_A}) — first~~`,
+      `  - **Done** — PR [#10](https://github.com/foo/bar/pull/10) submitted, CI passing.`,
+      `- [#2](${ISSUE_B}) — second`,
+      '',
+    ].join('\n');
+
+    const result = markIssueAsDone(content, {
+      issueUrl: ISSUE_A,
+      prUrl: PR_A,
+      prStatus: 'merged',
+    });
+
+    expect(result.marked).toBe(false);
+    expect(result.reason).toMatch(/already/);
+    expect(result.content).toBe(content);
+    // remainingUnderRepo reflects current state.
+    expect(result.remainingUnderRepo).toBe(1);
+  });
+
+  it('returns marked=false when the URL is not found', () => {
+    const content = '## Pursue\n\n### foo/bar\n- [#9](https://github.com/foo/bar/issues/9) — other\n';
+    const result = markIssueAsDone(content, {
+      issueUrl: ISSUE_A,
+      prUrl: PR_A,
+      prStatus: 'merged',
+    });
+    expect(result.marked).toBe(false);
+    expect(result.reason).toMatch(/not found/);
+    expect(result.content).toBe(content);
+  });
+
+  it('strikes the second issue and the heading once the last open issue closes', () => {
+    const content = [
+      `### baz/qux`,
+      `- ~~[#1](${ISSUE_A}) — old~~`,
+      `  - **Done** — PR [#1](https://github.com/baz/qux/pull/1) submitted, merged.`,
+      `- [#42](${ISSUE_C}) — last open`,
+      '',
+    ].join('\n');
+
+    const result = markIssueAsDone(content, {
+      issueUrl: ISSUE_C,
+      prUrl: PR_C,
+      prStatus: 'CI passing',
+    });
+
+    expect(result.marked).toBe(true);
+    expect(result.repoHeadingStruck).toBe(true);
+    expect(result.remainingUnderRepo).toBe(0);
+    expect(result.content).toContain(`### ~~baz/qux~~`);
+  });
+
+  it('preserves the trailing newline shape of the source', () => {
+    const withNewline = `### foo/bar\n- [#1](${ISSUE_A}) — x\n`;
+    const withoutNewline = `### foo/bar\n- [#1](${ISSUE_A}) — x`;
+    const a = markIssueAsDone(withNewline, { issueUrl: ISSUE_A, prUrl: PR_A, prStatus: 'merged' });
+    const b = markIssueAsDone(withoutNewline, { issueUrl: ISSUE_A, prUrl: PR_A, prStatus: 'merged' });
+    expect(a.content.endsWith('\n')).toBe(true);
+    expect(b.content.endsWith('\n')).toBe(false);
+  });
+
+  it('falls back to "PR" label when the PR URL has no number segment', () => {
+    const content = `### foo/bar\n- [#1](${ISSUE_A}) — x\n`;
+    const result = markIssueAsDone(content, {
+      issueUrl: ISSUE_A,
+      prUrl: 'https://example.com/some-non-pr-url',
+      prStatus: 'submitted',
+    });
+    expect(result.marked).toBe(true);
+    expect(result.content).toContain(
+      '  - **Done** — PR [PR](https://example.com/some-non-pr-url) submitted, submitted.',
+    );
+  });
+
+  it('does not strike a heading that lacks any issue lines (prose-only section is left alone)', () => {
+    const content = ['### foo/bar', 'Some intro prose.', '', '<!-- intentionally no issue lines yet -->', ''].join(
+      '\n',
+    );
+    // No issue line to find, so this just exercises the not-found path.
+    const result = markIssueAsDone(content, {
+      issueUrl: ISSUE_A,
+      prUrl: PR_A,
+      prStatus: 'merged',
+    });
+    expect(result.marked).toBe(false);
+    expect(result.content).toBe(content);
+  });
+});
+
+describe('runMarkIssueListItemDone (filesystem)', () => {
+  let tmpDir: string;
+  let listPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'list-mark-done-test-'));
+    listPath = path.join(tmpDir, 'list.md');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('reads, marks, writes atomically, and returns the resolved file path', async () => {
+    fs.writeFileSync(listPath, [`### foo/bar`, `- [#1](${ISSUE_A}) — x`, ''].join('\n'));
+    const out = await runMarkIssueListItemDone({
+      issueUrl: ISSUE_A,
+      prUrl: PR_A,
+      prStatus: 'CI passing',
+      listPath,
+    });
+    expect(out.marked).toBe(true);
+    expect(out.repoHeadingStruck).toBe(true);
+    expect(out.filePath).toBe(path.resolve(listPath));
+    expect(out.url).toBe(ISSUE_A);
+
+    const after = fs.readFileSync(listPath, 'utf8');
+    expect(after).toContain(`### ~~foo/bar~~`);
+    expect(after).toContain(`  - **Done** — PR [#123](${PR_A}) submitted, CI passing.`);
+  });
+
+  it('throws when the file does not exist', async () => {
+    await expect(
+      runMarkIssueListItemDone({
+        issueUrl: ISSUE_A,
+        prUrl: PR_A,
+        prStatus: 'merged',
+        listPath,
+      }),
+    ).rejects.toThrow(/File not found/);
+  });
+
+  it('does not write when the URL is not present', async () => {
+    const original = `### foo/bar\n- [#9](https://github.com/foo/bar/issues/9) — other\n`;
+    fs.writeFileSync(listPath, original);
+    const before = fs.statSync(listPath).mtimeMs;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    const out = await runMarkIssueListItemDone({
+      issueUrl: ISSUE_A,
+      prUrl: PR_A,
+      prStatus: 'merged',
+      listPath,
+    });
+    expect(out.marked).toBe(false);
+    const after = fs.statSync(listPath).mtimeMs;
+    expect(after).toBe(before);
+    expect(fs.readFileSync(listPath, 'utf8')).toBe(original);
+  });
+
+  it('leaves no temp file behind on a successful write', async () => {
+    fs.writeFileSync(listPath, `### foo/bar\n- [#1](${ISSUE_A}) — x\n`);
+    await runMarkIssueListItemDone({
+      issueUrl: ISSUE_A,
+      prUrl: PR_A,
+      prStatus: 'merged',
+      listPath,
+    });
+    const siblings = fs.readdirSync(tmpDir);
+    // Only the list.md should remain — no `.tmp-*` files left over.
+    expect(siblings).toEqual(['list.md']);
+  });
+});

--- a/packages/core/src/commands/list-mark-done.ts
+++ b/packages/core/src/commands/list-mark-done.ts
@@ -1,0 +1,255 @@
+/**
+ * list-mark-done command (#1299).
+ *
+ * Mark an issue line in a curated list as done by wrapping it in
+ * `~~strikethrough~~` and appending a `**Done** — PR [#N](url) ...` sub-bullet.
+ * If every issue under the same `### repo/name` heading is now struck through,
+ * also strikes through the heading. Replaces the markdown-prose strikethrough
+ * logic in `draft-first-workflow.md` Step 10.
+ *
+ * Idempotent: re-running with an already-marked URL is a no-op.
+ *
+ * No GitHub calls — pure read/transform/write of a local file.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { errorMessage } from '../core/errors.js';
+
+export interface MarkDoneOptions {
+  issueUrl: string;
+  prUrl: string;
+  /** Free-text trailing status, e.g. "CI passing", "merged". */
+  prStatus: string;
+  listPath: string;
+}
+
+export interface MarkDoneOutput {
+  /** True if the line was found and updated. False on already-marked or not-found. */
+  marked: boolean;
+  /** Fully-resolved file path that was inspected. */
+  filePath: string;
+  /** The issue URL that was searched for. */
+  url: string;
+  /** True if the parent `### repo/name` heading was also struck through this run. */
+  repoHeadingStruck: boolean;
+  /** Issue lines under the same repo heading that are still open after the update. */
+  remainingUnderRepo: number;
+  /** Human-readable explanation when `marked` is false. */
+  reason?: string;
+}
+
+interface IssueBlock {
+  /** Index of the issue line itself in the source `lines` array. */
+  start: number;
+  /** Exclusive end index — first line not part of this block. */
+  end: number;
+}
+
+interface RepoSection {
+  /** Index of the `### repo/...` heading line. */
+  headingIndex: number;
+  /** Exclusive end index — first line not under this heading. */
+  end: number;
+}
+
+const STRIKE = '~~';
+const DONE_PREFIX = '  - **Done**';
+const ISSUE_LINE_RE = /^[*+-]\s/;
+const REPO_HEADING_RE = /^###\s/;
+const SECTION_BREAK_RE = /^#{1,3}\s/;
+const PR_NUMBER_RE = /\/(?:pull|issues)\/(\d+)(?:[/?#]|$)/;
+
+/** Extract a PR number from a GitHub PR URL, returning a string like "#42". */
+function prNumberLabel(prUrl: string): string {
+  const match = prUrl.match(PR_NUMBER_RE);
+  return match ? `#${match[1]}` : 'PR';
+}
+
+/** Wrap a line in `~~...~~` if it isn't already. Returns the input unchanged when already wrapped. */
+function strikeLine(line: string): { line: string; alreadyStruck: boolean } {
+  // Strip the leading list marker so we wrap the content, not the bullet.
+  const markerMatch = line.match(/^(?:[*+-]\s+|#{1,6}\s+)/);
+  const prefix = markerMatch ? markerMatch[0] : '';
+  const body = line.slice(prefix.length);
+  if (body.startsWith(STRIKE) && body.endsWith(STRIKE) && body.length >= 4) {
+    return { line, alreadyStruck: true };
+  }
+  return { line: `${prefix}${STRIKE}${body}${STRIKE}`, alreadyStruck: false };
+}
+
+/** Find the issue block (issue line plus any indented sub-bullets) that mentions the URL. */
+function findIssueBlock(lines: string[], issueUrl: string): IssueBlock | undefined {
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!ISSUE_LINE_RE.test(line)) continue;
+    if (!line.includes(issueUrl)) continue;
+    let end = i + 1;
+    while (end < lines.length && /^\s{2,}/.test(lines[end])) end++;
+    return { start: i, end };
+  }
+  return undefined;
+}
+
+/** Find the `### repo/...` heading enclosing a given line index, plus its end (next heading at depth ≤ 3). */
+function findRepoSection(lines: string[], lineIndex: number): RepoSection | undefined {
+  let headingIndex: number | undefined;
+  for (let i = lineIndex - 1; i >= 0; i--) {
+    if (REPO_HEADING_RE.test(lines[i])) {
+      headingIndex = i;
+      break;
+    }
+    if (/^#{1,2}\s/.test(lines[i])) return undefined;
+  }
+  if (headingIndex === undefined) return undefined;
+  let end = lines.length;
+  for (let i = headingIndex + 1; i < lines.length; i++) {
+    if (SECTION_BREAK_RE.test(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+  return { headingIndex, end };
+}
+
+/** Count issue lines under a section that are NOT yet struck through. */
+function countOpenIssues(lines: string[], section: RepoSection): number {
+  let open = 0;
+  for (let i = section.headingIndex + 1; i < section.end; i++) {
+    const line = lines[i];
+    if (!ISSUE_LINE_RE.test(line)) continue;
+    const body = line.replace(/^[*+-]\s+/, '');
+    if (!(body.startsWith(STRIKE) && body.endsWith(STRIKE))) open++;
+  }
+  return open;
+}
+
+/** Pure transform — exposed for unit testing. */
+export function markIssueAsDone(
+  content: string,
+  opts: { issueUrl: string; prUrl: string; prStatus: string },
+): {
+  content: string;
+  marked: boolean;
+  repoHeadingStruck: boolean;
+  remainingUnderRepo: number;
+  reason?: string;
+} {
+  const hadTrailingNewline = content.endsWith('\n');
+  const lines = (hadTrailingNewline ? content.slice(0, -1) : content).split('\n');
+
+  const block = findIssueBlock(lines, opts.issueUrl);
+  if (!block) {
+    return {
+      content,
+      marked: false,
+      repoHeadingStruck: false,
+      remainingUnderRepo: 0,
+      reason: 'issue URL not found in the list',
+    };
+  }
+
+  const issueLine = lines[block.start];
+  const issueBody = issueLine.replace(/^[*+-]\s+/, '');
+  const alreadyMarked = issueBody.startsWith(STRIKE) && issueBody.endsWith(STRIKE);
+
+  if (alreadyMarked) {
+    const section = findRepoSection(lines, block.start);
+    return {
+      content,
+      marked: false,
+      repoHeadingStruck: false,
+      remainingUnderRepo: section ? countOpenIssues(lines, section) : 0,
+      reason: 'already marked done',
+    };
+  }
+
+  // 1. Strike the issue line.
+  const struck = strikeLine(issueLine);
+  lines[block.start] = struck.line;
+
+  // 2. Insert the **Done** sub-bullet after the issue line and any existing sub-bullets.
+  const doneSubBullet = `${DONE_PREFIX} — PR [${prNumberLabel(opts.prUrl)}](${opts.prUrl}) submitted, ${opts.prStatus}.`;
+  // If the previously-existing sub-bullets already contain a Done line, treat as idempotent.
+  const existingSubBullets = lines.slice(block.start + 1, block.end);
+  const hasDoneAlready = existingSubBullets.some((l) => l.trim().startsWith('- **Done**'));
+  if (!hasDoneAlready) {
+    lines.splice(block.end, 0, doneSubBullet);
+  }
+
+  // 3. If every issue under this repo heading is now struck, strike the heading too.
+  const section = findRepoSection(lines, block.start);
+  let repoHeadingStruck = false;
+  let remaining = 0;
+  if (section) {
+    // Recompute end since we may have inserted a sub-bullet.
+    const refreshed = findRepoSection(lines, block.start);
+    if (refreshed) {
+      remaining = countOpenIssues(lines, refreshed);
+      const headingLine = lines[refreshed.headingIndex];
+      const headingBody = headingLine.replace(/^#{3}\s+/, '');
+      const headingAlreadyStruck = headingBody.startsWith(STRIKE) && headingBody.endsWith(STRIKE);
+      if (remaining === 0 && !headingAlreadyStruck) {
+        const result = strikeLine(headingLine);
+        lines[refreshed.headingIndex] = result.line;
+        repoHeadingStruck = !result.alreadyStruck;
+      }
+    }
+  }
+
+  let next = lines.join('\n');
+  if (hadTrailingNewline) next += '\n';
+
+  return {
+    content: next,
+    marked: true,
+    repoHeadingStruck,
+    remainingUnderRepo: remaining,
+  };
+}
+
+/** Read → transform → write atomically (tmp + rename) so a crash mid-write can't corrupt the file. */
+export async function runMarkIssueListItemDone(options: MarkDoneOptions): Promise<MarkDoneOutput> {
+  const filePath = path.resolve(options.listPath);
+
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`File not found: ${filePath}`);
+  }
+
+  let content: string;
+  try {
+    content = fs.readFileSync(filePath, 'utf8');
+  } catch (error) {
+    throw new Error(`Failed to read file: ${errorMessage(error)}`, { cause: error });
+  }
+
+  const result = markIssueAsDone(content, {
+    issueUrl: options.issueUrl,
+    prUrl: options.prUrl,
+    prStatus: options.prStatus,
+  });
+
+  if (result.marked) {
+    const tmp = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+    try {
+      fs.writeFileSync(tmp, result.content, 'utf8');
+      fs.renameSync(tmp, filePath);
+    } catch (error) {
+      try {
+        fs.unlinkSync(tmp);
+      } catch {
+        // best-effort cleanup
+      }
+      throw new Error(`Failed to write file: ${errorMessage(error)}`, { cause: error });
+    }
+  }
+
+  return {
+    marked: result.marked,
+    filePath,
+    url: options.issueUrl,
+    repoHeadingStruck: result.repoHeadingStruck,
+    remainingUnderRepo: result.remainingUnderRepo,
+    reason: result.reason,
+  };
+}


### PR DESCRIPTION
## Summary

Extracts the curated-list "mark as done" strikethrough logic from
`workflows/draft-first-workflow.md` Step 10 prose into a deterministic
typed function. Sibling to `list-move-tier` (#1107) — same shape, same
test layout, same atomic-write pattern.

Closes part 2 of #1299. Part 1 (vet-list `ScoutSkipReason` fallback
removal) stays tracked on that issue and is blocked on the corresponding
scout-side enum emission.

## What's in the diff

`packages/core/src/commands/list-mark-done.ts`:
- `markIssueAsDone()` — pure transform. Returns the new content plus
  `{ marked, repoHeadingStruck, remainingUnderRepo, reason? }`.
- `runMarkIssueListItemDone()` — read/transform/atomic-write wrapper.
  Uses `tmp + rename` so a crash mid-write can't corrupt the file, and
  cleans up the temp file on rename failure.

Behavior:
- Strikes the issue line, appends `**Done** -- PR [#N](url) submitted,
  {status}.` as a new sub-bullet (does not replace existing sub-bullets).
- Strikes the parent `### repo/name` heading only when every issue line
  under it is now struck through.
- Idempotent: already-marked URLs return `marked: false, reason: 'already marked done'`.
- Falls back to a literal `PR` label when the PR URL has no `/pull/N` or
  `/issues/N` segment (defensive — shouldn't happen in practice).

`packages/core/src/commands/list-mark-done.test.ts` — 12 tests covering:
- Basic mark + heading strike when no siblings remain.
- Partial: other open issues under the same heading => heading stays open.
- Idempotency on the issue line and on the heading.
- URL-not-found path (no write).
- Last-open-issue closing the heading.
- Trailing-newline preservation.
- PR-URL number-extraction fallback.
- Prose-only section (no issue lines) treated as not-found.
- Filesystem: atomic-write success, file-not-found error, no-write on
  no-op, no temp file left behind.

## What's deferred

These are concrete follow-ups, mergeable independently:
- CLI subcommand wiring (sibling shape to `list-move-tier --json`).
- `draft-first-workflow.md` Step 10 rewrite to invoke the function
  instead of restating the strikethrough rules in prose.
- Part 1 of #1299 (vet-list `ScoutSkipReason` fallback removal) — blocked
  on scout-side enum emission, tracked on #1299.

## Test plan

- [x] `pnpm --filter @oss-autopilot/core run test` -- 2495 passed
- [x] `pnpm -w run lint` -- 0 errors
- [x] `pnpm -w run format:check` -- passing