### PR TITLE
refactor: consolidate Claim Verification Protocol into reference.md (#1295)

### DIFF
--- a/agents/pr-responder.md
+++ b/agents/pr-responder.md
@@ -113,19 +113,9 @@ Read ONLY files explicitly mentioned. Use targeted line-range reads. Don't read 
 git diff HEAD~1..HEAD   # or the appropriate range
 ```
 
-Draft only from verified facts. **Zero-assumption policy:** common traps:
-- "This should fix the issue" — only if you've verified the fix addresses the reported problem.
-- "I've updated the tests" — only if the diff shows test changes.
-- "The function now handles X" — only if the diff shows the handling code.
-
-**Verify each claim against the diff:**
-- "Updated function X" → X appears in diff.
-- "Changed X to Y" → old was X, new is Y.
-- "Added a check for Z" → the check exists in new code.
-
-**Handle unverifiable or incorrect claims:**
-- Unverifiable (runtime behavior) → rephrase to something verifiable ("Added handling for X").
-- Incorrect (contradicted by diff) → auto-correct (wrong function name, wrong file path, "added" when actually "modified").
+Draft only from verified facts. Apply the **Claim Verification Protocol** in
+`workflows/reference.md` to every factual claim — the common drafting traps,
+verification mapping, and handling rules for unverifiable/incorrect claims live there.
 
 ### 6. Present the verified draft
 

--- a/workflows/reference.md
+++ b/workflows/reference.md
@@ -307,3 +307,31 @@ When working on contributions to external repositories, the maintainer's judgmen
 - **Never substitute TODOs for requested changes.** If a maintainer asks for a change in this PR, make the change. Do not propose deferring to a follow-up unless the maintainer suggested it.
 
 This principle applies across all agents (`pr-responder`, `pre-commit-reviewer`, etc.) and all workflows (`pre-commit-review`, `draft-first-workflow`, etc.).
+
+---
+
+## Claim Verification Protocol
+
+Before reporting that a maintainer ask was addressed, that a tool passed, or that code behaves a certain way, verify the claim against actual evidence. The applicable rules:
+
+1. **Read the current code, not just diffs or descriptions.** "Already addressed" means you opened the file and confirmed. PR descriptions and comment threads are not authoritative.
+2. **Run commands instead of inferring outputs.** When claiming a check, lint, test, or build passes or fails, run it. Do not assume from the prior round's status.
+3. **Distinguish review rounds.** Only report what the LATEST review round asks for. Earlier rounds may have been resolved already.
+4. **State what you can't verify.** If a file is missing, a command fails, or the diff doesn't include the relevant range, say so explicitly. Do not guess.
+5. **Stay in scope.** Report only what the maintainer asked for. Do not propose extra improvements, test cases, or cleanup beyond the request.
+
+**Common drafting traps** when responding to maintainer comments:
+- "This should fix the issue" — only if you verified the fix addresses the reported problem.
+- "I've updated the tests" — only if the diff shows test changes.
+- "The function now handles X" — only if the diff shows the handling code.
+
+**Verification mapping** for every factual claim in a draft:
+- "Updated function X" → X appears in diff.
+- "Changed X to Y" → old was X, new is Y.
+- "Added a check for Z" → the check exists in new code.
+
+**Handling unverifiable or incorrect claims:**
+- Unverifiable (runtime behavior) → rephrase to something verifiable ("Added handling for X").
+- Incorrect (contradicted by diff) → auto-correct (wrong function name, wrong file path, "added" when actually "modified").
+
+This protocol applies to all agents that report findings (`pr-responder`, `pre-commit-reviewer`, `pr-health-checker`, etc.), all workflows that prompt agents to verify state (`work-through-issues`, `pre-commit-review`, `draft-first-workflow`, etc.), and all draft generation that includes factual claims about the code.

--- a/workflows/work-through-issues.md
+++ b/workflows/work-through-issues.md
@@ -100,17 +100,11 @@ After a successful rebase, you MUST follow these steps in order:
      the error to the user. The --force-with-lease safety check exists to prevent
      overwriting commits pushed by others. Falling back to --force defeats this protection.
 
-**Code Verification Rules (MANDATORY):**
-- Verify every claim by reading the actual current code. Do NOT say "already addressed"
-  or "this is handled" without reading the current file to confirm.
-- When claiming a tool, check, or test passes or fails, run the actual command. Do not
-  assume based on PR descriptions or comment threads alone.
-- Distinguish between what the LATEST review round asks for vs what earlier rounds asked
-  for. Only report items that are outstanding in the latest round.
-- If you cannot verify a claim (file not found, command fails), say so explicitly rather
-  than guessing.
-- Report ONLY what the maintainer asked for in the latest review round. Do not suggest
-  additional improvements, extra test cases, or code cleanup beyond what was requested.
+**Code Verification Rules (MANDATORY):** follow the **Claim Verification Protocol** in
+`workflows/reference.md` (rules 1-5). In particular, verify every "already addressed"
+claim by reading the current file, run commands rather than inferring their outputs,
+distinguish what the LATEST review round asks for from earlier rounds, state explicitly
+when you cannot verify a claim, and stay in scope (only what the maintainer asked for).
 
 Report back:
 (a) Commits behind / rebase result


### PR DESCRIPTION
## Summary

Adds a fifth cross-cutting policy section ("Claim Verification Protocol") to `workflows/reference.md`, alongside the existing AskUserQuestion Validation, Prompt Injection Awareness, AI Attribution, and Maintainer Authority sections.

The new section captures the verify-every-claim rule that previously lived in two places with slightly drifted wording. Both consumers now reference the protocol instead of restating it -- same pattern as the `<github-content>` fence convention (#1192) and the AI Attribution / Maintainer Authority principles already in reference.md.

Closes #1295.

## Diff at a glance

- `workflows/reference.md` -- new "Claim Verification Protocol" section (5 numbered rules + drafting traps + verification mapping + unverifiable/incorrect claim handling).
- `workflows/work-through-issues.md` -- Phase A "Code Verification Rules" reduced from 11 lines of inline rules to a 5-line summary that points at the protocol.
- `agents/pr-responder.md` -- Step 5 "Zero-assumption policy" + verification mapping + handling rules collapsed to a single pointer at the protocol. The brief "Claim Verification Rule" non-negotiable headline near the top of the agent is left intact as a deliberate emphasis callout (same pattern as the Maintainer Authority Principle which is also restated as a headline despite living in reference.md).

3 files changed, 36 insertions, 24 deletions.

## What's intentionally not in scope

Per the issue body:
- No extraction to a typed core function. Verification is judgment work for agents, not an algorithm.
- No automated claim-verification tooling.
- No policy change. This is consolidation, not new rules. The wording in the protocol matches the union of what was in the two source surfaces (no rule was dropped).

The `pre-commit-reviewer` agent has its own assertion-strength check that's adjacent but distinct (it polices code-review claims, not response drafts), and is left alone per the issue's "Out of scope" guidance.

## Test plan

- [x] `pnpm -w run format:check` passes (no source files touched).
- [x] No code changes; CI tests run unchanged. Will verify after push.