### PR TITLE
feat: inject per-repo guidelines (#867) at draft-first Step 1e (#1294 steps 1-2)

### DIFF
--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -130,7 +130,7 @@ Never make a recommendation that contradicts the SLM call without saying so expl
 
 ### Per-repo learning guidelines (#867)
 
-After feasibility analysis but before claiming, the work-through-issues workflow injects any stored per-repo guidelines via `oss-autopilot guidelines view --repo OWNER/REPO --json`. These are extracted from past PR feedback in the user's Gist and encode durable maintainer preferences (code style, process, architecture, testing rules).
+At the implementation entry point (`draft-first-workflow.md` Step 1e), any stored per-repo guidelines are loaded via `oss-autopilot guidelines view --repo OWNER/REPO --json` and made available to the agent. These are extracted from past PR feedback in the user's Gist and encode durable maintainer preferences (code style, process, architecture, testing rules).
 
 When implementing, treat injected guidelines as **strong preferences**, not absolute rules:
 

--- a/workflows/draft-first-workflow.md
+++ b/workflows/draft-first-workflow.md
@@ -93,9 +93,9 @@ DEVELOPMENT.md
 docs/DEVELOPMENT.md
 ```
 
-**If no guidelines file found:** Note "No CONTRIBUTING.md found — skipping compliance check." and proceed to Step 2.
+**If no guidelines file found:** Note "No CONTRIBUTING.md found — skipping compliance check." and proceed to Step 1e.
 
-**If a file is found but cannot be read** (permission error, encoding issue, excessively large): Note "Found {path} but could not read it: {reason}. Skipping compliance check." and proceed to Step 2.
+**If a file is found but cannot be read** (permission error, encoding issue, excessively large): Note "Found {path} but could not read it: {reason}. Skipping compliance check." and proceed to Step 1e.
 
 Store the file content in session context as `contributingGuidelines` for reuse in later steps (PR body generation in Step 8, review context in Step 3).
 
@@ -145,7 +145,7 @@ Source: {path to guidelines file}
 
 #### 5. Handle gaps
 
-**If all requirements met:** Note "All CONTRIBUTING.md requirements satisfied." and proceed to Step 2.
+**If all requirements met:** Note "All CONTRIBUTING.md requirements satisfied." and proceed to Step 1e.
 
 **If gaps found:**
 
@@ -161,9 +161,33 @@ Options:
 
 **"Address the gaps":** For each gap, attempt to resolve it (add changelog entry, update docs, run formatter, etc.). If resolution fails for a gap (tool not installed, requires manual web interaction like CLA signing, introduces new errors), report: "Could not automatically resolve: {requirement}. Reason: {error}." Mark it as requiring manual attention and continue to the next gap. After all gaps have been attempted, re-verify and present the updated checklist. If unresolvable gaps remain, re-present the 3-option prompt. **Soft limit after 3 resolution cycles:** if gaps remain after 3 attempts, note "Some requirements could not be automatically resolved after 3 attempts" and present the proceed/done options.
 
-**"Proceed anyway":** Store skipped requirements in session context as `skippedComplianceRequirements` (list of `{requirement, reason}`). Display to the user: "Proceeding with {count} skipped requirements: {list}." When generating the PR description in Step 8, include a "Compliance Notes" section listing any consciously skipped requirements. Proceed to Step 2.
+**"Proceed anyway":** Store skipped requirements in session context as `skippedComplianceRequirements` (list of `{requirement, reason}`). Display to the user: "Proceeding with {count} skipped requirements: {list}." When generating the PR description in Step 8, include a "Compliance Notes" section listing any consciously skipped requirements. Proceed to Step 1e.
 
 **"Done for now":** Report: "Compliance check paused — {resolvedCount} requirements met, {gapCount} remaining. Run `/oss` to resume." Return to the core router.
+
+### 1e. Per-Repo Guidelines Injection (#867)
+
+Fetch any stored guidelines for the target repo. These encode durable maintainer preferences extracted from past PR feedback (#867). Loading them once at the implementation entry point covers every path that lands here — curated-list flow, `review-issue-replies.md` "Start working on this issue", `action-menu.md` "Other" issue selection, and direct invocation.
+
+```bash
+GUIDELINES_OUT=$(GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" guidelines view --repo {owner}/{repo} --json 2>/dev/null)
+```
+
+Parse `data.exists` and `data.content`:
+
+- **If `data.exists === true` and `data.content` is non-empty:** Store as `repoGuidelines` in session context for downstream use (review dispatches in Step 3, PR description generation in Step 8). Display to the user once before continuing:
+
+  > **Maintainer preferences for {owner}/{repo}** (from past PR feedback):
+  >
+  > {data.content}
+  >
+  > These take precedence over CONTRIBUTING.md when they conflict. When implementing, flag any case where your proposed approach contradicts a stated preference so the user can confirm.
+
+- **If `data.exists === false`** or `data.storageMode === 'local-unavailable'`: skip silently. Per-repo guidelines are opt-in and only available in Gist mode.
+
+- **If the command fails** (network error, malformed output): skip silently. Never block implementation on guidelines unavailability — the flow must work even when the guidelines layer is offline.
+
+Proceed to Step 2.
 
 ---
 

--- a/workflows/work-through-issues.md
+++ b/workflows/work-through-issues.md
@@ -374,27 +374,8 @@ Show the vetting summary, then automatically proceed to investigate the issue. I
 Confidence: {High|Medium|Low — how confident in the diagnosis}
 ```
 
-7. **Inject per-repo guidelines (#867).** Before presenting the post-investigation options, fetch any stored guidelines for the target repo. These encode durable maintainer preferences extracted from past PR feedback.
+7. **Post-investigation options:**
 
-```bash
-GUIDELINES_OUT=$(GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" guidelines view --repo {owner}/{repo} --json 2>/dev/null)
-```
-
-Parse `data.exists` and `data.content`:
-
-- **If `data.exists === true` and `data.content` is non-empty:** Display to the user before offering the options:
-
-  > **Maintainer preferences for {owner}/{repo}** (from past PR feedback):
-  >
-  > {data.content}
-  >
-  > These take precedence over CONTRIBUTING.md when they conflict. When implementing, flag any case where your proposed approach contradicts a stated preference so the user can confirm.
-
-- **If `data.exists === false`** or `data.storageMode === 'local-unavailable'`: skip silently. Per-repo guidelines are opt-in and only available in Gist mode.
-
-- **If the command fails** (network error, malformed output): skip silently. Never block claim on guidelines unavailability — the implementation flow must work even when the guidelines layer is offline.
-
-8. **Post-investigation options:**
 
 ```
 Question: "Investigation complete. How would you like to proceed?"


### PR DESCRIPTION
## Summary

Moves the per-repo-guidelines fetch out of `workflows/work-through-issues.md` Section 5 (which only fires for the curated-list flow) into `workflows/draft-first-workflow.md` Step 1e -- the canonical implementation entry point. Every path that lands in implementation now benefits from stored maintainer preferences:

- Curated-list flow (`work-through-issues.md` Pick Issue From List).
- `review-issue-replies.md` "Start working on this issue".
- `action-menu.md` "Other" issue selection.
- Direct invocation of `draft-first-workflow.md`.

Closes steps 1 and 2 of #1294. Step 3 (Phase A guidelines load + dispatch-prompt inclusion) is deferred -- it's a larger change to the agent dispatch template and benefits from this Step 1e baseline.

## What's in the diff

- `workflows/draft-first-workflow.md` -- new `### 1e. Per-Repo Guidelines Injection (#867)` after Step 1d (CONTRIBUTING compliance) and before Step 2 (Stage and Commit). Identical fetch logic to the previous Section 5 implementation: silent skip on absence, silent skip on `local-unavailable` storage mode, silent skip on command failure. When guidelines exist, stores them as `repoGuidelines` in session context for downstream review dispatches and PR-description generation, and surfaces once to the user with the precedence-over-CONTRIBUTING note.
- `workflows/draft-first-workflow.md` -- four "proceed to Step 2" references in Step 1d updated to "proceed to Step 1e" so the flow stays consistent regardless of which compliance branch is taken.
- `workflows/work-through-issues.md` -- old sub-step 7 (guidelines fetch) removed; renumbered sub-step 8 to sub-step 7. The Investigate Feasibility sub-steps above remain unchanged per the issue body.
- `agents/issue-scout.md` -- "Per-repo learning guidelines" callout updated to reference the new injection site (Step 1e of draft-first-workflow) instead of the old work-through-issues injection.

3 files changed, 30 insertions, 25 deletions.

## Side effects worth flagging

- **User no longer sees guidelines during feasibility analysis.** Previously they were displayed inline before the post-investigation options. Now they appear once during Step 1e of draft-first, after the user has chosen "Start implementing". The agent context still gets them; the user-facing display moves slightly later. Per the issue: "agent context > user display" -- the user has `/oss-guidelines` for direct read access.
- **Section 5 sub-step renumbering** is local: it doesn't affect any cross-references. The pre-commit-review.md "sub-step 7" references are a different workflow.

## Test plan

- [x] `pnpm --filter @oss-autopilot/core run test` -- 2495 passed
- [x] `pnpm -w run format:check` -- passing
- [x] No source files touched; CI test surface unchanged.