### PR TITLE
refactor: extract build-cli-if-stale helper, fix session-start staleness bug (#1292)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,9 @@ jobs:
       - name: Test session-start hook helpers
         run: bash hooks/safe-refresh-marketplace.test.sh
 
+      - name: Test build-cli-if-stale helper (#1292)
+        run: bash scripts/build-cli-if-stale.test.sh
+
       - name: Test guard-public-posts hook
         run: bash hooks/guard-public-posts.test.sh
 

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -28,27 +28,31 @@ MARKETPLACE_DIR="$HOME/.claude/plugins/marketplaces/oss-autopilot"
 MARKETPLACE_LOCK="${HOME}/.oss-autopilot/.marketplace-refresh.lock"
 
 # --- Step 1: Rebuild stale CLI bundle (if needed) ---
-# Use pnpm if available (this is a pnpm workspace; running `npm install` from
-# packages/core/ would generate a stray package-lock.json next to pnpm-lock.yaml
-# and confuse pnpm on the next install). Fall back to npm for end users that
-# only have npm — works today because @oss-autopilot/core has no workspace:*
-# deps. Mirrors the Step 1.5 dashboard pattern.
-if [ -f "${PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" ] && [ "${PLUGIN_ROOT}/packages/core/package.json" -nt "${PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" ]; then
-  if command -v pnpm &>/dev/null; then
-    cli_build() { cd "${PLUGIN_ROOT}" && pnpm install --silent 2>/dev/null && pnpm --silent --filter @oss-autopilot/core run bundle 2>/dev/null; }
-  else
-    cli_build() { cd "${PLUGIN_ROOT}/packages/core" && npm install --silent 2>/dev/null && npm run bundle --silent 2>/dev/null; }
-  fi
-  if (cli_build); then
-    rebuilt_cli=true
-  else
-    if command -v pnpm &>/dev/null; then
-      cli_rebuild_error="cd ${PLUGIN_ROOT} && pnpm install && pnpm --filter @oss-autopilot/core run bundle"
-    else
-      cli_rebuild_error="cd ${PLUGIN_ROOT}/packages/core && npm install && npm run bundle"
+# Delegate the staleness + build to scripts/build-cli-if-stale.sh (#1292).
+# That helper checks src/, package.json, AND tsconfig.json against the bundle
+# (the previous inline check only watched package.json, missing the common
+# `git pull` case where only src/ changed). Exit codes:
+#   0 → not stale; 1 → rebuilt OK; 2 → build attempted and failed.
+# `set -e` would short-circuit before the case below, since the helper
+# uses non-zero exits as signals (1 = rebuilt, 2 = build failed). Capture
+# the exit code without tripping `set -e`.
+cli_helper_rc=0
+"${PLUGIN_ROOT}/scripts/build-cli-if-stale.sh" "${PLUGIN_ROOT}" >/tmp/oss-autopilot-cli-build.log 2>&1 || cli_helper_rc=$?
+case $cli_helper_rc in
+  0) ;;  # bundle is current
+  1) rebuilt_cli=true ;;
+  2)
+    cli_rebuild_error="$(grep '^BUILD_FAILED' /tmp/oss-autopilot-cli-build.log | sed 's/^BUILD_FAILED: //')"
+    if [ -z "$cli_rebuild_error" ]; then
+      if command -v pnpm &>/dev/null; then
+        cli_rebuild_error="cd ${PLUGIN_ROOT} && pnpm install && pnpm --filter @oss-autopilot/core run bundle"
+      else
+        cli_rebuild_error="cd ${PLUGIN_ROOT}/packages/core && npm install && npm run bundle"
+      fi
     fi
-  fi
-fi
+    ;;
+  *) ;;  # exit 3 (invocation error) — leave both rebuilt_cli=false and cli_rebuild_error empty
+esac
 
 # --- Step 1.5: Build dashboard SPA if missing or stale ---
 # Stale check scans src/, vite.config.ts, tsconfig.json, and package.json

--- a/scripts/build-cli-if-stale.sh
+++ b/scripts/build-cli-if-stale.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Rebuild the @oss-autopilot/core CLI bundle if it's stale relative to source.
+#
+# A bundle is "stale" when it's missing OR when any of the following are
+# newer than the built artifact:
+#   packages/core/src/**         (source files)
+#   packages/core/package.json   (dep changes)
+#   packages/core/tsconfig.json  (compiler config changes)
+#
+# Editor swap files (.DS_Store, *~, *.swp, *.swo, .#*) and node_modules / .git
+# trees are excluded so an editor leaving a temp file alongside src/ does not
+# trigger a rebuild on every session.
+#
+# Exit codes:
+#   0 — bundle is current; no rebuild attempted.
+#   1 — bundle was rebuilt successfully.
+#   2 — bundle is stale and the rebuild attempt FAILED. The remediation
+#       command is printed to stdout for the caller to surface.
+#   3 — invocation error (PLUGIN_ROOT missing, packages/core not found).
+#
+# Usage:
+#   build-cli-if-stale.sh <plugin-root>
+#
+# Or, equivalently, with $CLAUDE_PLUGIN_ROOT exported:
+#   build-cli-if-stale.sh
+#
+# All build noise (npm/pnpm install + bundle output) is sent to stderr so
+# stdout stays clean for the caller (the BUILD_FAILED hint, if emitted, is
+# the only stdout output).
+
+set -uo pipefail
+
+PLUGIN_ROOT="${1:-${CLAUDE_PLUGIN_ROOT:-}}"
+if [ -z "${PLUGIN_ROOT}" ]; then
+  echo "build-cli-if-stale.sh: missing plugin root (pass as arg or export CLAUDE_PLUGIN_ROOT)" >&2
+  exit 3
+fi
+if [ ! -d "${PLUGIN_ROOT}/packages/core" ]; then
+  echo "build-cli-if-stale.sh: packages/core not found under ${PLUGIN_ROOT}" >&2
+  exit 3
+fi
+
+CLI_BUNDLE="${PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs"
+
+# --- Staleness check ------------------------------------------------------
+needs_rebuild=false
+if [ ! -f "${CLI_BUNDLE}" ]; then
+  needs_rebuild=true
+else
+  # `find -newer` returns the first newer file found (-print -quit). If the
+  # output is non-empty, something was modified after the bundle was built.
+  newer=$(find \
+    "${PLUGIN_ROOT}/packages/core/src" \
+    "${PLUGIN_ROOT}/packages/core/package.json" \
+    "${PLUGIN_ROOT}/packages/core/tsconfig.json" \
+    -type f \
+    ! -path '*/node_modules/*' \
+    ! -path '*/.git/*' \
+    ! -name '.DS_Store' \
+    ! -name '*~' \
+    ! -name '*.swp' \
+    ! -name '*.swo' \
+    ! -name '.#*' \
+    -newer "${CLI_BUNDLE}" -print -quit 2>/dev/null)
+  if [ -n "$newer" ]; then
+    needs_rebuild=true
+  fi
+fi
+
+if [ "$needs_rebuild" = false ]; then
+  exit 0
+fi
+
+# --- Rebuild --------------------------------------------------------------
+# Prefer pnpm: this is a pnpm workspace, and running `npm install` from
+# packages/core/ would generate a stray package-lock.json next to
+# pnpm-lock.yaml. Fall back to npm only when pnpm isn't installed (works
+# today because @oss-autopilot/core has no workspace:* deps).
+remediation=""
+if command -v pnpm >/dev/null 2>&1; then
+  remediation="cd ${PLUGIN_ROOT} && pnpm install && pnpm --filter @oss-autopilot/core run bundle"
+  if (cd "${PLUGIN_ROOT}" && pnpm install --silent && pnpm --silent --filter @oss-autopilot/core run bundle) >&2; then
+    exit 1
+  fi
+else
+  remediation="cd ${PLUGIN_ROOT}/packages/core && npm install && npm run bundle"
+  if (cd "${PLUGIN_ROOT}/packages/core" && npm install --silent && npm run bundle --silent) >&2; then
+    exit 1
+  fi
+fi
+
+echo "BUILD_FAILED: ${remediation}"
+exit 2

--- a/scripts/build-cli-if-stale.test.sh
+++ b/scripts/build-cli-if-stale.test.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# Test harness for scripts/build-cli-if-stale.sh.
+#
+# Exercises the staleness-detection paths (missing bundle, src newer, swap-file
+# excluded, fully-current). Build-success and build-failure paths are NOT
+# exercised end-to-end because that requires a real pnpm/npm install which
+# is expensive and brittle in CI; those paths get a tightly-scoped fake-PATH
+# unit test instead. Run with:
+#   bash scripts/build-cli-if-stale.test.sh
+# Exits 0 on all-pass, 1 on first failure.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+SUBJECT="${SCRIPT_DIR}/build-cli-if-stale.sh"
+
+if [ ! -x "$SUBJECT" ]; then
+    echo "FAIL: subject under test is not executable: $SUBJECT"
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+CURRENT_CASE=""
+
+fail() {
+    echo "  FAIL: ${CURRENT_CASE}: $*"
+    FAIL=$((FAIL + 1))
+}
+
+pass() {
+    echo "  PASS: ${CURRENT_CASE}"
+    PASS=$((PASS + 1))
+}
+
+# Build a fake plugin tree: <root>/packages/core/{src,package.json,tsconfig.json,dist/cli.bundle.cjs}.
+# All freshness checks operate on file mtimes within this tree.
+setup() {
+    WORK=$(mktemp -d)
+    PLUGIN="${WORK}/plugin"
+    mkdir -p "${PLUGIN}/packages/core/src" "${PLUGIN}/packages/core/dist"
+    echo "{}" >"${PLUGIN}/packages/core/package.json"
+    echo "{}" >"${PLUGIN}/packages/core/tsconfig.json"
+    echo "// existing bundle" >"${PLUGIN}/packages/core/dist/cli.bundle.cjs"
+    echo "export const x = 1;" >"${PLUGIN}/packages/core/src/index.ts"
+
+    # Make sure the bundle starts as the most-recent file so a later
+    # `touch` of a source file unambiguously beats it.
+    sleep 1
+    touch "${PLUGIN}/packages/core/dist/cli.bundle.cjs"
+}
+
+teardown() {
+    rm -rf "$WORK"
+}
+
+run() {
+    CURRENT_CASE="$1"
+    shift
+    setup
+    "$@"
+    teardown
+}
+
+# --- Cases -----------------------------------------------------------------
+
+case_missing_plugin_root() {
+    "$SUBJECT" >/dev/null 2>&1
+    rc=$?
+    [ "$rc" = 3 ] && pass || fail "expected exit 3 with no arg + no env, got $rc"
+}
+
+case_packages_core_missing() {
+    bare=$(mktemp -d)
+    "$SUBJECT" "$bare" >/dev/null 2>&1
+    rc=$?
+    rm -rf "$bare"
+    [ "$rc" = 3 ] && pass || fail "expected exit 3 when packages/core absent, got $rc"
+}
+
+case_bundle_current_returns_0() {
+    # Default fixture: bundle is freshly touched, all sources older. Expect
+    # no rebuild attempt — exit 0, no PATH manipulation needed.
+    "$SUBJECT" "$PLUGIN" >/dev/null 2>&1
+    rc=$?
+    [ "$rc" = 0 ] && pass || fail "expected exit 0 when bundle is current, got $rc"
+}
+
+case_src_newer_triggers_rebuild() {
+    # Bump a src file so it beats the bundle, then point pnpm/npm at a stub
+    # that succeeds — expect exit 1 (rebuilt OK).
+    sleep 1
+    touch "${PLUGIN}/packages/core/src/index.ts"
+
+    fake_bin=$(mktemp -d)
+    cat >"${fake_bin}/pnpm" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    cat >"${fake_bin}/npm" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "${fake_bin}/pnpm" "${fake_bin}/npm"
+
+    PATH="${fake_bin}:${PATH}" "$SUBJECT" "$PLUGIN" >/dev/null 2>&1
+    rc=$?
+    rm -rf "$fake_bin"
+    [ "$rc" = 1 ] && pass || fail "expected exit 1 (rebuilt OK) when src is newer, got $rc"
+}
+
+case_missing_bundle_triggers_rebuild() {
+    rm "${PLUGIN}/packages/core/dist/cli.bundle.cjs"
+
+    fake_bin=$(mktemp -d)
+    cat >"${fake_bin}/pnpm" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    cat >"${fake_bin}/npm" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "${fake_bin}/pnpm" "${fake_bin}/npm"
+
+    PATH="${fake_bin}:${PATH}" "$SUBJECT" "$PLUGIN" >/dev/null 2>&1
+    rc=$?
+    rm -rf "$fake_bin"
+    [ "$rc" = 1 ] && pass || fail "expected exit 1 (rebuilt OK) when bundle is missing, got $rc"
+}
+
+case_swap_files_do_not_trigger_rebuild() {
+    # Editor swap files alongside src/ must NOT make the bundle look stale.
+    sleep 1
+    touch "${PLUGIN}/packages/core/src/.index.ts.swp"
+    touch "${PLUGIN}/packages/core/src/.DS_Store"
+    touch "${PLUGIN}/packages/core/src/index.ts~"
+
+    "$SUBJECT" "$PLUGIN" >/dev/null 2>&1
+    rc=$?
+    [ "$rc" = 0 ] && pass || fail "expected exit 0 when only swap files are newer, got $rc"
+}
+
+case_build_failure_returns_2() {
+    # Bundle is missing, but the build tool fails. Expect exit 2 + a
+    # BUILD_FAILED line on stdout containing a remediation hint.
+    rm "${PLUGIN}/packages/core/dist/cli.bundle.cjs"
+
+    fake_bin=$(mktemp -d)
+    cat >"${fake_bin}/pnpm" <<'EOF'
+#!/usr/bin/env bash
+exit 7
+EOF
+    cat >"${fake_bin}/npm" <<'EOF'
+#!/usr/bin/env bash
+exit 7
+EOF
+    chmod +x "${fake_bin}/pnpm" "${fake_bin}/npm"
+
+    out=$(PATH="${fake_bin}:${PATH}" "$SUBJECT" "$PLUGIN" 2>/dev/null)
+    rc=$?
+    rm -rf "$fake_bin"
+
+    if [ "$rc" != 2 ]; then
+        fail "expected exit 2 on build failure, got $rc"
+        return
+    fi
+    if ! echo "$out" | grep -q "BUILD_FAILED"; then
+        fail "expected BUILD_FAILED on stdout, got '$out'"
+        return
+    fi
+    pass
+}
+
+case_package_json_newer_triggers_rebuild() {
+    # Dependency change without src change must still rebuild (catches
+    # the original session-start.sh bug from a different angle).
+    sleep 1
+    touch "${PLUGIN}/packages/core/package.json"
+
+    fake_bin=$(mktemp -d)
+    cat >"${fake_bin}/pnpm" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    cat >"${fake_bin}/npm" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "${fake_bin}/pnpm" "${fake_bin}/npm"
+
+    PATH="${fake_bin}:${PATH}" "$SUBJECT" "$PLUGIN" >/dev/null 2>&1
+    rc=$?
+    rm -rf "$fake_bin"
+    [ "$rc" = 1 ] && pass || fail "expected exit 1 when package.json is newer, got $rc"
+}
+
+# --- Driver ----------------------------------------------------------------
+
+echo "Running build-cli-if-stale.sh tests..."
+run case_missing_plugin_root              case_missing_plugin_root
+run case_packages_core_missing            case_packages_core_missing
+run case_bundle_current_returns_0         case_bundle_current_returns_0
+run case_src_newer_triggers_rebuild       case_src_newer_triggers_rebuild
+run case_missing_bundle_triggers_rebuild  case_missing_bundle_triggers_rebuild
+run case_swap_files_do_not_trigger_rebuild case_swap_files_do_not_trigger_rebuild
+run case_build_failure_returns_2          case_build_failure_returns_2
+run case_package_json_newer_triggers_rebuild case_package_json_newer_triggers_rebuild
+
+echo
+echo "Results: ${PASS} passed, ${FAIL} failed."
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds `scripts/build-cli-if-stale.sh` -- a reusable helper for the rebuild-if-stale pattern -- and rewrites `hooks/session-start.sh` Step 1 to use it. Same change incidentally fixes a real bug noted in the audit walkthrough: the inline staleness check in session-start.sh only watched `package.json`, so a `git pull` that touched `packages/core/src/` without modifying the manifest left the CLI bundle silently stale.

Closes step 1 of #1292 (helper + tests + session-start.sh refactor). Step 2 (dashboard helper), step 3-4 (workflow + slash-command refactors) are deferred follow-ups, each independently mergeable per the issue body.

## What's in the diff

**`scripts/build-cli-if-stale.sh`** -- the helper. Staleness check scans `packages/core/src/`, `package.json`, AND `tsconfig.json` against `dist/cli.bundle.cjs`, excluding editor swap files (`.DS_Store`, `*~`, `*.swp`, `*.swo`, `.#*`) so a stray vim swap doesn't trigger a rebuild every session. Exit codes:

| Code | Meaning |
|---|---|
| `0` | bundle is current; no rebuild attempted |
| `1` | bundle was rebuilt successfully |
| `2` | bundle is stale and rebuild FAILED (BUILD_FAILED + remediation hint on stdout) |
| `3` | invocation error (PLUGIN_ROOT missing, packages/core not found) |

Prefers `pnpm` (this is a pnpm workspace), falls back to `npm` for end users without pnpm -- mirrors the existing session-start logic.

**`hooks/session-start.sh`** -- Step 1 rewritten to call the helper and branch on the exit code. Captures the exit via `|| cli_helper_rc=$?` so the hook's `set -euo pipefail` doesn't short-circuit on the rebuild paths (1 and 2 are non-zero by design). User-visible rebuild summary line and the warning fallback are preserved exactly.

**`scripts/build-cli-if-stale.test.sh`** -- bash test harness following the existing `safe-refresh-marketplace.test.sh` pattern. 8 cases against a fixture-tree fake plugin:

- missing plugin root → exit 3
- packages/core absent → exit 3
- bundle current → exit 0
- src/ file newer → exit 1 (rebuilt)
- bundle missing → exit 1 (rebuilt)
- only swap files newer → exit 0 (must NOT rebuild)
- build failure → exit 2 + BUILD_FAILED on stdout
- package.json newer → exit 1 (rebuilt)

Build-success and build-failure cases use a fake-PATH technique to stub `pnpm`/`npm` so the test doesn't run a real `pnpm install` (which would be slow and brittle in CI).

**`.github/workflows/ci.yml`** -- new step that runs the test as a sibling to `safe-refresh-marketplace.test.sh`.

## Why now

This is the bug-fix half of #1292. Workflow + slash command callers still have their own (mostly-correct) inline staleness checks; the second half consolidates those once the helper has bedded in.

## Test plan

- [x] `bash scripts/build-cli-if-stale.test.sh` -- 8/8 pass locally
- [x] `bash -n hooks/session-start.sh` -- syntax OK
- [x] `pnpm --filter @oss-autopilot/core run test` -- 2496 passed (no behavior change to core)
- [x] `pnpm -w run lint` -- 0 errors