### PR TITLE
feat: surface dashboard build status in /oss startup output (#1293)

### DIFF
--- a/packages/core/src/commands/startup.test.ts
+++ b/packages/core/src/commands/startup.test.ts
@@ -481,6 +481,54 @@ describe('runStartup behavior', () => {
     consoleSpy.mockRestore();
   });
 
+  it('passes through OSS_DASHBOARD_BUILD_STATUS=failed and the error tail (#1293)', async () => {
+    const daily = makeDailyOutput(0);
+    executeDailyCheck.mockResolvedValue(daily);
+    launchDashboardServer.mockResolvedValue({ url: 'http://localhost:3000', port: 3000, alreadyRunning: false });
+    process.env.OSS_DASHBOARD_BUILD_STATUS = 'failed';
+    process.env.OSS_DASHBOARD_BUILD_ERROR_TAIL = 'tsc: error TS2322 in src/index.tsx:42';
+
+    try {
+      const result = await runStartup();
+      expect(result.dashboardBuildStatus).toBe('failed');
+      expect(result.dashboardBuildErrorTail).toBe('tsc: error TS2322 in src/index.tsx:42');
+    } finally {
+      delete process.env.OSS_DASHBOARD_BUILD_STATUS;
+      delete process.env.OSS_DASHBOARD_BUILD_ERROR_TAIL;
+    }
+  });
+
+  it('drops dashboardBuildErrorTail when status is fresh (no failure to surface)', async () => {
+    const daily = makeDailyOutput(0);
+    executeDailyCheck.mockResolvedValue(daily);
+    launchDashboardServer.mockResolvedValue({ url: 'http://localhost:3000', port: 3000, alreadyRunning: false });
+    process.env.OSS_DASHBOARD_BUILD_STATUS = 'fresh';
+    process.env.OSS_DASHBOARD_BUILD_ERROR_TAIL = 'leftover from a prior session';
+
+    try {
+      const result = await runStartup();
+      expect(result.dashboardBuildStatus).toBe('fresh');
+      expect(result.dashboardBuildErrorTail).toBeUndefined();
+    } finally {
+      delete process.env.OSS_DASHBOARD_BUILD_STATUS;
+      delete process.env.OSS_DASHBOARD_BUILD_ERROR_TAIL;
+    }
+  });
+
+  it('rejects malformed OSS_DASHBOARD_BUILD_STATUS values (typed enum guard)', async () => {
+    const daily = makeDailyOutput(0);
+    executeDailyCheck.mockResolvedValue(daily);
+    launchDashboardServer.mockResolvedValue({ url: 'http://localhost:3000', port: 3000, alreadyRunning: false });
+    process.env.OSS_DASHBOARD_BUILD_STATUS = 'arbitrary-injection';
+
+    try {
+      const result = await runStartup();
+      expect(result.dashboardBuildStatus).toBeUndefined();
+    } finally {
+      delete process.env.OSS_DASHBOARD_BUILD_STATUS;
+    }
+  });
+
   it('should return setup incomplete when setup is not done', async () => {
     const { getStateManager } = await import('../core/index.js');
     const mockGetStateManager = getStateManager as ReturnType<typeof vi.fn>;

--- a/packages/core/src/commands/startup.ts
+++ b/packages/core/src/commands/startup.ts
@@ -292,6 +292,25 @@ export async function runStartup(): Promise<StartupOutput> {
   // 5. Detect issue list
   const issueList = detectIssueList();
 
+  // 6. Pass through dashboard-build status set by the workflow shell (#1293).
+  // The workflow runs the SPA build BEFORE invoking startup, so the status
+  // arrives here via env vars rather than being something runStartup itself
+  // computes. Validate the env value so a malformed export can't sneak an
+  // arbitrary string into a typed enum.
+  const rawBuildStatus = process.env.OSS_DASHBOARD_BUILD_STATUS;
+  const dashboardBuildStatus: StartupOutput['dashboardBuildStatus'] =
+    rawBuildStatus === 'fresh' ||
+    rawBuildStatus === 'rebuilt' ||
+    rawBuildStatus === 'failed' ||
+    rawBuildStatus === 'missing-pnpm'
+      ? rawBuildStatus
+      : undefined;
+  const rawBuildErrorTail = process.env.OSS_DASHBOARD_BUILD_ERROR_TAIL;
+  const dashboardBuildErrorTail =
+    (dashboardBuildStatus === 'failed' || dashboardBuildStatus === 'missing-pnpm') && rawBuildErrorTail
+      ? rawBuildErrorTail
+      : undefined;
+
   return {
     version,
     setupComplete: true,
@@ -299,6 +318,8 @@ export async function runStartup(): Promise<StartupOutput> {
     daily,
     dashboardUrl,
     dashboardError,
+    dashboardBuildStatus,
+    dashboardBuildErrorTail,
     issueList,
   };
 }

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -805,6 +805,25 @@ export interface StartupOutput {
    * a structured signal to surface or recover from the failure.
    */
   dashboardError?: string;
+  /**
+   * Status of the dashboard SPA build that ran (or didn't) before this
+   * startup invocation (#1293). Populated by the workflow shell via
+   * `OSS_DASHBOARD_BUILD_STATUS`; absent when the CLI is invoked outside
+   * the plugin workflow:
+   * - `'fresh'` — built artifact was up-to-date, no rebuild attempted.
+   * - `'rebuilt'` — rebuild ran and succeeded.
+   * - `'failed'` — rebuild ran and failed; `dashboardUrl` may serve stale
+   *    or missing assets until the build is fixed.
+   * - `'missing-pnpm'` — rebuild was needed but pnpm (required for the
+   *    workspace dependency) was unavailable.
+   */
+  dashboardBuildStatus?: 'fresh' | 'rebuilt' | 'failed' | 'missing-pnpm';
+  /**
+   * Last few lines of the dashboard build log when `dashboardBuildStatus`
+   * is `'failed'` or `'missing-pnpm'`. Surfaced by the workflow as a
+   * one-line warning so the user sees what broke without leaving `/oss`.
+   */
+  dashboardBuildErrorTail?: string;
   issueList?: IssueListInfo;
 }
 

--- a/workflows/startup-and-build.md
+++ b/workflows/startup-and-build.md
@@ -43,15 +43,30 @@ if [ ! -f "${CLI_BUNDLE}" ] || [ -n "$(find "${CLAUDE_PLUGIN_ROOT}/packages/core
 fi
 # Build dashboard SPA if missing or stale (source files newer than built output) (#567)
 # Dashboard's tsc needs core's .d.ts types (the CLI bundle step above runs esbuild, not tsc).
+# Capture the exit code in OSS_DASHBOARD_BUILD_STATUS so the CLI can include it
+# in the startup output and the workflow can surface a warning when the build
+# failed (#1293). The dashboard build is non-blocking — startup proceeds either
+# way — but a silent failure leaves /oss-dashboard showing stale assets.
 DASHBOARD_INDEX="${CLAUDE_PLUGIN_ROOT}/packages/dashboard/dist/index.html"
 DASHBOARD_PKG="${CLAUDE_PLUGIN_ROOT}/packages/dashboard/package.json"
+OSS_DASHBOARD_BUILD_STATUS=fresh
+OSS_DASHBOARD_BUILD_ERROR_TAIL=""
 if [ -f "${DASHBOARD_PKG}" ] && { [ ! -f "${DASHBOARD_INDEX}" ] || [ -n "$(find "${CLAUDE_PLUGIN_ROOT}/packages/dashboard/src" "${DASHBOARD_PKG}" "${CLAUDE_PLUGIN_ROOT}/packages/dashboard/vite.config.ts" "${CLAUDE_PLUGIN_ROOT}/packages/dashboard/tsconfig.json" -newer "${DASHBOARD_INDEX}" -print -quit 2>/dev/null)" ]; }; then
   if command -v pnpm &>/dev/null; then
-    (cd "${CLAUDE_PLUGIN_ROOT}" && pnpm install --silent && pnpm --silent --filter @oss-autopilot/core run build && pnpm --silent --filter @oss-autopilot/dashboard run build) >/tmp/oss-dashboard-build.log 2>&1 || true
+    if (cd "${CLAUDE_PLUGIN_ROOT}" && pnpm install --silent && pnpm --silent --filter @oss-autopilot/core run build && pnpm --silent --filter @oss-autopilot/dashboard run build) >/tmp/oss-dashboard-build.log 2>&1; then
+      OSS_DASHBOARD_BUILD_STATUS=rebuilt
+    else
+      OSS_DASHBOARD_BUILD_STATUS=failed
+      OSS_DASHBOARD_BUILD_ERROR_TAIL=$(tail -5 /tmp/oss-dashboard-build.log 2>/dev/null | tr '\n' ' ' | tr -s ' ')
+    fi
   else
-    (cd "${CLAUDE_PLUGIN_ROOT}/packages/dashboard" && npm install --silent && npm run build) >/tmp/oss-dashboard-build.log 2>&1 || true
+    # The dashboard depends on @oss-autopilot/core via workspace:* — npm cannot
+    # resolve that protocol, so without pnpm the build can't run.
+    OSS_DASHBOARD_BUILD_STATUS=missing-pnpm
+    OSS_DASHBOARD_BUILD_ERROR_TAIL="pnpm not on PATH; install with: npm install -g pnpm"
   fi
 fi
+export OSS_DASHBOARD_BUILD_STATUS OSS_DASHBOARD_BUILD_ERROR_TAIL
 GITHUB_TOKEN=$(gh auth token 2>/dev/null || echo "$GITHUB_TOKEN")
 export GITHUB_TOKEN
 node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" startup --json --compact 2>/tmp/oss-startup-stderr.log
@@ -77,12 +92,24 @@ The output is a single JSON object with the standard envelope: `{ success: boole
 | `data.authError` | Set when no GitHub token | If present, show auth instructions |
 | `data.daily` | DailyOutput (same shape as before) | Extract `briefSummary`, `actionableIssues`, `actionMenu`, etc. |
 | `data.dashboardUrl` | URL of interactive dashboard SPA (e.g., `http://localhost:3000`) | Show `Dashboard: <url>` so user can re-open it |
+| `data.dashboardBuildStatus` | `'fresh' \| 'rebuilt' \| 'failed' \| 'missing-pnpm'` (when set by the workflow) | If `'failed'` or `'missing-pnpm'`, render the warning below before the action menu |
+| `data.dashboardBuildErrorTail` | Last few lines of the dashboard build log when `dashboardBuildStatus` is a failure | Quote in the warning so the user sees what broke |
 | `data.issueList` | Issue list info (if detected) | `hasIssueList` = present; extract `path`, `source`, `availableCount`, `completedCount` |
 
 **Routing based on parsed data:**
 - `data.authError` is present → Tell the user: show `data.authError` message. Then offer recovery: "Run `gh auth login` to authenticate, then run `/oss` again." End the session — do not continue to Summary or Action Menu without valid auth.
 - `data.setupComplete === false` → Auto-detection failed (gh CLI not available or not authenticated). Tell the user: "I couldn't auto-detect your GitHub username. You'll need to set up first." Use AskUserQuestion to let them choose "Run setup (Recommended)" (launch `/setup-oss`) or "Continue with defaults". If they choose "Continue with defaults", re-run the daily check directly (`GITHUB_TOKEN=$(gh auth token 2>/dev/null || echo "$GITHUB_TOKEN") node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" daily --json 2>/tmp/oss-startup-stderr.log`), use `data.version` from the startup output already received, and return to the core router (`commands/oss.md`) **Summary** section with the daily result as `data.daily`.
 - `data.daily` is present → Return to the core router (`commands/oss.md`) **Summary** section.
+
+**Dashboard build warning (#1293):** When `data.dashboardBuildStatus === 'failed'` or `'missing-pnpm'`, render this one-time line above the action menu (after `briefSummary`, before the menu itself):
+
+```
+Warning: Dashboard build {failed|requires pnpm} — `/oss-dashboard` may show stale data until rebuilt.
+  {data.dashboardBuildErrorTail}
+  Rebuild: cd ${CLAUDE_PLUGIN_ROOT} && pnpm install && pnpm --filter @oss-autopilot/dashboard run build
+```
+
+Skip the warning when `data.dashboardBuildStatus` is `'fresh'`, `'rebuilt'`, or absent (CLI invoked outside the plugin workflow).
 
 **If output is empty or not valid JSON**: Tell the user "Something went wrong running the startup check." Suggest running manually: `GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" startup --json`. Then show error recovery steps (see **Error Recovery** below).
 


### PR DESCRIPTION
## Summary

Adds `dashboardBuildStatus` + `dashboardBuildErrorTail` fields to `StartupOutput`, populated by the workflow shell via `OSS_DASHBOARD_BUILD_STATUS` / `OSS_DASHBOARD_BUILD_ERROR_TAIL` env vars. The dashboard build is still non-blocking (workflow proceeds either way), but a failed build is now surfaced in the structured output rather than silently buried at `/tmp/oss-dashboard-build.log`.

Closes #1293.

## What's in the diff

**Schema (`packages/core/src/formatters/json.ts`):**
- `StartupOutput.dashboardBuildStatus`: optional enum `'fresh' | 'rebuilt' | 'failed' | 'missing-pnpm'`.
- `StartupOutput.dashboardBuildErrorTail`: optional string with the build log tail.
- Both optional so direct CLI users (no workflow env vars) see no change.

**`packages/core/src/commands/startup.ts`:**
- Reads the two env vars at the end of `runStartup` and includes them in the output.
- Validates `OSS_DASHBOARD_BUILD_STATUS` against the enum (a malformed value is dropped, never passed through as an arbitrary string).

**Workflow (`workflows/startup-and-build.md`):**
- Captures the dashboard build exit code instead of `|| true`.
- Sets `OSS_DASHBOARD_BUILD_STATUS=fresh|rebuilt|failed|missing-pnpm` and the error tail (last 5 lines of `/tmp/oss-dashboard-build.log`, normalized to single-line whitespace).
- Documents both new fields in the Parse Output table.
- Renders a one-time warning above the action menu when the status is `failed` or `missing-pnpm`.

**Test coverage (`packages/core/src/commands/startup.test.ts`):** three new cases covering pass-through with error tail, fresh-status drops the tail, and malformed status values are rejected.

## What's intentionally not included

Per the issue's "Out of scope":
- No auto-retry of failed builds.
- Build failure is non-blocking (existing design preserved).
- CLI build failure path is unchanged — the existing `BUILD_FAILED` sentinel + halt is correct.

## Test plan

- [x] `pnpm --filter @oss-autopilot/core run test` -- 2499 passed (3 new for #1293)
- [x] `pnpm --filter @oss-autopilot/core run build && pnpm -w run typecheck` -- all green
- [x] `pnpm -w run lint` -- 0 errors
- [x] `pnpm -w run format:check` -- passing