### PR TITLE
feat: pre-fetch per-repo guidelines for Phase A Tier 2 dispatches (#1294 step 3)

### DIFF
--- a/workflows/work-through-issues.md
+++ b/workflows/work-through-issues.md
@@ -60,6 +60,16 @@ This flow uses a three-phase approach: parallel investigation, consolidated pres
 
 **CRITICAL: Dispatch ALL agents in a SINGLE message for true parallelism.**
 
+**Per-repo guidelines pre-fetch (#867, #1294 step 3).** Before assembling the dispatch, identify the set of repos with at least one **Tier 2** issue type (`Needs Response`, `Changes Requested`, `CI Failing`, `Merge Conflict`, `Missing Required Files`). For each such repo, fetch any stored guidelines once:
+
+```bash
+GUIDELINES_OUT=$(GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" guidelines view --repo {owner}/{repo} --json 2>/dev/null)
+```
+
+Cache the parsed `data.content` per repo. Routine-maintenance-only repos (Tier 1: rebase, CI status check, "no action needed" report) do NOT load guidelines — maintainer preferences don't change a clean rebase.
+
+If a fetch fails or `data.exists === false`, skip that repo silently (the dispatch proceeds without guidelines).
+
 For each issue in `actionableIssues`, include a Task tool call grouped by repo:
 
 | Issue Type | Tier | Agent Action |
@@ -105,6 +115,18 @@ After a successful rebase, you MUST follow these steps in order:
 claim by reading the current file, run commands rather than inferring their outputs,
 distinguish what the LATEST review round asks for from earlier rounds, state explicitly
 when you cannot verify a claim, and stay in scope (only what the maintainer asked for).
+
+**Per-repo guidelines (#867, when present):** if guidelines were pre-fetched for this
+repo (Tier 2 dispatch), include them verbatim in the agent's working context as
+authoritative repo-specific rules. They take precedence over CONTRIBUTING.md when
+they conflict. Flag any case where the agent's proposed approach contradicts a
+stated preference so the user can confirm. Omit this section entirely when no
+guidelines were fetched.
+
+```
+Maintainer preferences for {owner}/{repo} (from past PR feedback):
+{repo_guidelines}
+```
 
 Report back:
 (a) Commits behind / rebase result


### PR DESCRIPTION
## Summary

Adds the third entry point for the per-repo learnings system (#867): existing-PR investigation in `work-through-issues.md` Phase A. Steps 1-2 of #1294 covered the new-contribution path (draft-first Step 1e in PR #1305). This closes the loop for the existing-PR path so Phase A Tier 2 agents reviewing maintainer feedback also see the durable preferences extracted from past rounds.

Closes step 3 of #1294. With #1305 already merged, this completes the full scope of #1294.

## What changes

`workflows/work-through-issues.md` Phase A:
- New "Per-repo guidelines pre-fetch" sub-step before the dispatch. Identifies the set of repos that have at least one **Tier 2** issue type (`Needs Response`, `Changes Requested`, `CI Failing`, `Merge Conflict`, `Missing Required Files`) and fetches guidelines once per repo.
- Routine-maintenance-only repos (Tier 1: rebase, CI status check, "no action needed") skip the fetch entirely -- maintainer preferences don't change a clean rebase, and Tier 1 paths shouldn't pay the network cost.
- Silent skip on missing guidelines or fetch failure (matches the existing pattern in draft-first Step 1e).
- Dispatch prompt template gains a "Maintainer preferences for {owner}/{repo}" block alongside the existing Code Verification Rules. Agents flag any contradictions with stated preferences so the user can confirm.

22 insertions, no deletions. Workflow-doc only -- no source changes.

## Out of scope (per issue)

- No metrics on guideline effectiveness ("did these reduce review iterations?").
- No fetch on every routine-maintenance dispatch -- gated to Tier 2 only.
- No user-facing display of the loaded guidelines (the user has `/oss-guidelines` for direct read access; this is for the agent's context).

## Test plan

- [x] `pnpm -w run format:check` -- passing (no source files touched)
- [x] No code changes; CI test suite is informational only on this PR