### PR TITLE
feat: add Reply with a question action to review-issue-replies (#1290 step 3)

### DIFF
--- a/workflows/review-issue-replies.md
+++ b/workflows/review-issue-replies.md
@@ -39,10 +39,27 @@ Both `userLastCommentBody` and `lastResponseBody` are present on every `new_resp
 
 For each issue, use AskUserQuestion to offer actions:
 - "Start working on this issue" — Dismiss the issue reply by running `GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" dismiss ISSUE_URL --json`. Then set `isNewContribution = true` and `issueContext = { title, url, description }` from the issue data, and return to the core router (`commands/oss.md`) — the Pre-Commit Review routing will direct to the draft-first workflow. Do NOT post a claim comment on the issue; the PR will be the first interaction. If the dismiss fails, show the error but still proceed to the implementation flow.
+- "Reply with a question" — Draft a follow-up comment to ask for clarification before deciding (#1290 step 3). See **Drafting a clarifying reply** below. Routes through the `draft-review-post` skill — saves the draft to `/tmp/claude-drafts/...` and hands the user the `gh issue comment` command. **Never auto-post.** Do NOT dismiss the issue afterward — a pending question means the issue should reappear next session if the maintainer hasn't replied yet. After the draft is saved, re-prompt with the same actions for this issue (the user may then mark-as-reviewed, skip, or pick another action).
 - "Mark as reviewed" — The user has seen the reply but doesn't want to work on the issue right now. Dismiss it so it won't reappear next session: run `GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" dismiss ISSUE_URL --json`. If a genuinely new response arrives later (after the dismiss timestamp), the auto-undismiss logic will resurface it.
 - "View full thread" — Display the issue URL for the user to open in browser. After viewing, re-prompt with the same options for this issue (do not advance to the next issue).
 - "Skip" — Leave the reply undismissed. It will reappear next session. Use this when the user wants to defer action to a future session.
 - "Done for now" — End session with summary. Routes to Session End in the core router.
+
+### Drafting a clarifying reply
+
+When the user picks "Reply with a question":
+
+1. **Surface context first.** Re-display the user's original comment and the maintainer's reply (the `userLastCommentBody` / `lastResponseBody` already shown above) so the user has both visible while composing the question.
+2. **Prompt for the question text.** Use a free-form input ("What do you want to ask?"). Keep it short — clarifying questions are typically 1–2 sentences. Discourage rehashing the original comment; the maintainer can scroll up.
+3. **Route through `draft-review-post`.** Pass the question text, target URL (`{data.url}`), and a hint that this is an issue comment (not a PR comment) so the skill emits the correct `gh issue comment {URL} --body-file ...` command.
+4. **Do NOT dismiss the issue.** The issue stays in the next session's `commentedIssues` so the user is reminded if the maintainer hasn't replied yet. Auto-undismiss handles the case where the maintainer answers the follow-up.
+5. **Re-prompt for this same issue** with the standard action list above. The user can then mark-as-reviewed, skip, or pick a different action — the question is in their drafts folder either way.
+
+**Tone constraints** for the drafted question (mirror the dormant-pr-follow-up rules):
+- 1–2 sentences max.
+- No sycophancy ("Thanks so much for your detailed reply!") or formulaic openings.
+- No restating what the maintainer already said.
+- No AI attribution.
 
 **Error handling:** If any CLI command (`dismiss`) returns `{ success: false }`, show the `error` field to the user and skip the remaining steps for that issue. Offer to retry or skip to the next issue.
 


### PR DESCRIPTION
## Summary

Closes the final piece of #1290. Steps 1-2 (data layer + inline display of user's comment alongside maintainer reply) landed in #1306; this PR adds the new action that lets the user draft a clarifying follow-up without leaving the workflow.

Closes #1290 in full once this lands.

## What changes

`workflows/review-issue-replies.md`:
- New "Reply with a question" entry between "Start working on this issue" and "Mark as reviewed" in the action list.
- New "Drafting a clarifying reply" subsection covering the 5-step flow: surface context, prompt for free-form question text, route through `draft-review-post`, do NOT dismiss the issue, re-prompt the standard action list on the same issue.
- Tone constraints copied from `dormant-pr-follow-up.md` (1-2 sentences, no sycophancy, no restating what the maintainer already said, no AI attribution).

17 insertions, 0 deletions. Workflow-doc only.

## Decisions worth flagging

- **No auto-dismiss after drafting.** A pending question means the issue should reappear next session if the maintainer hasn't replied yet — the existing auto-undismiss logic handles the case where the maintainer answers the follow-up.
- **Re-prompts the same action list after drafting** so the user can also mark-as-reviewed or skip if they want, even if the question is in their drafts folder. The previous flow advanced to the next issue.
- **Mirrors `dormant-pr-follow-up`'s draft-review-post pattern** -- never auto-post, always hand the user the `gh issue comment` command.

Out of scope (per the issue body):
- No batch actions ("Reply to all").
- No `pr-responder` integration (would be alternate routing; `draft-review-post` is the simpler and consistent path).
- No threaded reply support (GitHub issues are flat).

## Test plan

- [x] `pnpm -w run format:check` -- passing
- [x] No source files touched; CI test surface unchanged.