### PR TITLE
feat: auto-generate agent integration table in reference.md (#1289 step 1+2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,18 @@ jobs:
       - name: Test build-dashboard-if-stale helper (#1292)
         run: bash scripts/build-dashboard-if-stale.test.sh
 
+      - name: Verify generated reference.md is up to date (#1289)
+        # Regenerates the auto-managed sections of workflows/reference.md from
+        # source (agents/*.md frontmatter today; cli-registry + workflow index
+        # later). Fails when an agent was added/edited without running
+        # `pnpm run generate:reference`.
+        run: |
+          pnpm run generate:reference
+          if ! git diff --exit-code workflows/reference.md; then
+            echo "::error::workflows/reference.md is out of sync. Run 'pnpm run generate:reference' and commit the result."
+            exit 1
+          fi
+
       - name: Test guard-public-posts hook
         run: bash hooks/guard-public-posts.test.sh
 

--- a/agents/contribution-strategist.md
+++ b/agents/contribution-strategist.md
@@ -20,6 +20,7 @@ User wants strategic guidance on where to contribute.
 </commentary>
 </example>
 
+purpose: Strategic OSS advice
 model: haiku
 color: magenta
 tools: ["Bash", "Read"]

--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -20,6 +20,7 @@ User wants to evaluate a specific issue before investing time.
 </commentary>
 </example>
 
+purpose: Find and vet new issues
 model: sonnet
 color: green
 tools: ["Bash", "Read", "mcp__plugin_oss-autopilot_oss-autopilot__search", "mcp__plugin_oss-autopilot_oss-autopilot__vet", "mcp__plugin_oss-autopilot_oss-autopilot__vet-list"]

--- a/agents/pr-compliance-checker.md
+++ b/agents/pr-compliance-checker.md
@@ -20,6 +20,7 @@ User explicitly wants a PR compliance check.
 </commentary>
 </example>
 
+purpose: Validate PRs against opensource.guide
 model: haiku
 color: orange
 tools: ["Bash", "Read", "Glob", "Grep", "mcp__plugin_oss-autopilot_oss-autopilot__track", "mcp__plugin_oss-autopilot_oss-autopilot__comments", "mcp__plugin_oss-autopilot_oss-autopilot__compliance-score", "mcp__plugin_oss-autopilot_oss-autopilot__guidelines-get"]

--- a/agents/pr-health-checker.md
+++ b/agents/pr-health-checker.md
@@ -20,6 +20,7 @@ Rebase checking and execution is a core health check responsibility.
 </commentary>
 </example>
 
+purpose: Diagnose CI failures, merge conflicts, rebase status
 model: sonnet
 color: yellow
 tools: ["Bash", "Read", "Grep", "mcp__plugin_oss-autopilot_oss-autopilot__track", "mcp__plugin_oss-autopilot_oss-autopilot__comments"]

--- a/agents/pr-responder.md
+++ b/agents/pr-responder.md
@@ -20,6 +20,7 @@ User needs help understanding and responding to a specific code review comment.
 </commentary>
 </example>
 
+purpose: Draft responses to maintainer feedback
 model: sonnet
 color: cyan
 tools: ["Bash", "Read", "Write", "Glob", "Grep", "mcp__plugin_oss-autopilot_oss-autopilot__track", "mcp__plugin_oss-autopilot_oss-autopilot__comments", "mcp__plugin_oss-autopilot_oss-autopilot__guidelines-get"]

--- a/agents/pre-commit-reviewer.md
+++ b/agents/pre-commit-reviewer.md
@@ -20,6 +20,7 @@ Post-conflict resolution is a critical moment where bugs can be introduced. Revi
 </commentary>
 </example>
 
+purpose: Review code changes before committing (fallback for PR review toolkit)
 model: sonnet
 color: red
 tools: ["Bash", "Read", "Glob", "Grep", "mcp__plugin_oss-autopilot_oss-autopilot__guidelines-get"]

--- a/agents/repo-evaluator.md
+++ b/agents/repo-evaluator.md
@@ -20,6 +20,7 @@ User wants to predict maintainer engagement before contributing.
 </commentary>
 </example>
 
+purpose: Analyze repository health
 model: haiku
 color: blue
 tools: ["Bash", "Read", "Glob", "mcp__plugin_oss-autopilot_oss-autopilot__vet"]

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "docs:check": "pnpm --filter @oss-autopilot/core run docs:check",
     "dashboard:dev": "pnpm --filter @oss-autopilot/dashboard run dev",
     "dashboard:build": "pnpm --filter @oss-autopilot/dashboard run build",
+    "generate:reference": "node scripts/generate-reference.mjs",
     "prepare": "[ -n \"$CI\" ] || simple-git-hooks"
   },
   "simple-git-hooks": {

--- a/scripts/generate-reference.mjs
+++ b/scripts/generate-reference.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+/**
+ * Auto-generate the agent integration table in workflows/reference.md (#1289).
+ *
+ * Reads each agents/*.md frontmatter (skipping README) for `name` and
+ * `purpose`, and writes the result between
+ *   <!-- BEGIN AUTO:agent-table -->
+ *   <!-- END AUTO:agent-table -->
+ * markers in workflows/reference.md.
+ *
+ * Run via: pnpm run generate:reference
+ *
+ * In CI, the same script runs followed by `git diff --exit-code workflows/reference.md`
+ * — which fails if you changed an agent without regenerating the table.
+ *
+ * Future-scope (separate PRs):
+ *   - Auto-generate the workflow index (workflows/*.md headers).
+ *   - Auto-generate the CLI command reference (cli-registry.ts).
+ */
+
+import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+const AGENTS_DIR = join(REPO_ROOT, 'agents');
+const REFERENCE_PATH = join(REPO_ROOT, 'workflows', 'reference.md');
+
+/**
+ * Explicit ordering preserves the semantic grouping of the table (PR
+ * lifecycle first, then issue lifecycle, then strategic) rather than
+ * alphabetical. New agents must be added here AND get a `purpose:`
+ * field — both are validated by this script.
+ */
+const AGENT_ORDER = [
+  'pr-responder',
+  'pr-health-checker',
+  'pr-compliance-checker',
+  'pre-commit-reviewer',
+  'issue-scout',
+  'repo-evaluator',
+  'contribution-strategist',
+];
+
+const BEGIN_MARKER = '<!-- BEGIN AUTO:agent-table -->';
+const END_MARKER = '<!-- END AUTO:agent-table -->';
+
+/** Pull a value out of YAML frontmatter. Handles single-line scalar fields only. */
+function readField(frontmatter, key) {
+  const re = new RegExp(`^${key}:\\s*(.*)$`, 'm');
+  const match = frontmatter.match(re);
+  if (!match) return undefined;
+  // Strip optional surrounding quotes; YAML allows `key: "value"` or `key: value`.
+  return match[1].replace(/^["'](.*)["']$/, '$1').trim();
+}
+
+/** Parse the leading frontmatter block out of an agent file. */
+function readFrontmatter(filePath) {
+  const content = readFileSync(filePath, 'utf8');
+  const fenceMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!fenceMatch) {
+    throw new Error(`Could not find frontmatter in ${filePath}`);
+  }
+  return fenceMatch[1];
+}
+
+function buildAgentTable() {
+  const files = readdirSync(AGENTS_DIR)
+    .filter((f) => f.endsWith('.md') && f !== 'README.md')
+    .map((f) => join(AGENTS_DIR, f));
+
+  const byName = new Map();
+  for (const file of files) {
+    const frontmatter = readFrontmatter(file);
+    const name = readField(frontmatter, 'name');
+    const purpose = readField(frontmatter, 'purpose');
+    if (!name) {
+      throw new Error(`agents/${file.split('/').pop()}: missing 'name' frontmatter field`);
+    }
+    if (!purpose) {
+      throw new Error(
+        `agents/${file.split('/').pop()}: missing 'purpose' frontmatter field — needed for the auto-generated agent table in workflows/reference.md (#1289). Add a one-line description.`,
+      );
+    }
+    byName.set(name, purpose);
+  }
+
+  // Surface contract violations in either direction so adding a new agent
+  // forces a deliberate update to AGENT_ORDER and removing one is loud.
+  for (const name of AGENT_ORDER) {
+    if (!byName.has(name)) {
+      throw new Error(`AGENT_ORDER lists '${name}' but no matching agents/${name}.md was found`);
+    }
+  }
+  for (const name of byName.keys()) {
+    if (!AGENT_ORDER.includes(name)) {
+      throw new Error(
+        `agents/${name}.md exists but is not in AGENT_ORDER inside scripts/generate-reference.mjs — add it in the right slot or remove it.`,
+      );
+    }
+  }
+
+  const rows = ['| Agent | Purpose |', '|-------|---------|'];
+  for (const name of AGENT_ORDER) {
+    rows.push(`| \`${name}\` | ${byName.get(name)} |`);
+  }
+  return rows.join('\n');
+}
+
+function spliceBetweenMarkers(content, beginMarker, endMarker, replacement) {
+  const beginIdx = content.indexOf(beginMarker);
+  const endIdx = content.indexOf(endMarker);
+  if (beginIdx === -1 || endIdx === -1) {
+    throw new Error(`Could not find both markers (${beginMarker} ... ${endMarker}) in reference.md`);
+  }
+  if (endIdx < beginIdx) {
+    throw new Error(`END marker appears before BEGIN marker in reference.md`);
+  }
+  const before = content.slice(0, beginIdx + beginMarker.length);
+  const after = content.slice(endIdx);
+  return `${before}\n${replacement}\n${after}`;
+}
+
+function main() {
+  const reference = readFileSync(REFERENCE_PATH, 'utf8');
+  const table = buildAgentTable();
+  const next = spliceBetweenMarkers(reference, BEGIN_MARKER, END_MARKER, table);
+
+  if (next === reference) {
+    process.stdout.write('reference.md is already up to date.\n');
+    return;
+  }
+  writeFileSync(REFERENCE_PATH, next, 'utf8');
+  process.stdout.write('reference.md regenerated.\n');
+}
+
+main();

--- a/workflows/reference.md
+++ b/workflows/reference.md
@@ -178,6 +178,11 @@ rejected with a did-you-mean suggestion.
 
 ## Agent Integration
 
+<!-- The table below is generated from each agent's `purpose:` frontmatter
+     by scripts/generate-reference.mjs (#1289). To change a row, edit the
+     agent file and run `pnpm run generate:reference`. CI fails if this
+     section is out of sync. -->
+<!-- BEGIN AUTO:agent-table -->
 | Agent | Purpose |
 |-------|---------|
 | `pr-responder` | Draft responses to maintainer feedback |
@@ -187,6 +192,7 @@ rejected with a did-you-mean suggestion.
 | `issue-scout` | Find and vet new issues |
 | `repo-evaluator` | Analyze repository health |
 | `contribution-strategist` | Strategic OSS advice |
+<!-- END AUTO:agent-table -->
 
 ---
 


### PR DESCRIPTION
## Summary

Establishes the auto-generation marker convention for `workflows/reference.md` (#1289 step 1) and ships the agent-table generator end-to-end (#1289 step 2). With this PR, adding/editing an agent without running the generator fails CI loudly instead of silently shipping a stale Agent Integration table.

The two larger generators (workflow index, CLI command reference) remain as independently mergeable follow-ups — they plug into the same marker pattern.

## What's in the diff

**Agents (`agents/*.md`, all 7):** new `purpose:` frontmatter field. Values match the prior hand-maintained reference.md table verbatim, so the generated output is byte-identical to today's content. Insertion point is right before `model:` for consistency across files.

**`workflows/reference.md`:** Agent Integration table wrapped in `<!-- BEGIN AUTO:agent-table -->` / `<!-- END AUTO:agent-table -->`. The "regenerate, don't hand-edit" comment sits OUTSIDE the markers so subsequent generator runs preserve it.

**`scripts/generate-reference.mjs`:** new Node ESM script (matches root `"type": "module"`). Reads each `agents/*.md` frontmatter (skipping README), validates that every agent in `AGENT_ORDER` exists and vice-versa, and splices a fresh table between the markers. Atomic — only writes when the content would actually change.

**`package.json`:** `pnpm run generate:reference` script.

**`.github/workflows/ci.yml`:** new "Verify generated reference.md is up to date" step. Runs the generator then `git diff --exit-code workflows/reference.md`. Fails with an actionable message that names the script to run.

## Why this scope

Per the issue body: "Each step is independently mergeable. The pattern is established by step 1; subsequent sections plug into it." This PR ships the simplest of the three generators end-to-end (CI included), establishing the marker convention + the contract-violation handling (missing `purpose:`, `AGENT_ORDER` mismatch) that the larger generators will reuse.

## Out of scope (future PRs in this issue)

- Workflow index generator (`## Workflow Index` table from `workflows/*.md` headers).
- CLI command reference generator (the much larger `## CLI Commands` section, which would parse `cli-registry.ts` or consume `manifest --json`).

Both remain hand-maintained in the same file. Adding their markers + generators is a matter of repeating this PR's pattern.

## Test plan

- [x] `node scripts/generate-reference.mjs` -- "reference.md is already up to date." (idempotent on the first run since the generated content matches the hand-maintained version verbatim)
- [x] Manually toggled a `purpose:` field and re-ran -- table updates as expected; CI diff check would fail without the regenerate
- [x] Removed an agent's `purpose:` and re-ran -- script throws a clear error pointing at the missing field
- [x] `pnpm --filter @oss-autopilot/core run test` -- 2499 passed (no source changes)
- [x] `pnpm -w run lint` -- 0 errors
- [x] `pnpm -w run format:check` -- passing