### PR TITLE
feat: auto-generate workflow index in reference.md (#1289 step 3)

### DIFF
--- a/scripts/generate-reference.mjs
+++ b/scripts/generate-reference.mjs
@@ -1,31 +1,36 @@
 #!/usr/bin/env node
 /**
- * Auto-generate the agent integration table in workflows/reference.md (#1289).
+ * Auto-generate the agent integration table and the workflow index in
+ * workflows/reference.md (#1289).
  *
- * Reads each agents/*.md frontmatter (skipping README) for `name` and
- * `purpose`, and writes the result between
- *   <!-- BEGIN AUTO:agent-table -->
- *   <!-- END AUTO:agent-table -->
- * markers in workflows/reference.md.
+ * Sources of truth:
+ *   - Agent table: each agents/*.md frontmatter (`name`, `purpose`).
+ *   - Workflow index: workflows/manifest.json (explicit curated list).
+ *
+ * The result is spliced between marker comments in reference.md:
+ *   <!-- BEGIN AUTO:agent-table --> ... <!-- END AUTO:agent-table -->
+ *   <!-- BEGIN AUTO:workflow-index --> ... <!-- END AUTO:workflow-index -->
  *
  * Run via: pnpm run generate:reference
  *
  * In CI, the same script runs followed by `git diff --exit-code workflows/reference.md`
- * — which fails if you changed an agent without regenerating the table.
+ * — which fails if you changed an agent or the manifest without regenerating.
  *
- * Future-scope (separate PRs):
- *   - Auto-generate the workflow index (workflows/*.md headers).
- *   - Auto-generate the CLI command reference (cli-registry.ts).
+ * Future scope (separate PR):
+ *   - Auto-generate the CLI command reference (the much larger CLI Commands
+ *     section, which would parse cli-registry.ts or consume `manifest --json`).
  */
 
-import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..');
 const AGENTS_DIR = join(REPO_ROOT, 'agents');
-const REFERENCE_PATH = join(REPO_ROOT, 'workflows', 'reference.md');
+const WORKFLOWS_DIR = join(REPO_ROOT, 'workflows');
+const REFERENCE_PATH = join(WORKFLOWS_DIR, 'reference.md');
+const WORKFLOW_MANIFEST_PATH = join(WORKFLOWS_DIR, 'manifest.json');
 
 /**
  * Explicit ordering preserves the semantic grouping of the table (PR
@@ -108,6 +113,36 @@ function buildAgentTable() {
   return rows.join('\n');
 }
 
+function buildWorkflowIndex() {
+  const raw = readFileSync(WORKFLOW_MANIFEST_PATH, 'utf8');
+  let manifest;
+  try {
+    manifest = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`workflows/manifest.json is not valid JSON: ${err.message}`);
+  }
+  if (!Array.isArray(manifest.workflows)) {
+    throw new Error(`workflows/manifest.json must have a "workflows" array`);
+  }
+
+  const rows = ['| Workflow | Purpose |', '|---|---|'];
+  for (const entry of manifest.workflows) {
+    if (!entry.file || !entry.purpose) {
+      throw new Error(
+        `workflows/manifest.json: every entry needs both "file" and "purpose" keys (got ${JSON.stringify(entry)})`,
+      );
+    }
+    const absPath = join(REPO_ROOT, entry.file);
+    if (!existsSync(absPath)) {
+      throw new Error(
+        `workflows/manifest.json references "${entry.file}" but that file doesn't exist — remove the manifest entry or fix the path`,
+      );
+    }
+    rows.push(`| \`${entry.file}\` | ${entry.purpose} |`);
+  }
+  return rows.join('\n');
+}
+
 function spliceBetweenMarkers(content, beginMarker, endMarker, replacement) {
   const beginIdx = content.indexOf(beginMarker);
   const endIdx = content.indexOf(endMarker);
@@ -123,11 +158,18 @@ function spliceBetweenMarkers(content, beginMarker, endMarker, replacement) {
 }
 
 function main() {
-  const reference = readFileSync(REFERENCE_PATH, 'utf8');
-  const table = buildAgentTable();
-  const next = spliceBetweenMarkers(reference, BEGIN_MARKER, END_MARKER, table);
+  const original = readFileSync(REFERENCE_PATH, 'utf8');
+  let next = original;
 
-  if (next === reference) {
+  next = spliceBetweenMarkers(next, BEGIN_MARKER, END_MARKER, buildAgentTable());
+  next = spliceBetweenMarkers(
+    next,
+    '<!-- BEGIN AUTO:workflow-index -->',
+    '<!-- END AUTO:workflow-index -->',
+    buildWorkflowIndex(),
+  );
+
+  if (next === original) {
     process.stdout.write('reference.md is already up to date.\n');
     return;
   }

--- a/workflows/manifest.json
+++ b/workflows/manifest.json
@@ -1,0 +1,37 @@
+{
+  "_comment": "Source-of-truth for the auto-generated Workflow Index table in reference.md (#1289). Order = display order. Each entry must reference a real file under workflows/. New workflow files are silently omitted from the table until added here — that's intentional, the table is a curated list of the workflows users typically need to look up, not an exhaustive directory listing.",
+  "workflows": [
+    {
+      "file": "workflows/startup-and-build.md",
+      "purpose": "CLI build, startup command, output parsing, error recovery"
+    },
+    {
+      "file": "workflows/action-menu.md",
+      "purpose": "PR display, menu rendering, input parsing, informational questions"
+    },
+    {
+      "file": "workflows/work-through-issues.md",
+      "purpose": "Orchestrate actionable PR resolution and issue list browsing"
+    },
+    {
+      "file": "workflows/draft-first-workflow.md",
+      "purpose": "Full new contribution pipeline (10 steps)"
+    },
+    {
+      "file": "workflows/pre-commit-review.md",
+      "purpose": "Code review gate for existing PR updates"
+    },
+    {
+      "file": "workflows/dispatch-review.md",
+      "purpose": "Shared multi-agent review-dispatch template (consumed by both review workflows)"
+    },
+    {
+      "file": "workflows/review-issue-replies.md",
+      "purpose": "Issue reply triage and dismiss handler"
+    },
+    {
+      "file": "workflows/dormant-pr-follow-up.md",
+      "purpose": "Operationalizes the 7/14/30-day follow-up cadence for waiting-on-maintainer PRs"
+    }
+  ]
+}

--- a/workflows/reference.md
+++ b/workflows/reference.md
@@ -198,6 +198,11 @@ rejected with a did-you-mean suggestion.
 
 ## Workflow Index
 
+<!-- The table below is generated from workflows/manifest.json by
+     scripts/generate-reference.mjs (#1289). To change a row, edit the
+     manifest and run `pnpm run generate:reference`. CI fails if this
+     section is out of sync. -->
+<!-- BEGIN AUTO:workflow-index -->
 | Workflow | Purpose |
 |---|---|
 | `workflows/startup-and-build.md` | CLI build, startup command, output parsing, error recovery |
@@ -208,6 +213,7 @@ rejected with a did-you-mean suggestion.
 | `workflows/dispatch-review.md` | Shared multi-agent review-dispatch template (consumed by both review workflows) |
 | `workflows/review-issue-replies.md` | Issue reply triage and dismiss handler |
 | `workflows/dormant-pr-follow-up.md` | Operationalizes the 7/14/30-day follow-up cadence for waiting-on-maintainer PRs |
+<!-- END AUTO:workflow-index -->
 
 ---
 


### PR DESCRIPTION
## Summary

Extends the agent-table generator landed in #1313 to also produce the Workflow Index table. Source-of-truth is `workflows/manifest.json` — a new explicit-curation file that lists which workflows belong in the table and in what order.

Closes step 3 of #1289. The remaining piece (CLI command reference generator) is the largest of the three sections and is an independently mergeable follow-up.

## What's in the diff

**`workflows/manifest.json`** (new): 8 entries matching the prior hand-maintained table verbatim. Generated output is byte-identical to today's content. Includes a `_comment` field documenting the curation intent (silently-omitted workflows = "not commonly looked up", not "missing").

**`workflows/reference.md`:** Workflow Index section wrapped in `<!-- BEGIN AUTO:workflow-index -->` / `<!-- END AUTO:workflow-index -->`. Same "edit the source, run the generator" hint pattern as the agent table.

**`scripts/generate-reference.mjs`:** Adds `buildWorkflowIndex()` which parses `manifest.json` and emits a markdown table. Validates that every manifest entry references an existing file under `workflows/` — fails loudly when a manifest entry points at a deleted or renamed file.

## Why a manifest instead of parsing each workflow

The hand-maintained table lists 8 workflows out of 12 in `workflows/`. The omissions (`reference.md`, `edit-guidelines.md`, `extract-learnings.md`, `plan-review.md`) are intentional — they're loaded on demand by other workflows and aren't entry points users typically look up. Auto-discovering all `.md` files would surface them and bloat the table.

Adding a `> **Purpose:** ...` blockquote to each workflow file was the alternative considered. Rejected because it scatters the curation decision across 12 files instead of centralizing it in one. The manifest format also makes the explicit ordering trivially editable.

## CI

The existing "Verify generated reference.md is up to date" step (added in #1313) already covers this — no new CI plumbing needed.

## Out of scope

- CLI command reference generator. The `## CLI Commands` section is much larger than these tables and would either parse `packages/core/src/cli-registry.ts` (AST) or consume the `manifest --json` runtime contract. Either route is its own PR.

## Test plan

- [x] `node scripts/generate-reference.mjs` -- regenerates both tables; second run reports "already up to date"
- [x] Manually pointed manifest.json at a non-existent file -- script throws a clear error naming the bogus path
- [x] Manually flipped manifest.json to invalid JSON -- error names the parse failure
- [x] `pnpm -w run format:check` -- passing