### PR TITLE
feat: auto-generate Local-only commands list from manifest --json (#1289 step 4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,10 +126,12 @@ jobs:
 
       - name: Verify generated reference.md is up to date (#1289)
         # Regenerates the auto-managed sections of workflows/reference.md from
-        # source (agents/*.md frontmatter today; cli-registry + workflow index
-        # later). Fails when an agent was added/edited without running
-        # `pnpm run generate:reference`.
+        # source (agents/*.md frontmatter, workflows/manifest.json, and the
+        # bundled CLI's `manifest --json` output for the localOnly command list).
+        # The build-cli-if-stale helper is reused so the regen step can rely on
+        # a fresh bundle without rebuilding from scratch.
         run: |
+          bash scripts/build-cli-if-stale.sh "$PWD"
           pnpm run generate:reference
           if ! git diff --exit-code workflows/reference.md; then
             echo "::error::workflows/reference.md is out of sync. Run 'pnpm run generate:reference' and commit the result."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,9 +129,16 @@ jobs:
         # source (agents/*.md frontmatter, workflows/manifest.json, and the
         # bundled CLI's `manifest --json` output for the localOnly command list).
         # The build-cli-if-stale helper is reused so the regen step can rely on
-        # a fresh bundle without rebuilding from scratch.
+        # a fresh bundle without rebuilding from scratch. The helper uses
+        # exit 1 = "rebuilt successfully" (a signal, not an error), so we
+        # capture the exit code instead of letting `bash -e` kill the step.
         run: |
-          bash scripts/build-cli-if-stale.sh "$PWD"
+          HELPER_RC=0
+          bash scripts/build-cli-if-stale.sh "$PWD" || HELPER_RC=$?
+          if [ "$HELPER_RC" = "2" ] || [ "$HELPER_RC" = "3" ]; then
+            echo "::error::CLI bundle helper failed (exit $HELPER_RC); cannot regenerate reference.md"
+            exit 1
+          fi
           pnpm run generate:reference
           if ! git diff --exit-code workflows/reference.md; then
             echo "::error::workflows/reference.md is out of sync. Run 'pnpm run generate:reference' and commit the result."

--- a/scripts/generate-reference.mjs
+++ b/scripts/generate-reference.mjs
@@ -1,29 +1,37 @@
 #!/usr/bin/env node
 /**
- * Auto-generate the agent integration table and the workflow index in
- * workflows/reference.md (#1289).
+ * Auto-generate the agent integration table, the workflow index, and the
+ * "Local-only commands" line in workflows/reference.md (#1289).
  *
  * Sources of truth:
  *   - Agent table: each agents/*.md frontmatter (`name`, `purpose`).
  *   - Workflow index: workflows/manifest.json (explicit curated list).
+ *   - Local-only commands: live `manifest --json` output from the bundled CLI
+ *     (filters commands where `localOnly === true`). This requires
+ *     packages/core/dist/cli.bundle.cjs to exist — run
+ *     `bash scripts/build-cli-if-stale.sh "$PWD"` first if it's missing.
  *
  * The result is spliced between marker comments in reference.md:
  *   <!-- BEGIN AUTO:agent-table --> ... <!-- END AUTO:agent-table -->
  *   <!-- BEGIN AUTO:workflow-index --> ... <!-- END AUTO:workflow-index -->
+ *   <!-- BEGIN AUTO:local-only-commands --> ... <!-- END AUTO:local-only-commands -->
  *
  * Run via: pnpm run generate:reference
  *
  * In CI, the same script runs followed by `git diff --exit-code workflows/reference.md`
- * — which fails if you changed an agent or the manifest without regenerating.
+ * — which fails if you changed an agent, the manifest, or the CLI registry's
+ * localOnly flags without regenerating.
  *
  * Future scope (separate PR):
- *   - Auto-generate the CLI command reference (the much larger CLI Commands
- *     section, which would parse cli-registry.ts or consume `manifest --json`).
+ *   - Auto-generate the rich grouped CLI command listings (Core Workflow,
+ *     Issue Discovery, etc.) once cli-registry.ts gains description metadata
+ *     that the table needs (group + usage + flags).
  */
 
 import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..');
@@ -31,6 +39,7 @@ const AGENTS_DIR = join(REPO_ROOT, 'agents');
 const WORKFLOWS_DIR = join(REPO_ROOT, 'workflows');
 const REFERENCE_PATH = join(WORKFLOWS_DIR, 'reference.md');
 const WORKFLOW_MANIFEST_PATH = join(WORKFLOWS_DIR, 'manifest.json');
+const CLI_BUNDLE_PATH = join(REPO_ROOT, 'packages', 'core', 'dist', 'cli.bundle.cjs');
 
 /**
  * Explicit ordering preserves the semantic grouping of the table (PR
@@ -143,6 +152,46 @@ function buildWorkflowIndex() {
   return rows.join('\n');
 }
 
+function buildLocalOnlyCommandsLine() {
+  if (!existsSync(CLI_BUNDLE_PATH)) {
+    throw new Error(
+      `CLI bundle not found at ${CLI_BUNDLE_PATH}. Run \`bash scripts/build-cli-if-stale.sh "$PWD"\` (or \`pnpm run bundle\`) before \`pnpm run generate:reference\`.`,
+    );
+  }
+
+  let stdout;
+  try {
+    stdout = execFileSync('node', [CLI_BUNDLE_PATH, 'manifest', '--json'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (err) {
+    throw new Error(`Failed to invoke 'manifest --json' on the CLI bundle: ${err.message}`);
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch (err) {
+    throw new Error(`'manifest --json' did not produce parseable JSON: ${err.message}`);
+  }
+  if (!parsed.success || !Array.isArray(parsed.data?.commands)) {
+    throw new Error(`'manifest --json' returned an unexpected envelope: ${stdout.slice(0, 200)}`);
+  }
+
+  const localOnly = parsed.data.commands
+    .filter((c) => c.localOnly === true)
+    .map((c) => c.name)
+    .sort();
+  if (localOnly.length === 0) {
+    throw new Error(`'manifest --json' reports zero localOnly commands — that's almost certainly wrong, refusing to regenerate`);
+  }
+
+  // Inline (non-table) format matches the existing prose so the surrounding
+  // sentence stays readable. Backticks render as code in markdown.
+  return `Local-only commands (no GitHub token needed): ${localOnly.map((n) => `\`${n}\``).join(', ')}.`;
+}
+
 function spliceBetweenMarkers(content, beginMarker, endMarker, replacement) {
   const beginIdx = content.indexOf(beginMarker);
   const endIdx = content.indexOf(endMarker);
@@ -167,6 +216,12 @@ function main() {
     '<!-- BEGIN AUTO:workflow-index -->',
     '<!-- END AUTO:workflow-index -->',
     buildWorkflowIndex(),
+  );
+  next = spliceBetweenMarkers(
+    next,
+    '<!-- BEGIN AUTO:local-only-commands -->',
+    '<!-- END AUTO:local-only-commands -->',
+    buildLocalOnlyCommandsLine(),
   );
 
   if (next === original) {

--- a/workflows/reference.md
+++ b/workflows/reference.md
@@ -8,7 +8,14 @@ All commands support `--json` flag for structured output.
 
 **Prefix:** `GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs"`
 
-Local-only commands (no GitHub token needed): `status`, `setup`, `checkSetup`, `config`, `local-repos`, `parse-issue-list`, `serve`, `manifest`.
+<!-- The line below is generated from the bundled CLI's `manifest --json`
+     output by scripts/generate-reference.mjs (#1289). To change the list,
+     toggle the `localOnly` flag on a command in cli-registry.ts and run
+     `bash scripts/build-cli-if-stale.sh "$PWD" && pnpm run generate:reference`.
+     CI fails if this line is out of sync with the registry. -->
+<!-- BEGIN AUTO:local-only-commands -->
+Local-only commands (no GitHub token needed): `checkSetup`, `clear-override`, `config`, `detect-formatters`, `dismiss`, `doctor`, `guidelines`, `list-move-tier`, `local-repos`, `manifest`, `move`, `orphan-files`, `override`, `parse-issue-list`, `serve`, `setup`, `shelve`, `skip-add`, `startup`, `stats`, `status`, `undismiss`, `unshelve`.
+<!-- END AUTO:local-only-commands -->
 
 ### Core Workflow
 


### PR DESCRIPTION
## Summary

Adds the third auto-generated block to `workflows/reference.md` — the "Local-only commands" sentence — sourced from the bundled CLI's `manifest --json` output. The prior hand-maintained line listed 8 commands; the live registry has 23 localOnly entries, so this PR also incidentally surfaces 15 commands that had drifted off the docs.

Closes step 4 of #1289. The remaining piece (rich grouped command listings with usage examples + flag tables) requires extending `cli-registry.ts` with `description`/`group` metadata first, and is independently mergeable.

## What's in the diff

**`scripts/generate-reference.mjs`** — new `buildLocalOnlyCommandsLine()`:
- Verifies `packages/core/dist/cli.bundle.cjs` exists (instructive error pointing at `bash scripts/build-cli-if-stale.sh "$PWD"` if not).
- Spawns `node cli.bundle.cjs manifest --json`, parses the envelope, validates `success === true` and `data.commands` is an array.
- Filters `localOnly === true`, alphabetically sorts, emits a backticked comma-separated list.
- Defensive guards: empty list → refuses to write (manifest must be wrong); malformed JSON → parse error with first 200 chars; spawn failure → wraps the cause.

**`workflows/reference.md`** — wraps the existing "Local-only commands" line in `<!-- BEGIN AUTO:local-only-commands -->` markers, with a hint comment outside the markers explaining how to update the source.

**`.github/workflows/ci.yml`** — the existing "Verify generated reference.md is up to date" step now runs `bash scripts/build-cli-if-stale.sh "$PWD"` first, reusing the helper from #1307 so the bundle is fresh before the regen step. No new step, no reorganization of CI ordering.

## Why manifest --json over parsing cli-registry.ts

- Single source of truth — the live runtime contract that `agents-contract.test.ts` already consumes.
- No AST parsing required; script stays small.
- Extending later to grouped command listings is straightforward once `cli-registry.ts` gains `description`/`group` metadata.

## Out of scope (final follow-up for #1289)

Auto-generating the rich grouped CLI listings (Core Workflow, Issue Discovery, etc.) with bash usage examples and flag tables. Requires `cli-registry.ts` schema work to carry the metadata `manifest --json` would need.

## Test plan

- [x] Bundle present locally (built earlier this session) — `pnpm run generate:reference` regenerates the line successfully (8 → 23 commands)
- [x] Removed the bundle and re-ran — script throws clear "run build-cli-if-stale.sh first" error
- [x] Idempotent on second run ("reference.md is already up to date")
- [x] `pnpm -w run format:check` passing