### PR TITLE
chore(deps): pin fast-uri >=3.1.1 for GHSA-q3j6-qgpj-74h6

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
       "flatted": ">=3.4.2",
       "picomatch": ">=4.0.4",
       "path-to-regexp": ">=8.4.0",
-      "yaml": ">=2.8.3"
+      "yaml": ">=2.8.3",
+      "fast-uri": ">=3.1.1"
     }
   },
   "_pnpmOverridesRationale": {
@@ -68,7 +69,8 @@
     "flatted": "Dev-only, transitive via eslint -> flat-cache. Pin >=3.4.2 for ReDoS advisory. Confirmed still in tree.",
     "picomatch": "Dev-only, transitive via typescript-eslint -> tinyglobby. Pin >=4.0.4 for ReDoS advisory. Confirmed still in tree.",
     "path-to-regexp": "Transitive via @modelcontextprotocol/sdk -> express/router. Pin >=8.4.0 for ReDoS advisory. Confirmed still in tree.",
-    "yaml": "Dev-only, transitive via vitest -> vite. Pin >=2.8.3 for code-execution advisory. Confirmed still in tree."
+    "yaml": "Dev-only, transitive via vitest -> vite. Pin >=2.8.3 for code-execution advisory. Confirmed still in tree.",
+    "fast-uri": "Transitive via @modelcontextprotocol/sdk -> ajv. Pin >=3.1.1 for path-traversal advisory GHSA-q3j6-qgpj-74h6. Confirmed still in tree."
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   picomatch: '>=4.0.4'
   path-to-regexp: '>=8.4.0'
   yaml: '>=2.8.3'
+  fast-uri: '>=3.1.1'
 
 importers:
 
@@ -1905,8 +1906,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -4101,7 +4102,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4691,7 +4692,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:


### PR DESCRIPTION
## Summary

Just-published high-severity advisory: [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) — path-traversal via percent-encoded dot segments. Reaches us as a transitive: `@modelcontextprotocol/sdk` -> `ajv` -> `fast-uri`. CI `pnpm audit --audit-level=high` started failing across all branches as soon as the advisory landed (caught while #1315 was waiting on CI).

## What changes

- `package.json` — adds `"fast-uri": ">=3.1.1"` to the existing `pnpm.overrides` block, sibling to `hono` / `express-rate-limit` / `yaml`. Adds a matching entry to `_pnpmOverridesRationale` documenting the why and the dep path.
- `pnpm-lock.yaml` — lockfile update from `pnpm install`. fast-uri 3.0.x → 3.1.1.

No code changes. Single concern: unblock CI on every branch.

## Verification

- `pnpm audit --audit-level=high` post-fix: `3 moderate` remain (below threshold, CI passes).
- `pnpm install`: clean, no peer-dep warnings.

## Test plan

- [x] CI `Security audit` step now passes on this PR (was failing on every other open PR).