### PR TITLE
feat: pr-compliance-checker template preservation check (#1252 item 2)

### DIFF
--- a/agents/pr-compliance-checker.md
+++ b/agents/pr-compliance-checker.md
@@ -116,6 +116,28 @@ Bad: `Update file.js`, `WIP`, `asdfasdf`, titles > 72 chars.
 Good: `feature/add-user-auth`, `fix/login-timeout`, `123-fix-bug`.
 Bad: `patch-1` (GitHub default), `main`/`master` as source, random strings.
 
+### 7. Template Preservation — Sanity Check (#1252 Item 2)
+
+Wiping the upstream PR template is the most common reason a maintainer flags a contribution as careless. This check runs BEFORE the weighted scoring above. It does not contribute to the percentage but a Critical failure here should be surfaced prominently in the output (and typically downgrades the overall rating regardless of score).
+
+**1.** Fetch the repo's template via the `pr-template` CLI (the call is already listed in the Data Access section above). The response shape is `{ template, source, error? }`.
+
+**2.** If `template` is `null` or empty, skip this check (✅ Pass / Not Applicable — the repo has no template, so there's nothing to preserve).
+
+**3.** If a template exists, compare the PR description against it:
+
+- **Headings:** every level-1, level-2, and level-3 heading from the template must appear (verbatim) in the PR description. Reordering is OK; renaming or removal is not.
+- **HTML comments:** any `<!-- ... -->` blocks in the template (often used by maintainer bots to look up metadata) must be preserved verbatim in the description.
+- **Checklist items:** every `- [ ]` line from the template must appear in the PR description AS UNCHECKED (`- [ ]`, not `- [x]`). Maintainers' bots (DCO, changesets, license headers, etc.) rely on those items being actively ticked when the work meets each criterion. Pre-checking them defeats the bot.
+
+**4.** Classify the result:
+
+- ✅ **Pass:** all template headings + comments + checklist items are present, and no checklist items were pre-checked. The contributor's summary is added under an existing summary/description heading or prepended to the body.
+- ⚠️ **Warning (partial preservation):** template was used but at least one heading is missing, or a maintainer-bot HTML comment was removed, or the contributor pre-checked a checklist item the bot expects to manage. List the specific deviations.
+- ❌ **Critical (template wiped):** none of the template headings appear in the PR description (the contributor replaced the template entirely with a freeform body).
+
+**5.** Surface in the output. A Critical here downgrades the overall rating to ⚠️ at most, even when the weighted score would otherwise reach 🌟. Maintainer-perceived carelessness outweighs a strong checkbox score.
+
 ## Scoring
 
 | Check | Weight |
@@ -144,6 +166,7 @@ Bad: `patch-1` (GitHub default), `main`/`master` as source, random strings.
 ### Checks
 | Check | Status | Notes |
 |---|---|---|
+| Template preservation | ✅/⚠️/❌ | [headings present? comments preserved? checklist intact?] |
 | Issue reference | ✅/⚠️/❌ | [details] |
 | Description | ✅/⚠️/❌ | [details] |
 | Focused changes | ✅/⚠️/❌ | [X files, Y lines] |


### PR DESCRIPTION
## Summary

Closes the second item of #1252. Item 1 (extracting `getPRQualityRubric()` to typed core) shipped earlier in #1285. This PR adds the previously-unenforced template-preservation rule to `pr-compliance-checker`.

The `pr-etiquette` skill states a precise rule — preserve template headings, HTML comments, and checklist items verbatim; leave checkboxes unchecked — because maintainer bots (DCO, changesets, license headers) depend on those items being actively ticked when criteria are met. No agent was verifying it.

## What changes

`agents/pr-compliance-checker.md` — adds section "7. Template Preservation — Sanity Check" between Branch Naming (6) and Scoring:

1. Fetches the repo's template via the existing `pr-template` CLI call (already wired in the Data Access section).
2. If the repo has no template → ✅ Pass / N/A (nothing to preserve).
3. Otherwise compares the PR description against the template:
   - Every template heading appears verbatim (reorder OK, rename or remove not OK).
   - HTML comment blocks preserved verbatim (bots look up metadata in those).
   - Checklist items present AS UNCHECKED (`- [ ]` not `- [x]`).
4. Classifies the result:
   - ✅ **Pass** — template structure preserved, summary added under appropriate heading
   - ⚠️ **Warning** — partial preservation; specific deviations listed
   - ❌ **Critical** — template was wiped entirely
5. A Critical here caps the overall rating at ⚠️ regardless of the weighted score — maintainer-perceived carelessness outweighs a strong checkbox tally.

The output-format table also gets a new "Template preservation" row at the top so deviations are immediately visible.

## Why a sanity check vs a weighted entry

The issue body proposed the four-state classification (Critical / 2 Warnings / Pass) but didn't propose a weight. Adding it as a sanity gate (not in the percentage but capable of capping the rating) matches the failure mode: a wiped template doesn't make a PR 5% worse — it makes the PR look careless, which is a different category of harm than missing tests. The cap-the-rating mechanic captures that without disrupting the existing weights.

## Out of scope

Per the issue body — specific bot-checklist heuristics ("DCO requires ..., changesets require ...") aren't needed. The check just enforces "match the template structure"; the bots themselves enforce their own rules at PR time.

## Test plan

- [x] `pnpm -w run format:check` — passing
- [x] No code changes; CI test surface unchanged.