### PR TITLE
feat: add repo-vet CLI command (#1271 step 1)

### DIFF
--- a/.claude-plugin/expected-cli-contract.json
+++ b/.claude-plugin/expected-cli-contract.json
@@ -23,6 +23,7 @@
     "parse-issue-list",
     "post",
     "pr-template",
+    "repo-vet",
     "search",
     "serve",
     "setup",

--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -1244,6 +1244,47 @@ export const commands: CLICommandDef[] = [
     },
   },
 
+  // ── Repo Vet (#1271) ────────────────────────────────────────────────
+  {
+    name: 'repo-vet',
+    register(program) {
+      program
+        .command('repo-vet <repo>')
+        .description('Compute repo health rubric (1–10 score + verdict) for `owner/repo`')
+        .option('--json', 'Output as JSON')
+        .action(async (repo, options) => {
+          const { RepoVetOutputSchema } = await import('./formatters/json.js');
+          await executeAction(
+            options,
+            async () => (await import('./commands/repo-vet.js')).runRepoVet({ repo }),
+            (data) => {
+              const verdictEmoji =
+                data.rubricVerdict === 'recommended'
+                  ? '✅'
+                  : data.rubricVerdict === 'proceed_with_caution'
+                    ? '⚠️'
+                    : '❌';
+              console.log(
+                `\n${verdictEmoji} ${data.repoSlug}: ${data.rubricScore.toFixed(1)}/10 — ${data.rubricVerdict}`,
+              );
+              console.log(`  Stars: ${data.repoMeta.stars}  Last push: ${data.repoMeta.lastPushed}`);
+              if (data.prMergeTime.medianDays !== null) {
+                console.log(
+                  `  Median merge time (90d): ${data.prMergeTime.medianDays.toFixed(1)} days (${data.prMergeTime.sampleSize} samples)`,
+                );
+              }
+              if (data.mergeRate.percent !== null) {
+                console.log(
+                  `  Merge rate (90d): ${data.mergeRate.percent.toFixed(0)}% (${data.mergeRate.merged}/${data.mergeRate.opened})`,
+                );
+              }
+            },
+            RepoVetOutputSchema,
+          );
+        });
+    },
+  },
+
   // ── Detect Formatters ────────────────────────────────────────────────
   {
     name: 'detect-formatters',

--- a/packages/core/src/cli.test.ts
+++ b/packages/core/src/cli.test.ts
@@ -410,6 +410,7 @@ describe('Command registration', () => {
       'dismiss',
       'undismiss',
       'pr-template',
+      'repo-vet',
       'override',
       'clear-override',
       'stats',

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -37,6 +37,8 @@ export { runVetList } from './vet-list.js';
 export { runTrack } from './track.js';
 /** Score a PR against opensource.guide best practices via the typed core function (#1245). */
 export { runComplianceScore } from './compliance-score.js';
+/** Compute repo health rubric (1–10 score + verdict) via the typed core function (#1271, follow-up to #1242). */
+export { runRepoVet } from './repo-vet.js';
 /** Temporarily hide a PR from the daily digest. */
 export { runShelve } from './shelve.js';
 /** Restore a shelved PR to the daily digest. */

--- a/packages/core/src/commands/repo-vet.ts
+++ b/packages/core/src/commands/repo-vet.ts
@@ -1,0 +1,212 @@
+/**
+ * repo-vet command (#1271, follow-up to #1242).
+ *
+ * Fetches repo health signals via the GitHub API, runs the typed
+ * `computeRepoVet` core function, and returns the structured result.
+ * Used by the `repo-evaluator` agent (and the future `repo-vet` MCP tool)
+ * to replace per-prompt rubric assembly with a deterministic, testable
+ * evaluation.
+ *
+ * Same architectural shape as `compliance-score`: read-only API calls,
+ * no state mutation, runs against a public `owner/repo` slug.
+ */
+
+import { getOctokit, requireGitHubToken } from '../core/index.js';
+import { validateRepoIdentifier } from './validation.js';
+import { computeRepoVet, type RepoVetInput, type RepoVetResult } from '../core/repo-vet.js';
+import type { RepoVetOutput } from '../formatters/json.js';
+
+const DAY_MS = 86400000;
+const COMMUNITY_HEALTH_PATHS = [
+  // Each entry can live at the repo root OR under .github/. We probe both
+  // because some repos prefer the visible-at-root convention and some
+  // prefer the .github/ folder convention.
+  { key: 'hasContributing', candidates: ['CONTRIBUTING.md', '.github/CONTRIBUTING.md'] },
+  { key: 'hasIssueTemplates', candidates: ['.github/ISSUE_TEMPLATE'] },
+  {
+    key: 'hasPRTemplate',
+    candidates: ['.github/pull_request_template.md', 'pull_request_template.md', 'PULL_REQUEST_TEMPLATE.md'],
+  },
+  { key: 'hasCodeOfConduct', candidates: ['CODE_OF_CONDUCT.md', '.github/CODE_OF_CONDUCT.md'] },
+] as const;
+
+async function probePath(
+  octokit: ReturnType<typeof getOctokit>,
+  owner: string,
+  repo: string,
+  path: string,
+): Promise<boolean> {
+  try {
+    await octokit.repos.getContent({ owner, repo, path });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function checkCommunityHealth(
+  octokit: ReturnType<typeof getOctokit>,
+  owner: string,
+  repo: string,
+): Promise<{
+  hasContributing: boolean;
+  hasIssueTemplates: boolean;
+  hasPRTemplate: boolean;
+  hasCodeOfConduct: boolean;
+}> {
+  const out: Record<string, boolean> = {
+    hasContributing: false,
+    hasIssueTemplates: false,
+    hasPRTemplate: false,
+    hasCodeOfConduct: false,
+  };
+  await Promise.all(
+    COMMUNITY_HEALTH_PATHS.map(async ({ key, candidates }) => {
+      for (const path of candidates) {
+        if (await probePath(octokit, owner, repo, path)) {
+          out[key] = true;
+          return;
+        }
+      }
+    }),
+  );
+  return out as {
+    hasContributing: boolean;
+    hasIssueTemplates: boolean;
+    hasPRTemplate: boolean;
+    hasCodeOfConduct: boolean;
+  };
+}
+
+interface ClosedPR {
+  created_at: string;
+  merged_at: string | null;
+  updated_at: string;
+}
+
+function summarizePRMerges(
+  prs: ClosedPR[],
+  windowDays: number,
+  now: Date,
+): { prMergeTimesDays: number[]; mergedCount: number; openedCount: number } {
+  const cutoff = now.getTime() - windowDays * DAY_MS;
+  const prMergeTimesDays: number[] = [];
+  let mergedCount = 0;
+  let openedCount = 0;
+
+  for (const pr of prs) {
+    const createdAt = new Date(pr.created_at).getTime();
+    if (createdAt >= cutoff) openedCount += 1;
+
+    if (pr.merged_at) {
+      const mergedAt = new Date(pr.merged_at).getTime();
+      if (mergedAt >= cutoff) {
+        mergedCount += 1;
+        const days = (mergedAt - createdAt) / DAY_MS;
+        if (Number.isFinite(days) && days >= 0) prMergeTimesDays.push(days);
+      }
+    }
+  }
+  return { prMergeTimesDays, mergedCount, openedCount };
+}
+
+interface CommitEntry {
+  commit: { author?: { date?: string } | null };
+  author?: { login?: string } | null;
+}
+
+function summarizeCommits(
+  commits: CommitEntry[],
+  now: Date,
+): { commitsLast30Days: number; contributorsLast90d: number; lastCommitISO: string | null } {
+  const cutoff30 = now.getTime() - 30 * DAY_MS;
+  const cutoff90 = now.getTime() - 90 * DAY_MS;
+  const contributors90 = new Set<string>();
+  let commitsLast30Days = 0;
+  let lastCommitMs: number | null = null;
+
+  for (const c of commits) {
+    const dateStr = c.commit.author?.date;
+    if (!dateStr) continue;
+    const ts = new Date(dateStr).getTime();
+    if (Number.isNaN(ts)) continue;
+
+    if (lastCommitMs === null || ts > lastCommitMs) lastCommitMs = ts;
+    if (ts >= cutoff30) commitsLast30Days += 1;
+    if (ts >= cutoff90 && c.author?.login) contributors90.add(c.author.login);
+  }
+
+  return {
+    commitsLast30Days,
+    contributorsLast90d: contributors90.size,
+    lastCommitISO: lastCommitMs ? new Date(lastCommitMs).toISOString() : null,
+  };
+}
+
+/**
+ * Run the repo-vet evaluation against an `owner/repo` slug.
+ *
+ * @throws {ValidationError} If the repo identifier is malformed.
+ */
+export async function runRepoVet(options: { repo: string }): Promise<RepoVetOutput> {
+  validateRepoIdentifier(options.repo);
+  const [owner, repo] = options.repo.split('/');
+
+  const token = requireGitHubToken();
+  const octokit = getOctokit(token);
+  const now = new Date();
+
+  const [repoMetaResp, closedPRsResp, commitsResp, releasesResp, communityHealth] = await Promise.all([
+    octokit.repos.get({ owner, repo }),
+    octokit.pulls.list({ owner, repo, state: 'closed', sort: 'updated', direction: 'desc', per_page: 100 }),
+    octokit.repos.listCommits({ owner, repo, per_page: 100 }),
+    octokit.repos
+      .listReleases({ owner, repo, per_page: 1 })
+      .catch(() => ({ data: [] as Array<{ published_at: string | null; created_at: string }> })),
+    checkCommunityHealth(octokit, owner, repo),
+  ]);
+
+  const prs: ClosedPR[] = closedPRsResp.data.map((p) => ({
+    created_at: p.created_at,
+    merged_at: p.merged_at,
+    updated_at: p.updated_at,
+  }));
+  const { prMergeTimesDays, mergedCount, openedCount } = summarizePRMerges(prs, 90, now);
+  const commitSummary = summarizeCommits(commitsResp.data as CommitEntry[], now);
+
+  const releases = releasesResp.data;
+  const lastReleaseISO = releases.length > 0 ? (releases[0].published_at ?? releases[0].created_at ?? null) : null;
+
+  const input: RepoVetInput = {
+    stars: repoMetaResp.data.stargazers_count ?? 0,
+    forks: repoMetaResp.data.forks_count ?? 0,
+    openIssues: repoMetaResp.data.open_issues_count ?? 0,
+    watchers: repoMetaResp.data.subscribers_count ?? 0,
+    isArchived: repoMetaResp.data.archived ?? false,
+    lastPushed: repoMetaResp.data.pushed_at ?? new Date(0).toISOString(),
+    createdAt: repoMetaResp.data.created_at ?? new Date(0).toISOString(),
+    commitsLast30Days: commitSummary.commitsLast30Days,
+    prMergeTimesDays,
+    mergedCount90Days: mergedCount,
+    openedCount90Days: openedCount,
+    lastCommitISO: commitSummary.lastCommitISO,
+    contributorsLast90d: commitSummary.contributorsLast90d,
+    lastReleaseISO,
+    hasContributing: communityHealth.hasContributing,
+    hasIssueTemplates: communityHealth.hasIssueTemplates,
+    hasPRTemplate: communityHealth.hasPRTemplate,
+    hasCodeOfConduct: communityHealth.hasCodeOfConduct,
+  };
+
+  const result: RepoVetResult = computeRepoVet(input);
+
+  // The core function names its metadata object `repo`. Rename to `repoMeta`
+  // at the CLI boundary so the top-level slug doesn't collide with it.
+  const { repo: repoMeta, ...rest } = result;
+  return {
+    repoSlug: options.repo,
+    fetchedAt: now.toISOString(),
+    repoMeta,
+    ...rest,
+  };
+}

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -616,6 +616,24 @@ export const PRTemplateOutputSchema = z.object({
   error: z.string().optional(),
 });
 
+/** Output of the `repo-vet` CLI command (#1271, follow-up to #1242). */
+export const RepoVetOutputSchema = z
+  .object({
+    repoSlug: z.string(),
+    fetchedAt: z.string(),
+  })
+  .passthrough();
+/**
+ * The CLI wrapper renames the core function's `repo` metadata object to
+ * `repoMeta` so the top-level slug doesn't collide with it. Everything
+ * else mirrors `RepoVetResult` verbatim.
+ */
+export type RepoVetOutput = {
+  repoSlug: string;
+  fetchedAt: string;
+  repoMeta: import('../core/repo-vet.js').RepoVetResult['repo'];
+} & Omit<import('../core/repo-vet.js').RepoVetResult, 'repo'>;
+
 const ComplianceCheckSchema = z.object({
   status: z.enum(['pass', 'warn', 'fail']),
   weight: z.number(),

--- a/workflows/reference.md
+++ b/workflows/reference.md
@@ -105,6 +105,9 @@ The full extraction workflow lives at [`workflows/extract-learnings.md`](extract
 
 # Fetch the target repo's PR description template (used by the draft-first workflow)
 <prefix> pr-template <pr-url> --json
+
+# Compute repo health rubric (1–10 score + verdict) for owner/repo (#1271)
+<prefix> repo-vet <owner/repo> --json
 ```
 
 ### Dashboard


### PR DESCRIPTION
## Summary

First of three steps in #1271. Wraps the typed `computeRepoVet()` core function (#1242) with the Octokit plumbing it needs, exposes it as a `repo-vet <owner/repo>` CLI command, and re-exports `runRepoVet` so future MCP wiring can import it directly.

Same architectural shape as `compliance-score` (#1245): read-only API calls batched with `Promise.all`, no state mutation, runs against a public `owner/repo` slug.

Steps 2 (MCP tool wrapping) and 3 (`repo-evaluator` agent prompt update to call the new tool) stay deferred — both are independently mergeable once this lands.

## What's in the diff

**`packages/core/src/commands/repo-vet.ts`** (new) — the wrapper:
- 5 batched Octokit calls: `repos.get`, `pulls.list` (closed, last 100), `repos.listCommits`, `repos.listReleases`, plus a `getContent` probe over the four community-health files (each at root and `.github/`).
- Helpers `summarizePRMerges` (90-day window, computes merge times + counts) and `summarizeCommits` (computes 30-day commit count + 90-day distinct contributor count + last commit ISO).
- Renames the core function's `repo` metadata object to `repoMeta` at the boundary so the top-level slug doesn't collide with it.

**Wiring (mechanical):**
- `packages/core/src/formatters/json.ts` — `RepoVetOutputSchema` (passthrough) + `RepoVetOutput` type (uses `Omit` + intersection to splice the renamed metadata field cleanly).
- `packages/core/src/cli-registry.ts` — registration with text-mode summary line (verdict emoji, score, stars, last push, median merge time, merge rate).
- `packages/core/src/commands/index.ts` — `runRepoVet` re-export so `@oss-autopilot/mcp` can pull it.
- `packages/core/src/cli.test.ts` — adds `'repo-vet'` to `expectedCommands` so the count test (35 → 36) passes.
- `.claude-plugin/expected-cli-contract.json` — pins the new command (drift-detected by the existing session-start hook + `cli-registry.docs.test.ts`).
- `workflows/reference.md` — bash example under PR Management section so the `cli-registry ↔ reference.md` parity test passes.

7 files, 278 insertions.

## Output shape

```jsonc
{
  "repoSlug": "facebook/react",
  "fetchedAt": "2026-05-08T18:30:00.000Z",
  "repoMeta": { "stars": 230000, "forks": 47000, ... },
  "prMergeTime": { "avgDays": 6.4, "medianDays": 4.2, "sampleSize": 27, "sourceWindowDays": 90 },
  "mergeRate": { "merged": 27, "opened": 41, "percent": 65, "windowDays": 90 },
  "maintainerActivity": { "lastCommitISO": "...", "contributorsLast90d": 18, "lastReleaseISO": "..." },
  "communityHealth": { "contributing": true, "issueTemplates": true, "prTemplate": true, "codeOfConduct": true },
  "rubricScore": 8.7,
  "rubricVerdict": "recommended"
}
```

## Test plan

- [x] `pnpm --filter @oss-autopilot/core run build` -- typecheck clean
- [x] `pnpm -w run typecheck` -- workspace clean
- [x] `pnpm --filter @oss-autopilot/core run test` -- 2499 passed (cli.test.ts updated to expect 36 commands)
- [x] `pnpm -w run lint` -- 0 errors
- [x] `pnpm -w run format:check` -- passing
- [x] `cli-registry.docs.test.ts` (existing parity test) — passes against the new reference.md entry