### PR TITLE
feat: add repo-vet MCP tool (#1271 step 2)

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -10,7 +10,7 @@ MCP server for [OSS Autopilot](https://github.com/costajohnt/oss-autopilot) — 
 
 | Feature | Count | Description |
 |---------|-------|-------------|
-| **Tools** | 27 | `daily`, `status`, `search`, `vet`, `vet-list`, `track`, `compliance-score`, `comments`, `post`, `claim`, `config`, `init`, `setup`, `check-setup`, `startup`, `shelve`, `unshelve`, `dismiss`, `undismiss`, `move`, `state-show`, `state-sync`, `state-unlink`, `guidelines-get`, `guidelines-store`, `guidelines-reset`, `guidelines-fetch-corpus` |
+| **Tools** | 28 | `daily`, `status`, `search`, `vet`, `vet-list`, `track`, `compliance-score`, `repo-vet`, `comments`, `post`, `claim`, `config`, `init`, `setup`, `check-setup`, `startup`, `shelve`, `unshelve`, `dismiss`, `undismiss`, `move`, `state-show`, `state-sync`, `state-unlink`, `guidelines-get`, `guidelines-store`, `guidelines-reset`, `guidelines-fetch-corpus` |
 | **Resources** | 6 | `oss://status`, `oss://config`, `oss://prs`, `oss://prs/shelved`, `oss://pr/{owner}/{repo}/{number}`, `oss://repo/{owner}/{repo}/guidelines` |
 | **Prompts** | 4 | `triage` (PR prioritization), `respond-to-pr` (draft response), `find-issues` (discover issues), `extract-learnings` (distill per-repo guidance from past PR feedback) |
 
@@ -120,6 +120,7 @@ The token persists across restarts. To rotate, delete the file and restart — a
 | `vet-list` | Re-vet all available issues in the curated issue list | No |
 | `track` | Fetch metadata for a pull request (informational; nothing persists) | No |
 | `compliance-score` | Score a PR against opensource.guide best practices (#1245) | Yes |
+| `repo-vet` | Compute the repo health rubric (1–10 + verdict) for `owner/repo` (#1271) | Yes |
 | `comments` | Fetch and display PR comments | Yes |
 | `post` | Post a comment on an issue or PR | No |
 | `claim` | Claim an issue by posting a comment | No |

--- a/packages/mcp-server/src/index-main.test.ts
+++ b/packages/mcp-server/src/index-main.test.ts
@@ -9,6 +9,7 @@ vi.mock('@oss-autopilot/core/commands', () => ({
   runVetList: vi.fn(),
   runTrack: vi.fn(),
   runComplianceScore: vi.fn(),
+  runRepoVet: vi.fn(),
   runComments: vi.fn(),
   runPost: vi.fn(),
   runClaim: vi.fn(),

--- a/packages/mcp-server/src/index.test.ts
+++ b/packages/mcp-server/src/index.test.ts
@@ -161,9 +161,10 @@ describe('MCP server stdio transport', { timeout: 30_000 }, () => {
   it('lists tools via stdio', async () => {
     client = await createStdioClient();
     const { tools } = await client.listTools();
-    expect(tools.length).toBe(27);
+    expect(tools.length).toBe(28);
     expect(tools.some((t) => t.name === 'daily')).toBe(true);
     expect(tools.some((t) => t.name === 'compliance-score')).toBe(true);
+    expect(tools.some((t) => t.name === 'repo-vet')).toBe(true);
   });
 
   it('lists resources via stdio', async () => {

--- a/packages/mcp-server/src/prompts.test.ts
+++ b/packages/mcp-server/src/prompts.test.ts
@@ -45,6 +45,7 @@ vi.mock('@oss-autopilot/core/commands', () => ({
   runVetList: vi.fn(),
   runTrack: vi.fn(),
   runComplianceScore: vi.fn(),
+  runRepoVet: vi.fn(),
   runPost: vi.fn(),
   runClaim: vi.fn(),
   runConfig: vi.fn(),

--- a/packages/mcp-server/src/resources.test.ts
+++ b/packages/mcp-server/src/resources.test.ts
@@ -19,6 +19,7 @@ vi.mock('@oss-autopilot/core/commands', () => ({
   runVetList: vi.fn(),
   runTrack: vi.fn(),
   runComplianceScore: vi.fn(),
+  runRepoVet: vi.fn(),
   runComments: vi.fn(),
   runPost: vi.fn(),
   runClaim: vi.fn(),

--- a/packages/mcp-server/src/tools-execution.test.ts
+++ b/packages/mcp-server/src/tools-execution.test.ts
@@ -29,6 +29,7 @@ vi.mock('@oss-autopilot/core/commands', () => ({
   runVetList: vi.fn(),
   runTrack: vi.fn(),
   runComplianceScore: vi.fn(),
+  runRepoVet: vi.fn(),
   runComments: vi.fn(),
   runPost: vi.fn(),
   runClaim: vi.fn(),

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -13,6 +13,7 @@ const EXPECTED_TOOLS = [
   'vet-list',
   'track',
   'compliance-score',
+  'repo-vet',
   'comments',
   'post',
   'claim',
@@ -61,8 +62,8 @@ describe('MCP tool registrations', () => {
     await client.close();
   });
 
-  it('registers exactly 27 tools', () => {
-    expect(tools).toHaveLength(27);
+  it('registers exactly 28 tools', () => {
+    expect(tools).toHaveLength(28);
   });
 
   it('registers all expected tool names', () => {
@@ -146,7 +147,16 @@ describe('MCP tool registrations', () => {
   describe('annotations', () => {
     // track is read-only in v2: fetches metadata from GitHub, does not persist (#1001).
     // untrack and read v1→v2 stubs were removed in v4 (#1133).
-    const readOnlyTools = ['status', 'search', 'vet', 'comments', 'check-setup', 'track', 'compliance-score'];
+    const readOnlyTools = [
+      'status',
+      'search',
+      'vet',
+      'comments',
+      'check-setup',
+      'track',
+      'compliance-score',
+      'repo-vet',
+    ];
     const mutatingTools = [
       'daily',
       'startup',

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -16,6 +16,7 @@ import {
   runVetList,
   runTrack,
   runComplianceScore,
+  runRepoVet,
   runComments,
   runPost,
   runClaim,
@@ -243,6 +244,25 @@ export function registerTools(server: McpServer): void {
       annotations: { readOnlyHint: true },
     },
     wrapTool(runComplianceScore),
+  );
+
+  // 5c. repo-vet — Run the typed repo-vet rubric against an `owner/repo`
+  // slug (#1271, follow-up to #1242). Replaces the in-prompt `gh` plumbing
+  // that lived in the `repo-evaluator` agent with deterministic scoring.
+  server.registerTool(
+    'repo-vet',
+    {
+      description:
+        'Compute the repo health rubric (1–10 weighted score + verdict) for an `owner/repo` slug. Returns repo metadata, PR merge times + merge rate over the trailing 90 days, maintainer activity, community-health flags, and the rubric verdict (recommended / proceed_with_caution / avoid). Read-only; no state mutation.',
+      inputSchema: {
+        repo: z
+          .string()
+          .regex(/^[\w.-]+\/[\w.-]+$/, 'Repository must be in `owner/repo` format')
+          .describe('Repository slug, e.g. `facebook/react` or `vercel/next.js`'),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    wrapTool(runRepoVet),
   );
 
   // 6. comments — Show PR comments


### PR DESCRIPTION
## Summary

Step 2 of #1271. Wraps the `runRepoVet` command (#1318, step 1) as MCP tool 28 on the `@oss-autopilot/mcp` surface so the `repo-evaluator` agent and external MCP clients can pull repo-health rubric output without shelling out to the CLI.

Same pattern as `compliance-score` (#1245). Step 3 (agents/repo-evaluator.md prompt edit to call the tool) stays deferred — it's a self-contained agent edit now that the tool surface exists.

## What's in the diff

- `tools.ts` — import `runRepoVet`, register the tool (slot 5c) with `readOnlyHint: true`, owner/repo regex schema, descriptive copy.
- `tools.test.ts` — added `'repo-vet'` to `EXPECTED_TOOLS`, bumped count to 28, added to `readOnlyTools` annotation list.
- `index.test.ts` — bumped tool count to 28, added explicit `repo-vet` registration assertion.
- `prompts.test.ts` / `resources.test.ts` / `tools-execution.test.ts` / `index-main.test.ts` — added `runRepoVet: vi.fn()` to each `@oss-autopilot/core/commands` mock so other tests don't fail with `No "runRepoVet" export is defined`.
- `README.md` — bumped Capabilities tool count to 28, added `repo-vet` row to the Tools Reference table. The CI guard (`Guard MCP metadata consistency`) verifies tools.ts registrations match README count + table rows.

8 files, 41 insertions, 5 deletions.

## Defers

`agents/repo-evaluator.md` prompt edit — drop the inline `gh repo view` / `gh pr list` plumbing and call the new tool. Independent next PR; this one delivers the tool surface so the edit becomes a strict simplification.

## Test plan

- [x] `pnpm --filter @oss-autopilot/mcp run test` — 206 passed
- [x] `pnpm --filter @oss-autopilot/core run test` — 2499 passed (no impact)
- [x] `pnpm -w run typecheck` — clean
- [x] `pnpm -w run lint` — 0 errors
- [x] `pnpm -w run format:check` — passing