### PR TITLE
feat: route repo-evaluator through repo-vet MCP tool (#1271 step 3)

### DIFF
--- a/agents/repo-evaluator.md
+++ b/agents/repo-evaluator.md
@@ -23,7 +23,7 @@ User wants to predict maintainer engagement before contributing.
 purpose: Analyze repository health
 model: haiku
 color: blue
-tools: ["Bash", "Read", "Glob", "mcp__plugin_oss-autopilot_oss-autopilot__vet"]
+tools: ["Bash", "Read", "Glob", "mcp__plugin_oss-autopilot_oss-autopilot__vet", "mcp__plugin_oss-autopilot_oss-autopilot__repo-vet"]
 ---
 
 > **Input validation:** See "AskUserQuestion Validation Protocol" in `workflows/reference.md`.
@@ -41,42 +41,32 @@ You are a Repository Health Analyst who evaluates open source projects to help c
 ## Data Access
 
 **Prefer MCP tools** (typed, no shell exec):
-- `mcp__plugin_oss-autopilot_oss-autopilot__vet` — vets an issue URL and returns project health + viability score.
-- `mcp__plugin_oss-autopilot_oss-autopilot__status` — user's tracked PRs and cached repo scores.
+
+1. `mcp__plugin_oss-autopilot_oss-autopilot__repo-vet` — primary input. Returns the structured repo health result for `owner/repo`: metadata, PR merge time over the trailing 90 days, merge rate, maintainer activity, community-health flags, the 1–10 weighted score, and the verdict (`recommended` / `proceed_with_caution` / `avoid`). Same rubric `issue-scout` references for its repo-health portion. Use this output verbatim — do NOT re-derive the metrics inline.
+2. `mcp__plugin_oss-autopilot_oss-autopilot__vet` — issue-level vetting (use when the user asks about a specific issue rather than the repo as a whole).
+3. `mcp__plugin_oss-autopilot_oss-autopilot__status` — user's tracked PRs and cached repo scores.
 
 **CLI fallback** (only when MCP is unavailable):
 
 ```bash
+GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" repo-vet <owner/repo> --json
 GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" vet <issue-url> --json
 GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" status --json
 ```
 
 **On failure:** Report the error and stop — do not improvise raw `gh api` calls.
 
-## Complementary: Raw Repo Metadata via gh
+## What you do (and don't) compute
 
-The MCP/CLI surface provides viability scoring. For raw repo metadata (commits, releases, PR timing), the `gh` CLI is the complementary primary tool:
+`repo-vet` is the source of truth for the rubric. Your job is to render its output and add interpretive context, not to recompute the numbers in markdown:
 
-```bash
-gh repo view OWNER/REPO --json name,description,stargazerCount,forkCount,openIssues,watchers,createdAt,pushedAt,updatedAt,isArchived
-gh pr list --repo OWNER/REPO --state merged --limit 20 --json number,title,createdAt,mergedAt,author
-gh pr list --repo OWNER/REPO --state open --limit 20 --json number,title,createdAt,updatedAt,author
-gh issue list --repo OWNER/REPO --state closed --limit 20 --json number,title,createdAt,closedAt
-gh api repos/OWNER/REPO/contents/CONTRIBUTING.md --jq '.content' 2>/dev/null | base64 -d | head -50
-```
-
-## Metrics to Compute
-
-- **PR merge time:** avg time from `createdAt` to `mergedAt` on recent merged PRs (available from `gh pr list --state merged --json createdAt,mergedAt`); flag > 14 days.
-- **Merge rate:** merged / opened (last 90 days); >70% good, <30% concerning.
-- **Maintainer activity:** last commit date, contributors in last 90 days, issue response times.
-- **Community health:** CONTRIBUTING.md, issue templates, PR templates, code of conduct, recent releases.
-
-**Do not attempt to compute "time to first review" from `gh pr list` JSON.** That payload does not include review timestamps, so any such number would be fabricated. If you want review timing, fetch `gh api repos/OWNER/REPO/pulls/PULL_NUMBER/reviews` per PR — otherwise omit the metric.
+- **Use the structured fields directly:** `repoMeta.{stars,forks,...}`, `prMergeTime.{avgDays,medianDays,sampleSize}`, `mergeRate.{merged,opened,percent}`, `maintainerActivity.{lastCommitISO,contributorsLast90d,lastReleaseISO}`, `communityHealth.{contributing,issueTemplates,prTemplate,codeOfConduct}`, `rubricScore`, `rubricVerdict`.
+- **Do not estimate "time to first review."** That metric is intentionally absent from `repo-vet` (the underlying API doesn't expose review timestamps without a per-PR fetch). If the user explicitly asks for it, do `gh api repos/OWNER/REPO/pulls/PULL_NUMBER/reviews` for the PRs they care about. Otherwise omit it — never fabricate from list metadata.
+- **Add interpretive context** the typed function can't produce: how the score compares against repos the user already contributes to (via `status`), what the maintainer's response cadence implies for an actual PR, where the contributor is most likely to get traction.
 
 ## Scoring Rubric
 
-Use the canonical 1–10 rubric in [`docs/repo-rubric.md`](../docs/repo-rubric.md). It is the same rubric `issue-scout` references for the repo-health portion of its score, so two agents looking at the same repo produce comparable numbers.
+Use the canonical 1–10 rubric in [`docs/repo-rubric.md`](../docs/repo-rubric.md). It is the same rubric `repo-vet` implements and `issue-scout` references for the repo-health portion of its score, so all three surfaces produce comparable numbers.
 
 ## Output Format
 

--- a/packages/core/src/agents-contract.test.ts
+++ b/packages/core/src/agents-contract.test.ts
@@ -44,6 +44,7 @@ const REGISTERED_MCP_TOOLS = new Set([
   'vet-list',
   'track',
   'compliance-score',
+  'repo-vet',
   'comments',
   'post',
   'claim',


### PR DESCRIPTION
## Summary

Closes #1271. Steps 1 (CLI command, #1318) and 2 (MCP tool, #1319) shipped earlier this session. This PR rewires `repo-evaluator` to consume the typed surface instead of assembling repo-health rubrics inline.

## What changes

**`agents/repo-evaluator.md`:**

- **Frontmatter:** new `mcp__plugin_oss-autopilot_oss-autopilot__repo-vet` entry in the tools array.
- **Data Access section:** lists `repo-vet` as the primary input, describes what it returns, and tells the agent to use the output verbatim rather than re-deriving metrics inline.
- **Removed:** the `gh repo view` / `gh pr list` / `gh issue list` / `gh api ... CONTRIBUTING.md` plumbing block (~7 lines). One `repo-vet` call replaces it.
- **Renamed "Metrics to Compute" → "What you do (and don't) compute"** to refocus the agent on interpretive context (how the score compares against the user's existing repos, what the maintainer cadence implies for an actual PR, where the contributor will get traction). Keeps the explicit warning against fabricating "time to first review" numbers.
- **Scoring Rubric note** now mentions all three surfaces (repo-vet, repo-evaluator, issue-scout) consume the same canonical rubric so numbers stay comparable.

**`packages/core/src/agents-contract.test.ts`:** added `'repo-vet'` to `REGISTERED_MCP_TOOLS` so the parity check (#1245) accepts the new tool reference. (The MCP server's own test list was updated in #1319; this duplicate exists in core to avoid a cross-package import.)

Net diff: -22 / +13 lines (the prompt shrinks).

## Test plan

- [x] `pnpm --filter @oss-autopilot/core run test` — 2499 passed, including `agents/*.md ↔ MCP tool registry parity (#1245)` which now sees `repo-vet` in the registered set.
- [x] `pnpm -w run lint` — 0 errors.
- [x] `pnpm -w run format:check` — passing.

## What this completes

`#1271` had three pieces:
- ✅ Step 1 (#1318): `repo-vet` CLI command
- ✅ Step 2 (#1319): `repo-vet` MCP tool
- ✅ Step 3 (this PR): `repo-evaluator` agent rewired

`computeRepoVet()` (#1242, shipped in #1263) now has full surface coverage: typed core function, CLI command, MCP tool, agent consumer.