### PR TITLE
fix: pre-3.5.0 release blockers (review-loop convergence)

### DIFF
--- a/packages/core/src/commands/compliance-score.ts
+++ b/packages/core/src/commands/compliance-score.ts
@@ -116,10 +116,11 @@ async function verifyLinkedIssues(
         if (status === 404) {
           return { number, repo: fullRepo, crossRepo, state: 'not_found' as const };
         }
-        // Rate limit / network — surface as not_found so the agent does
-        // not silently pass on an unverified reference. The agent's
-        // recommendation text already tells the user to confirm.
-        return { number, repo: fullRepo, crossRepo, state: 'not_found' as const };
+        // Rate limit, 5xx, network — distinct from "not found" so the
+        // score function treats it neutrally. Mapping a 429 on a valid
+        // open issue to `not_found` would falsely fail the
+        // issue-reference check on a perfectly good PR.
+        return { number, repo: fullRepo, crossRepo, state: 'unverifiable' as const };
       }
     }),
   );

--- a/packages/core/src/commands/list-mark-done.test.ts
+++ b/packages/core/src/commands/list-mark-done.test.ts
@@ -125,6 +125,21 @@ describe('markIssueAsDone (pure transform)', () => {
     expect(result.content).toContain(`### ~~baz/qux~~`);
   });
 
+  it('does not match a URL whose number is a prefix of another listed URL (substring guard)', () => {
+    // `issues/1` is a substring of `issues/10`. Without the digit-boundary
+    // guard, marking issue 1 would clobber whichever appears first.
+    const URL_1 = 'https://github.com/foo/bar/issues/1';
+    const URL_10 = 'https://github.com/foo/bar/issues/10';
+    const content = [`### foo/bar`, `- [#10](${URL_10}) — ten`, `- [#1](${URL_1}) — one`, ''].join('\n');
+    const result = markIssueAsDone(content, { issueUrl: URL_1, prUrl: PR_A, prStatus: 'merged' });
+    expect(result.marked).toBe(true);
+    // Issue 10 must remain untouched.
+    expect(result.content).toContain(`- [#10](${URL_10}) — ten`);
+    expect(result.content).toContain(`- ~~[#1](${URL_1}) — one~~`);
+    // The Done sub-bullet should reference issue 1, not issue 10.
+    expect(result.content).toContain(`- **Done** — PR [#123](${PR_A}) submitted, merged.`);
+  });
+
   it('preserves the trailing newline shape of the source', () => {
     const withNewline = `### foo/bar\n- [#1](${ISSUE_A}) — x\n`;
     const withoutNewline = `### foo/bar\n- [#1](${ISSUE_A}) — x`;

--- a/packages/core/src/commands/list-mark-done.ts
+++ b/packages/core/src/commands/list-mark-done.ts
@@ -78,12 +78,27 @@ function strikeLine(line: string): { line: string; alreadyStruck: boolean } {
   return { line: `${prefix}${STRIKE}${body}${STRIKE}`, alreadyStruck: false };
 }
 
+/**
+ * Match the URL only when followed by a non-digit, non-word character (or
+ * end of line). A bare `includes(issueUrl)` would match `issues/1` against
+ * a line containing `issues/10`, so finding/marking issue 1 would mark
+ * whichever number-prefix line appears first.
+ */
+function lineMentionsUrl(line: string, issueUrl: string): boolean {
+  const idx = line.indexOf(issueUrl);
+  if (idx === -1) return false;
+  const next = line.charCodeAt(idx + issueUrl.length);
+  // NaN (end of string) → digit boundary OK. Otherwise reject any digit
+  // immediately after the URL so 'issues/1' doesn't match 'issues/10'.
+  return Number.isNaN(next) || next < 48 /* '0' */ || next > 57; /* '9' */
+}
+
 /** Find the issue block (issue line plus any indented sub-bullets) that mentions the URL. */
 function findIssueBlock(lines: string[], issueUrl: string): IssueBlock | undefined {
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     if (!ISSUE_LINE_RE.test(line)) continue;
-    if (!line.includes(issueUrl)) continue;
+    if (!lineMentionsUrl(line, issueUrl)) continue;
     let end = i + 1;
     while (end < lines.length && /^\s{2,}/.test(lines[end])) end++;
     return { start: i, end };

--- a/packages/core/src/commands/repo-vet.ts
+++ b/packages/core/src/commands/repo-vet.ts
@@ -12,9 +12,13 @@
  */
 
 import { getOctokit, requireGitHubToken } from '../core/index.js';
+import { errorMessage } from '../core/errors.js';
+import { warn } from '../core/logger.js';
 import { validateRepoIdentifier } from './validation.js';
 import { computeRepoVet, type RepoVetInput, type RepoVetResult } from '../core/repo-vet.js';
 import type { RepoVetOutput } from '../formatters/json.js';
+
+const MODULE = 'repo-vet';
 
 const DAY_MS = 86400000;
 const COMMUNITY_HEALTH_PATHS = [
@@ -30,6 +34,14 @@ const COMMUNITY_HEALTH_PATHS = [
   { key: 'hasCodeOfConduct', candidates: ['CODE_OF_CONDUCT.md', '.github/CODE_OF_CONDUCT.md'] },
 ] as const;
 
+/**
+ * Returns true when the path exists. Treats 404 as "absent" (the only
+ * shape we care about for community-health flags). Re-throws everything
+ * else — auth/rate-limit failures must not silently scrub the
+ * `hasContributing` etc. flags to `false`, which would understate a
+ * repo's community health on a token that lacks scope or has been
+ * throttled mid-sequence.
+ */
 async function probePath(
   octokit: ReturnType<typeof getOctokit>,
   owner: string,
@@ -39,11 +51,23 @@ async function probePath(
   try {
     await octokit.repos.getContent({ owner, repo, path });
     return true;
-  } catch {
-    return false;
+  } catch (err) {
+    const status = (err as { status?: number }).status;
+    if (status === 404) return false;
+    throw err;
   }
 }
 
+/**
+ * Probe each community-health path. Treats 404 as "absent" (a definitive
+ * signal). On any other error (auth, rate-limit, 5xx) the per-key result
+ * stays `false` AND the whole-function `incomplete` flag is set so the
+ * caller knows community-health was unverified rather than confirmed-absent.
+ *
+ * This is the per-key analogue of the call-level catch: instead of either
+ * silently misclassifying 403 → absent OR aborting the entire repo-vet
+ * call, we degrade gracefully and surface the gap.
+ */
 async function checkCommunityHealth(
   octokit: ReturnType<typeof getOctokit>,
   owner: string,
@@ -53,6 +77,7 @@ async function checkCommunityHealth(
   hasIssueTemplates: boolean;
   hasPRTemplate: boolean;
   hasCodeOfConduct: boolean;
+  incomplete: boolean;
 }> {
   const out: Record<string, boolean> = {
     hasContributing: false,
@@ -60,21 +85,40 @@ async function checkCommunityHealth(
     hasPRTemplate: false,
     hasCodeOfConduct: false,
   };
+  let incomplete = false;
   await Promise.all(
     COMMUNITY_HEALTH_PATHS.map(async ({ key, candidates }) => {
+      let sawError = false;
       for (const path of candidates) {
-        if (await probePath(octokit, owner, repo, path)) {
-          out[key] = true;
-          return;
+        try {
+          if (await probePath(octokit, owner, repo, path)) {
+            out[key] = true;
+            return;
+          }
+        } catch (err) {
+          // probePath only throws on non-404 errors. Don't abandon
+          // remaining candidates — `CONTRIBUTING.md` failing with 403
+          // does NOT imply `.github/CONTRIBUTING.md` will fail too. Mark
+          // the per-key probe as incomplete only if every candidate
+          // either errored or returned absent.
+          warn(MODULE, `community-health probe for ${owner}/${repo}/${path} failed: ${errorMessage(err)}`);
+          sawError = true;
+          continue;
         }
       }
+      // Reached only when no candidate hit. If any candidate errored,
+      // the absent flag is unreliable — surface that to the caller so
+      // the agent prompt distinguishes "probed all candidates and
+      // absent" from "couldn't tell".
+      if (sawError) incomplete = true;
     }),
   );
-  return out as {
-    hasContributing: boolean;
-    hasIssueTemplates: boolean;
-    hasPRTemplate: boolean;
-    hasCodeOfConduct: boolean;
+  return {
+    hasContributing: out.hasContributing,
+    hasIssueTemplates: out.hasIssueTemplates,
+    hasPRTemplate: out.hasPRTemplate,
+    hasCodeOfConduct: out.hasCodeOfConduct,
+    incomplete,
   };
 }
 
@@ -156,7 +200,7 @@ export async function runRepoVet(options: { repo: string }): Promise<RepoVetOutp
   const octokit = getOctokit(token);
   const now = new Date();
 
-  const [repoMetaResp, closedPRsResp, commitsResp, releasesResp, communityHealth] = await Promise.all([
+  const [repoMetaResp, closedPRsResp, commitsResp, releasesResp, communityHealthSummary] = await Promise.all([
     octokit.repos.get({ owner, repo }),
     octokit.pulls.list({ owner, repo, state: 'closed', sort: 'updated', direction: 'desc', per_page: 100 }),
     octokit.repos.listCommits({ owner, repo, per_page: 100 }),
@@ -192,21 +236,25 @@ export async function runRepoVet(options: { repo: string }): Promise<RepoVetOutp
     lastCommitISO: commitSummary.lastCommitISO,
     contributorsLast90d: commitSummary.contributorsLast90d,
     lastReleaseISO,
-    hasContributing: communityHealth.hasContributing,
-    hasIssueTemplates: communityHealth.hasIssueTemplates,
-    hasPRTemplate: communityHealth.hasPRTemplate,
-    hasCodeOfConduct: communityHealth.hasCodeOfConduct,
+    hasContributing: communityHealthSummary.hasContributing,
+    hasIssueTemplates: communityHealthSummary.hasIssueTemplates,
+    hasPRTemplate: communityHealthSummary.hasPRTemplate,
+    hasCodeOfConduct: communityHealthSummary.hasCodeOfConduct,
   };
 
   const result: RepoVetResult = computeRepoVet(input);
 
   // The core function names its metadata object `repo`. Rename to `repoMeta`
   // at the CLI boundary so the top-level slug doesn't collide with it.
-  const { repo: repoMeta, ...rest } = result;
+  // Also overlay the community-health `incomplete` flag the wrapper
+  // tracks (the core type doesn't carry it because computeRepoVet is
+  // pure — only the wrapper makes the API calls that can fail mid-probe).
+  const { repo: repoMeta, communityHealth, ...rest } = result;
   return {
     repoSlug: options.repo,
     fetchedAt: now.toISOString(),
     repoMeta,
+    communityHealth: { ...communityHealth, incomplete: communityHealthSummary.incomplete },
     ...rest,
   };
 }

--- a/packages/core/src/core/ci-enforced-tools.test.ts
+++ b/packages/core/src/core/ci-enforced-tools.test.ts
@@ -46,6 +46,10 @@ jobs:
     });
     expect(out.find((e) => e.tool === 'test')?.source).toBe('github-workflow');
     expect(out.find((e) => e.tool === 'typecheck')?.source).toBe('github-workflow');
+    // Negative: `tsc --noEmit` is a typecheck, not a build step. Earlier
+    // versions of the build pattern caught it and emitted both, which
+    // mis-categorized the workflow.
+    expect(out.find((e) => e.tool === 'build')).toBeUndefined();
   });
 
   it('detects security scanners', () => {

--- a/packages/core/src/core/ci-enforced-tools.ts
+++ b/packages/core/src/core/ci-enforced-tools.ts
@@ -79,9 +79,14 @@ function detectFromHaystack(haystack: string, source: CIEnforcedTool['source'], 
       evidenceFor: ['vitest', 'jest', 'pytest', 'rspec', 'go test', 'cargo test', 'mocha'],
     },
     {
+      // `tsc` alone (or `tsc --noEmit`) is a typecheck, not a build artifact
+      // step — keep it out of this pattern so a workflow with only
+      // `tsc --noEmit` doesn't fire BOTH `typecheck` and `build`. Real
+      // build steps that do produce artifacts (tsup, esbuild, webpack,
+      // cargo build, go build) stay here.
       tool: 'build',
-      pattern: /\b(?:tsc --noemit|tsup|esbuild|webpack|cargo build|go build)\b/i,
-      evidenceFor: ['tsc --noemit', 'tsup', 'esbuild', 'webpack', 'cargo build', 'go build'],
+      pattern: /\b(?:tsup|esbuild|webpack|cargo build|go build)\b/i,
+      evidenceFor: ['tsup', 'esbuild', 'webpack', 'cargo build', 'go build'],
     },
     {
       tool: 'commit-format',

--- a/packages/core/src/core/compliance-score.test.ts
+++ b/packages/core/src/core/compliance-score.test.ts
@@ -108,6 +108,32 @@ describe('issueReference check — verified linked issues (#1246 B)', () => {
     const result = computeComplianceScore(meta({ body: 'No reference here.' }), ctx);
     expect(result.checks.issueReference.status).toBe('fail');
   });
+
+  it('warns (not fails) when every linked issue is unverifiable (rate limit / 5xx)', () => {
+    // A 429 on a perfectly valid open issue must NOT downgrade the
+    // PR's compliance check to "fail" — that would false-positive on
+    // every PR during a rate-limit window.
+    const ctx: RepoContext = {
+      linkedIssues: [{ number: 1, repo: 'owner/repo', crossRepo: false, state: 'unverifiable' }],
+    };
+    const result = computeComplianceScore(meta({ body: 'Closes #1' }), ctx);
+    expect(result.checks.issueReference.status).toBe('warn');
+    expect(result.checks.issueReference.detail).toMatch(/could not be verified/);
+  });
+
+  it('passes when one issue is unverifiable but another is open (mixed set)', () => {
+    // The score function ignores unverifiable entries when computing
+    // the worst-of-precedence ranking, so a single rate-limited entry
+    // alongside a verified-open one does not pull the score down.
+    const ctx: RepoContext = {
+      linkedIssues: [
+        { number: 1, repo: 'owner/repo', crossRepo: false, state: 'open' },
+        { number: 2, repo: 'owner/repo', crossRepo: false, state: 'unverifiable' },
+      ],
+    };
+    const result = computeComplianceScore(meta({ body: 'Closes #1, see #2' }), ctx);
+    expect(result.checks.issueReference.status).toBe('pass');
+  });
 });
 
 describe('issueReference check', () => {

--- a/packages/core/src/core/compliance-score.ts
+++ b/packages/core/src/core/compliance-score.ts
@@ -70,9 +70,15 @@ export interface LinkedIssueInfo {
   repo: string;
   /** True when the reference targeted a different repo than the PR. */
   crossRepo: boolean;
-  /** Result of the verification API call. `not_found` covers HTTP 404
-   * and missing-repo cases alike. */
-  state: 'open' | 'closed' | 'not_found';
+  /**
+   * Result of the verification API call.
+   *  - `open` / `closed`: confirmed live state.
+   *  - `not_found`: HTTP 404 — the referenced issue does not exist.
+   *  - `unverifiable`: a non-404 failure (rate-limit, 5xx, network).
+   *    The check treats this neutrally rather than as a broken link, so a
+   *    GitHub API hiccup doesn't downgrade a valid PR's compliance score.
+   */
+  state: 'open' | 'closed' | 'not_found' | 'unverifiable';
   /** Whole days since the issue was closed, when state === 'closed'.
    * Used to distinguish "recently closed, may still apply" from "long
    * stale, almost certainly the wrong reference." */
@@ -175,7 +181,21 @@ function evaluateLinkedIssues(weight: number, linkedIssues: LinkedIssueInfo[]): 
       detail: `linked issue ${tag} does not exist — typo or wrong repo?`,
     };
   }
-  const staleClosed = linkedIssues.find(
+  // If every entry is unverifiable (and none were found-and-known-bad),
+  // neither pass nor fail — return a `warn` so the caller surfaces the
+  // gap without downgrading a valid PR's score. A rate-limit on a single
+  // reference shouldn't make a perfectly good PR look broken. Mixed sets
+  // fall through to the verifiable-state checks below; unverifiable
+  // entries are silently dropped from the worst-of-precedence ranking.
+  const verifiable = linkedIssues.filter((li) => li.state !== 'unverifiable');
+  if (verifiable.length === 0) {
+    return {
+      status: 'warn',
+      weight,
+      detail: `linked issue${linkedIssues.length > 1 ? 's' : ''} could not be verified (rate limit or network) — confirm manually`,
+    };
+  }
+  const staleClosed = verifiable.find(
     (li) => li.state === 'closed' && (li.closedDaysAgo ?? 0) > CLOSED_ISSUE_RECENT_DAYS,
   );
   if (staleClosed) {
@@ -187,7 +207,7 @@ function evaluateLinkedIssues(weight: number, linkedIssues: LinkedIssueInfo[]): 
         `${staleClosed.closedDaysAgo} days — reference is probably stale`,
     };
   }
-  const recentClosed = linkedIssues.find((li) => li.state === 'closed');
+  const recentClosed = verifiable.find((li) => li.state === 'closed');
   if (recentClosed) {
     return {
       status: 'warn',
@@ -197,7 +217,7 @@ function evaluateLinkedIssues(weight: number, linkedIssues: LinkedIssueInfo[]): 
         `${recentClosed.closedDaysAgo ?? '?'} days ago — confirm this PR is still relevant`,
     };
   }
-  const crossRepo = linkedIssues.find((li) => li.crossRepo);
+  const crossRepo = verifiable.find((li) => li.crossRepo);
   if (crossRepo) {
     return {
       status: 'warn',
@@ -210,7 +230,7 @@ function evaluateLinkedIssues(weight: number, linkedIssues: LinkedIssueInfo[]): 
   return {
     status: 'pass',
     weight,
-    detail: `linked issue${linkedIssues.length > 1 ? 's' : ''} verified open`,
+    detail: `linked issue${verifiable.length > 1 ? 's' : ''} verified open`,
   };
 }
 

--- a/packages/core/src/core/repo-vet.test.ts
+++ b/packages/core/src/core/repo-vet.test.ts
@@ -111,6 +111,16 @@ describe('computeRepoVet — merge rate', () => {
     // opened>0 AND merged=0).
     expect(result.mergeRate.percent).toBeNull();
   });
+
+  it('caps percent at 100 when mergedCount > openedCount (backlog clearance)', () => {
+    // PRs opened before the window can merge inside it, producing
+    // mergedCount > openedCount. Without the cap, the displayed value
+    // would be 160%, which looks like a tool bug to readers.
+    const result = computeRepoVet(input({ mergedCount90Days: 8, openedCount90Days: 5 }));
+    expect(result.mergeRate.percent).toBe(100);
+    expect(result.mergeRate.merged).toBe(8);
+    expect(result.mergeRate.opened).toBe(5);
+  });
 });
 
 describe('computeRepoVet — community health', () => {

--- a/packages/core/src/core/repo-vet.ts
+++ b/packages/core/src/core/repo-vet.ts
@@ -209,8 +209,13 @@ export function computeRepoVet(input: RepoVetInput): RepoVetResult {
   const avgDays = sampleSize === 0 ? null : input.prMergeTimesDays.reduce((s, d) => s + d, 0) / sampleSize;
   const medianDays = sampleSize === 0 ? null : median(input.prMergeTimesDays);
 
+  // Cap at 100. A repo clearing a backlog can have mergedCount > openedCount
+  // because PRs opened before the window can merge inside it — without the
+  // cap, the surfaced text would read "Merge rate (90d): 160% (8/5)" which
+  // looks like a tool bug. The score itself is fine (mergeRateSubScore
+  // clamps separately); this just keeps the display sensible.
   const mergeRatePercent =
-    input.openedCount90Days === 0 ? null : (input.mergedCount90Days / input.openedCount90Days) * 100;
+    input.openedCount90Days === 0 ? null : Math.min(100, (input.mergedCount90Days / input.openedCount90Days) * 100);
 
   const verdict = deriveVerdict(rubricScore, hasRedFlags(input));
 

--- a/packages/core/src/core/strategy.ts
+++ b/packages/core/src/core/strategy.ts
@@ -118,8 +118,11 @@ function topNByCount(counts: Record<string, number>, n: number): string[] {
     .map(([name]) => name);
 }
 
-function determineStyle(totalPRs: number, primaryLanguages: string[], favoriteRepos: string[]): ContributorStyle {
-  if (totalPRs < 5) return 'explorer';
+function determineStyle(_totalPRs: number, primaryLanguages: string[], favoriteRepos: string[]): ContributorStyle {
+  // `totalPRs` is reserved for future "explorer" classification (low-volume
+  // contributors). Today the function is only reachable from `computeStrategy`
+  // which gates at `merged.length >= STRATEGY_MIN_PRS` (10), so a `totalPRs < 5`
+  // branch could never fire — removed to avoid misleading future readers.
   // Heavy concentration in 1-2 repos → maintainer; spread across many → generalist.
   if (favoriteRepos.length === 1) return 'maintainer';
   if (primaryLanguages.length === 1 && favoriteRepos.length >= 2 && favoriteRepos.length <= 3) {

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -616,23 +616,68 @@ export const PRTemplateOutputSchema = z.object({
   error: z.string().optional(),
 });
 
-/** Output of the `repo-vet` CLI command (#1271, follow-up to #1242). */
-export const RepoVetOutputSchema = z
-  .object({
-    repoSlug: z.string(),
-    fetchedAt: z.string(),
-  })
-  .passthrough();
+/**
+ * Output of the `repo-vet` CLI command (#1271, follow-up to #1242).
+ *
+ * Validates the full nested shape so a refactor that drops or
+ * mis-types one of these fields trips `outputJsonValidated` rather
+ * than silently shipping a broken envelope (#1245 contract pattern,
+ * matching `ComplianceScoreOutputSchema` below).
+ */
+const RepoVetMetaSchema = z.object({
+  stars: z.number(),
+  forks: z.number(),
+  openIssues: z.number(),
+  watchers: z.number(),
+  isArchived: z.boolean(),
+  lastPushed: z.string(),
+  createdAt: z.string(),
+});
+export const RepoVetOutputSchema = z.object({
+  repoSlug: z.string(),
+  fetchedAt: z.string(),
+  repoMeta: RepoVetMetaSchema,
+  prMergeTime: z.object({
+    avgDays: z.number().nullable(),
+    medianDays: z.number().nullable(),
+    sampleSize: z.number().int().nonnegative(),
+    sourceWindowDays: z.literal(90),
+  }),
+  mergeRate: z.object({
+    merged: z.number().int().nonnegative(),
+    opened: z.number().int().nonnegative(),
+    percent: z.number().nullable(),
+    windowDays: z.literal(90),
+  }),
+  maintainerActivity: z.object({
+    lastCommitISO: z.string().nullable(),
+    contributorsLast90d: z.number().int().nonnegative(),
+    lastReleaseISO: z.string().nullable(),
+  }),
+  communityHealth: z.object({
+    contributing: z.boolean(),
+    issueTemplates: z.boolean(),
+    prTemplate: z.boolean(),
+    codeOfConduct: z.boolean(),
+    /**
+     * True when at least one community-health probe failed for a non-404
+     * reason (auth, rate-limit, 5xx). The boolean flags above stay
+     * `false` for unprobed paths in that case, so consumers should treat
+     * the false flags as "could not determine" rather than "confirmed
+     * absent" when this is set.
+     */
+    incomplete: z.boolean().optional(),
+  }),
+  rubricScore: z.number(),
+  rubricVerdict: z.enum(['recommended', 'proceed_with_caution', 'avoid']),
+});
 /**
  * The CLI wrapper renames the core function's `repo` metadata object to
- * `repoMeta` so the top-level slug doesn't collide with it. Everything
- * else mirrors `RepoVetResult` verbatim.
+ * `repoMeta` so the top-level slug doesn't collide with it. The TS type
+ * is derived from the Zod schema so any drift between schema and type
+ * fails at compile time.
  */
-export type RepoVetOutput = {
-  repoSlug: string;
-  fetchedAt: string;
-  repoMeta: import('../core/repo-vet.js').RepoVetResult['repo'];
-} & Omit<import('../core/repo-vet.js').RepoVetResult, 'repo'>;
+export type RepoVetOutput = z.infer<typeof RepoVetOutputSchema>;
 
 const ComplianceCheckSchema = z.object({
   status: z.enum(['pass', 'warn', 'fail']),


### PR DESCRIPTION
## Summary

Three rounds of review caught seven defects in code already in `main` this session. All fixed in one PR before merging release-please #1254 so `@oss-autopilot/core` v3.5.0 ships clean.

Convergence: round 4 ran the devil's advocate over the round-3 fixes and found no new issues. 2503 tests pass, 0 lint errors, all three workspace packages typecheck.

## Round 1 — three correctness bugs

| Fix | Defect | Location |
|---|---|---|
| 1 | `findIssueBlock` `line.includes(issueUrl)` matches `issues/1` against `issues/10` (substring collision). New `lineMentionsUrl` helper requires a non-digit (or end-of-line) after the URL. | `packages/core/src/commands/list-mark-done.ts` |
| 2 | `mergeRate.percent` uncapped — backlog-clearance produces display strings like "Merge rate (90d): 160% (8/5)". Score itself was already clamped; this clamps the surfaced percent. | `packages/core/src/core/repo-vet.ts` |
| 3 | `tsc --noEmit` matched both `typecheck` and `build` patterns. Removed from the build pattern — it's a typecheck step, not a build artifact. Existing test gained a negative assertion. | `packages/core/src/core/ci-enforced-tools.ts` |

## Round 2 — bug I introduced + bug I missed

| Fix | Defect | Location |
|---|---|---|
| 4 | Round 1's `probePath` re-throw aborted the whole `repo-vet` call on a 403. Now re-throws on non-404 but `checkCommunityHealth` catches per-key, surfaces `communityHealth.incomplete: boolean`, and degrades the affected key to `false`. `RepoVetOutputSchema` tightened from `.passthrough()` to strict nested shape. | `packages/core/src/commands/repo-vet.ts`, `packages/core/src/formatters/json.ts` |
| 5 | Compliance-score linked-issue verification mapped rate-limit / 5xx into `not_found`, falsely failing valid PRs during a rate-limit window. New `unverifiable` enum member; `evaluateLinkedIssues` filters it from the worst-of-precedence ranking and returns `warn` ("could not be verified — confirm manually") when every entry is unverifiable. | `packages/core/src/core/compliance-score.ts`, `packages/core/src/commands/compliance-score.ts` |

## Round 3 — bug + doc fix

| Fix | Defect | Location |
|---|---|---|
| 6 | `checkCommunityHealth` per-key error handler did `return` instead of `continue`, abandoning the second candidate path. Now uses a `sawError` flag, continues to subsequent candidates, and marks `incomplete` only when no candidate succeeded. | `packages/core/src/commands/repo-vet.ts` |
| 7 | Misleading comment claimed "return null"; actual return is `{status: 'warn', ...}`. Corrected. | `packages/core/src/core/compliance-score.ts` |

## Out of scope

- `agents-contract.test.ts` duplicates `EXPECTED_TOOLS` from `mcp-server/src/tools.test.ts`. Round 2 flagged this as drift risk; the fix would require a shared constant module across packages. Filed as follow-up rather than blocking the release.
- `RepoVetInput.lastCommitISO === null` doesn't fire the dormant red flag. Defensible either way (an empty commits response is rare and ambiguous); the conservative behavior of NOT flagging stays.
- `strategy.ts` dead-branch removal: the `_totalPRs` parameter is kept (with underscore prefix) for future low-volume classification rather than dropped from the signature.

## Test plan

- [x] `pnpm --filter @oss-autopilot/core run build` — clean
- [x] `pnpm -w run typecheck` — clean across core, dashboard, mcp-server
- [x] `pnpm --filter @oss-autopilot/core run test` — 2503 passed (+4 new tests for the fixes)
- [x] `pnpm -w run lint` — 0 errors
- [x] `pnpm -w run format:check` — passing