### PR TITLE
fix: actionable error when configured githubUsername is invalid (#1323)

### DIFF
--- a/packages/core/src/core/errors.test.ts
+++ b/packages/core/src/core/errors.test.ts
@@ -6,6 +6,7 @@ import {
   GistCorruptError,
   errorMessage,
   getHttpStatusCode,
+  isInvalidUserSearchError,
   resolveErrorCode,
   isTransientNetworkError,
 } from './errors.js';
@@ -135,6 +136,120 @@ describe('getHttpStatusCode', () => {
   it('returns undefined for primitives', () => {
     expect(getHttpStatusCode('string')).toBeUndefined();
     expect(getHttpStatusCode(42)).toBeUndefined();
+  });
+});
+
+describe('isInvalidUserSearchError (#1323)', () => {
+  it('matches a 422 Search/invalid error whose entry message indicates user-resolution failure', () => {
+    const err = Object.assign(new Error('Validation Failed'), {
+      status: 422,
+      response: {
+        data: {
+          message: 'Validation Failed',
+          errors: [
+            {
+              resource: 'Search',
+              field: 'q',
+              code: 'invalid',
+              message:
+                'The listed users cannot be searched either because the users do not exist or you do not have permission to view the users.',
+            },
+          ],
+        },
+      },
+    });
+    expect(isInvalidUserSearchError(err)).toBe(true);
+  });
+
+  it('matches when entry message is missing but the top-level error message carries the signal', () => {
+    // Some Octokit serializations drop the per-entry message but keep it
+    // assembled in the Error's top-level message. The matcher falls back to
+    // checking the top-level message in that case.
+    const err = Object.assign(
+      new Error(
+        'Validation Failed: The listed users cannot be searched either because the users do not exist or you do not have permission to view the users.',
+      ),
+      {
+        status: 422,
+        response: {
+          data: { errors: [{ resource: 'Search', field: 'q', code: 'invalid' }] },
+        },
+      },
+    );
+    expect(isInvalidUserSearchError(err)).toBe(true);
+  });
+
+  it('matches via the message fallback when response.data is missing', () => {
+    // Octokit errors can lose the structured `response.data` after a rethrow
+    // boundary. The message string copies the API "users do not exist" line,
+    // so we keep that path as a substring fallback.
+    const err = Object.assign(
+      new Error(
+        'Validation Failed: The listed users cannot be searched either because the users do not exist or you do not have permission to view the users.',
+      ),
+      { status: 422 },
+    );
+    expect(isInvalidUserSearchError(err)).toBe(true);
+  });
+
+  it('does not match Search/invalid 422s for unrelated reasons (query too long, too many ORs)', () => {
+    // GitHub returns the same resource/code pair for other Search validation
+    // failures. Without the message-text gate, those would silently rewrite
+    // to "your configured username is wrong" which is actively misleading.
+    const queryTooLong = Object.assign(new Error('Validation Failed'), {
+      status: 422,
+      response: {
+        data: {
+          errors: [
+            {
+              resource: 'Search',
+              field: 'q',
+              code: 'invalid',
+              message: 'The search is longer than 256 characters.',
+            },
+          ],
+        },
+      },
+    });
+    expect(isInvalidUserSearchError(queryTooLong)).toBe(false);
+
+    const tooManyOperators = Object.assign(new Error('Validation Failed'), {
+      status: 422,
+      response: {
+        data: {
+          errors: [
+            {
+              resource: 'Search',
+              field: 'q',
+              code: 'invalid',
+              message: 'The search contains only logical operators (AND / OR / NOT) without any search terms.',
+            },
+          ],
+        },
+      },
+    });
+    expect(isInvalidUserSearchError(tooManyOperators)).toBe(false);
+  });
+
+  it('does not match unrelated 422 validation errors with a different resource', () => {
+    const err = Object.assign(new Error('Validation Failed'), {
+      status: 422,
+      response: {
+        data: { errors: [{ resource: 'Issue', field: 'title', code: 'missing' }] },
+      },
+    });
+    expect(isInvalidUserSearchError(err)).toBe(false);
+  });
+
+  it('does not match non-422 errors', () => {
+    expect(isInvalidUserSearchError(Object.assign(new Error('Not Found'), { status: 404 }))).toBe(false);
+    expect(isInvalidUserSearchError(Object.assign(new Error('Unauthorized'), { status: 401 }))).toBe(false);
+  });
+
+  it('returns false for null/undefined/primitives', () => {
+    expect(isInvalidUserSearchError(null)).toBe(false);
+    expect(isInvalidUserSearchError(undefined)).toBe(false);
+    expect(isInvalidUserSearchError('Validation Failed')).toBe(false);
   });
 });
 

--- a/packages/core/src/core/errors.ts
+++ b/packages/core/src/core/errors.ts
@@ -158,6 +158,59 @@ export function isRateLimitError(error: unknown): boolean {
   return false;
 }
 
+/**
+ * Match-text used to discriminate the user-resolution failure from sibling
+ * `resource: 'Search', code: 'invalid'` 422s (query-too-long,
+ * too-many-OR-operators, malformed qualifier). Both the structured and the
+ * fallback paths gate on this pattern so the matcher's name remains accurate
+ * if a future caller uses a different Search query.
+ */
+const USER_NOT_FOUND_SEARCH_MESSAGE = /users.*do not exist|cannot be searched/i;
+
+/**
+ * Check if an error is GitHub's "users do not exist" Search-API validation
+ * failure (HTTP 422 with `resource: 'Search', code: 'invalid'` and a message
+ * indicating the user couldn't be resolved). Returned when the Search API
+ * can't resolve the user named in an `author:`/`user:` qualifier — the
+ * typical cause is a stale or mis-typed `githubUsername` in
+ * `~/.oss-autopilot/state.json`.
+ *
+ * Surfaced as a generic "Validation Failed" string by Octokit, which gives
+ * the user no actionable signal. Callers wrap the search and rethrow this
+ * as a {@link ConfigurationError} so the CLI prints the configured username
+ * and points at `/setup-oss`.
+ *
+ * The message-text gate is load-bearing: GitHub returns the same
+ * `resource`/`code` pair for other Search 422s (query too long, too many
+ * ORs). Without the gate, those would silently rewrite to "your configured
+ * username is wrong," which is actively misleading.
+ */
+export function isInvalidUserSearchError(err: unknown): boolean {
+  if (getHttpStatusCode(err) !== 422) return false;
+  const data = (err as { response?: { data?: unknown } })?.response?.data;
+  const errors = data && typeof data === 'object' ? (data as { errors?: unknown }).errors : undefined;
+  if (Array.isArray(errors)) {
+    return errors.some((e) => {
+      if (!e || typeof e !== 'object') return false;
+      const entry = e as { resource?: unknown; code?: unknown; message?: unknown };
+      if (entry.resource !== 'Search' || entry.code !== 'invalid') return false;
+      // The Search API includes a per-error `message` for this case. When
+      // present, gate on it to avoid matching sibling validation failures
+      // that share the resource/code pair. When absent, fall back to the
+      // top-level message check below — some serializations drop the
+      // per-entry message but keep it on the response.
+      if (typeof entry.message === 'string') {
+        return USER_NOT_FOUND_SEARCH_MESSAGE.test(entry.message);
+      }
+      return USER_NOT_FOUND_SEARCH_MESSAGE.test(errorMessage(err));
+    });
+  }
+  // Fallback for serialized errors that lost the structured `response.data`
+  // (e.g. messages re-thrown across boundaries). The Search API's own copy
+  // is stable enough to match against.
+  return USER_NOT_FOUND_SEARCH_MESSAGE.test(errorMessage(err));
+}
+
 /** Return true for errors that should propagate (not degrade gracefully): rate limits, auth failures, abuse detection. */
 export function isRateLimitOrAuthError(err: unknown): boolean {
   const status = getHttpStatusCode(err);

--- a/packages/core/src/core/pr-monitor.test.ts
+++ b/packages/core/src/core/pr-monitor.test.ts
@@ -1997,6 +1997,75 @@ describe('fetchUserOpenPRs auto-repairs known placeholder usernames', () => {
   });
 });
 
+// When the configured githubUsername is set to a value GitHub can't resolve
+// (a stale handle, a typo, an aborted-setup leftover that isn't on the
+// known-placeholder list), the Search API returns 422 "Validation Failed:
+// users do not exist." Without the rewrite, that opaque string was the
+// top-level error a /oss run surfaced — no mention of the configured
+// username, state.json, or /setup-oss (#1323).
+describe('fetchUserOpenPRs rewrites Search-API "users do not exist" errors (#1323)', () => {
+  it('throws ConfigurationError naming the configured username and pointing at /setup-oss', async () => {
+    vi.mocked(getStateManager).mockReturnValue(
+      makeStateManagerMock({
+        config: { githubUsername: 'stale-handle', excludeRepos: [], excludeOrgs: [] },
+      }),
+    );
+
+    const validationError = Object.assign(new Error('Validation Failed'), {
+      status: 422,
+      response: {
+        data: {
+          message: 'Validation Failed',
+          errors: [
+            {
+              resource: 'Search',
+              field: 'q',
+              code: 'invalid',
+              message:
+                'The listed users cannot be searched either because the users do not exist or you do not have permission to view the users.',
+            },
+          ],
+        },
+      },
+    });
+    mockOctokitInstance = {
+      search: {
+        issuesAndPullRequests: vi.fn().mockRejectedValue(validationError),
+      },
+    };
+
+    const monitor = new PRMonitor('fake-token');
+    await expect(monitor.fetchUserOpenPRs()).rejects.toThrow(/stale-handle/);
+    await expect(monitor.fetchUserOpenPRs()).rejects.toThrow(/setup-oss/);
+  });
+
+  it('does not rewrite unrelated 422 validation errors', async () => {
+    vi.mocked(getStateManager).mockReturnValue(
+      makeStateManagerMock({
+        config: { githubUsername: 'real-user', excludeRepos: [], excludeOrgs: [] },
+      }),
+    );
+
+    // Different validation failure shape (e.g. malformed query) must propagate
+    // unchanged — only the user-not-found case maps to the actionable rewrite.
+    const otherError = Object.assign(new Error('Validation Failed'), {
+      status: 422,
+      response: {
+        data: { errors: [{ resource: 'Issue', field: 'title', code: 'missing' }] },
+      },
+    });
+    mockOctokitInstance = {
+      search: {
+        issuesAndPullRequests: vi.fn().mockRejectedValue(otherError),
+      },
+    };
+
+    const monitor = new PRMonitor('fake-token');
+    await expect(monitor.fetchUserOpenPRs()).rejects.toThrow('Validation Failed');
+    await expect(monitor.fetchUserOpenPRs()).rejects.not.toThrow(/setup-oss/);
+  });
+});
+
 describe('isBotAuthor (#143)', () => {
   it('should identify [bot] suffix accounts', () => {
     expect(isBotAuthor('dependabot[bot]')).toBe(true);

--- a/packages/core/src/core/pr-monitor.ts
+++ b/packages/core/src/core/pr-monitor.ts
@@ -26,6 +26,7 @@ import {
   ValidationError,
   errorMessage,
   getHttpStatusCode,
+  isInvalidUserSearchError,
   isRateLimitOrAuthError,
 } from './errors.js';
 import { paginateAll } from './pagination.js';
@@ -193,18 +194,34 @@ export class PRMonitor {
     debug('pr-monitor', `Fetching open PRs for @${searchUsername}...`);
 
     // Search for all open PRs authored by the user with pagination
-    const allItems: typeof firstPage.data.items = [];
     let page = 1;
     const perPage = 100;
 
-    const firstPage = await this.octokit.search.issuesAndPullRequests({
-      q: `is:pr is:open is:public author:${searchUsername}`,
-      sort: 'updated',
-      order: 'desc',
-      per_page: perPage,
-      page: 1,
-    });
+    let firstPage: Awaited<ReturnType<typeof this.octokit.search.issuesAndPullRequests>>;
+    try {
+      firstPage = await this.octokit.search.issuesAndPullRequests({
+        q: `is:pr is:open is:public author:${searchUsername}`,
+        sort: 'updated',
+        order: 'desc',
+        per_page: perPage,
+        page: 1,
+      });
+    } catch (err) {
+      // Rewrite the Search API's "users do not exist" 422 into an actionable
+      // ConfigurationError naming the configured username (#1323). The raw
+      // Octokit message ("Validation Failed: ...") gives the user no signal
+      // that the cause is local config rather than a transient GitHub issue.
+      if (isInvalidUserSearchError(err)) {
+        throw new ConfigurationError(
+          `Configured GitHub username "${searchUsername}" was not found on GitHub. ` +
+            `Run \`/setup-oss\` to reconfigure, or edit \`config.githubUsername\` in ` +
+            `\`~/.oss-autopilot/state.json\` directly.`,
+        );
+      }
+      throw err;
+    }
 
+    const allItems: typeof firstPage.data.items = [];
     allItems.push(...firstPage.data.items);
     const totalCount = firstPage.data.total_count;
     debug(MODULE, `Found ${totalCount} open PRs`);


### PR DESCRIPTION
## Summary

Closes #1323. When `config.githubUsername` is set to a value GitHub can't resolve (a stale handle, a typo, an aborted-setup leftover that's not on the known-placeholder list), the Search API returns 422 "Validation Failed: users do not exist" — which previously surfaced as the top-level error from `/oss --json` with no mention of the configured username, state.json, or `/setup-oss`.

Before:

\`\`\`json
{
  \"error\": \"Validation Failed: {\\\"message\\\":\\\"The listed users cannot be searched either because the users do not exist or you do not have permission to view the users.\\\",\\\"resource\\\":\\\"Search\\\",\\\"field\\\":\\\"q\\\",\\\"code\\\":\\\"invalid\\\"}...\",
  \"errorCode\": \"UNKNOWN\"
}
\`\`\`

After:

\`\`\`
Configured GitHub username \"stale-handle\" was not found on GitHub. Run \`/setup-oss\` to reconfigure, or edit \`config.githubUsername\` in \`~/.oss-autopilot/state.json\` directly.
\`\`\`

## What's in the diff

- `core/errors.ts`: new `isInvalidUserSearchError(err)` matches HTTP 422 + `resource:'Search'` + `code:'invalid'` + a message indicating user-resolution failure (`users.*do not exist|cannot be searched`). The message-text gate is load-bearing — GitHub returns the same resource/code pair for query-too-long and too-many-OR errors, so without it the matcher would silently rewrite those as \"your username is wrong\" which is actively misleading.
- `core/pr-monitor.ts`: `fetchUserOpenPRs()` wraps the first search call and rethrows the matched error as `ConfigurationError` naming the configured username and pointing at `/setup-oss`. Pagination loop (pages 2..N) is intentionally not wrapped — if page 1 succeeded the username is valid, and any 422 on page 2+ would indicate a different transient issue that shouldn't be misattributed to config.
- Tests: 7 unit cases for `isInvalidUserSearchError` (structured-form match, top-level-message fallback, message-fallback only, query-too-long doesn't match, too-many-ORs doesn't match, unrelated 422 doesn't match, non-422 doesn't match, primitives) and 2 integration cases on `fetchUserOpenPRs` (rewrite path, unrelated 422 propagates unchanged).

## What's deferred

- Pre-flight validation (calling `users.getByUsername(searchUsername)` before every search) was considered but rejected — adds an API call to every run for a rare case. The post-error rewrite gives the same actionable signal at zero steady-state cost.
- Wrapping `fetchRecentlyClosedPRs` and other PRMonitor methods. Same pattern would apply, but the issue surfaces specifically from the startup path through `fetchUserOpenPRs`. If a similar opaque error shows up from a sibling method, the same helper is ready to wrap it.
- A general-purpose \"opaque GitHub error → actionable config error\" framework. Premature; one call site so far.

## Test plan

- [x] `pnpm --filter @oss-autopilot/core run test` — 2512 passing (was 2510, +2 new cases)
- [x] `pnpm -w run typecheck` — clean
- [x] `pnpm -w run lint` — 0 errors (1547 pre-existing warnings, none new)
- [x] `pnpm --filter @oss-autopilot/core run build` — clean
- [x] Pre-commit review: parallel `code-reviewer` + `silent-failure-hunter`. One Recommended finding (matcher too broad) addressed before commit.