### PR TITLE
refactor: wire list-mark-done CLI + Step 10 workflow (#1299 part 2)

### DIFF
--- a/.claude-plugin/expected-cli-contract.json
+++ b/.claude-plugin/expected-cli-contract.json
@@ -14,6 +14,7 @@
     "doctor",
     "guidelines",
     "init",
+    "list-mark-done",
     "list-move-tier",
     "local-repos",
     "manifest",

--- a/packages/core/src/cli-registry.test.ts
+++ b/packages/core/src/cli-registry.test.ts
@@ -42,6 +42,7 @@ vi.mock('./formatters/json.js', () => ({
   DoctorOutputSchema: {},
   SkipAddOutputSchema: {},
   ListMoveTierOutputSchema: {},
+  ListMarkDoneOutputSchema: {},
   PostOutputSchema: {},
   ClaimOutputSchema: {},
   InitOutputSchema: {},

--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -480,6 +480,64 @@ export const commands: CLICommandDef[] = [
     },
   },
 
+  // ── List Mark Done ─────────────────────────────────────────────────────
+  {
+    name: 'list-mark-done',
+    localOnly: true,
+    register(program) {
+      program
+        .command('list-mark-done <issue-url>')
+        .description('Mark an issue line in a curated list as done with strikethrough + Done sub-bullet (#1299)')
+        .requiredOption('--pr-url <url>', 'PR URL to record on the Done sub-bullet')
+        .requiredOption('--pr-status <text>', 'Trailing status, e.g. "merged" or "CI passing"')
+        .requiredOption('--list-path <file>', 'Path to the markdown issue list')
+        .option('--json', 'Output as JSON')
+        .action(async (issueUrl, options) => {
+          const { ListMarkDoneOutputSchema } = await import('./formatters/json.js');
+          await executeAction(
+            options,
+            async () => {
+              const result = await (
+                await import('./commands/list-mark-done.js')
+              ).runMarkIssueListItemDone({
+                issueUrl,
+                prUrl: options.prUrl,
+                prStatus: options.prStatus,
+                listPath: options.listPath,
+              });
+              // Convert "URL not in list" into a real CLI error so the JSON
+              // envelope reports `success: false` and the process exits non-zero.
+              // The pure transform's success-shaped not-found return is fine for
+              // library consumers, but as a CLI command "I asked you to mark X
+              // and you couldn't find X" is a failure the caller must see.
+              // The "already marked done" case stays as a success-shape return
+              // (it's idempotent — the caller's intent was achieved).
+              if (!result.marked && result.reason === 'issue URL not found in the list') {
+                throw new Error(
+                  `Issue URL not found in ${result.filePath}: ${result.url}. ` +
+                    `Verify --list-path and the issue URL.`,
+                );
+              }
+              return result;
+            },
+            (data) => {
+              if (data.marked) {
+                const headingNote = data.repoHeadingStruck ? ' (repo heading also struck)' : '';
+                console.log(`Marked ${data.url} done${headingNote}`);
+                console.log(`  File: ${data.filePath}`);
+                console.log(`  Remaining under repo: ${data.remainingUnderRepo}`);
+              } else {
+                // Reach here only on the idempotent "already marked done" path.
+                console.log(`No mark: ${data.url} — ${data.reason ?? 'unchanged'}`);
+                console.log(`  File: ${data.filePath}`);
+              }
+            },
+            ListMarkDoneOutputSchema,
+          );
+        });
+    },
+  },
+
   // ── Track ──────────────────────────────────────────────────────────────
   {
     name: 'track',

--- a/packages/core/src/cli.test.ts
+++ b/packages/core/src/cli.test.ts
@@ -126,6 +126,7 @@ describe('LOCAL_ONLY_COMMANDS (derived from registry)', () => {
     'stats',
     'skip-add',
     'list-move-tier',
+    'list-mark-done',
     'manifest',
     'guidelines',
   ];
@@ -417,6 +418,7 @@ describe('Command registration', () => {
       'state',
       'skip-add',
       'list-move-tier',
+      'list-mark-done',
       'guidelines',
       'manifest',
     ];

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -101,6 +101,13 @@ export {
   type ListMoveTierOptions,
   type ListMoveTierOutput,
 } from './list-move-tier.js';
+/** Mark an issue line in a curated list as done with strikethrough + Done sub-bullet (#1299). */
+export {
+  runMarkIssueListItemDone,
+  markIssueAsDone,
+  type MarkDoneOptions,
+  type MarkDoneOutput,
+} from './list-mark-done.js';
 /** Check if new files are properly referenced/integrated. */
 export { runCheckIntegration } from './check-integration.js';
 /** System-health diagnostic — verifies tokens, bundle, state, scout, rate limit. */

--- a/packages/core/src/formatters/json.test.ts
+++ b/packages/core/src/formatters/json.test.ts
@@ -19,6 +19,7 @@ import {
   DoctorOutputSchema,
   SkipAddOutputSchema,
   ListMoveTierOutputSchema,
+  ListMarkDoneOutputSchema,
   PostOutputSchema,
   ClaimOutputSchema,
   InitOutputSchema,
@@ -638,6 +639,52 @@ describe('ListMoveTierOutputSchema (#1148)', () => {
       count: 1,
     } as unknown;
     expect(() => formatJson(ListMoveTierOutputSchema, data)).toThrow(/contract drift.*totier/i);
+  });
+});
+
+describe('ListMarkDoneOutputSchema (#1299)', () => {
+  it('round-trips a successful mark', () => {
+    const data = {
+      marked: true,
+      filePath: '/tmp/list.md',
+      url: 'https://github.com/foo/bar/issues/1',
+      repoHeadingStruck: false,
+      remainingUnderRepo: 2,
+    };
+    expect(formatJson(ListMarkDoneOutputSchema, data).success).toBe(true);
+  });
+
+  it('round-trips a no-op mark with reason', () => {
+    const data = {
+      marked: false,
+      filePath: '/tmp/list.md',
+      url: 'https://github.com/foo/bar/issues/1',
+      repoHeadingStruck: false,
+      remainingUnderRepo: 0,
+      reason: 'already marked done',
+    };
+    expect(formatJson(ListMarkDoneOutputSchema, data).success).toBe(true);
+  });
+
+  it('rejects drift: missing repoHeadingStruck', () => {
+    const data = {
+      marked: true,
+      filePath: '/tmp/list.md',
+      url: 'https://github.com/foo/bar/issues/1',
+      remainingUnderRepo: 2,
+    } as unknown;
+    expect(() => formatJson(ListMarkDoneOutputSchema, data)).toThrow(/contract drift.*repoheadingstruck/i);
+  });
+
+  it('rejects drift: negative remainingUnderRepo', () => {
+    const data = {
+      marked: true,
+      filePath: '/tmp/list.md',
+      url: 'https://github.com/foo/bar/issues/1',
+      repoHeadingStruck: false,
+      remainingUnderRepo: -1,
+    } as unknown;
+    expect(() => formatJson(ListMarkDoneOutputSchema, data)).toThrow(/contract drift.*remainingunderrepo/i);
   });
 });
 

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -506,6 +506,19 @@ export const ListMoveTierOutputSchema = z.object({
   reason: z.string().optional(),
 });
 
+// list-mark-done (#1299): mirrors {@link MarkDoneOutput} from the command
+// module. Strict shape — additional keys must be added here AND in the
+// command output, otherwise the validator's `parse()` rejects the response
+// before it reaches consumers.
+export const ListMarkDoneOutputSchema = z.object({
+  marked: z.boolean(),
+  filePath: z.string(),
+  url: z.string(),
+  repoHeadingStruck: z.boolean(),
+  remainingUnderRepo: z.number().int().nonnegative(),
+  reason: z.string().optional(),
+});
+
 // ── #1155: Zod coverage for remaining CLI commands ───────────────────
 
 export const PostOutputSchema = z.object({

--- a/workflows/draft-first-workflow.md
+++ b/workflows/draft-first-workflow.md
@@ -644,24 +644,28 @@ Options:
 2. "No, I'll update it manually"
 ```
 
-If yes, use the Edit tool to update the list file:
-- Wrap the repo heading and issue line in `~~strikethrough~~`
-- Change or add the status to: `**Done** — PR [#NUMBER](URL) submitted, {brief status}.`
+If yes, run the deterministic `list-mark-done` CLI command (#1299) — it strikes through the issue line, appends the `**Done**` sub-bullet, and strikes through the repo heading if all issues under it are now done. Idempotent on a re-run.
 
-Example transformation:
-```markdown
-# Before:
-### suitenumerique/meet (1.6k★) — Open-source video conferencing (LiveKit)
-- [#804](https://github.com/suitenumerique/meet/issues/804) — Test mic while "muted"
-  - **Low complexity** — Help wanted, unassigned, no PRs, active repo.
-
-# After:
-### ~~suitenumerique/meet (1.6k★) — Open-source video conferencing (LiveKit)~~
-- ~~[#804](https://github.com/suitenumerique/meet/issues/804) — Test mic while "muted"~~
-  - **Done** — PR [#42](https://github.com/suitenumerique/meet/pull/42) submitted, CI passing.
+```bash
+<prefix> list-mark-done <issue-url> --pr-url <pr-url> --pr-status "<brief-status>" --list-path <issueListPath> --json
 ```
 
-**Important:** Only strike through the specific repo heading if ALL issues under it are now done. If other issues remain under the same repo heading, only strike through the individual issue lines.
+Example invocation:
+
+```bash
+<prefix> list-mark-done https://github.com/suitenumerique/meet/issues/804 \
+  --pr-url https://github.com/suitenumerique/meet/pull/42 \
+  --pr-status "CI passing" \
+  --list-path /Users/me/issues.md --json
+```
+
+Inspect the JSON output before announcing anything:
+
+- `success: true` with `data.marked: true` → the file was updated. Continue to step 2. Note that `data.remainingUnderRepo` reports issues left under THIS repo's heading only — for the whole-list `remainingCount` in step 2, use `availableCount - 1` from the session-start `data.issueList`.
+- `success: true` with `data.marked: false` and `data.reason: "already marked done"` → idempotent re-run. Tell the user the line was already struck. Use the same whole-list `remainingCount` calculation (don't double-decrement).
+- `success: false` with the error mentioning "Issue URL not found" → STOP. Do NOT announce the list was updated and do NOT advance to step 2. Surface the error to the user with the URL and `--list-path` you used; ask whether to retry with a different path/URL or fall back to a manual edit.
+
+Do NOT hand-edit the list file with the Edit tool; the deterministic command avoids drift between this prose and the marker logic.
 
 ### 2. Show remaining count
 

--- a/workflows/reference.md
+++ b/workflows/reference.md
@@ -14,7 +14,7 @@ All commands support `--json` flag for structured output.
      `bash scripts/build-cli-if-stale.sh "$PWD" && pnpm run generate:reference`.
      CI fails if this line is out of sync with the registry. -->
 <!-- BEGIN AUTO:local-only-commands -->
-Local-only commands (no GitHub token needed): `checkSetup`, `clear-override`, `config`, `detect-formatters`, `dismiss`, `doctor`, `guidelines`, `list-move-tier`, `local-repos`, `manifest`, `move`, `orphan-files`, `override`, `parse-issue-list`, `serve`, `setup`, `shelve`, `skip-add`, `startup`, `stats`, `status`, `undismiss`, `unshelve`.
+Local-only commands (no GitHub token needed): `checkSetup`, `clear-override`, `config`, `detect-formatters`, `dismiss`, `doctor`, `guidelines`, `list-mark-done`, `list-move-tier`, `local-repos`, `manifest`, `move`, `orphan-files`, `override`, `parse-issue-list`, `serve`, `setup`, `shelve`, `skip-add`, `startup`, `stats`, `status`, `undismiss`, `unshelve`.
 <!-- END AUTO:local-only-commands -->
 
 ### Core Workflow
@@ -53,6 +53,9 @@ Local-only commands (no GitHub token needed): `checkSetup`, `clear-override`, `c
 
 # Move an issue between Pursue / Maybe / Skip sections of a curated list (#1107)
 <prefix> list-move-tier <issue-url> --tier <pursue|maybe|skip> --list-path <file> --json
+
+# Mark an issue done with strikethrough + Done sub-bullet (#1299)
+<prefix> list-mark-done <issue-url> --pr-url <pr-url> --pr-status "<status>" --list-path <file> --json
 ```
 
 ### Per-Repo Guidelines (#867)


### PR DESCRIPTION
## Summary

Closes #1299 part 2. The pure-transform `list-mark-done` core function and its tests already exist (shipped in v3.5.0). This wires it through the same surfaces that #1107's `list-move-tier` already has so the workflow's Step 10 strikethrough+Done prose can call a deterministic command instead of hand-editing the file.

Part 1 (vet-list ScoutSkipReason fallback removal) is blocked on `@oss-scout/core` shipping the enum emitter and stays open.

## What's in the diff

| File | Change |
|---|---|
| `cli-registry.ts` | Register `list-mark-done` (--pr-url, --pr-status, --list-path, --json). Action wrapper throws on the core function's "issue URL not found" success-shaped return so JSON envelope reports `success: false` with exit code 1. |
| `formatters/json.ts` | New `ListMarkDoneOutputSchema` (strict zod, mirrors `MarkDoneOutput`). |
| `formatters/json.test.ts` | 4 schema tests (round-trip, no-op-with-reason, drift on missing field, drift on negative integer). |
| `cli-registry.test.ts` | Add `ListMarkDoneOutputSchema: {}` to schemas mock. |
| `cli.test.ts` | Add `list-mark-done` to `expectedLocalOnly` + `expectedCommands` arrays. |
| `commands/index.ts` | Re-export `runMarkIssueListItemDone`, `markIssueAsDone`, types. |
| `expected-cli-contract.json` | Add `list-mark-done` to `expectedCommands`. |
| `workflows/reference.md` | Bash example for the new command + auto-generated local-only commands line picks it up. |
| `workflows/draft-first-workflow.md` Step 10 | Replace Edit-tool prose with `list-mark-done` invocation. New prose tells the agent to inspect the JSON envelope and branch on `marked` + `reason` — so a "URL not found" return is surfaced, NOT silently celebrated as completion. |

## Polish addressed in review

The pre-commit review surfaced two real bugs in my initial wiring:

1. The CLI registered `--pr-status` with default `'submitted'`, which produced a duplicated word in the rendered Done bullet (`submitted, submitted.`). Fixed: `--pr-status` is now required (no default).
2. The first workflow draft told the agent to use `data.remainingUnderRepo` to populate Step 2's `remainingCount`. But `remainingUnderRepo` is per-repo (issues left under THIS repo's heading), while Step 2's `remainingCount` is whole-list. With a multi-repo list, the agent would have under-reported and incorrectly hidden "Pick another from your list" when issues remained under other repo headings. Fixed: prose now points at session-state `availableCount - 1`.

Also: the silent-failure-hunter flagged that the pure-transform's success-shaped not-found return enables the workflow trap. Fixed at the CLI surface (action wrapper throws) without changing the underlying function (so library consumers and the `list-move-tier` precedent stay consistent).

## What's deferred

- MCP wrapper for `list-mark-done`. `list-move-tier` doesn't have one either; precedent-matching is fine here.
- Two pre-existing concerns in `list-mark-done.ts` itself: ambiguous-URL match (a URL embedded in a different issue's sub-bullet could match) and the empty catch on tmp file cleanup. Both deserve follow-ups but predate this PR.

## Test plan

- [x] `pnpm --filter @oss-autopilot/core run test` — 2508 passing
- [x] `pnpm --filter @oss-autopilot/core run build` — clean
- [x] `pnpm -w run typecheck` — clean across core, mcp-server, dashboard
- [x] `pnpm -w run lint` — 0 errors (1557 pre-existing warnings, none new)
- [x] CLI smoke test on a real markdown list:
  - Success path strikes the issue line + adds Done sub-bullet
  - Not-found exits 1 with `success: false` JSON
  - Missing `--pr-status` exits 1 with commander's required-option message
- [x] Pre-commit review: parallel `code-reviewer` + `silent-failure-hunter`. 2 Critical + 2 Important findings, all addressed before commit.