### PR TITLE
feat: scanAIDisclosureRequirement + tri-modal AI-attribution rule (#1269 Improvement C)

### DIFF
--- a/agents/pr-compliance-checker.md
+++ b/agents/pr-compliance-checker.md
@@ -194,7 +194,20 @@ Use AskUserQuestion to offer assistance.
 
 ## AI Attribution Check
 
-See "AI Attribution Rule" in `workflows/reference.md`. Flag any AI attribution in commit messages, PR descriptions, or comments as an issue.
+See "AI Attribution Rule" in `workflows/reference.md` for the default policy.
+
+Before flagging, read the target repo's docs (CONTRIBUTING.md / README / CODE_OF_CONDUCT) and classify the project's AI-assistance regime. The deterministic patterns are documented as reference scans in `packages/core/src/core/anti-llm-policy.ts` (`scanForAntiLLMPolicy` and `scanAIDisclosureRequirement` from #911 / #1269); the function names tell you what to grep for.
+
+| Regime detected | Rule |
+|---|---|
+| **Anti-LLM** — phrases like "no AI-generated", "ban Copilot", "AI contributions will be closed" | Flag AI attribution as a `Critical` issue. The maintainer does not accept AI-assisted contributions. |
+| **Disclosure mandatory** — "must disclose AI", "required to indicate AI assistance", "PRs using AI must be labeled" | Flag the ABSENCE of AI attribution as `Critical` when the contribution involved AI. Presence of attribution is correct. |
+| **Disclosure recommended / invited** — "should disclose", "we ask you to indicate AI", "feel free to mention AI tools" | Treat presence of AI attribution as acceptable. Do NOT flag it. |
+| **No explicit policy** | Default rule — flag AI attribution as a `Recommended` issue (verify the target repo accepts this before merge). |
+
+When the repo's docs are unfetchable (network failure, repo without CONTRIBUTING.md), state that explicitly in the report instead of silently falling through to the default — the user should know the rule was inferred without evidence.
+
+Precision over recall: a false positive on either side actively misleads the user. If a phrase doesn't combine an explicit verb (`must`, `ban`, `disclose`, `should`) with an AI/LLM noun, do NOT classify the regime.
 
 ## Principles
 - Constructive, not critical.

--- a/packages/core/src/core/anti-llm-policy.test.ts
+++ b/packages/core/src/core/anti-llm-policy.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { scanForAntiLLMPolicy } from './anti-llm-policy.js';
+import { scanForAntiLLMPolicy, scanAIDisclosureRequirement } from './anti-llm-policy.js';
 
 describe('scanForAntiLLMPolicy', () => {
   it('returns matched=false for empty text', () => {
@@ -160,6 +160,142 @@ describe('scanForAntiLLMPolicy', () => {
       expect(() => scanForAntiLLMPolicy(undefined)).toThrow(TypeError);
       // @ts-expect-error — runtime contract check
       expect(() => scanForAntiLLMPolicy(Buffer.from('hello'))).toThrow(TypeError);
+    });
+  });
+});
+
+describe('scanAIDisclosureRequirement (#1269)', () => {
+  it('returns matched=false for empty text', () => {
+    const result = scanAIDisclosureRequirement('');
+    expect(result.matched).toBe(false);
+    expect(result.matches).toEqual([]);
+  });
+
+  it('returns matched=false for ordinary contributing prose', () => {
+    const result = scanAIDisclosureRequirement(
+      'Welcome! Please read the contributing guide. Open a PR with tests and a clear description.',
+    );
+    expect(result.matched).toBe(false);
+  });
+
+  describe('mandatory disclosure signals', () => {
+    it('matches "must disclose AI use"', () => {
+      const result = scanAIDisclosureRequirement('Contributors must disclose AI use in the PR description.');
+      expect(result.matched).toBe(true);
+      expect(result.matches.some((m) => m.category === 'mandatory')).toBe(true);
+    });
+
+    it('matches "required to indicate AI assistance"', () => {
+      const result = scanAIDisclosureRequirement('You are required to indicate AI assistance when submitting a PR.');
+      expect(result.matched).toBe(true);
+      expect(result.matches.some((m) => m.category === 'mandatory')).toBe(true);
+    });
+
+    it('matches "PRs using AI must be labeled"', () => {
+      const result = scanAIDisclosureRequirement('PRs using AI tools must be labeled with [ai].');
+      expect(result.matched).toBe(true);
+      expect(result.matches.some((m) => m.category === 'mandatory')).toBe(true);
+    });
+
+    it('matches passive form "disclosure of AI is required"', () => {
+      const result = scanAIDisclosureRequirement('Disclosure of AI use is required in commit messages.');
+      expect(result.matched).toBe(true);
+      expect(result.matches.some((m) => m.category === 'mandatory')).toBe(true);
+    });
+
+    it('matches "must credit Copilot" (named tool)', () => {
+      const result = scanAIDisclosureRequirement('All contributors must credit Copilot when used.');
+      expect(result.matched).toBe(true);
+      expect(result.matches.some((m) => m.category === 'mandatory')).toBe(true);
+    });
+  });
+
+  describe('recommended disclosure signals', () => {
+    it('matches "should disclose AI"', () => {
+      const result = scanAIDisclosureRequirement('You should disclose AI use in your PR.');
+      expect(result.matched).toBe(true);
+      expect(result.matches.some((m) => m.category === 'recommended')).toBe(true);
+    });
+
+    it('matches "we ask you to indicate AI"', () => {
+      const result = scanAIDisclosureRequirement('We ask you to indicate AI assistance for transparency.');
+      expect(result.matched).toBe(true);
+      expect(result.matches.some((m) => m.category === 'recommended')).toBe(true);
+    });
+
+    it('matches "we strongly encourage acknowledging AI"', () => {
+      const result = scanAIDisclosureRequirement('We strongly encourage acknowledging AI tools.');
+      expect(result.matched).toBe(true);
+      expect(result.matches.some((m) => m.category === 'recommended')).toBe(true);
+    });
+
+    it('matches imperative "credit AI tools you used"', () => {
+      const result = scanAIDisclosureRequirement('Credit AI tools you used.');
+      expect(result.matched).toBe(true);
+      expect(result.matches.some((m) => m.category === 'recommended')).toBe(true);
+    });
+  });
+
+  describe('invited disclosure signals', () => {
+    it('matches "feel free to mention AI"', () => {
+      const result = scanAIDisclosureRequirement('Feel free to mention AI tools you used in the PR description.');
+      expect(result.matched).toBe(true);
+      expect(result.matches.some((m) => m.category === 'invited')).toBe(true);
+    });
+
+    it('matches "you are welcome to disclose AI"', () => {
+      const result = scanAIDisclosureRequirement(
+        'You are welcome to disclose AI assistance, though it is not required.',
+      );
+      expect(result.matched).toBe(true);
+      expect(result.matches.some((m) => m.category === 'invited')).toBe(true);
+    });
+  });
+
+  describe('false-positive resistance', () => {
+    it('does not match anti-AI policy as disclosure', () => {
+      // The text bans AI; it should not also register as inviting AI disclosure.
+      const result = scanAIDisclosureRequirement('We do not accept AI-generated code.');
+      expect(result.matched).toBe(false);
+    });
+
+    it('does not match incidental "AI" mentions without a disclosure verb', () => {
+      const result = scanAIDisclosureRequirement(
+        'Our team uses AI tools internally. The release process is documented in RELEASING.md.',
+      );
+      expect(result.matched).toBe(false);
+    });
+
+    it('does not match a feature description with "credit" in unrelated context', () => {
+      // "credit" appears, but not paired with an AI-tool noun.
+      const result = scanAIDisclosureRequirement('See the CREDITS file for our list of contributors.');
+      expect(result.matched).toBe(false);
+    });
+
+    it('does not match "we use AI to label issues" (workflow description, not policy)', () => {
+      const result = scanAIDisclosureRequirement('Our triage bot uses AI to label issues automatically.');
+      expect(result.matched).toBe(false);
+    });
+  });
+
+  describe('input validation', () => {
+    it('throws on non-string input rather than silently returning matched=false', () => {
+      // @ts-expect-error — runtime contract check
+      expect(() => scanAIDisclosureRequirement(null)).toThrow(TypeError);
+      // @ts-expect-error — runtime contract check
+      expect(() => scanAIDisclosureRequirement(undefined)).toThrow(TypeError);
+    });
+  });
+
+  describe('excerpt extraction', () => {
+    it('returns the matched phrase and a windowed excerpt', () => {
+      const text =
+        'Lots of preamble here describing the project. Contributors must disclose AI use in the PR. Then more text follows.';
+      const result = scanAIDisclosureRequirement(text);
+      expect(result.matched).toBe(true);
+      const match = result.matches[0];
+      expect(match.excerpt).toContain('disclose');
+      expect(match.excerpt.length).toBeLessThan(text.length);
     });
   });
 });

--- a/packages/core/src/core/anti-llm-policy.ts
+++ b/packages/core/src/core/anti-llm-policy.ts
@@ -1,26 +1,35 @@
 /**
- * Anti-LLM policy scan (#108, #911, #979).
+ * AI/LLM policy scans (#108, #911, #979, #1269).
  *
- * Scan concatenated repo docs (CONTRIBUTING.md, CODE_OF_CONDUCT.md,
- * README) for language that indicates the project does not accept
- * AI/LLM-generated contributions. Previously described as a keyword
- * table in prose in agents/issue-scout.md.
+ * Two complementary scanners over the same input (concatenated repo docs
+ * — CONTRIBUTING.md, CODE_OF_CONDUCT.md, README, etc.):
+ *
+ * 1. {@link scanForAntiLLMPolicy} — detects language indicating the
+ *    project does NOT accept AI/LLM-generated contributions. Used by
+ *    issue-scout / repo-evaluator to filter out repos where landing a
+ *    PR is impossible.
+ *
+ * 2. {@link scanAIDisclosureRequirement} — detects the opposite:
+ *    language requiring or inviting AI disclosure ("must disclose AI
+ *    use", "credit AI tools"). Used by pr-compliance-checker to decide
+ *    whether AI attribution should be flagged as a violation, encouraged,
+ *    or required (#1269 Improvement C).
  *
  * The long-term home for this logic is `@oss-scout/core`, where the
  * relevant files are already fetched during vetting. Keeping it here
  * for now lets the agent invoke it directly and gives scout a
  * reference implementation + test fixtures to adopt. See #979.
  *
- * Precision matters more than recall. False positives (flagging a
- * project that actually welcomes AI help) silently shrink the user's
- * contribution surface without recourse. We only match on phrases
- * that combine a rejection keyword (no / reject / will be closed /
- * don't accept) with an AI/LLM noun.
+ * Precision matters more than recall in both directions. A false
+ * positive on the anti-LLM side silently shrinks the user's
+ * contribution surface; a false positive on the disclosure side tells
+ * the user to add attribution that the maintainer didn't actually ask
+ * for. Patterns require an explicit verb-phrase + AI/LLM-noun pairing.
  *
  * **User-facing reference:** `docs/anti-llm-policy.md` — explains the
- * three categories, example phrases per category, and the false-positive-
- * resistance design (why "AI division will be closed at end of Q4"
- * does NOT match).
+ * three anti-LLM categories, example phrases per category, and the
+ * false-positive-resistance design (why "AI division will be closed at
+ * end of Q4" does NOT match).
  */
 
 export type AntiLLMCategory = 'explicit_ban' | 'tool_ban' | 'reject_framing';
@@ -118,6 +127,131 @@ export function scanForAntiLLMPolicy(text: string): AntiLLMScanResult {
   const matches: AntiLLMMatch[] = [];
 
   for (const pattern of PATTERNS) {
+    const hit = normalized.match(pattern.regex);
+    if (!hit || hit.index === undefined) continue;
+    const phrase = hit[0];
+    const key = `${pattern.category}:${phrase.toLowerCase()}`;
+    if (seenLabels.has(key)) continue;
+    seenLabels.add(key);
+    matches.push({
+      category: pattern.category,
+      phrase,
+      excerpt: makeExcerpt(normalized, hit.index, phrase.length),
+    });
+  }
+
+  return { matched: matches.length > 0, matches };
+}
+
+// ── AI Disclosure Requirement Scan (#1269 Improvement C) ─────────────────
+//
+// Sibling to scanForAntiLLMPolicy, scanning the same input for the OPPOSITE
+// signal: language that requires or invites disclosure of AI assistance.
+// Three categories (most → least binding):
+//
+//   - 'mandatory'  — "must disclose", "required to indicate", etc.
+//   - 'recommended' — "credit AI tools", "we appreciate disclosure"
+//   - 'invited'    — "feel free to mention if you used AI"
+//
+// Consumers (today: pr-compliance-checker via prompt) combine this with
+// scanForAntiLLMPolicy to choose between three regimes:
+//
+//   - Anti-LLM matched → flag AI attribution as fail
+//   - Disclosure required → flag MISSING attribution as fail (when caller
+//     knows AI was used) / no-op otherwise
+//   - Neither matched → keep current default (flag attribution as warn)
+
+export type AIDisclosureCategory = 'mandatory' | 'recommended' | 'invited';
+
+export interface AIDisclosureMatch {
+  category: AIDisclosureCategory;
+  phrase: string;
+  excerpt: string;
+}
+
+export interface AIDisclosureScanResult {
+  matched: boolean;
+  matches: AIDisclosureMatch[];
+}
+
+interface DisclosurePattern {
+  category: AIDisclosureCategory;
+  regex: RegExp;
+}
+
+const DISCLOSURE_PATTERNS: DisclosurePattern[] = [
+  // Mandatory: imperative verbs binding to an AI/LLM disclosure noun.
+  // Match shape: <verb-phrase> <AI noun> <disclosure noun>?
+  // Verb phrases: "must disclose", "required to disclose", "are required
+  // to indicate", "you must indicate". The optional disclosure-action
+  // noun catches "must disclose use of AI" without requiring a separate
+  // pattern. The AI noun can be plain "ai/llm" or a tool name.
+  {
+    category: 'mandatory',
+    regex:
+      /\b(must|required\s+to|are\s+required\s+to)\s+(disclose|indicate|declare|note|state|mention|label|tag|credit|acknowledge)\s+(?:[a-z\s'-]{0,40}?\b)?(ai|llm|generative\s+ai|copilot|chatgpt|claude|cursor)\b/i,
+  },
+  // "PRs using AI must be labeled / tagged / disclosed"
+  {
+    category: 'mandatory',
+    regex:
+      /\b(prs?|contributions?|commits?|code)\s+(using|generated\s+by|written\s+by|made\s+with)\s+(ai|llm|copilot|chatgpt|claude|cursor)\s+(?:tools?\s+)?(must\s+be|need\s+to\s+be|are\s+to\s+be)\s+(labeled|tagged|disclosed|marked|flagged|noted)\b/i,
+  },
+  // "Disclosure of AI assistance is required" — passive form
+  {
+    category: 'mandatory',
+    regex:
+      /\b(disclosure|disclosing|labeling|labelling|tagging|crediting)\s+(of\s+)?(ai|llm|copilot|chatgpt|claude|cursor)(\s+(use|usage|assistance|tools?|contributions?|generated\s+code))?\s+(is\s+required|is\s+mandatory|must\s+be\s+included)\b/i,
+  },
+
+  // Recommended: softer "should" or "we ask" framing. Same noun anchors.
+  // Verb forms allow optional gerund (-ing) endings since "we strongly
+  // encourage acknowledging AI" reads naturally even though "acknowledge"
+  // is the bare verb in the imperative list.
+  {
+    category: 'recommended',
+    regex:
+      /\b(should|we\s+ask\s+you\s+to|we\s+ask\s+that\s+you|we\s+(?:strongly\s+)?(?:encourage|recommend))\s+(disclose|disclosing|indicate|indicating|declare|declaring|note|noting|mention|mentioning|label|labeling|labelling|tag|tagging|credit|crediting|acknowledge|acknowledging)\s+(?:[a-z\s'-]{0,40}?\b)?(ai|llm|generative\s+ai|copilot|chatgpt|claude|cursor)\b/i,
+  },
+  // "credit AI tools you used" — direct imperative without "must/should"
+  {
+    category: 'recommended',
+    regex: /\b(credit|acknowledge|attribute)\s+(ai|llm|generative\s+ai)\s+(tools?|assistants?|use|usage|assistance)\b/i,
+  },
+
+  // Invited: permissive framing. Lower confidence.
+  // The "please" branch is dropped intentionally — bare "please mention X"
+  // doesn't carry enough policy weight on its own, and including it as
+  // `please\s+(?:feel\s+free\s+to)?\s+` introduces super-linear backtracking
+  // (regexp/no-super-linear-backtracking) because of the ambiguous \s+
+  // boundary on either side of the optional group.
+  {
+    category: 'invited',
+    regex:
+      /\b(feel\s+free\s+to|please\s+feel\s+free\s+to|you('re|\s+are)\s+welcome\s+to|welcome\s+to)\s+(disclose|mention|note|indicate|label|tag|credit)\s+(?:[a-z\s'-]{0,40}?\b)?(ai|llm|generative\s+ai|copilot|chatgpt|claude|cursor)\b/i,
+  },
+];
+
+/**
+ * Scan repo docs for language requiring or inviting AI disclosure (#1269).
+ *
+ * Mirrors {@link scanForAntiLLMPolicy}'s shape: same input contract,
+ * same false-positive-resistance discipline, same per-match excerpt for
+ * surfacing to the user. Categories are ordered by binding strength —
+ * callers that want to avoid false-positive flagging on weak invitations
+ * can filter to 'mandatory' / 'recommended' only.
+ */
+export function scanAIDisclosureRequirement(text: string): AIDisclosureScanResult {
+  if (typeof text !== 'string') {
+    throw new TypeError(`scanAIDisclosureRequirement: expected string, received ${typeof text}`);
+  }
+  if (text === '') return { matched: false, matches: [] };
+
+  const normalized = normalizeText(text);
+  const seenLabels = new Set<string>();
+  const matches: AIDisclosureMatch[] = [];
+
+  for (const pattern of DISCLOSURE_PATTERNS) {
     const hit = normalized.match(pattern.regex);
     if (!hit || hit.index === undefined) continue;
     const phrase = hit[0];


### PR DESCRIPTION
## Summary

Closes #1269 Improvement C. Adds a sibling to `scanForAntiLLMPolicy` (#911) that scans repo docs for language requiring or inviting AI disclosure, and updates the `pr-compliance-checker` agent prompt to apply the matching regime instead of unconditionally flagging AI attribution.

## What's in the diff

**Core**: `packages/core/src/core/anti-llm-policy.ts`
- New `scanAIDisclosureRequirement(text)` function with three categories (`mandatory` / `recommended` / `invited`).
- Patterns require an explicit verb (`must` / `should` / `disclose` / `credit`) + an AI/LLM noun. False-positive-resistant by design: "we use AI to label issues" (workflow description) and "see CREDITS file" (unrelated context) don't match.
- Module doc updated to cover both directions of the policy spectrum.

**Tests**: 22 new unit cases in `anti-llm-policy.test.ts` covering each category, false-positive resistance, excerpt extraction, and input validation.

**Agent prompt**: `agents/pr-compliance-checker.md` — replaces the one-line "flag any AI attribution" rule with a four-row regime table:

| Regime detected | Rule |
|---|---|
| Anti-LLM matched | Flag attribution as Critical |
| Disclosure mandatory | Flag ABSENCE as Critical when AI was used |
| Disclosure recommended / invited | Treat attribution as acceptable, do NOT flag |
| No explicit policy | Default — flag attribution as Recommended |

## What's deferred

- **Improvement A** (size thresholds become relative to repo norms): overlaps with #1242's repo-vet integration; better landed after the per-PR repo-vet hookup is in place.
- **CLI / MCP wrapping**: the typed scan function exists in core for future programmatic invocation. Today the agent applies the rule via its reasoning over fetched CONTRIBUTING.md content. The function names in the prompt point at the deterministic implementation as a reference for when the scan output gets wired into the vet pipeline (or surfaced as a separate CLI command).

## Test plan

- [x] `pnpm --filter @oss-autopilot/core run test` — 2536 passing (+22 new for #1269)
- [x] `pnpm --filter @oss-autopilot/core run build` — clean
- [x] `pnpm -w run typecheck` — clean
- [x] `pnpm -w run lint` — 0 errors (1567 pre-existing warnings, none new)
- [x] Lint flagged super-linear backtracking on one initial pattern; tightened the regex to remove the ambiguous \\s+ boundary (kept only "feel free to" / "please feel free to" as full phrases, dropped bare "please").