### PR TITLE
refactor: bump repo-evaluator model haiku → sonnet (#1242 Improvement 4)

### DIFF
--- a/agents/repo-evaluator.md
+++ b/agents/repo-evaluator.md
@@ -21,7 +21,7 @@ User wants to predict maintainer engagement before contributing.
 </example>
 
 purpose: Analyze repository health
-model: haiku
+model: sonnet
 color: blue
 tools: ["Bash", "Read", "Glob", "mcp__plugin_oss-autopilot_oss-autopilot__vet", "mcp__plugin_oss-autopilot_oss-autopilot__repo-vet"]
 ---


### PR DESCRIPTION
## Summary

Closes #1242 Improvement 4. With #1's repo-vet plumbing landed (#1271), the agent's job has shifted from data assembly to interpretive synthesis. Sonnet handles "weigh contradictory signals + write the recommendation paragraph" better than haiku.

The agent is not hot-pathed (one invocation per repo evaluated, cached after), so the cost increase is bounded.

## What's deferred

- **Improvement 2** (dormant-self-PR personalization): the proposed `status`-based check assumes per-PR dormancy data in status's output, but status only returns aggregates today. Cleanly implementing requires either extending status to surface open PRs with maintainer-activity metadata, OR adding `daily` to the agent's tool list — both bigger than this PR's scope.
- **Improvement 3** (proactively fetch first-review timing): the prompt already has a per-PR `gh api .../reviews` fallback for explicit user requests; making it proactive cleanly needs a small data-shape change so the agent doesn't fabricate from list metadata.

## Test plan

- [x] `pnpm --filter @oss-autopilot/core run test` — 2517 passing
- [x] `pnpm -w run lint` — 0 errors
- [x] Verified `repo-evaluator` not present in any test that pins the haiku/sonnet split (the model bump is invisible to the contract layer).