### PR TITLE
test: pin guard-public-posts matcher to destructiveHint annotations (#1302 item 2)

### DIFF
--- a/hooks/guard-public-posts.sh
+++ b/hooks/guard-public-posts.sh
@@ -9,6 +9,13 @@
 #   - Bash — inspects `tool_input.command` against a regex of gh/CLI patterns
 #   - mcp__plugin_oss-autopilot_oss-autopilot__(post|claim) — always asks
 #
+# Drift-resistance: `packages/mcp-server/src/tools.test.ts`
+# (`describe('hooks.json guard-public-posts matcher (#1302 item 2)')`)
+# pins the matcher's plugin-tool list to the tool registry's
+# `destructiveHint` annotations. Adding a new tool with `destructiveHint:
+# true` that posts publicly without updating the matcher fails CI; an
+# explicit exclusion list covers the LOCAL_ONLY_DESTRUCTIVE case.
+#
 # Known static-analysis limits (regressions here are intentional gaps, not
 # silent failures — they're called out with explicit test assertions in
 # guard-public-posts.test.sh):

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -1,7 +1,13 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { createServer } from './server.js';
+
+const TESTS_DIR = path.dirname(fileURLToPath(import.meta.url));
+const HOOKS_JSON_PATH = path.resolve(TESTS_DIR, '../../../hooks/hooks.json');
 
 /** All registered tool names (untrack and read removed in v4 — #1133;
  * compliance-score added in #1245). */
@@ -199,6 +205,94 @@ describe('MCP tool registrations', () => {
     it.each(['post', 'claim'])('destructive tool "%s" description warns about irreversibility', (name) => {
       const tool = tools.find((t) => t.name === name);
       expect(tool!.description).toMatch(/irreversible/i);
+    });
+  });
+
+  // ── hooks.json guard-public-posts matcher consistency (#1302 item 2) ──
+  //
+  // The guard-public-posts.sh hook fires on a PreToolUse matcher in
+  // hooks/hooks.json. Today the matcher is hand-curated; this contract
+  // makes it drift-resistant by pinning it to the tool registry's
+  // `destructiveHint` annotation: every plugin tool with
+  // `destructiveHint: true` that produces an externally-visible event
+  // MUST be in the matcher, and every plugin tool in the matcher MUST
+  // carry the destructiveHint annotation. New gating tools therefore get
+  // covered automatically — adding a tool with `destructiveHint: true`
+  // and forgetting to update the matcher fails CI.
+  //
+  // Tools that are destructive to LOCAL state but don't post publicly
+  // (the canonical example today is `guidelines-reset`, which tombstones
+  // the user's gist file) are listed below as explicit exclusions. The
+  // exclusion is a rare exception, not the default — the bar is "this
+  // tool is destructive but does not produce an externally-visible
+  // GitHub event under the user's identity."
+  describe('hooks.json guard-public-posts matcher (#1302 item 2)', () => {
+    /** Plugin tools with destructiveHint:true that operate on local state only. */
+    const LOCAL_ONLY_DESTRUCTIVE = new Set(['guidelines-reset']);
+    const PLUGIN_TOOL_PREFIX = 'mcp__plugin_oss-autopilot_oss-autopilot__';
+
+    function loadGuardMatcher(): string {
+      const hooksJson = JSON.parse(fs.readFileSync(HOOKS_JSON_PATH, 'utf8'));
+      const preToolUse = hooksJson.hooks.PreToolUse as Array<{
+        matcher: string;
+        hooks: Array<{ command: string }>;
+      }>;
+      const guardEntry = preToolUse.find((entry) =>
+        entry.hooks.some((h) => h.command.includes('guard-public-posts.sh')),
+      );
+      if (!guardEntry) {
+        throw new Error('hooks.json has no PreToolUse entry pointing at guard-public-posts.sh');
+      }
+      return guardEntry.matcher;
+    }
+
+    function pluginToolsInMatcher(matcher: string): string[] {
+      return matcher
+        .split('|')
+        .map((m) => m.trim())
+        .filter((m) => m.startsWith(PLUGIN_TOOL_PREFIX))
+        .map((m) => m.slice(PLUGIN_TOOL_PREFIX.length));
+    }
+
+    it('every destructive plugin tool that posts publicly is in the matcher', () => {
+      const matcher = loadGuardMatcher();
+      const missing: string[] = [];
+      for (const tool of tools) {
+        const ann = (tool.annotations ?? {}) as Record<string, unknown>;
+        if (ann.destructiveHint !== true) continue;
+        if (LOCAL_ONLY_DESTRUCTIVE.has(tool.name)) continue;
+        const fullName = `${PLUGIN_TOOL_PREFIX}${tool.name}`;
+        if (!matcher.includes(fullName)) missing.push(tool.name);
+      }
+      expect(missing, `Tools missing from guard-public-posts matcher: ${missing.join(', ')}`).toEqual([]);
+    });
+
+    it('every plugin tool in the matcher has destructiveHint:true', () => {
+      const matcher = loadGuardMatcher();
+      const matchedNames = pluginToolsInMatcher(matcher);
+      for (const name of matchedNames) {
+        const tool = tools.find((t) => t.name === name);
+        expect(tool, `Matcher references "${name}" but no such tool is registered`).toBeDefined();
+        const ann = (tool!.annotations ?? {}) as Record<string, unknown>;
+        expect(
+          ann.destructiveHint,
+          `"${name}" is in the matcher but lacks destructiveHint:true — either add the annotation or remove from matcher`,
+        ).toBe(true);
+      }
+    });
+
+    it('LOCAL_ONLY_DESTRUCTIVE entries actually exist as registered tools with destructiveHint:true', () => {
+      // Guard against the exclusion list going stale (a tool gets renamed
+      // or de-flagged but still appears here).
+      for (const name of LOCAL_ONLY_DESTRUCTIVE) {
+        const tool = tools.find((t) => t.name === name);
+        expect(tool, `LOCAL_ONLY_DESTRUCTIVE entry "${name}" is not a registered tool`).toBeDefined();
+        const ann = (tool!.annotations ?? {}) as Record<string, unknown>;
+        expect(
+          ann.destructiveHint,
+          `LOCAL_ONLY_DESTRUCTIVE entry "${name}" must have destructiveHint:true (or remove from list)`,
+        ).toBe(true);
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #1302 item 2. The `hooks.json` PreToolUse matcher for `guard-public-posts.sh` has been hand-curated. Adding a new MCP tool that posts publicly without remembering to update the matcher silently bypasses the guard — exactly the drift class #1302 targets.

This pins the matcher to the tool registry's `destructiveHint` annotations via three contract tests. New gating tools get auto-covered.

## What's in the diff

**`packages/mcp-server/src/tools.test.ts`** — three new tests under `describe('hooks.json guard-public-posts matcher (#1302 item 2)')`:

1. **Forward direction**: every plugin tool with `destructiveHint: true` MUST appear in the matcher. Catches "added a destructive tool, forgot the hook."
2. **Reverse direction**: every plugin tool in the matcher MUST carry `destructiveHint: true`. Catches typos and removed tools.
3. **Exclusion-list health**: the `LOCAL_ONLY_DESTRUCTIVE` set (currently `['guidelines-reset']`) must contain only registered tools with `destructiveHint: true`. Catches stale entries.

The exclusion list is for the rare "destructive but doesn't post publicly" case. `guidelines-reset` tombstones the user's gist file — destructive but local-only. Future destructive-but-local tools land there with a one-line justification rather than slipping into the public-posts matcher unnecessarily.

**`hooks/guard-public-posts.sh`** — comment documenting the new test coverage so a future maintainer reading the hook sees where the contract is enforced.

## What's deferred (#1302 item 1)

Item 1 (general MCP tool contract test) is mostly already covered by existing `tools.test.ts` assertions on `EXPECTED_TOOLS` and the per-tool annotation checks. If specific gaps remain those should ship as small follow-ups rather than expanding this PR.

## Test plan

- [x] `pnpm --filter @oss-autopilot/mcp run test` — 209 passing (+3 new for #1302 item 2)
- [x] `pnpm -w run lint` — 0 errors
- [x] Verified the test fails as expected when I temporarily removed `post` from the matcher (would catch a real regression).