### PR TITLE
feat: surface periodic strategy snapshot in /oss action menu (#1270 Steps 2+3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ env:
   #   - **Don't bump for a flaky measurement:** esbuild output is
   #     deterministic. If the threshold trips on a no-op rebuild, it's a
   #     real increase somewhere upstream — not noise.
-  BUNDLE_MAX_CORE: 820000 # ~801 KB (increased for compliance-score command + linked-issue verification, #1245/#1246)
+  BUNDLE_MAX_CORE: 832000 # ~812 KB (increased for the post-3.5 batch: list-mark-done CLI + ciCategorization on FetchedPR + strategy snapshot wiring + AI-disclosure scan; #1270/#1272/#1299)
   BUNDLE_MAX_MCP: 2000000 # ~1953 KB
   STARTUP_WARN_MS: 500 # Warn if CLI startup exceeds 500ms
 

--- a/commands/oss.md
+++ b/commands/oss.md
@@ -185,7 +185,32 @@ Use AskUserQuestion with these options:
 
 ## Action Menu
 
-Read `${CLAUDE_PLUGIN_ROOT}/workflows/action-menu.md` and follow the instructions to display PRs and present the action menu. After the user selects an action, continue to **Execute** below.
+**If `data.daily.strategySummary` is present and non-null** (#1270), render a brief snapshot inline ahead of the action options. The cadence gate fires every 30 days OR after 5+ PRs merge since the last snapshot, whichever comes first; below the merge floor (`STRATEGY_MIN_PRS = 10`) the field is omitted.
+
+Format:
+
+```
+## Strategy snapshot
+- {profile.totalPRs} PRs tracked, {profile.mergedCount} merged ({Math.round(profile.mergeRate × 100)}% merge rate). Profile: {profile.style}.
+- {capacity.dormantPRCount} dormant PR(s) across {capacity.dormantRepoCount} repo(s). {SUGGESTED_ACTION_PROSE}
+- Top languages: {profile.primaryLanguages.join(', ')}. Top repos: {profile.favoriteRepos.join(', ')}.
+- Pattern: {patterns.trajectoryDirection}.
+
+For a deeper dive, ask the contribution-strategist agent.
+```
+
+`SUGGESTED_ACTION_PROSE` is a fixed mapping from `capacity.suggestedAction` — render exactly the matching string, do NOT paraphrase:
+
+| `suggestedAction` | Prose |
+|---|---|
+| `'open_more'` | "Capacity to open more PRs." |
+| `'follow_up_dormant'` | "Follow up on dormant PRs before opening more." |
+| `'wait_on_maintainers'` | "Wait on maintainers; don't open new PRs yet." |
+| `null` | omit the sentence (and the trailing period after `repo(s)`) |
+
+If `recommendations.avoidPatterns` is non-empty, append a fifth bullet `- Watch for: {recommendations.avoidPatterns[0]}` — those strings come from `computeStrategy()` pre-formatted, render verbatim.
+
+Then read `${CLAUDE_PLUGIN_ROOT}/workflows/action-menu.md` and follow the instructions to display PRs and present the action menu. After the user selects an action, continue to **Execute** below.
 
 ---
 

--- a/packages/core/src/commands/daily-orchestration.test.ts
+++ b/packages/core/src/commands/daily-orchestration.test.ts
@@ -74,6 +74,7 @@ vi.mock('../core/index.js', async (importOriginal) => {
       setMonthlyClosedCounts: mockSetMonthlyClosedCounts,
       setMonthlyOpenedCounts: mockSetMonthlyOpenedCounts,
       setLastDigest: mockSetLastDigest,
+      setLastStrategyAt: vi.fn(),
       save: mockSave,
       isPRShelved: mockIsPRShelved,
       unshelvePR: mockUnshelvePR,

--- a/packages/core/src/commands/daily.ts
+++ b/packages/core/src/commands/daily.ts
@@ -33,6 +33,7 @@ import {
   type RepoGroup,
 } from '../core/index.js';
 import { errorMessage, isRateLimitOrAuthError } from '../core/errors.js';
+import { computeStrategy, shouldComputeStrategy, type StrategyResult } from '../core/strategy.js';
 import { warn } from '../core/logger.js';
 import { emptyPRCountsResult } from '../core/github-stats.js';
 import { createAutopilotScout } from './scout-bridge.js';
@@ -127,6 +128,13 @@ export interface DailyCheckResult {
   failures: PRCheckFailure[];
   /** Non-fatal warnings from ancillary pipeline phases — see #1042. */
   warnings: DailyWarning[];
+  /**
+   * Periodic strategy snapshot (#1270). Set when the cadence trigger
+   * fires AND the user has crossed `STRATEGY_MIN_PRS`. The action-menu
+   * renderer in `commands/oss.md` reads this; absent or null on runs
+   * where the gate stays silent.
+   */
+  strategySummary?: StrategyResult | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -600,6 +608,24 @@ function generateDigestOutput(
   const actionMenu = computeActionMenu(actionableIssues, capacity, filteredCommentedIssues);
   const repoGroups = groupPRsByRepo(activePRs);
 
+  // Periodic strategy snapshot (#1270 Step 2). Cadence-gated to fire every
+  // 30 days OR after 5+ PRs merge since the last snapshot, whichever comes
+  // first. Below STRATEGY_MIN_PRS the gate stays silent. Compute failures
+  // are non-fatal — the daily run continues and the snapshot is omitted.
+  let strategySummary: StrategyResult | null | undefined;
+  try {
+    const state = stateManager.getState();
+    const nowIso = new Date().toISOString();
+    if (shouldComputeStrategy(state, nowIso)) {
+      strategySummary = computeStrategy(state);
+      if (strategySummary) {
+        stateManager.setLastStrategyAt(nowIso);
+      }
+    }
+  } catch (error) {
+    recordWarning(warnings, 'analytics', 'compute strategy snapshot', error);
+  }
+
   return {
     digest,
     capacity,
@@ -611,6 +637,7 @@ function generateDigestOutput(
     repoGroups,
     failures,
     warnings,
+    strategySummary,
   };
 }
 
@@ -638,6 +665,7 @@ export function toDailyOutput(result: DailyCheckResult): DailyOutput {
     repoGroups: compactRepoGroups(result.repoGroups),
     failures: result.failures,
     warnings: result.warnings,
+    strategySummary: result.strategySummary,
   };
 }
 

--- a/packages/core/src/core/state-schema.ts
+++ b/packages/core/src/core/state-schema.ts
@@ -363,6 +363,16 @@ export const AgentStateSchema = z.object({
 
   lastDigestAt: z.string().optional(),
 
+  /**
+   * ISO timestamp of the most recent {@link computeStrategy} invocation
+   * embedded in a daily run output (#1270). The cadence gate in
+   * `daily.ts` consults this — strategy snapshots fire every 30 days OR
+   * when 5+ PRs have merged since the last snapshot, whichever comes
+   * first. Below {@link STRATEGY_MIN_PRS} merged PRs the gate stays
+   * silent regardless of cadence.
+   */
+  lastStrategyAt: z.string().optional(),
+
   lastDigest: DailyDigestSchema.optional(),
 
   monthlyMergedCounts: z.record(z.string(), z.number()).optional(),

--- a/packages/core/src/core/state.ts
+++ b/packages/core/src/core/state.ts
@@ -491,6 +491,17 @@ export class StateManager {
   }
 
   /**
+   * Persist the timestamp of the most recent strategy snapshot embedded
+   * in a daily run output (#1270). Called from the daily pipeline after
+   * `computeStrategy()` succeeds; the cadence gate in
+   * {@link shouldComputeStrategy} reads this on the next run.
+   */
+  setLastStrategyAt(iso: string): void {
+    this.state.lastStrategyAt = iso;
+    this.autoSave();
+  }
+
+  /**
    * Update monthly merged PR counts for dashboard display.
    * @param counts - Monthly merged PR counts keyed by YYYY-MM
    */

--- a/packages/core/src/core/strategy.test.ts
+++ b/packages/core/src/core/strategy.test.ts
@@ -8,7 +8,13 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { computeStrategy, STRATEGY_MIN_PRS } from './strategy.js';
+import {
+  computeStrategy,
+  shouldComputeStrategy,
+  STRATEGY_CADENCE_DAYS,
+  STRATEGY_CADENCE_MERGED_DELTA,
+  STRATEGY_MIN_PRS,
+} from './strategy.js';
 import { AgentStateSchema } from './state-schema.js';
 import type { AgentState } from './state-schema.js';
 
@@ -257,5 +263,88 @@ describe('computeStrategy — trajectory', () => {
       },
     });
     expect(computeStrategy(state)?.patterns.trajectoryDirection).toBe('declining');
+  });
+});
+
+describe('shouldComputeStrategy — cadence gate (#1270 Step 2)', () => {
+  const NOW = '2026-05-09T12:00:00.000Z';
+  const NOW_MS = Date.parse(NOW);
+  const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+  function isoDaysAgo(days: number): string {
+    return new Date(NOW_MS - days * ONE_DAY_MS).toISOString();
+  }
+
+  it('returns false below the merge floor regardless of timestamps', () => {
+    const state = makeState({
+      mergedPRs: Array.from({ length: STRATEGY_MIN_PRS - 1 }, (_, i) =>
+        makeMergedPR('a/r', i + 1, { mergedAt: isoDaysAgo(60) }),
+      ),
+    });
+    expect(shouldComputeStrategy(state, NOW)).toBe(false);
+  });
+
+  it('returns true on the first run (lastStrategyAt absent) above the merge floor', () => {
+    const state = makeState({
+      mergedPRs: Array.from({ length: STRATEGY_MIN_PRS }, (_, i) =>
+        makeMergedPR('a/r', i + 1, { mergedAt: isoDaysAgo(60) }),
+      ),
+    });
+    expect(shouldComputeStrategy(state, NOW)).toBe(true);
+  });
+
+  it('returns false when last snapshot is recent and merge delta is below the threshold', () => {
+    // 5 days ago, with 2 PRs merged since — both gates should be silent.
+    const state = makeState({
+      mergedPRs: [
+        ...Array.from({ length: STRATEGY_MIN_PRS }, (_, i) => makeMergedPR('a/r', i + 1, { mergedAt: isoDaysAgo(60) })),
+        makeMergedPR('a/r', 99, { mergedAt: isoDaysAgo(2) }),
+        makeMergedPR('a/r', 100, { mergedAt: isoDaysAgo(1) }),
+      ],
+      lastStrategyAt: isoDaysAgo(5),
+    });
+    expect(shouldComputeStrategy(state, NOW)).toBe(false);
+  });
+
+  it(`returns true when ${STRATEGY_CADENCE_DAYS}+ days have elapsed since the last snapshot`, () => {
+    const state = makeState({
+      mergedPRs: Array.from({ length: STRATEGY_MIN_PRS }, (_, i) =>
+        makeMergedPR('a/r', i + 1, { mergedAt: isoDaysAgo(120) }),
+      ),
+      lastStrategyAt: isoDaysAgo(STRATEGY_CADENCE_DAYS + 1),
+    });
+    expect(shouldComputeStrategy(state, NOW)).toBe(true);
+  });
+
+  it(`returns true when ${STRATEGY_CADENCE_MERGED_DELTA}+ PRs merged since the last snapshot`, () => {
+    const state = makeState({
+      mergedPRs: [
+        ...Array.from({ length: STRATEGY_MIN_PRS }, (_, i) => makeMergedPR('a/r', i + 1, { mergedAt: isoDaysAgo(60) })),
+        ...Array.from({ length: STRATEGY_CADENCE_MERGED_DELTA }, (_, i) =>
+          makeMergedPR('a/r', 100 + i, { mergedAt: isoDaysAgo(1) }),
+        ),
+      ],
+      lastStrategyAt: isoDaysAgo(3),
+    });
+    expect(shouldComputeStrategy(state, NOW)).toBe(true);
+  });
+
+  it('does not double-count PRs merged before the last snapshot', () => {
+    // 6 PRs merged 60 days ago, snapshot taken 10 days ago, no PRs since.
+    const state = makeState({
+      mergedPRs: Array.from({ length: STRATEGY_MIN_PRS + 6 }, (_, i) =>
+        makeMergedPR('a/r', i + 1, { mergedAt: isoDaysAgo(60) }),
+      ),
+      lastStrategyAt: isoDaysAgo(10),
+    });
+    expect(shouldComputeStrategy(state, NOW)).toBe(false);
+  });
+
+  it('fails open and returns true when timestamps are unparseable rather than silently never re-firing', () => {
+    const state = makeState({
+      mergedPRs: Array.from({ length: STRATEGY_MIN_PRS }, (_, i) => makeMergedPR('a/r', i + 1)),
+      lastStrategyAt: 'not-an-iso-string',
+    });
+    expect(shouldComputeStrategy(state, NOW)).toBe(true);
   });
 });

--- a/packages/core/src/core/strategy.ts
+++ b/packages/core/src/core/strategy.ts
@@ -36,9 +36,15 @@ export interface StrategyProfile {
 export interface StrategyCapacity {
   openPRCount: number;
   dormantPRCount: number;
+  /** Distinct repos hosting at least one dormant PR. Surfaces alongside
+   * `dormantPRCount` so consumers can render "N PRs across M repos"
+   * without re-deriving from `openPRs` themselves. */
+  dormantRepoCount: number;
   /** True when dormant PRs span >=2 distinct repos (a signal that the
    * contributor is awaiting reviews from multiple maintainers, not just
-   * one slow project). */
+   * one slow project). Equivalent to `dormantPRCount >= 2 &&
+   * dormantRepoCount >= 2` — exposed as a separate boolean so callers
+   * with a strict yes/no presentation don't have to recompute. */
   overExtended: boolean;
   /** The single highest-priority next action — null when state is too
    * thin to recommend anything. */
@@ -236,6 +242,7 @@ export function computeStrategy(state: AgentState): StrategyResult | null {
   const capacity: StrategyCapacity = {
     openPRCount,
     dormantPRCount,
+    dormantRepoCount: dormantRepos.size,
     overExtended,
     suggestedAction: recommendForOverExtension(openPRCount, dormantPRCount, overExtended),
   };
@@ -260,6 +267,50 @@ export function computeStrategy(state: AgentState): StrategyResult | null {
   };
 
   return { profile, capacity, patterns, recommendations };
+}
+
+/** Cadence trigger thresholds for the auto-display in `/oss` (#1270). */
+export const STRATEGY_CADENCE_DAYS = 30;
+export const STRATEGY_CADENCE_MERGED_DELTA = 5;
+
+/**
+ * Decide whether a strategy snapshot should be embedded in this daily run.
+ * Returns true when EITHER 30 days have elapsed since the last snapshot OR
+ * 5+ PRs have merged since then, AND the merge floor in
+ * {@link STRATEGY_MIN_PRS} is met. The caller is responsible for calling
+ * {@link computeStrategy} when this returns true and for persisting
+ * `state.lastStrategyAt` after a successful compute.
+ *
+ * `nowIso` is injected so tests can pin time without mocking `Date`.
+ */
+export function shouldComputeStrategy(state: AgentState, nowIso: string): boolean {
+  const merged = state.mergedPRs ?? [];
+  if (merged.length < STRATEGY_MIN_PRS) return false;
+
+  const lastIso = state.lastStrategyAt;
+  if (!lastIso) return true;
+
+  // Time-based trigger: 30+ days since last snapshot.
+  const lastMs = Date.parse(lastIso);
+  const nowMs = Date.parse(nowIso);
+  if (Number.isFinite(lastMs) && Number.isFinite(nowMs)) {
+    const daysSince = (nowMs - lastMs) / (1000 * 60 * 60 * 24);
+    if (daysSince >= STRATEGY_CADENCE_DAYS) return true;
+  } else {
+    // Unparseable timestamps — fail open and recompute rather than
+    // silently never re-firing. The lastStrategyAt write below will
+    // refresh to a valid ISO string.
+    return true;
+  }
+
+  // Merge-count trigger: count PRs merged after `lastStrategyAt`.
+  // `mergedAt` is required on StoredMergedPRSchema; `Date.parse` returns
+  // NaN for malformed-but-stored data and Number.isFinite excludes those.
+  const mergedSince = merged.filter((pr) => {
+    const mergedMs = Date.parse(pr.mergedAt);
+    return Number.isFinite(mergedMs) && mergedMs > lastMs;
+  }).length;
+  return mergedSince >= STRATEGY_CADENCE_MERGED_DELTA;
 }
 
 function deriveIssueTypePreferences(distribution: StrategyPatterns['prTypeDistribution']): string[] {

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -171,6 +171,13 @@ export interface DailyOutput {
    * on clean runs. See #1042.
    */
   warnings: DailyWarning[];
+  /**
+   * Periodic contribution-strategy snapshot (#1270). Populated when the
+   * cadence trigger fires AND the user has crossed the merge floor. The
+   * `/oss` action menu renders this inline ahead of the action options;
+   * absent or null on runs where the gate stays silent.
+   */
+  strategySummary?: import('../core/strategy.js').StrategyResult | null;
 }
 
 /**
@@ -197,6 +204,8 @@ export interface CompactDailyOutput {
    * the `--compact` payload. See #1042.
    */
   warnings: DailyWarning[];
+  /** Periodic strategy snapshot, threaded through compact mode for parity. See {@link DailyOutput.strategySummary}. */
+  strategySummary?: import('../core/strategy.js').StrategyResult | null;
 }
 
 /**
@@ -214,6 +223,7 @@ export function toCompactDailyOutput(output: DailyOutput): CompactDailyOutput {
     commentedIssues: output.commentedIssues,
     failureCount: output.failures.length,
     warnings: output.warnings,
+    strategySummary: output.strategySummary,
   };
 }
 
@@ -406,6 +416,66 @@ const CompactRepoGroupSchema = z.object({
 // DailyWarning schemas were hoisted above StatusOutputSchema (#1193) so the
 // status output can reference them without `z.lazy()`.
 
+// Mirrors {@link StrategyResult} in core/strategy.ts. Kept passthrough on the
+// inner objects so additive shape changes there don't break Zod validation
+// before the schema catches up — drift on required keys still fails.
+const StrategyResultSchema = z
+  .object({
+    profile: z
+      .object({
+        style: z.enum(['maintainer', 'explorer', 'specialist', 'generalist']),
+        totalPRs: z.number().int().nonnegative(),
+        mergedCount: z.number().int().nonnegative(),
+        mergeRate: z.number(),
+        primaryLanguages: z.array(z.string()),
+        favoriteRepos: z.array(z.string()),
+      })
+      .passthrough(),
+    capacity: z
+      .object({
+        openPRCount: z.number().int().nonnegative(),
+        dormantPRCount: z.number().int().nonnegative(),
+        dormantRepoCount: z.number().int().nonnegative(),
+        overExtended: z.boolean(),
+        suggestedAction: z.union([
+          z.literal('open_more'),
+          z.literal('follow_up_dormant'),
+          z.literal('wait_on_maintainers'),
+          z.null(),
+        ]),
+      })
+      .passthrough(),
+    patterns: z
+      .object({
+        // Closed set on the six required PR-type buckets — drift on any
+        // of these breaks the snapshot rendering. `.passthrough()` allows
+        // additive growth (e.g., a future 'security' bucket) without a
+        // schema bump, but a typo on `features` → `feauters` fails here.
+        prTypeDistribution: z
+          .object({
+            docs: z.number(),
+            fixes: z.number(),
+            features: z.number(),
+            refactors: z.number(),
+            tests: z.number(),
+            other: z.number(),
+          })
+          .passthrough(),
+        trajectoryDirection: z.enum(['growing', 'steady', 'declining']),
+        averagePRSize: z.number(),
+      })
+      .passthrough(),
+    recommendations: z
+      .object({
+        languages: z.array(z.string()),
+        repos: z.array(z.string()),
+        issueTypes: z.array(z.string()),
+        avoidPatterns: z.array(z.string()),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
 export const DailyOutputSchema = z.object({
   digest: DailyDigestCompactSchema,
   capacity: CapacityAssessmentSchema,
@@ -417,6 +487,7 @@ export const DailyOutputSchema = z.object({
   repoGroups: z.array(CompactRepoGroupSchema),
   failures: z.array(PRCheckFailurePassthroughSchema),
   warnings: z.array(DailyWarningSchema),
+  strategySummary: StrategyResultSchema.nullable().optional(),
 });
 
 export const CompactDailyOutputSchema = z.object({
@@ -428,6 +499,7 @@ export const CompactDailyOutputSchema = z.object({
   commentedIssues: z.array(CommentedIssuePassthroughSchema),
   failureCount: z.number().int().nonnegative(),
   warnings: z.array(DailyWarningSchema),
+  strategySummary: StrategyResultSchema.nullable().optional(),
 });
 
 // ── Search output schema (#1147) ─────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #1270 Steps 2 and 3. Builds on #1262 (typed `computeStrategy()` shipped). Step 4 (agent rewrite + MCP tool) stays deferred.

The strategy snapshot is now cadence-gated and surfaces inline in the `/oss` action menu when triggered.

## What's in the diff

| File | Change |
|---|---|
| `core/strategy.ts` | New `shouldComputeStrategy(state, nowIso)` (30-day OR 5+ merge-delta gate). New `dormantRepoCount` field on `StrategyCapacity` (the value was already computed for `overExtended` but never surfaced — needed for the renderer). |
| `core/state-schema.ts` + `core/state.ts` | Optional `lastStrategyAt` ISO timestamp + `setLastStrategyAt(iso)` autoSave mutator. |
| `commands/daily.ts` | `generateDigestOutput` consults the cadence helper, runs `computeStrategy(state)` on a hit, persists `lastStrategyAt`, threads `strategySummary` through `DailyCheckResult` and `toDailyOutput`. Compute failures are non-fatal (warning + omit field). |
| `formatters/json.ts` | `StrategyResultSchema` mirrors `StrategyResult`. `prTypeDistribution` gates on the six required keys with passthrough for additive growth. `strategySummary` added to `DailyOutputSchema` and `CompactDailyOutputSchema` as nullable optional. |
| `commands/oss.md` | Render block ahead of the action menu. `SUGGESTED_ACTION_PROSE` table provides a fixed mapping for `capacity.suggestedAction` so two runs over the same data render the same prose. |
| `core/strategy.test.ts` | 7 new tests for `shouldComputeStrategy` (below-floor, first-run, time + merge-delta gates, no double-counting, fail-open on unparseable timestamps). |
| `commands/daily-orchestration.test.ts` | Adds `setLastStrategyAt` to the mock state manager. |

## Pre-commit review findings (all addressed)

- **Critical**: oss.md template referenced `{distinct repos in capacity}` with no source field → added `dormantRepoCount` to `StrategyCapacity`.
- **Important**: `{capacity.suggestedAction-translated to plain text}` is non-deterministic → replaced with a fixed `SUGGESTED_ACTION_PROSE` mapping table.
- **Important**: `prTypeDistribution: z.record(z.string(), z.number())` accepts typos (`feauters`) → tightened to a closed-set object with passthrough for future additive growth.

## What's deferred

- **Step 4** (agent rewrite + MCP tool wrapping): the `contribution-strategist` agent still has its in-prompt categorization logic. Rewriting it to consume the typed output is independent of this PR and best landed once the MCP tool surface for `computeStrategy` is added.

## Test plan

- [x] `pnpm --filter @oss-autopilot/core run test` — 2543 passing (+7 new for the cadence helper)
- [x] `pnpm --filter @oss-autopilot/core run build` — clean
- [x] `pnpm -w run typecheck` — clean across core / mcp-server / dashboard
- [x] `pnpm -w run lint` — 0 errors (1587 pre-existing warnings, none new)
- [x] Pre-commit review: parallel `code-reviewer`. 1 Critical + 2 Important findings, all addressed before commit.