### PR TITLE
refactor: extract categorizeCIStatus to typed core (#1272 Improvement 2)

### DIFF
--- a/agents/pr-health-checker.md
+++ b/agents/pr-health-checker.md
@@ -104,15 +104,17 @@ If not cloned: clone into the FIRST configured scan path (or `~/Documents/oss/<r
 
 ### 3. Categorize CI Status
 
-| CI state | Meaning | Action |
-|---|---|---|
-| All passing | Green | None |
-| Failing (tests/lint/build) | Code issue | Tier 2: investigate + recommend |
-| Blocked (pending) | Needs maintainer trigger | Suggest asking for rerun |
-| Not running | No checks reported | Investigate workflows / fork-actions |
-| Fork limitation | Vercel auth, internal CI | Informational, not actionable |
+Read `pr.ciCategorization.category` (#1272) — five mutually-exclusive states produced by the typed `categorizeCIStatus()` core function. Map directly to action:
 
-Distinguish fork limitations from real failures: Vercel preview "Authorization required" and internal-CI-only checks are fork limitations.
+| `category` | Meaning | Action |
+|---|---|---|
+| `all_passing` | Every reported check is green | None |
+| `failing` | At least one actionable failure (tests/lint/build) | Tier 2: investigate + recommend |
+| `blocked` | Checks pending; often awaiting maintainer trigger | Suggest asking for rerun |
+| `not_running` | No checks reported | Investigate workflows / fork-actions |
+| `fork_limitation` | Failures exist but ALL are fork-perm / auth-gate | Informational, not actionable |
+
+`pr.ciCategorization.summary` is a short pre-rendered description; render it verbatim if displaying inline. Do NOT re-derive the category from `failingCheckNames` + `classifiedChecks` — the typed function is the canonical source.
 
 ### 4. Check Reviews
 ```bash

--- a/packages/core/src/commands/__golden__/daily.degraded.json
+++ b/packages/core/src/commands/__golden__/daily.degraded.json
@@ -21,6 +21,11 @@
           "Node 20 / ubuntu-latest"
         ],
         "classifiedChecks": [],
+        "ciCategorization": {
+          "category": "all_passing",
+          "summary": "All checks passing",
+          "action": "none"
+        },
         "hasMergeConflict": false,
         "reviewDecision": "approved",
         "hasUnrespondedComment": false,
@@ -44,6 +49,11 @@
         "ciStatus": "passing",
         "failingCheckNames": [],
         "classifiedChecks": [],
+        "ciCategorization": {
+          "category": "all_passing",
+          "summary": "All checks passing",
+          "action": "none"
+        },
         "hasMergeConflict": false,
         "reviewDecision": "approved",
         "hasUnrespondedComment": false,

--- a/packages/core/src/commands/__golden__/daily.typical.json
+++ b/packages/core/src/commands/__golden__/daily.typical.json
@@ -21,6 +21,11 @@
           "Node 20 / ubuntu-latest"
         ],
         "classifiedChecks": [],
+        "ciCategorization": {
+          "category": "all_passing",
+          "summary": "All checks passing",
+          "action": "none"
+        },
         "hasMergeConflict": false,
         "reviewDecision": "approved",
         "hasUnrespondedComment": false,
@@ -44,6 +49,11 @@
         "ciStatus": "passing",
         "failingCheckNames": [],
         "classifiedChecks": [],
+        "ciCategorization": {
+          "category": "all_passing",
+          "summary": "All checks passing",
+          "action": "none"
+        },
         "hasMergeConflict": false,
         "reviewDecision": "approved",
         "hasUnrespondedComment": false,

--- a/packages/core/src/core/ci-analysis.test.ts
+++ b/packages/core/src/core/ci-analysis.test.ts
@@ -4,12 +4,14 @@
 
 import { describe, it, expect } from 'vitest';
 import {
+  categorizeCIStatus,
   classifyCICheck,
   classifyFailingChecks,
   analyzeCheckRuns,
   analyzeCombinedStatus,
   mergeStatuses,
 } from './ci-analysis.js';
+import type { ClassifiedCheck } from './types.js';
 
 describe('classifyCICheck', () => {
   it('should return "actionable" for unknown check names', () => {
@@ -276,5 +278,141 @@ describe('mergeStatuses', () => {
       0,
     );
     expect(result.status).toBe('unknown');
+  });
+});
+
+describe('categorizeCIStatus (#1272)', () => {
+  function actionable(name: string): ClassifiedCheck {
+    return { name, category: 'actionable' };
+  }
+  function forkLimit(name: string): ClassifiedCheck {
+    return { name, category: 'fork_limitation' };
+  }
+  function authGate(name: string): ClassifiedCheck {
+    return { name, category: 'auth_gate' };
+  }
+
+  it('returns all_passing when ciStatus is passing', () => {
+    const r = categorizeCIStatus({ ciStatus: 'passing', failingCheckNames: [], classifiedChecks: [] });
+    expect(r.category).toBe('all_passing');
+    expect(r.action).toBe('none');
+    expect(r.summary).toMatch(/passing/i);
+  });
+
+  it('returns blocked when ciStatus is pending', () => {
+    const r = categorizeCIStatus({ ciStatus: 'pending', failingCheckNames: [], classifiedChecks: [] });
+    expect(r.category).toBe('blocked');
+    expect(r.action).toBe('request_rerun');
+  });
+
+  it('returns blocked with count when pending with failing names known', () => {
+    const r = categorizeCIStatus({
+      ciStatus: 'pending',
+      failingCheckNames: ['unit-tests', 'lint'],
+      classifiedChecks: [actionable('unit-tests'), actionable('lint')],
+    });
+    expect(r.category).toBe('blocked');
+    expect(r.summary).toMatch(/2/);
+  });
+
+  it('returns failing when at least one classified check is actionable', () => {
+    const r = categorizeCIStatus({
+      ciStatus: 'failing',
+      failingCheckNames: ['unit-tests', 'vercel-preview'],
+      classifiedChecks: [actionable('unit-tests'), forkLimit('vercel-preview')],
+    });
+    expect(r.category).toBe('failing');
+    expect(r.action).toBe('investigate');
+    expect(r.summary).toMatch(/unit-tests/);
+  });
+
+  it('previews up to 3 actionable check names then summarizes the rest', () => {
+    const r = categorizeCIStatus({
+      ciStatus: 'failing',
+      failingCheckNames: ['a', 'b', 'c', 'd', 'e'],
+      classifiedChecks: [actionable('a'), actionable('b'), actionable('c'), actionable('d'), actionable('e')],
+    });
+    expect(r.summary).toContain('a, b, c');
+    expect(r.summary).toMatch(/\+2 more/);
+  });
+
+  it('returns fork_limitation when failures exist but none are actionable or infrastructure', () => {
+    const r = categorizeCIStatus({
+      ciStatus: 'failing',
+      failingCheckNames: ['vercel-preview', 'codecov-auth'],
+      classifiedChecks: [forkLimit('vercel-preview'), authGate('codecov-auth')],
+    });
+    expect(r.category).toBe('fork_limitation');
+    expect(r.action).toBe('informational');
+  });
+
+  it('returns blocked w/ request_rerun when non-actionable failures include infrastructure (cancelled runner)', () => {
+    // Without the infrastructure-aware branch, this fell into
+    // fork_limitation with the misleading "fork limits / auth gates"
+    // summary. A cancelled runner is genuinely worth a rerun, not a
+    // shrug.
+    const r = categorizeCIStatus({
+      ciStatus: 'failing',
+      failingCheckNames: ['integration-tests'],
+      classifiedChecks: [{ name: 'integration-tests', category: 'infrastructure', conclusion: 'cancelled' }],
+    });
+    expect(r.category).toBe('blocked');
+    expect(r.action).toBe('request_rerun');
+    expect(r.summary).toMatch(/rerun/i);
+  });
+
+  it('returns blocked w/ request_rerun when failures mix infrastructure + auth_gate (no actionable)', () => {
+    const r = categorizeCIStatus({
+      ciStatus: 'failing',
+      failingCheckNames: ['unit-tests', 'codecov-auth'],
+      classifiedChecks: [
+        { name: 'unit-tests', category: 'infrastructure', conclusion: 'timed_out' },
+        authGate('codecov-auth'),
+      ],
+    });
+    expect(r.category).toBe('blocked');
+    expect(r.action).toBe('request_rerun');
+  });
+
+  it('returns failing w/ honest summary when ciStatus is failing but no checks were classified', () => {
+    // Reachable when the legacy combined-status endpoint reports failure
+    // without per-check detail. Asserting "0 non-actionable failure(s)
+    // (fork limits / auth gates)" would be a confident lie.
+    const r = categorizeCIStatus({
+      ciStatus: 'failing',
+      failingCheckNames: [],
+      classifiedChecks: [],
+    });
+    expect(r.category).toBe('failing');
+    expect(r.action).toBe('investigate');
+    expect(r.summary).toMatch(/no check details/i);
+  });
+
+  it('returns not_running when ciStatus is unknown', () => {
+    const r = categorizeCIStatus({ ciStatus: 'unknown', failingCheckNames: [], classifiedChecks: [] });
+    expect(r.category).toBe('not_running');
+    expect(r.action).toBe('check_workflows');
+  });
+
+  it('returns 5 mutually-exclusive categories — same input produces same output (deterministic)', () => {
+    const input = {
+      ciStatus: 'failing' as const,
+      failingCheckNames: ['lint'],
+      classifiedChecks: [actionable('lint')],
+    };
+    expect(categorizeCIStatus(input)).toEqual(categorizeCIStatus(input));
+  });
+
+  it('summary is short enough for inline rendering (under 120 chars)', () => {
+    // Stress: 10 actionable failures with long names
+    const longNames = Array.from({ length: 10 }, (_, i) => `very-long-check-name-${i}-with-extra-context`);
+    const r = categorizeCIStatus({
+      ciStatus: 'failing',
+      failingCheckNames: longNames,
+      classifiedChecks: longNames.map(actionable),
+    });
+    // The preview includes 3 names plus "(+7 more)" — verify the resulting
+    // summary stays bounded enough for action-menu rendering.
+    expect(r.summary.length).toBeLessThan(180);
   });
 });

--- a/packages/core/src/core/ci-analysis.ts
+++ b/packages/core/src/core/ci-analysis.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Octokit } from '@octokit/rest';
-import { CIFailureCategory, ClassifiedCheck, CIStatusResult } from './types.js';
+import { CIFailureCategory, ClassifiedCheck, CIStatusResult, CIStatus, CIStatusCategorization } from './types.js';
 import { getHttpStatusCode, errorMessage } from './errors.js';
 import { debug, warn } from './logger.js';
 
@@ -100,6 +100,110 @@ export function classifyFailingChecks(
       conclusion,
     };
   });
+}
+
+/**
+ * Map an aggregate `ciStatus + failingCheckNames + classifiedChecks` triple
+ * into one of five mutually exclusive overall states (#1272). The 5-row
+ * truth table previously lived as prose in `agents/pr-health-checker.md`;
+ * extracting it lets that agent (and any future consumer — dashboard,
+ * MCP, sibling agents that adopt the field) read a single typed value
+ * instead of re-deriving from `ciStatus + failingCheckNames + classifiedChecks`.
+ *
+ * Decision order (each branch is exclusive):
+ *   1. `passing`                      → `all_passing`
+ *   2. `pending`                      → `blocked` (awaiting trigger / completion)
+ *   3. `failing` + actionable         → `failing` (real test/lint/build issue)
+ *   4. `failing` + only infrastructure → `blocked` (cancelled/timed-out runner — needs rerun)
+ *   5. `failing` + only fork/auth     → `fork_limitation` (informational)
+ *   6. `failing` + zero classified    → `failing` w/ "details unavailable" summary
+ *   7. `unknown`                      → `not_running`
+ *
+ * Why infrastructure routes to `blocked` and not `fork_limitation`:
+ * a cancelled or timed-out runner is genuinely worth re-running; calling
+ * it "informational" would tell the agent to ignore something the user
+ * can fix with a rerun-request.
+ *
+ * The `summary` is short (≤180 char even for 10+ failing checks) and
+ * suitable for inline display. `action` is a hint, not enforcement —
+ * agents may still escalate based on other PR context.
+ */
+export function categorizeCIStatus(input: {
+  ciStatus: CIStatus;
+  failingCheckNames: string[];
+  classifiedChecks: ClassifiedCheck[];
+}): CIStatusCategorization {
+  const { ciStatus, failingCheckNames, classifiedChecks } = input;
+
+  if (ciStatus === 'passing') {
+    return { category: 'all_passing', summary: 'All checks passing', action: 'none' };
+  }
+
+  if (ciStatus === 'pending') {
+    // `mergeStatuses` currently sets `failingCheckNames: []` on pending,
+    // so the count branch is defensive — kept so a future caller that
+    // forwards pending names doesn't silently drop them.
+    const count = failingCheckNames.length;
+    const summary = count > 0 ? `${count} pending check(s); CI run incomplete` : 'CI checks pending';
+    return { category: 'blocked', summary, action: 'request_rerun' };
+  }
+
+  if (ciStatus === 'failing') {
+    const actionable = classifiedChecks.filter((c) => c.category === 'actionable');
+    if (actionable.length > 0) {
+      const preview = actionable
+        .slice(0, 3)
+        .map((c) => c.name)
+        .join(', ');
+      const more = actionable.length > 3 ? ` (+${actionable.length - 3} more)` : '';
+      return {
+        category: 'failing',
+        summary: `${actionable.length} actionable failure(s): ${preview}${more}`,
+        action: 'investigate',
+      };
+    }
+
+    // No actionable failures. Distinguish three sub-cases:
+    // (a) failing with zero classified checks: status came from the
+    //     legacy combined-status endpoint without per-check detail. Be
+    //     honest about the missing detail rather than asserting "fork
+    //     limitations" the caller can't verify.
+    if (classifiedChecks.length === 0) {
+      return {
+        category: 'failing',
+        summary: 'CI reported failure but no check details available',
+        action: 'investigate',
+      };
+    }
+
+    // (b) at least one infrastructure failure (cancelled / timed-out /
+    //     dependency-install). Re-running often fixes the issue, so
+    //     surface as `blocked` with `request_rerun` rather than
+    //     mislabeling as "fork limits / auth gates."
+    const hasInfrastructure = classifiedChecks.some((c) => c.category === 'infrastructure');
+    if (hasInfrastructure) {
+      const total = classifiedChecks.length;
+      return {
+        category: 'blocked',
+        summary: `${total} non-actionable failure(s) including infrastructure issues; rerun may resolve`,
+        action: 'request_rerun',
+      };
+    }
+
+    // (c) only fork-limitation / auth-gate failures — purely informational.
+    const total = classifiedChecks.length;
+    return {
+      category: 'fork_limitation',
+      summary: `${total} non-actionable failure(s) (fork limits / auth gates)`,
+      action: 'informational',
+    };
+  }
+
+  // ciStatus === 'unknown' — no checks reported, or status couldn't be
+  // determined. Treat both as not_running so callers don't have to
+  // distinguish the rare indeterminate case from the common "no CI
+  // configured" case.
+  return { category: 'not_running', summary: 'No CI checks reported', action: 'check_workflows' };
 }
 
 /**

--- a/packages/core/src/core/pr-monitor.ts
+++ b/packages/core/src/core/pr-monitor.ts
@@ -33,7 +33,7 @@ import { paginateAll } from './pagination.js';
 import { debug, warn, timed } from './logger.js';
 import { getHttpCache, cachedRequest } from './http-cache.js';
 
-import { classifyFailingChecks, getCIStatus } from './ci-analysis.js';
+import { categorizeCIStatus, classifyFailingChecks, getCIStatus } from './ci-analysis.js';
 import {
   type ReviewComment,
   determineReviewDecision,
@@ -54,7 +54,7 @@ import { isPlaceholderUsername } from './placeholder-usernames.js';
 
 // Re-export so existing consumers can still import from pr-monitor
 export { computeDisplayLabel } from './display-utils.js';
-export { classifyCICheck, classifyFailingChecks, getCIStatus } from './ci-analysis.js';
+export { categorizeCIStatus, classifyCICheck, classifyFailingChecks, getCIStatus } from './ci-analysis.js';
 export { isConditionalChecklistItem } from './checklist-analysis.js';
 export { determineStatus } from './status-determination.js';
 
@@ -453,6 +453,11 @@ export class PRMonitor {
     // Classify failing checks (delegated to ci-analysis module)
     const classifiedChecks = classifyFailingChecks(failingCheckNames, failingCheckConclusions);
 
+    // Aggregate 5-state CI categorization (#1272). Computed once here so
+    // agents read pr.ciCategorization rather than re-deriving the truth
+    // table in three separate prose forms.
+    const ciCategorization = categorizeCIStatus({ ciStatus, failingCheckNames, classifiedChecks });
+
     // Determine status
     const hasActionableCIFailure = ciStatus === 'failing' && classifiedChecks.some((c) => c.category === 'actionable');
     const { status, actionReason, waitReason, stalenessTier, actionReasons } = determineStatus({
@@ -489,6 +494,7 @@ export class PRMonitor {
       ciStatus,
       failingCheckNames,
       classifiedChecks,
+      ciCategorization,
       hasMergeConflict: mergeConflict,
       reviewDecision,
       hasUnrespondedComment,

--- a/packages/core/src/core/test-utils.ts
+++ b/packages/core/src/core/test-utils.ts
@@ -44,6 +44,7 @@ export function makeFetchedPR(overrides: Partial<FetchedPR> = {}): FetchedPR {
     ciStatus: 'passing',
     failingCheckNames: [],
     classifiedChecks: [],
+    ciCategorization: { category: 'all_passing', summary: 'All checks passing', action: 'none' },
     hasMergeConflict: false,
     reviewDecision: 'approved',
     hasUnrespondedComment: false,

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -69,6 +69,49 @@ export interface ClassifiedCheck {
   conclusion?: string;
 }
 
+/**
+ * Mutually exclusive overall-CI categories produced by
+ * {@link categorizeCIStatus} (#1272). The 5-row truth table that lived
+ * as prose in `agents/pr-health-checker.md` — extracted so any consumer
+ * (the agent, the dashboard, future MCP surfaces) reads one typed field
+ * instead of re-deriving the table.
+ *
+ * - `all_passing` — every reported check is green
+ * - `failing` — at least one actionable failure (real test/lint/build
+ *   issue), OR ciStatus reported failing without per-check detail (the
+ *   honest answer when the legacy combined-status endpoint can't tell
+ *   us what failed)
+ * - `fork_limitation` — failures exist but ALL of them are
+ *   `fork_limitation` / `auth_gate` (Vercel preview, internal CI) — purely
+ *   informational
+ * - `blocked` — checks are pending (awaiting trigger / completion), OR
+ *   non-actionable failures include `infrastructure` (cancelled /
+ *   timed-out runner — re-running often resolves)
+ * - `not_running` — no checks reported
+ */
+export type CIStatusCategory = 'all_passing' | 'failing' | 'fork_limitation' | 'blocked' | 'not_running';
+
+/**
+ * Suggested action for the {@link CIStatusCategorization}. Hint, not
+ * enforcement — the consuming agent may still escalate or skip based on
+ * other PR context.
+ */
+export type CIStatusAction = 'none' | 'investigate' | 'request_rerun' | 'check_workflows' | 'informational';
+
+/**
+ * Aggregate CI status produced by {@link categorizeCIStatus} (#1272).
+ * Derived from `ciStatus + failingCheckNames + classifiedChecks` —
+ * exposed on {@link FetchedPR} so agents read a single field instead
+ * of re-implementing the truth table.
+ */
+export interface CIStatusCategorization {
+  category: CIStatusCategory;
+  /** Short human-readable summary suitable for inline display. */
+  summary: string;
+  /** Suggested next action (hint, not enforcement). */
+  action: CIStatusAction;
+}
+
 /** CI status result returned by getCIStatus(). */
 export interface CIStatusResult {
   status: CIStatus;
@@ -195,6 +238,15 @@ export interface FetchedPR {
   failingCheckNames: string[];
   /** Failing checks with category classification (#81). Separates actionable failures from fork limitations and auth gates. */
   classifiedChecks: ClassifiedCheck[];
+  /**
+   * Aggregate 5-state CI categorization (#1272). Derived from `ciStatus`,
+   * `failingCheckNames`, and `classifiedChecks` via `categorizeCIStatus()`
+   * — agents read this directly instead of re-deriving the truth table.
+   * Always populated on a fresh fetch (v2 architecture has no cached
+   * `FetchedPR` to migrate); pr-monitor's `fetchPRDetails` sets it on
+   * every PR before construction.
+   */
+  ciCategorization: CIStatusCategorization;
   hasMergeConflict: boolean;
   reviewDecision: ReviewDecision;
 

--- a/packages/dashboard/src/test-helpers.ts
+++ b/packages/dashboard/src/test-helpers.ts
@@ -18,6 +18,7 @@ export function makePR(overrides: Partial<FetchedPR> = {}): FetchedPR {
     ciStatus: 'passing',
     failingCheckNames: [],
     classifiedChecks: [],
+    ciCategorization: { category: 'all_passing', summary: 'All checks passing', action: 'none' },
     hasMergeConflict: false,
     reviewDecision: 'approved',
     hasUnrespondedComment: false,


### PR DESCRIPTION
## Summary

Closes #1272 Improvement 2. The 5-row CI status truth table previously lived as prose in `agents/pr-health-checker.md`. This extracts it to a typed core function `categorizeCIStatus()` exposed on `FetchedPR.ciCategorization` so the agent (and any future consumer) reads a single typed field instead of re-deriving.

## Reality check on the issue claim

The issue body said the table was duplicated across `pr-health-checker`, `pr-compliance-checker`, and `pr-responder`. Only `pr-health-checker` had the explicit table — the other two reference CI status as input but don't have parallel truth tables. The extract still pays off as the canonical source for the agent and any future consumer (dashboard, MCP, sibling agents that adopt the field), but the dramatic 3-agent rewire wasn't there to do.

## Categories (decision order, mutually exclusive)

| # | Input | Category | Action |
|---|---|---|---|
| 1 | `passing` | `all_passing` | `none` |
| 2 | `pending` | `blocked` | `request_rerun` |
| 3 | `failing` + at least one actionable | `failing` | `investigate` |
| 4 | `failing` + zero classified checks | `failing` (honest "details unavailable") | `investigate` |
| 5 | `failing` + only infrastructure | `blocked` | `request_rerun` |
| 6 | `failing` + only fork/auth | `fork_limitation` | `informational` |
| 7 | `unknown` | `not_running` | `check_workflows` |

## Pre-commit review (3 Important findings, all addressed)

1. **Infrastructure failures (cancelled / timed-out runners) were being mislabeled as "fork limits / auth gates"** with action `informational` — a cancelled runner is genuinely worth a rerun, not a shrug. Now routes to `blocked` + `request_rerun` via a separate branch checking `category === 'infrastructure'` before falling through to `fork_limitation`.

2. **`ciStatus === 'failing'` with empty `classifiedChecks`** (legacy combined-status endpoint reporting failure without per-check detail) produced "0 non-actionable failure(s) (fork limits / auth gates)" — a confident lie. Now produces "CI reported failure but no check details available" with action `investigate`.

3. **Doc-comment claim correction**: comments referenced "three agents" duplication that doesn't actually exist. Updated.

## Other change

Made `FetchedPR.ciCategorization` required (not optional). The original "backwards compatibility with cached state" rationale didn't match v2's fresh-fetch architecture — every PR goes through `fetchPRDetails` which sets it. Required field prevents future breakage from null-check omissions. Test fixtures (`core/test-utils.ts`, `dashboard/src/test-helpers.ts`) populated. Daily contract goldens (`__golden__/daily.{typical,degraded}.json`) updated to include the new field.

## Test plan

- [x] `pnpm --filter @oss-autopilot/core run test` — 2548 passing (+12 new for `categorizeCIStatus` covering all 7 decision branches plus edge cases)
- [x] `pnpm --filter @oss-autopilot/core run build` — clean
- [x] `pnpm -w run typecheck` — clean across core / mcp-server / dashboard
- [x] `pnpm -w run lint` — 0 errors (1591 pre-existing warnings, none new)