### PR TITLE
refactor: document parallel-execution structure in pre-commit-reviewer (#1274 Improvement 2)

### DIFF
--- a/agents/pre-commit-reviewer.md
+++ b/agents/pre-commit-reviewer.md
@@ -30,6 +30,25 @@ tools: ["Bash", "Read", "Glob", "Grep", "mcp__plugin_oss-autopilot_oss-autopilot
 
 You are a Pre-Commit Code Reviewer for open source contributions. Your job is to catch issues BEFORE code is committed and pushed to a PR.
 
+## Phase Execution Order
+
+The phases below have this dependency graph (#1274 Improvement 2):
+
+```
+Phase 1 ──► Phase 2 ──► Phase 3 ──► Phase 5 ──► Phase 6
+        ├─► Phase 2.5 ─────────────► (joins at Phase 5)
+        ├─► Phase 4 ───────────────► (joins at Phase 5)
+        └─► Phase 4.5 ─────────────► (joins at Phase 5)
+```
+
+**Phase 1 must complete first** (every other phase reads its outputs). After Phase 1 is done, fan out: run **Phase 2, Phase 2.5, Phase 4, and Phase 4.5 concurrently** — they read the diff and repo state but do not depend on each other. **Phase 3 starts after Phase 2 completes** (it consumes the convention-detection findings). **Phase 5 waits on all of 2 / 2.5 / 3 / 4 / 4.5** before assembling the report. Phase 6 is sequential after Phase 5.
+
+Concrete tactics for the fan-out:
+- When invoked through the `Task` tool with sub-agent dispatch available: dispatch Phase 2, 2.5, 4, and 4.5 as parallel sub-tasks in a single message.
+- When constrained to inline reasoning: interleave the four phases in your context window rather than walking them strictly in order — read the diff once, then form findings for all four categories before producing Phase 5.
+
+The numbering stays sequential below for backwards compatibility with prior references — read it as a logical structure, not a strict execution order.
+
 ## Phase 1: Context Gathering
 
 ```bash


### PR DESCRIPTION
## Summary

Closes #1274 Improvement 2. The six phases of `pre-commit-reviewer` were documented in numerical order, but the dependency graph between them is not strictly sequential:

\`\`\`
Phase 1 ──► Phase 2 ──► Phase 3 ──► Phase 5 ──► Phase 6
        ├─► Phase 2.5 ─────────────► (joins at Phase 5)
        ├─► Phase 4 ───────────────► (joins at Phase 5)
        └─► Phase 4.5 ─────────────► (joins at Phase 5)
\`\`\`

After Phase 1, **Phases 2, 2.5, 4, and 4.5 are mutually independent**. Phase 3 still waits on Phase 2 (consumes convention-detection findings). Phase 5 joins all four.

## What's in the diff

A new "Phase Execution Order" section before Phase 1 that:
- Shows the dependency graph
- Calls out which phases are independent vs which still wait
- Gives concrete tactics: sub-agent dispatch (parallel Task calls in one message) when available, or interleaved inline reasoning otherwise
- States that the numbered headers below stay sequential for backwards-compatibility with prior references — now a logical structure, not a strict execution order

Markdown-only change. No code, no tests modified.

## What's deferred

**Improvement 3** (extract shared `convention/security/API-naming` helpers) overlaps with #1272's helper-extract series. Best landed once those helpers settle so the three agents (`pre-commit-reviewer`, `pr-health-checker`, `pr-compliance-checker`) consume the same typed implementations rather than each pulling helpers in independently.

## Test plan

- [x] `pnpm --filter @oss-autopilot/core run test` — 2536 passing (no code changes; suite still green)
- [x] `pnpm -w run lint` — 0 errors
- [x] No phase numbering breaks — only added a section header before Phase 1