### PR TITLE
refactor: enable cross-repo parallel fan-out in pr-health-checker (#1272 Improvement 4)

### DIFF
--- a/agents/pr-health-checker.md
+++ b/agents/pr-health-checker.md
@@ -128,9 +128,16 @@ gh pr view NUMBER --repo OWNER/REPO --json reviews,reviewDecision
 
 `gh api repos/OWNER/REPO/issues/NUMBER/comments --jq '.[] | select(.user.login | endswith("[bot]")) | {author: .user.login, body: .body}'` — look for `changeset-bot` (missing changeset), `CLAassistant` (unsigned CLA), `codecov` (informational), `copilot` (automated suggestions).
 
-### 6. Same-Repo Coordination
+### 6. Cross-Repo Fan-Out and Same-Repo Coordination
 
-When checking multiple PRs in the same repo, handle them **sequentially** within a single agent invocation. Never try to check multiple branches in the same repo simultaneously.
+PRs in **different repos** are independent — git working directories don't overlap, no shared lock state. When the caller hands you multiple PRs to check, group them by repo and **dispatch one parallel sub-agent per repo** (`Task` tool with this same agent-name, one call per repo, sent in a single message so they run concurrently). Wait for all to complete, then merge their reports for the user (#1272 Improvement 4).
+
+Within a **single repo**, handle multiple PRs **sequentially** in the same sub-agent — branches share the working tree, so checking two PR branches concurrently corrupts git state.
+
+The split:
+- N PRs across M repos → M parallel sub-agents, each handling its repo's PRs sequentially.
+- Best speedup when PRs are spread across many repos (the common case for active contributors).
+- No speedup when all PRs are in one repo — the sequential rule still applies.
 
 ## Output Format
 


### PR DESCRIPTION
## Summary

Closes #1272 Improvement 4. Section 6 of `pr-health-checker.md` was titled "Same-Repo Coordination" and instructed agents to handle multiple PRs sequentially "within a single agent invocation." That was correct for PRs in the SAME repo (branches share the working tree — concurrent checkouts corrupt git state) but blanket-prohibited cross-repo parallelism, which is the case where fan-out wins the most.

## What's in the diff

Renamed Section 6 to "Cross-Repo Fan-Out and Same-Repo Coordination" and split the rule:

| Shape | Behavior |
|---|---|
| Multiple PRs across DIFFERENT repos | Dispatch one parallel sub-agent per repo via the `Task` tool (single message, multiple `Task` calls so they run concurrently). Wait for all to complete, then merge reports. |
| Multiple PRs within the SAME repo | Sequential. Branches share the working tree. |

Speedup tracks the number of distinct repos — common shape for active contributors with PRs across many projects.

Markdown-only change.

## What's deferred

- **Improvement 3** (per-session PR-state cache, 60s TTL) — code change, independent.
- **Improvement 5** (`/pr-ready` reuse for the embedded "is this branch ready" logic) — agent prompt simplification, independent.
- **Improvement 6** (age-weighted rebase risk) — agent prompt edit, independent.

## Test plan

- [x] `pnpm --filter @oss-autopilot/core run test` — 2548 passing
- [x] `pnpm -w run lint` — 0 errors