### PR TITLE
refactor: age-weighted rebase strategy in pr-health-checker (#1272 Improvement 6)

### DIFF
--- a/agents/pr-health-checker.md
+++ b/agents/pr-health-checker.md
@@ -45,11 +45,20 @@ You are a PR Health Specialist who diagnoses and helps resolve issues preventing
 
 ## Review-Aware Git Strategy
 
-- **No reviews yet (or all resolved):** rebase and force-push freely.
-- **Active review (`CHANGES_REQUESTED` or open threads):** always create new commits on top. Never amend, rebase, or force-push unless the user explicitly asks. If behind upstream, inform the user and let them decide.
-- **Approved and ready to merge:** squashing happens at merge time via GitHub's "Squash and merge", not during review.
+The base rule is binary on review state. The **age-weighted overlay** (#1272 Improvement 6) sharpens it: a stale PR carries higher rebase risk than the binary rule alone suggests, because the maintainer who hasn't looked in N weeks has lost context — the diff signature shifting under them when they finally circle back is a known annoyance.
 
-Reviewers rely on incremental commits to see what changed since their last review — rebasing invalidates review comments.
+| State (review × age) | Strategy |
+|---|---|
+| No reviews yet, fresh (`daysSinceActivity` ≤ 14) | Rebase + force-push freely. Tier 1. |
+| No reviews yet, stale (`daysSinceActivity` > 30) | Prefer commits-on-top. The PR is dormant — even without explicit review feedback, the maintainer's context is gone. Surface this in the report; let the user opt into rebase explicitly if they want a clean history before bumping. |
+| All reviews resolved, fresh | Rebase + force-push freely. Tier 1. |
+| All reviews resolved, stale (>30 days since `lastMaintainerComment`) | Prefer commits-on-top. Same context-decay reasoning. |
+| Active review (`CHANGES_REQUESTED` or open threads) | Always commits-on-top regardless of age. Never amend / rebase / force-push without explicit user request. |
+| Approved and ready to merge | Squash happens at merge time via GitHub's "Squash and merge". Don't rewrite history during review. |
+
+Between fresh (≤14 days) and stale (>30 days) is an "approaching dormant" window (15–30 days). Default to rebase but flag it in the report so the user can override before push.
+
+Reviewers rely on incremental commits to see what changed since their last review — rebasing invalidates review comments. Age-weighting extends that principle: even maintainers who never left a review have an implicit "context state" that decays.
 
 ## Data Access
 


### PR DESCRIPTION
## Summary

Closes #1272 Improvement 6. The Review-Aware Git Strategy section's rule was binary on review state: no reviews → rebase freely; active review → never rebase. That's correct for the active-review case but misses the dormant-PR edge:

> A 90-day-old PR carries higher rebase risk than a 5-day-old one because the maintainer (when they finally circle back) has lost their mental model of the diff. The signature shifting under them is a known annoyance.

## What's in the diff

Replaces the 3-row binary rule with a 6-row age-weighted overlay. Signals come from existing `FetchedPR` fields (`daysSinceActivity`, `lastMaintainerComment.createdAt`) — no new data plumbing required.

| State (review × age) | Strategy |
|---|---|
| No reviews, fresh (≤14d) | Rebase + force-push freely |
| No reviews, stale (>30d) | Prefer commits-on-top, flag for user opt-in |
| All resolved, fresh | Rebase + force-push freely |
| All resolved, stale (>30d) | Prefer commits-on-top |
| Active review | Commits-on-top regardless of age (unchanged) |
| Approved, ready to merge | No rewrite — squash at merge time (unchanged) |

Plus a 15–30d "approaching dormant" window: default to rebase but flag in the report so the user can override before push.

Markdown-only change. No code, no tests modified.

## Test plan

- [x] `pnpm -w run lint` — 0 errors
- [x] No phase numbering or section header changes that other docs reference