### PR TITLE
fix: persist auto-detected skippedIssuesPath to state.config (#1330)

### DIFF
--- a/packages/core/src/commands/startup.test.ts
+++ b/packages/core/src/commands/startup.test.ts
@@ -342,6 +342,7 @@ describe('detectIssueList', () => {
     vi.mocked(getStateManager).mockReturnValue({
       isSetupComplete: vi.fn(() => true),
       getState: vi.fn(() => ({ config: { issueListPath: 'open-source/issues.md' } })),
+      updateConfig: vi.fn(),
     } as any);
 
     const result = detectIssueList();
@@ -361,6 +362,63 @@ describe('detectIssueList', () => {
 
     expect(result).toBeDefined();
     expect(result?.skippedIssuesPath).toBeUndefined();
+  });
+
+  it('persists auto-detected skippedIssuesPath to state.config when not already set (#1330)', async () => {
+    // Repro: startup detects the file via the default-path probe but
+    // returns it only in the run output. Without persistence, every
+    // downstream `skip-add` and scout search reads `config.skippedIssuesPath`
+    // (undefined) and silently no-ops the skip filter.
+    existsSyncMock.mockImplementation((p: string) => {
+      if (typeof p === 'string' && p === 'open-source/issues.md') return true;
+      if (typeof p === 'string' && p === 'open-source/skipped-issues.md') return true;
+      return false;
+    });
+    (fsImport as any).readFileSync = vi.fn().mockReturnValue('- [#1](https://github.com/o/r/issues/1) — Issue\n');
+
+    const updateConfigSpy = vi.fn();
+    const { getStateManager } = await import('../core/index.js');
+    vi.mocked(getStateManager).mockReturnValue({
+      isSetupComplete: vi.fn(() => true),
+      // No skippedIssuesPath in config yet — the auto-detect must persist it.
+      getState: vi.fn(() => ({ config: { issueListPath: 'open-source/issues.md' } })),
+      updateConfig: updateConfigSpy,
+    } as any);
+
+    const result = detectIssueList();
+
+    expect(result?.skippedIssuesPath).toBe('open-source/skipped-issues.md');
+    expect(updateConfigSpy).toHaveBeenCalledWith({ skippedIssuesPath: 'open-source/skipped-issues.md' });
+  });
+
+  it('does NOT re-persist skippedIssuesPath when already set in config (#1330)', async () => {
+    // Re-running startup on a state that already has the path persisted
+    // shouldn't trigger an autoSave every run. The first conditional path
+    // (`config first`) takes the value, the default-path probe never
+    // runs, and updateConfig stays untouched.
+    existsSyncMock.mockImplementation((p: string) => {
+      if (typeof p === 'string' && p === 'open-source/issues.md') return true;
+      if (typeof p === 'string' && p === 'open-source/skipped-issues.md') return true;
+      return false;
+    });
+    (fsImport as any).readFileSync = vi.fn().mockReturnValue('- [#1](https://github.com/o/r/issues/1) — Issue\n');
+
+    const updateConfigSpy = vi.fn();
+    const { getStateManager } = await import('../core/index.js');
+    vi.mocked(getStateManager).mockReturnValue({
+      isSetupComplete: vi.fn(() => true),
+      getState: vi.fn(() => ({
+        config: {
+          issueListPath: 'open-source/issues.md',
+          skippedIssuesPath: 'open-source/skipped-issues.md',
+        },
+      })),
+      updateConfig: updateConfigSpy,
+    } as any);
+
+    detectIssueList();
+
+    expect(updateConfigSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/core/src/commands/startup.ts
+++ b/packages/core/src/commands/startup.ts
@@ -122,11 +122,32 @@ export function detectIssueList(): IssueListInfo | undefined {
     warn('startup', `Could not read skippedIssuesPath from state: ${errorMessage(err)}`);
   }
 
-  // Probe default path: same directory as issue list, named skipped-issues.md
+  // Probe default path: same directory as issue list, named skipped-issues.md.
+  // When found, also persist to state.config so downstream commands
+  // (`skip-add`, `scout search`'s skip-list filter) read the same path
+  // instead of silently no-opping with "No skipped-issues path configured"
+  // (#1330). Without persistence, the auto-detect printed the path on
+  // every startup but nothing else honored it — search would re-surface
+  // already-skipped candidates round after round.
   if (!skippedIssuesPath && issueListPath) {
     const defaultSkipPath = path.join(path.dirname(issueListPath), 'skipped-issues.md');
     if (fs.existsSync(defaultSkipPath)) {
       skippedIssuesPath = defaultSkipPath;
+      try {
+        const stateManager = getStateManager();
+        // Only write when config actually doesn't have one — re-running
+        // startup shouldn't trigger an autoSave on every run if the
+        // value is already there.
+        const current = stateManager.getState().config.skippedIssuesPath;
+        if (!current) {
+          stateManager.updateConfig({ skippedIssuesPath: defaultSkipPath });
+        }
+      } catch (err) {
+        // Persistence is best-effort — startup still surfaces the path
+        // in its return value so the current run benefits, but the next
+        // run won't. Log so the failure is debuggable.
+        warn('startup', `Could not persist auto-detected skippedIssuesPath: ${errorMessage(err)}`);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Closes #1330. Startup's default-path probe found a `skipped-issues.md` file alongside the issue list and surfaced it in the run output, but never wrote it back to `state.config.skippedIssuesPath`. Downstream commands (`skip-add`, scout search's skip-list filter) read from config and not from the run output, so they silently no-opped.

Repro:

\`\`\`sh
$ skip-add <url> --json
Error: No skipped-issues path configured. Set one via
'oss-autopilot setup --set skippedIssuesPath=<path>' or pass --path.

$ scout search
→ returns issues already appended to the skip file in earlier rounds.
\`\`\`

Net effect: the user vetted candidates, appended them to the skip file via `>>`, ran another search, and got the same candidates back. The auto-detect path was visible in the JSON output but no other code honored it.

## Fix

In `detectIssueList()`, when the default-path probe locates a skipped-issues file AND `config.skippedIssuesPath` is not already set, persist it via `stateManager.updateConfig({ skippedIssuesPath })`. The "not already set" guard prevents re-firing `autoSave` on every run when the value is already there.

Persistence is best-effort: if `updateConfig` throws, the current run still surfaces the path in its return value (so the daily output is unaffected), but the next run won't have the persisted value. A warning makes the failure debuggable.

## Test plan

- [x] `pnpm --filter @oss-autopilot/core run test` — 2550 passing (+2 new):
  - Asserts `updateConfig` is called with the detected path when config doesn't have one
  - Asserts `updateConfig` is NOT called when config already has it (no autoSave thrash on re-run)
- [x] `pnpm --filter @oss-autopilot/core run build` — clean
- [x] `pnpm -w run lint` — 0 errors