### PR TITLE
feat: integrate @oss-scout/core 0.9.0 (features command + stalled-PR detection)

### DIFF
--- a/.claude-plugin/expected-cli-contract.json
+++ b/.claude-plugin/expected-cli-contract.json
@@ -12,6 +12,7 @@
     "detect-formatters",
     "dismiss",
     "doctor",
+    "features",
     "guidelines",
     "init",
     "list-mark-done",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ env:
   #   - **Don't bump for a flaky measurement:** esbuild output is
   #     deterministic. If the threshold trips on a no-op rebuild, it's a
   #     real increase somewhere upstream — not noise.
-  BUNDLE_MAX_CORE: 832000 # ~812 KB (increased for the post-3.5 batch: list-mark-done CLI + ciCategorization on FetchedPR + strategy snapshot wiring + AI-disclosure scan; #1270/#1272/#1299)
+  BUNDLE_MAX_CORE: 880000 # ~860 KB (increased for scout 0.9.0 integration: features command + isLinkedPRStalled plumbing; current ~816 KB)
   BUNDLE_MAX_MCP: 2000000 # ~1953 KB
   STARTUP_WARN_MS: 500 # Warn if CLI startup exceeds 500ms
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "@octokit/plugin-throttling": "^11.0.3",
     "@octokit/rest": "^22.0.1",
-    "@oss-scout/core": "^0.8.0",
+    "@oss-scout/core": "^0.9.0",
     "commander": "^14.0.3",
     "zod": "^4.4.3"
   },

--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -476,6 +476,7 @@ export const commands: CLICommandDef[] = [
               console.log(`  Claimed:         ${data.summary.claimed}`);
               console.log(`  Closed:          ${data.summary.closed}`);
               console.log(`  Has PR:          ${data.summary.hasPR}`);
+              console.log(`  Stalled PR:      ${data.summary.hasStalledPR}`);
               console.log(`  Errors:          ${data.summary.errors}`);
               console.log('');
               for (const result of data.results) {
@@ -485,8 +486,9 @@ export const commands: CLICommandDef[] = [
                     : result.listStatus === 'error'
                       ? '\u274c'
                       : '\u26a0\ufe0f';
+                const annotation = result.listStatus === 'has_stalled_pr' ? ' (stalled PR, revive opportunity)' : '';
                 console.log(
-                  `${status} [${result.listStatus}] ${result.issue.repo}#${result.issue.number}: ${result.issue.title}`,
+                  `${status} [${result.listStatus}] ${result.issue.repo}#${result.issue.number}: ${result.issue.title}${annotation}`,
                 );
                 if (result.errorMessage) {
                   console.log(`   Error: ${result.errorMessage}`);

--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -328,6 +328,100 @@ export const commands: CLICommandDef[] = [
     },
   },
 
+  // ── Features ───────────────────────────────────────────────────────────
+  // scout 0.9.0 (#97/#98/#99): feature-scoped opportunities in repos with
+  // 3+ merged PRs, split into quick-wins / bigger-bets buckets.
+  {
+    name: 'features',
+    register(program) {
+      program
+        .command('features [count]')
+        .description('Find feature-scoped opportunities in repos with 3+ merged PRs')
+        .option('--json', 'Output as JSON')
+        .option('--anchor-threshold <n>', 'Override featuresAnchorThreshold (1-50)')
+        .option('--split-ratio <r>', 'Override featuresSplitRatio (0-1)')
+        .action(async (count, options) => {
+          const { FeaturesOutputSchema } = await import('./formatters/json.js');
+          await executeAction(
+            options,
+            async () => {
+              const { runFeatures, MAX_FEATURES_RESULTS } = await import('./commands/features.js');
+              let maxResults = 10;
+              if (count !== undefined) {
+                const parsed = Number(count);
+                if (!Number.isFinite(parsed) || parsed < 1 || !Number.isInteger(parsed)) {
+                  throw new Error(`Invalid count "${count}". Must be a positive integer.`);
+                }
+                maxResults = parsed;
+              }
+              if (maxResults > MAX_FEATURES_RESULTS) {
+                console.warn(`Capping features to ${MAX_FEATURES_RESULTS} results (requested: ${maxResults})`);
+                maxResults = MAX_FEATURES_RESULTS;
+              }
+              let anchorThreshold: number | undefined;
+              if (options.anchorThreshold !== undefined) {
+                const parsed = Number(options.anchorThreshold);
+                if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 1 || parsed > 50) {
+                  throw new Error(
+                    `Invalid --anchor-threshold "${options.anchorThreshold}". Must be an integer in [1, 50].`,
+                  );
+                }
+                anchorThreshold = parsed;
+              }
+              let splitRatio: number | undefined;
+              if (options.splitRatio !== undefined) {
+                const parsed = Number(options.splitRatio);
+                if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
+                  throw new Error(`Invalid --split-ratio "${options.splitRatio}". Must be a number in [0, 1].`);
+                }
+                splitRatio = parsed;
+              }
+              if (!options.json) {
+                console.log(`\nSearching for feature opportunities (max ${maxResults})...\n`);
+              }
+              return runFeatures({ maxResults, anchorThreshold, splitRatio });
+            },
+            (data) => {
+              if (data.anchorRepos.length > 0) {
+                console.log(`Anchor repos (${data.anchorRepos.length}): ${data.anchorRepos.join(', ')}`);
+                console.log('');
+              }
+              if (data.quickWins.length === 0 && data.biggerBets.length === 0) {
+                if (data.rateLimitWarning) {
+                  console.warn(`\n${data.rateLimitWarning}\n`);
+                } else if (data.message) {
+                  console.log(data.message);
+                } else {
+                  console.log('No feature opportunities found.');
+                }
+                return;
+              }
+              if (data.rateLimitWarning) {
+                console.warn(`\n${data.rateLimitWarning}\n`);
+              }
+              const printBucket = (heading: string, candidates: typeof data.quickWins) => {
+                if (candidates.length === 0) return;
+                console.log(`${heading} (${candidates.length}):\n`);
+                for (const candidate of candidates) {
+                  const { issue, recommendation, reasonsToApprove, reasonsToSkip, viabilityScore } = candidate;
+                  console.log(`[${recommendation.toUpperCase()}] ${issue.repo}#${issue.number}: ${issue.title}`);
+                  console.log(`  URL: ${issue.url}`);
+                  console.log(`  Viability: ${viabilityScore}/100`);
+                  if (reasonsToApprove.length > 0) console.log(`  Approve: ${reasonsToApprove.join(', ')}`);
+                  if (reasonsToSkip.length > 0) console.log(`  Skip: ${reasonsToSkip.join(', ')}`);
+                  console.log('---');
+                }
+                console.log('');
+              };
+              printBucket('Quick wins', data.quickWins);
+              printBucket('Bigger bets', data.biggerBets);
+            },
+            FeaturesOutputSchema,
+          );
+        });
+    },
+  },
+
   // ── Vet ────────────────────────────────────────────────────────────────
   {
     name: 'vet',

--- a/packages/core/src/cli.test.ts
+++ b/packages/core/src/cli.test.ts
@@ -387,6 +387,7 @@ describe('Command registration', () => {
       'daily',
       'status',
       'search',
+      'features',
       'vet',
       'vet-list',
       'track',

--- a/packages/core/src/commands/__golden__/vet-list.empty.json
+++ b/packages/core/src/commands/__golden__/vet-list.empty.json
@@ -6,6 +6,7 @@
     "claimed": 0,
     "closed": 0,
     "hasPR": 0,
+    "hasStalledPR": 0,
     "errors": 0
   }
 }

--- a/packages/core/src/commands/__golden__/vet-list.mixed.json
+++ b/packages/core/src/commands/__golden__/vet-list.mixed.json
@@ -101,6 +101,7 @@
     "claimed": 1,
     "closed": 0,
     "hasPR": 0,
+    "hasStalledPR": 0,
     "errors": 1
   }
 }

--- a/packages/core/src/commands/features.test.ts
+++ b/packages/core/src/commands/features.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Tests for features command (scout 0.9.0 #97/#98/#99).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockFeatures = vi.fn();
+
+vi.mock('./scout-bridge.js', () => ({
+  createAutopilotScout: vi.fn(async () => ({
+    features: mockFeatures,
+  })),
+}));
+
+vi.mock('../core/index.js', () => ({
+  getStateManager: vi.fn(),
+}));
+
+import { getStateManager } from '../core/index.js';
+import { runFeatures } from './features.js';
+
+const mockGetStateManager = vi.mocked(getStateManager);
+
+function makeScoutFeatureCandidate(overrides: Record<string, unknown> = {}) {
+  return {
+    issue: {
+      repo: 'owner/repo',
+      number: 5,
+      title: 'Add cool feature',
+      url: 'https://github.com/owner/repo/issues/5',
+      labels: ['enhancement'],
+    },
+    recommendation: 'approve' as const,
+    reasonsToApprove: ['Maintainer is responsive'],
+    reasonsToSkip: [],
+    searchPriority: 'merged_pr' as const,
+    viabilityScore: 80,
+    horizon: 'quick-win' as const,
+    ...overrides,
+  };
+}
+
+describe('runFeatures', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetStateManager.mockReturnValue({
+      getState: vi.fn().mockReturnValue({ config: {} }),
+      getRepoScore: vi.fn().mockReturnValue(null),
+    } as never);
+  });
+
+  it('passes options through to scout.features (count + per-call overrides)', async () => {
+    mockFeatures.mockResolvedValue({
+      quickWins: [],
+      biggerBets: [],
+      anchorRepos: [],
+      message: null,
+    });
+
+    await runFeatures({ maxResults: 7, anchorThreshold: 5, splitRatio: 0.7 });
+
+    expect(mockFeatures).toHaveBeenCalledWith({
+      count: 7,
+      anchorThreshold: 5,
+      splitRatio: 0.7,
+    });
+  });
+
+  it('omits per-call overrides when caller does not provide them', async () => {
+    mockFeatures.mockResolvedValue({
+      quickWins: [],
+      biggerBets: [],
+      anchorRepos: [],
+      message: null,
+    });
+
+    await runFeatures({ maxResults: 10 });
+
+    expect(mockFeatures).toHaveBeenCalledWith({
+      count: 10,
+      anchorThreshold: undefined,
+      splitRatio: undefined,
+    });
+  });
+
+  it('returns both buckets, anchorRepos, and a null message when scout reports a clean run', async () => {
+    mockFeatures.mockResolvedValue({
+      quickWins: [makeScoutFeatureCandidate({ horizon: 'quick-win' })],
+      biggerBets: [
+        makeScoutFeatureCandidate({
+          issue: {
+            repo: 'owner/other',
+            number: 12,
+            title: 'Big bet',
+            url: 'https://github.com/owner/other/issues/12',
+            labels: ['feature', 'roadmap'],
+          },
+          horizon: 'bigger-bet',
+        }),
+      ],
+      anchorRepos: ['owner/repo', 'owner/other'],
+      message: null,
+    });
+
+    const result = await runFeatures({ maxResults: 5 });
+
+    expect(result.anchorRepos).toEqual(['owner/repo', 'owner/other']);
+    expect(result.message).toBeNull();
+    expect(result.quickWins).toHaveLength(1);
+    expect(result.biggerBets).toHaveLength(1);
+    expect(result.quickWins[0]).toEqual(
+      expect.objectContaining({
+        issue: expect.objectContaining({
+          repo: 'owner/repo',
+          repoUrl: 'https://github.com/owner/repo',
+        }),
+        horizon: 'quick-win',
+      }),
+    );
+    expect(result.biggerBets[0].horizon).toBe('bigger-bet');
+  });
+
+  it('stamps a horizon literal on every candidate in each bucket', async () => {
+    mockFeatures.mockResolvedValue({
+      quickWins: [makeScoutFeatureCandidate({ horizon: 'quick-win' })],
+      biggerBets: [makeScoutFeatureCandidate({ horizon: 'bigger-bet' })],
+      anchorRepos: ['owner/repo'],
+      message: null,
+    });
+
+    const result = await runFeatures({ maxResults: 5 });
+
+    for (const c of result.quickWins) expect(c.horizon).toBe('quick-win');
+    for (const c of result.biggerBets) expect(c.horizon).toBe('bigger-bet');
+  });
+
+  it('sanitizes an out-of-contract viabilityScore from scout (#1043 boundary)', async () => {
+    mockFeatures.mockResolvedValue({
+      quickWins: [makeScoutFeatureCandidate({ viabilityScore: 999 })],
+      biggerBets: [],
+      anchorRepos: ['owner/repo'],
+      message: null,
+    });
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await runFeatures({ maxResults: 5 });
+
+    expect(result.quickWins[0].viabilityScore).toBe(0);
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('out-of-contract viabilityScore'));
+    errSpy.mockRestore();
+  });
+
+  it('assigns a grade letter to every candidate', async () => {
+    mockFeatures.mockResolvedValue({
+      quickWins: [makeScoutFeatureCandidate()],
+      biggerBets: [],
+      anchorRepos: ['owner/repo'],
+      message: null,
+    });
+
+    const result = await runFeatures({ maxResults: 5 });
+
+    // Repo has no autopilot-tracked score and projectHealth is sentinel-unknown,
+    // so the grader degrades to 'F' — same policy as runSearch (#1043).
+    expect(result.quickWins[0].grade.letter).toBe('F');
+  });
+
+  it('returns the scout-side message verbatim when no anchors qualify', async () => {
+    mockFeatures.mockResolvedValue({
+      quickWins: [],
+      biggerBets: [],
+      anchorRepos: [],
+      message: 'No anchor repos yet (need 3+ merged PRs in a repo). Try `scout search` to build relationships first.',
+    });
+
+    const result = await runFeatures({ maxResults: 5 });
+
+    expect(result.quickWins).toEqual([]);
+    expect(result.biggerBets).toEqual([]);
+    expect(result.anchorRepos).toEqual([]);
+    expect(result.message).toMatch(/No anchor repos/);
+  });
+
+  it('includes repoScore on candidates whose repo is autopilot-tracked', async () => {
+    mockFeatures.mockResolvedValue({
+      quickWins: [
+        makeScoutFeatureCandidate({ issue: { repo: 'scored/repo', number: 1, title: 't', url: 'u', labels: [] } }),
+      ],
+      biggerBets: [],
+      anchorRepos: ['scored/repo'],
+      message: null,
+    });
+    mockGetStateManager.mockReturnValue({
+      getState: vi.fn().mockReturnValue({ config: {} }),
+      getRepoScore: vi.fn().mockReturnValue({
+        score: 8,
+        mergedPRCount: 4,
+        closedWithoutMergeCount: 1,
+        signals: { isResponsive: true },
+        lastMergedAt: '2026-02-01T00:00:00Z',
+      }),
+    } as never);
+
+    const result = await runFeatures({ maxResults: 3 });
+
+    expect(result.quickWins[0].repoScore).toEqual({
+      score: 8,
+      mergedPRCount: 4,
+      closedWithoutMergeCount: 1,
+      isResponsive: true,
+      lastMergedAt: '2026-02-01T00:00:00Z',
+    });
+  });
+
+  it('propagates errors from scout.features (auth/rate-limit pass-through)', async () => {
+    mockFeatures.mockRejectedValue(new Error('API rate limit exceeded'));
+
+    await expect(runFeatures({ maxResults: 5 })).rejects.toThrow('API rate limit exceeded');
+  });
+});

--- a/packages/core/src/commands/features.test.ts
+++ b/packages/core/src/commands/features.test.ts
@@ -6,15 +6,23 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockFeatures = vi.fn();
 
-vi.mock('./scout-bridge.js', () => ({
-  createAutopilotScout: vi.fn(async () => ({
-    features: mockFeatures,
-  })),
-}));
+vi.mock('./scout-bridge.js', async () => {
+  const actual = await vi.importActual<typeof import('./scout-bridge.js')>('./scout-bridge.js');
+  return {
+    ...actual,
+    createAutopilotScout: vi.fn(async () => ({
+      features: mockFeatures,
+    })),
+  };
+});
 
-vi.mock('../core/index.js', () => ({
-  getStateManager: vi.fn(),
-}));
+vi.mock('../core/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../core/index.js')>('../core/index.js');
+  return {
+    ...actual,
+    getStateManager: vi.fn(),
+  };
+});
 
 import { getStateManager } from '../core/index.js';
 import { runFeatures } from './features.js';

--- a/packages/core/src/commands/features.ts
+++ b/packages/core/src/commands/features.ts
@@ -1,0 +1,159 @@
+/**
+ * Features command (scout 0.9.0 #97/#98/#99)
+ *
+ * Wraps `scout.features()` to surface feature-scoped contribution
+ * opportunities in repos where the user already has 3+ merged PRs
+ * (configurable via `featuresAnchorThreshold`). Returns two ranked
+ * buckets — "quick wins" and "bigger bets" — split by maintainer-
+ * commitment signals (milestones, roadmap membership, label set).
+ *
+ * Mirrors the shape of `runSearch`: each bucket entry is a
+ * {@link SearchCandidate} augmented with a `horizon` literal so callers
+ * can render bucket-specific UX while reusing the search candidate
+ * formatter.
+ */
+
+import { createAutopilotScout } from './scout-bridge.js';
+import { getStateManager } from '../core/index.js';
+import { type FeaturesOutput, type FeaturesCandidate, type SearchCandidate } from '../formatters/json.js';
+import { gradeFromCandidate } from '../core/issue-grading.js';
+import { warn } from '../core/logger.js';
+
+export { type FeaturesOutput, type FeaturesCandidate } from '../formatters/json.js';
+
+const MODULE = 'features';
+
+/**
+ * Hard cap on feature-search result count, matching `MAX_SEARCH_RESULTS`
+ * for `runSearch`. Shared between CLI (`cli-registry.ts`) and the MCP
+ * tool registration so a future adjustment lands in one place.
+ */
+export const MAX_FEATURES_RESULTS = 100;
+
+interface FeaturesOptions {
+  maxResults: number;
+  /** Override `featuresAnchorThreshold` for this call (1-50). */
+  anchorThreshold?: number;
+  /** Override `featuresSplitRatio` for this call (0-1). */
+  splitRatio?: number;
+}
+
+/**
+ * Coerce scout's raw `viabilityScore` into a trustworthy 0-100 number.
+ * Same defensive boundary check as `runSearch` — kept inline (not
+ * imported) so this command remains self-contained per the existing
+ * autopilot convention. See #1043.
+ */
+function sanitizeViabilityScore(raw: unknown): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw) || raw < 0 || raw > 100) {
+    warn(MODULE, `Ignoring out-of-contract viabilityScore from scout: ${JSON.stringify(raw)}`);
+    return 0;
+  }
+  return raw;
+}
+
+/**
+ * Map one scout `FeatureCandidate` into the autopilot output shape.
+ * Mirrors the candidate-mapping branch in `runSearch` and stamps the
+ * `horizon` field.
+ */
+function toFeaturesCandidate(
+  scoutCandidate: {
+    issue: { repo: string; number: number; title: string; url: string; labels: string[] };
+    recommendation: SearchCandidate['recommendation'];
+    reasonsToApprove: string[];
+    reasonsToSkip: string[];
+    searchPriority: SearchCandidate['searchPriority'];
+    viabilityScore: unknown;
+    horizon: FeaturesCandidate['horizon'];
+  },
+  getState: ReturnType<typeof getStateManager>,
+): FeaturesCandidate {
+  const repoScoreRecord = getState.getRepoScore(scoutCandidate.issue.repo);
+  // Same `checkFailed: true` sentinel `runSearch` uses — scout's `features`
+  // pipeline reuses the same vetting code that does emit projectHealth on
+  // `vetIssue`, but on this surface scout returns the multi-issue list view
+  // which today does not propagate per-candidate health into IssueCandidate.
+  // Treating health as unknown grades from the autopilot-tracked repoScore
+  // alone, falling to 'F' for unfamiliar repos — an honest "we haven't seen
+  // this repo" rather than a fabricated score.
+  const grade = gradeFromCandidate({
+    repo: scoutCandidate.issue.repo,
+    projectHealth: { avgIssueResponseDays: null, daysSinceLastCommit: null, checkFailed: true },
+    getRepoScore: (repo) => {
+      const score = getState.getRepoScore(repo);
+      return score
+        ? {
+            mergedPRCount: score.mergedPRCount,
+            closedWithoutMergeCount: score.closedWithoutMergeCount,
+            avgResponseDays: score.avgResponseDays ?? null,
+          }
+        : undefined;
+    },
+  });
+  return {
+    issue: {
+      repo: scoutCandidate.issue.repo,
+      repoUrl: `https://github.com/${scoutCandidate.issue.repo}`,
+      number: scoutCandidate.issue.number,
+      title: scoutCandidate.issue.title,
+      url: scoutCandidate.issue.url,
+      labels: scoutCandidate.issue.labels,
+    },
+    recommendation: scoutCandidate.recommendation,
+    reasonsToApprove: scoutCandidate.reasonsToApprove,
+    reasonsToSkip: scoutCandidate.reasonsToSkip,
+    searchPriority: scoutCandidate.searchPriority,
+    viabilityScore: sanitizeViabilityScore(scoutCandidate.viabilityScore),
+    grade,
+    repoScore: repoScoreRecord
+      ? {
+          score: repoScoreRecord.score,
+          mergedPRCount: repoScoreRecord.mergedPRCount,
+          closedWithoutMergeCount: repoScoreRecord.closedWithoutMergeCount,
+          isResponsive: repoScoreRecord.signals?.isResponsive ?? false,
+          lastMergedAt: repoScoreRecord.lastMergedAt,
+        }
+      : undefined,
+    horizon: scoutCandidate.horizon,
+  };
+}
+
+/**
+ * Run feature-scoped contribution discovery via `scout.features()`.
+ *
+ * @param options - Feature search configuration
+ * @param options.maxResults - Total candidates returned across both buckets
+ * @param options.anchorThreshold - Optional per-call override for the merged-PR threshold (default: scout's `featuresAnchorThreshold`)
+ * @param options.splitRatio - Optional per-call override for the quick-win split ratio (default: scout's `featuresSplitRatio`)
+ * @returns Two ranked buckets (quick-wins / bigger-bets) plus anchor list and an optional human message
+ * @throws {ConfigurationError} If no GitHub token is available
+ *
+ * @example
+ * ```typescript
+ * import { runFeatures } from '@oss-autopilot/core/commands';
+ *
+ * const result = await runFeatures({ maxResults: 10 });
+ * for (const c of [...result.quickWins, ...result.biggerBets]) {
+ *   console.log(`${c.issue.repo}#${c.issue.number} — ${c.horizon}`);
+ * }
+ * ```
+ */
+export async function runFeatures(options: FeaturesOptions): Promise<FeaturesOutput> {
+  const scout = await createAutopilotScout();
+  const result = await scout.features({
+    count: options.maxResults,
+    anchorThreshold: options.anchorThreshold,
+    splitRatio: options.splitRatio,
+  });
+
+  const stateManager = getStateManager();
+
+  const featuresOutput: FeaturesOutput = {
+    quickWins: result.quickWins.map((c) => toFeaturesCandidate(c, stateManager)),
+    biggerBets: result.biggerBets.map((c) => toFeaturesCandidate(c, stateManager)),
+    anchorRepos: result.anchorRepos,
+    message: result.message,
+  };
+  return featuresOutput;
+}

--- a/packages/core/src/commands/features.ts
+++ b/packages/core/src/commands/features.ts
@@ -13,7 +13,8 @@
  * formatter.
  */
 
-import { createAutopilotScout } from './scout-bridge.js';
+import type { LinkedPR as ScoutLinkedPR } from '@oss-scout/core';
+import { buildCandidateLinkedPR, createAutopilotScout } from './scout-bridge.js';
 import { getStateManager } from '../core/index.js';
 import { type FeaturesOutput, type FeaturesCandidate, type SearchCandidate } from '../formatters/json.js';
 import { gradeFromCandidate } from '../core/issue-grading.js';
@@ -66,6 +67,8 @@ function toFeaturesCandidate(
     searchPriority: SearchCandidate['searchPriority'];
     viabilityScore: unknown;
     horizon: FeaturesCandidate['horizon'];
+    /** Optional — present on real scout candidates, omitted in some test fixtures. */
+    vettingResult?: { linkedPR?: ScoutLinkedPR | null };
   },
   getState: ReturnType<typeof getStateManager>,
 ): FeaturesCandidate {
@@ -91,6 +94,7 @@ function toFeaturesCandidate(
         : undefined;
     },
   });
+  const linkedPR = buildCandidateLinkedPR(scoutCandidate.vettingResult?.linkedPR);
   return {
     issue: {
       repo: scoutCandidate.issue.repo,
@@ -115,6 +119,7 @@ function toFeaturesCandidate(
           lastMergedAt: repoScoreRecord.lastMergedAt,
         }
       : undefined,
+    ...(linkedPR ? { linkedPR } : {}),
     horizon: scoutCandidate.horizon,
   };
 }

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -26,6 +26,8 @@ export { runStartup } from './startup.js';
 export { runStatus } from './status.js';
 /** Search GitHub for contributable issues using multi-strategy discovery. */
 export { runSearch, MAX_SEARCH_RESULTS } from './search.js';
+/** Surface feature-scoped opportunities in repos with 3+ merged PRs (scout 0.9.0). */
+export { runFeatures, MAX_FEATURES_RESULTS } from './features.js';
 /** Vet a single GitHub issue for claimability (open, unassigned, no linked PRs, repo health). */
 export { runVet } from './vet.js';
 /** Re-vet all available issues in a curated issue list for freshness. */
@@ -127,7 +129,17 @@ export type { DashboardJsonData, DashboardStats, DashboardActionType, ActionRequ
 // All commands return JsonOutput<T> where T is the command-specific type below.
 
 export type { ErrorCode } from '../formatters/json.js';
-export type { DailyOutput, SearchOutput, StartupOutput, StatusOutput, TrackOutput } from '../formatters/json.js';
+export type {
+  DailyOutput,
+  SearchOutput,
+  SearchCandidate,
+  FeaturesOutput,
+  FeaturesCandidate,
+  FeaturesHorizon,
+  StartupOutput,
+  StatusOutput,
+  TrackOutput,
+} from '../formatters/json.js';
 export type {
   VetOutput,
   CommentsOutput,

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -133,6 +133,7 @@ export type {
   DailyOutput,
   SearchOutput,
   SearchCandidate,
+  CandidateLinkedPR,
   FeaturesOutput,
   FeaturesCandidate,
   FeaturesHorizon,

--- a/packages/core/src/commands/scout-bridge.test.ts
+++ b/packages/core/src/commands/scout-bridge.test.ts
@@ -18,7 +18,7 @@ vi.mock('./skip-file-parser.js', () => ({
 }));
 
 import { getStateManager } from '../core/index.js';
-import { buildScoutState } from './scout-bridge.js';
+import { buildScoutState, adaptScoutLinkedPR } from './scout-bridge.js';
 import { loadSkippedIssues } from './skip-file-parser.js';
 import { makeAgentState, makeDailyDigest, makeFetchedPR, makeStateManagerMock } from '../core/test-utils.js';
 
@@ -248,5 +248,65 @@ describe('buildScoutState', () => {
     const result = buildScoutState();
 
     expect(result.skippedIssues).toEqual([]);
+  });
+});
+
+describe('adaptScoutLinkedPR', () => {
+  it('returns null for null/undefined input', () => {
+    expect(adaptScoutLinkedPR(null)).toBeNull();
+    expect(adaptScoutLinkedPR(undefined)).toBeNull();
+  });
+
+  it('folds merged=true into state="merged"', () => {
+    const result = adaptScoutLinkedPR({
+      number: 1,
+      author: 'octocat',
+      state: 'closed',
+      merged: true,
+      url: 'https://github.com/owner/repo/pull/1',
+    });
+    expect(result).toEqual({ author: { login: 'octocat' }, state: 'merged' });
+  });
+
+  it('preserves "open" state when merged=false', () => {
+    const result = adaptScoutLinkedPR({
+      number: 1,
+      author: 'octocat',
+      state: 'open',
+      merged: false,
+      url: 'https://github.com/owner/repo/pull/1',
+    });
+    expect(result).toEqual({ author: { login: 'octocat' }, state: 'open' });
+  });
+
+  it('propagates updatedAt when present (scout 0.9.0)', () => {
+    const result = adaptScoutLinkedPR({
+      number: 1,
+      author: 'octocat',
+      state: 'open',
+      merged: false,
+      url: 'https://github.com/owner/repo/pull/1',
+      updatedAt: '2026-04-01T12:34:56Z',
+    });
+    expect(result).toEqual({
+      author: { login: 'octocat' },
+      state: 'open',
+      updatedAt: '2026-04-01T12:34:56Z',
+    });
+  });
+
+  it('omits updatedAt entirely when scout did not provide one', () => {
+    const result = adaptScoutLinkedPR({
+      number: 1,
+      author: 'octocat',
+      state: 'open',
+      merged: false,
+      url: 'https://github.com/owner/repo/pull/1',
+    });
+    expect(result).not.toBeNull();
+    // Use `in` to assert the field is absent rather than just undefined,
+    // since downstream JSON serializers strip explicit `undefined` values
+    // and we want the absence to be a structural property of the object.
+    expect('updatedAt' in (result as object)).toBe(false);
   });
 });

--- a/packages/core/src/commands/scout-bridge.test.ts
+++ b/packages/core/src/commands/scout-bridge.test.ts
@@ -4,10 +4,14 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('../core/index.js', () => ({
-  getStateManager: vi.fn(),
-  requireGitHubToken: vi.fn(),
-}));
+vi.mock('../core/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../core/index.js')>('../core/index.js');
+  return {
+    ...actual,
+    getStateManager: vi.fn(),
+    requireGitHubToken: vi.fn(),
+  };
+});
 
 vi.mock('@oss-scout/core', () => ({
   createScout: vi.fn(),
@@ -18,7 +22,7 @@ vi.mock('./skip-file-parser.js', () => ({
 }));
 
 import { getStateManager } from '../core/index.js';
-import { buildScoutState, adaptScoutLinkedPR } from './scout-bridge.js';
+import { adaptScoutLinkedPR, buildCandidateLinkedPR, buildScoutState } from './scout-bridge.js';
 import { loadSkippedIssues } from './skip-file-parser.js';
 import { makeAgentState, makeDailyDigest, makeFetchedPR, makeStateManagerMock } from '../core/test-utils.js';
 
@@ -308,5 +312,71 @@ describe('adaptScoutLinkedPR', () => {
     // since downstream JSON serializers strip explicit `undefined` values
     // and we want the absence to be a structural property of the object.
     expect('updatedAt' in (result as object)).toBe(false);
+  });
+});
+
+describe('buildCandidateLinkedPR', () => {
+  it('returns undefined when scout has no linked PR', () => {
+    expect(buildCandidateLinkedPR(null)).toBeUndefined();
+    expect(buildCandidateLinkedPR(undefined)).toBeUndefined();
+  });
+
+  it('returns the autopilot-shaped linkedPR slice with isStalled=false for a fresh open PR', () => {
+    // Use a far-future "now" to keep this stable; updatedAt set to ~today.
+    const recent = new Date().toISOString();
+    const result = buildCandidateLinkedPR({
+      number: 42,
+      author: 'octocat',
+      state: 'open',
+      merged: false,
+      url: 'https://github.com/owner/repo/pull/42',
+      updatedAt: recent,
+    });
+    expect(result).toEqual({
+      number: 42,
+      state: 'open',
+      url: 'https://github.com/owner/repo/pull/42',
+      updatedAt: recent,
+      isStalled: false,
+    });
+  });
+
+  it('flags isStalled=true for an open PR with updatedAt > 30 days ago', () => {
+    const result = buildCandidateLinkedPR({
+      number: 7,
+      author: 'octocat',
+      state: 'open',
+      merged: false,
+      url: 'https://github.com/owner/repo/pull/7',
+      updatedAt: '2020-01-01T00:00:00Z',
+    });
+    expect(result?.isStalled).toBe(true);
+  });
+
+  it('folds merged=true into state="merged" and never marks merged PRs as stalled', () => {
+    const result = buildCandidateLinkedPR({
+      number: 9,
+      author: 'octocat',
+      state: 'closed',
+      merged: true,
+      url: 'https://github.com/owner/repo/pull/9',
+      updatedAt: '2020-01-01T00:00:00Z',
+    });
+    expect(result?.state).toBe('merged');
+    expect(result?.isStalled).toBe(false);
+  });
+
+  it('omits updatedAt entirely when scout did not provide one', () => {
+    const result = buildCandidateLinkedPR({
+      number: 5,
+      author: 'octocat',
+      state: 'open',
+      merged: false,
+      url: 'https://github.com/owner/repo/pull/5',
+    });
+    expect(result).toBeDefined();
+    expect('updatedAt' in (result as object)).toBe(false);
+    // Without updatedAt, isStalled cannot be proved — defaults to false.
+    expect(result?.isStalled).toBe(false);
   });
 });

--- a/packages/core/src/commands/scout-bridge.ts
+++ b/packages/core/src/commands/scout-bridge.ts
@@ -61,6 +61,15 @@ export function buildScoutState(): ScoutState {
       persistence: config.persistence as 'local' | 'gist',
       slmTriageModel: config.slmTriageModel,
       slmTriageHost: config.slmTriageHost,
+      // Scout 0.9.0 made these required on `ScoutPreferences` (their schema
+      // ZodDefaults still apply at parse time, but the inferred TS type now
+      // demands the fields). We pass scout's documented defaults here so
+      // autopilot doesn't have to introduce a new pair of user-visible
+      // settings just to satisfy the type. The features CLI command
+      // (#runFeatures) accepts per-call `--anchor-threshold` and
+      // `--split-ratio` flags for overrides.
+      featuresAnchorThreshold: 3,
+      featuresSplitRatio: 0.6,
     },
     repoScores: state.repoScores,
     starredRepos: config.starredRepos,

--- a/packages/core/src/commands/scout-bridge.ts
+++ b/packages/core/src/commands/scout-bridge.ts
@@ -16,13 +16,20 @@ import { loadSkippedIssues } from './skip-file-parser.js';
  * written before scout surfaced this data and uses a tri-state
  * `'open' | 'closed' | 'merged'` enum. Folding `merged` into the state
  * preserves the function's existing contract + tests.
+ *
+ * `updatedAt` (added in scout 0.9.0) flows through unchanged so consumers
+ * can hand the result to `isLinkedPRStalled` without re-fetching.
  */
 export function adaptScoutLinkedPR(scoutLinkedPR: ScoutLinkedPR | null | undefined): LinkedPR | null {
   if (!scoutLinkedPR) return null;
-  return {
+  const adapted: LinkedPR = {
     author: { login: scoutLinkedPR.author },
     state: scoutLinkedPR.merged ? 'merged' : scoutLinkedPR.state,
   };
+  if (scoutLinkedPR.updatedAt !== undefined) {
+    adapted.updatedAt = scoutLinkedPR.updatedAt;
+  }
+  return adapted;
 }
 
 /**

--- a/packages/core/src/commands/scout-bridge.ts
+++ b/packages/core/src/commands/scout-bridge.ts
@@ -4,8 +4,9 @@
  */
 
 import { createScout, type LinkedPR as ScoutLinkedPR, type OssScout, type ScoutState } from '@oss-scout/core';
-import { getStateManager, requireGitHubToken } from '../core/index.js';
+import { getStateManager, isLinkedPRStalled, requireGitHubToken } from '../core/index.js';
 import type { LinkedPR } from '../core/linked-pr-classification.js';
+import type { CandidateLinkedPR } from '../formatters/json.js';
 import { loadSkippedIssues } from './skip-file-parser.js';
 
 /**
@@ -30,6 +31,29 @@ export function adaptScoutLinkedPR(scoutLinkedPR: ScoutLinkedPR | null | undefin
     adapted.updatedAt = scoutLinkedPR.updatedAt;
   }
   return adapted;
+}
+
+/**
+ * Build the autopilot-shaped `linkedPR` slice consumed by `SearchOutput`,
+ * `VetOutput`, and `FeaturesOutput` from scout's raw `LinkedPR`
+ * (#97 / scout 0.9.0). Returns `undefined` when scout reported no linked
+ * PR. Computes `isStalled` from the adapted (autopilot-shape) PR so the
+ * rule stays consistent with `classifyLinkedPR` and downstream consumers.
+ */
+export function buildCandidateLinkedPR(scoutLinkedPR: ScoutLinkedPR | null | undefined): CandidateLinkedPR | undefined {
+  if (!scoutLinkedPR) return undefined;
+  const adapted = adaptScoutLinkedPR(scoutLinkedPR);
+  if (!adapted) return undefined;
+  const linkedPR: CandidateLinkedPR = {
+    number: scoutLinkedPR.number,
+    state: adapted.state,
+    url: scoutLinkedPR.url,
+    isStalled: isLinkedPRStalled(adapted),
+  };
+  if (scoutLinkedPR.updatedAt !== undefined) {
+    linkedPR.updatedAt = scoutLinkedPR.updatedAt;
+  }
+  return linkedPR;
 }
 
 /**

--- a/packages/core/src/commands/search.contract.test.ts
+++ b/packages/core/src/commands/search.contract.test.ts
@@ -20,9 +20,13 @@ const mocks = vi.hoisted(() => ({
   getRepoScore: vi.fn(),
 }));
 
-vi.mock('./scout-bridge.js', () => ({
-  createAutopilotScout: vi.fn(async () => ({ search: mocks.search })),
-}));
+vi.mock('./scout-bridge.js', async () => {
+  const actual = await vi.importActual<typeof import('./scout-bridge.js')>('./scout-bridge.js');
+  return {
+    ...actual,
+    createAutopilotScout: vi.fn(async () => ({ search: mocks.search })),
+  };
+});
 
 vi.mock('../core/index.js', async () => {
   const actual = await vi.importActual<typeof import('../core/index.js')>('../core/index.js');

--- a/packages/core/src/commands/search.test.ts
+++ b/packages/core/src/commands/search.test.ts
@@ -6,15 +6,23 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockSearch = vi.fn();
 
-vi.mock('./scout-bridge.js', () => ({
-  createAutopilotScout: vi.fn(async () => ({
-    search: mockSearch,
-  })),
-}));
+vi.mock('./scout-bridge.js', async () => {
+  const actual = await vi.importActual<typeof import('./scout-bridge.js')>('./scout-bridge.js');
+  return {
+    ...actual,
+    createAutopilotScout: vi.fn(async () => ({
+      search: mockSearch,
+    })),
+  };
+});
 
-vi.mock('../core/index.js', () => ({
-  getStateManager: vi.fn(),
-}));
+vi.mock('../core/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../core/index.js')>('../core/index.js');
+  return {
+    ...actual,
+    getStateManager: vi.fn(),
+  };
+});
 
 import { getStateManager } from '../core/index.js';
 import { runSearch } from './search.js';
@@ -260,6 +268,79 @@ describe('runSearch', () => {
     // High merge rate (20/23 ≈ 87%) + fast response → at worst C after the
     // one-step degrade for unknown commit activity. Assert it beat F.
     expect(result.candidates[0].grade.letter).not.toBe('F');
+  });
+
+  it('surfaces a linkedPR slice with isStalled=true for an open PR last updated >30 days ago', async () => {
+    mockSearch.mockResolvedValue({
+      candidates: [
+        {
+          issue: {
+            repo: 'foo/bar',
+            number: 1,
+            title: 'Issue with stalled linked PR',
+            url: 'https://github.com/foo/bar/issues/1',
+            labels: [],
+          },
+          recommendation: 'needs_review',
+          reasonsToApprove: [],
+          reasonsToSkip: [],
+          searchPriority: 'normal',
+          viabilityScore: 50,
+          vettingResult: {
+            linkedPR: {
+              number: 88,
+              author: 'someone',
+              state: 'open',
+              merged: false,
+              url: 'https://github.com/foo/bar/pull/88',
+              updatedAt: '2020-01-01T00:00:00Z',
+            },
+          },
+        },
+      ],
+      excludedRepos: [],
+      aiPolicyBlocklist: [],
+      strategiesUsed: ['broad'],
+    });
+
+    const result = await runSearch({ maxResults: 5 });
+
+    expect(result.candidates[0].linkedPR).toEqual({
+      number: 88,
+      state: 'open',
+      url: 'https://github.com/foo/bar/pull/88',
+      updatedAt: '2020-01-01T00:00:00Z',
+      isStalled: true,
+    });
+  });
+
+  it('omits linkedPR from output when scout reported no linked PR', async () => {
+    mockSearch.mockResolvedValue({
+      candidates: [
+        {
+          issue: {
+            repo: 'foo/bar',
+            number: 1,
+            title: 'Plain issue',
+            url: 'https://github.com/foo/bar/issues/1',
+            labels: [],
+          },
+          recommendation: 'approve',
+          reasonsToApprove: [],
+          reasonsToSkip: [],
+          searchPriority: 'normal',
+          viabilityScore: 70,
+          vettingResult: { linkedPR: null },
+        },
+      ],
+      excludedRepos: [],
+      aiPolicyBlocklist: [],
+      strategiesUsed: ['broad'],
+    });
+
+    const result = await runSearch({ maxResults: 5 });
+
+    expect('linkedPR' in result.candidates[0]).toBe(false);
   });
 
   it('sanitizes an out-of-contract viabilityScore from scout (#1043)', async () => {

--- a/packages/core/src/commands/search.ts
+++ b/packages/core/src/commands/search.ts
@@ -3,7 +3,7 @@
  * Searches for new issues to work on via @oss-scout/core
  */
 
-import { createAutopilotScout } from './scout-bridge.js';
+import { buildCandidateLinkedPR, createAutopilotScout } from './scout-bridge.js';
 import { getStateManager } from '../core/index.js';
 import { type SearchOutput } from '../formatters/json.js';
 import { gradeFromCandidate } from '../core/issue-grading.js';
@@ -85,6 +85,7 @@ export async function runSearch(options: SearchOptions): Promise<SearchOutput> {
             : undefined;
         },
       });
+      const linkedPR = buildCandidateLinkedPR(c.vettingResult?.linkedPR);
       return {
         issue: {
           repo: c.issue.repo,
@@ -109,6 +110,7 @@ export async function runSearch(options: SearchOptions): Promise<SearchOutput> {
               lastMergedAt: repoScoreRecord.lastMergedAt,
             }
           : undefined,
+        ...(linkedPR ? { linkedPR } : {}),
       };
     }),
     excludedRepos: result.excludedRepos,

--- a/packages/core/src/commands/vet-list.test.ts
+++ b/packages/core/src/commands/vet-list.test.ts
@@ -133,6 +133,81 @@ describe('classifyListStatus', () => {
     expect(result).toBe('has_pr');
   });
 
+  // ── has_stalled_pr revive opportunity (#97 / scout 0.9.0) ──────────────
+
+  it('returns has_stalled_pr via skipReason when linked PR is open AND stalled', () => {
+    const result = classifyListStatus(
+      makeVetOutput({
+        recommendation: 'skip',
+        reasonsToSkip: ['Has linked PR #42'],
+        linkedPR: {
+          number: 42,
+          state: 'open',
+          url: 'https://github.com/owner/repo/pull/42',
+          updatedAt: '2020-01-01T00:00:00Z',
+          isStalled: true,
+        },
+      }),
+      'has_linked_pr',
+    );
+    expect(result).toBe('has_stalled_pr');
+  });
+
+  it('returns has_pr via skipReason when linked PR is open but fresh', () => {
+    const result = classifyListStatus(
+      makeVetOutput({
+        recommendation: 'skip',
+        reasonsToSkip: ['Has linked PR #42'],
+        linkedPR: {
+          number: 42,
+          state: 'open',
+          url: 'https://github.com/owner/repo/pull/42',
+          updatedAt: new Date().toISOString(),
+          isStalled: false,
+        },
+      }),
+      'has_linked_pr',
+    );
+    expect(result).toBe('has_pr');
+  });
+
+  it('routes stalled-PR substring fallback to has_stalled_pr when isStalled=true', () => {
+    const result = classifyListStatus(
+      makeVetOutput({
+        recommendation: 'skip',
+        reasonsToSkip: ['Has linked PR #42'],
+        linkedPR: {
+          number: 42,
+          state: 'open',
+          url: 'https://github.com/owner/repo/pull/42',
+          updatedAt: '2020-01-01T00:00:00Z',
+          isStalled: true,
+        },
+      }),
+    );
+    expect(result).toBe('has_stalled_pr');
+  });
+
+  it('does NOT route closed/merged linked PRs to has_stalled_pr even with stale updatedAt', () => {
+    // Defensive — buildCandidateLinkedPR should already set isStalled=false
+    // for non-open states, but the classifier also checks state explicitly.
+    const result = classifyListStatus(
+      makeVetOutput({
+        recommendation: 'skip',
+        reasonsToSkip: ['Has linked PR #42'],
+        linkedPR: {
+          number: 42,
+          state: 'merged',
+          url: 'https://github.com/owner/repo/pull/42',
+          updatedAt: '2020-01-01T00:00:00Z',
+          isStalled: false,
+        },
+      }),
+      'has_linked_pr',
+    );
+    expect(result).toBe('has_pr');
+  });
+
   it('should return still_available for skipped issues with other reasons', () => {
     const result = classifyListStatus(
       makeVetOutput({
@@ -231,7 +306,15 @@ describe('runVetList', () => {
     const result = await runVetList();
 
     expect(result.results).toEqual([]);
-    expect(result.summary).toEqual({ total: 0, stillAvailable: 0, claimed: 0, closed: 0, hasPR: 0, errors: 0 });
+    expect(result.summary).toEqual({
+      total: 0,
+      stillAvailable: 0,
+      claimed: 0,
+      closed: 0,
+      hasPR: 0,
+      hasStalledPR: 0,
+      errors: 0,
+    });
   });
 
   it('should vet available issues and return results', async () => {

--- a/packages/core/src/commands/vet-list.ts
+++ b/packages/core/src/commands/vet-list.ts
@@ -4,7 +4,7 @@
  */
 
 import * as fs from 'node:fs';
-import { adaptScoutLinkedPR, createAutopilotScout } from './scout-bridge.js';
+import { adaptScoutLinkedPR, buildCandidateLinkedPR, createAutopilotScout } from './scout-bridge.js';
 import { type VetListOutput, type VetOutput, type VetListItemStatus } from '../formatters/json.js';
 import { runParseList, pruneIssueList } from './parse-list.js';
 import { detectIssueList } from './startup.js';
@@ -162,6 +162,7 @@ export async function runVetList(options: VetListOptions = {}): Promise<VetListO
           linkedPR: adaptScoutLinkedPR(candidate.vettingResult.linkedPR),
           userLogin,
         });
+        const linkedPR = buildCandidateLinkedPR(candidate.vettingResult.linkedPR);
         const vetResult: VetOutput = {
           issue: {
             repo: candidate.issue.repo,
@@ -177,6 +178,7 @@ export async function runVetList(options: VetListOptions = {}): Promise<VetListO
           vettingResult: candidate.vettingResult,
           antiLLMPolicy: candidate.antiLLMPolicy,
           linkedPRClassification,
+          ...(linkedPR ? { linkedPR } : {}),
           slmTriage: candidate.slmTriage ?? null,
           grade,
         };

--- a/packages/core/src/commands/vet-list.ts
+++ b/packages/core/src/commands/vet-list.ts
@@ -47,7 +47,7 @@ const KNOWN_SKIP_REASONS: ReadonlySet<ScoutSkipReason> = new Set([
   'other',
 ]);
 
-function mapSkipReasonToStatus(reason: ScoutSkipReason): VetListItemStatus | null {
+function mapSkipReasonToStatus(reason: ScoutSkipReason, vetResult: VetOutput): VetListItemStatus | null {
   switch (reason) {
     case 'issue_closed': {
       return 'closed';
@@ -56,6 +56,12 @@ function mapSkipReasonToStatus(reason: ScoutSkipReason): VetListItemStatus | nul
       return 'claimed';
     }
     case 'has_linked_pr': {
+      // Open linked PRs that have been idle for 30+ days are revive
+      // opportunities (#97 / scout 0.9.0) — surface them with a distinct
+      // status rather than auto-dropping as `has_pr`.
+      if (vetResult.linkedPR?.state === 'open' && vetResult.linkedPR.isStalled) {
+        return 'has_stalled_pr';
+      }
       return 'has_pr';
     }
     case 'score_too_low':
@@ -87,7 +93,7 @@ export function extractSkipReason(candidate: unknown): ScoutSkipReason | undefin
  */
 export function classifyListStatus(vetResult: VetOutput, skipReason?: ScoutSkipReason): VetListItemStatus {
   if (skipReason) {
-    const fromEnum = mapSkipReasonToStatus(skipReason);
+    const fromEnum = mapSkipReasonToStatus(skipReason, vetResult);
     if (fromEnum) return fromEnum;
     // skipReason was set but maps to 'other' / low-score / policy — let the
     // recommendation-based branches below decide final status.
@@ -96,8 +102,15 @@ export function classifyListStatus(vetResult: VetOutput, skipReason?: ScoutSkipR
 
     if (skipReasons.some((r) => r.includes('closed'))) return 'closed';
     if (skipReasons.some((r) => r.includes('claimed') || r.includes('assigned'))) return 'claimed';
-    if (skipReasons.some((r) => r.includes('existing pr') || r.includes('linked pr') || r.includes('pull request')))
+    if (skipReasons.some((r) => r.includes('existing pr') || r.includes('linked pr') || r.includes('pull request'))) {
+      // Same revive-opportunity branch as the enum path above — when scout
+      // hasn't yet emitted skipReason but we can see a stalled open PR on
+      // the candidate, prefer the dedicated status (#97 / scout 0.9.0).
+      if (vetResult.linkedPR?.state === 'open' && vetResult.linkedPR.isStalled) {
+        return 'has_stalled_pr';
+      }
       return 'has_pr';
+    }
   }
 
   if (vetResult.recommendation === 'approve' || vetResult.recommendation === 'needs_review') {
@@ -135,7 +148,7 @@ export async function runVetList(options: VetListOptions = {}): Promise<VetListO
   if (parsed.available.length === 0) {
     return {
       results: [],
-      summary: { total: 0, stillAvailable: 0, claimed: 0, closed: 0, hasPR: 0, errors: 0 },
+      summary: { total: 0, stillAvailable: 0, claimed: 0, closed: 0, hasPR: 0, hasStalledPR: 0, errors: 0 },
     };
   }
 
@@ -215,6 +228,7 @@ export async function runVetList(options: VetListOptions = {}): Promise<VetListO
     claimed: results.filter((r) => r.listStatus === 'claimed').length,
     closed: results.filter((r) => r.listStatus === 'closed').length,
     hasPR: results.filter((r) => r.listStatus === 'has_pr').length,
+    hasStalledPR: results.filter((r) => r.listStatus === 'has_stalled_pr').length,
     errors: results.filter((r) => r.listStatus === 'error').length,
   };
 

--- a/packages/core/src/commands/vet.ts
+++ b/packages/core/src/commands/vet.ts
@@ -3,7 +3,7 @@
  * Vets a specific issue before working on it via @oss-scout/core
  */
 
-import { createAutopilotScout, adaptScoutLinkedPR } from './scout-bridge.js';
+import { adaptScoutLinkedPR, buildCandidateLinkedPR, createAutopilotScout } from './scout-bridge.js';
 import { type VetOutput } from '../formatters/json.js';
 import { ISSUE_URL_PATTERN, validateGitHubUrl, validateUrl } from './validation.js';
 import { gradeFromCandidate } from '../core/issue-grading.js';
@@ -42,6 +42,7 @@ export async function runVet(options: VetOptions): Promise<VetOutput> {
     userLogin,
   });
 
+  const linkedPR = buildCandidateLinkedPR(candidate.vettingResult.linkedPR);
   return {
     issue: {
       repo: candidate.issue.repo,
@@ -57,6 +58,7 @@ export async function runVet(options: VetOptions): Promise<VetOutput> {
     vettingResult: candidate.vettingResult,
     antiLLMPolicy: candidate.antiLLMPolicy,
     linkedPRClassification,
+    ...(linkedPR ? { linkedPR } : {}),
     slmTriage: candidate.slmTriage ?? null,
     grade,
   };

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -84,6 +84,8 @@ export { computeContributionStats, type ContributionStats, type ComputeStatsInpu
 export { fetchPRTemplate, type PRTemplateResult } from './pr-template.js';
 export {
   classifyLinkedPR,
+  isLinkedPRStalled,
+  STALLED_PR_THRESHOLD_DAYS,
   type LinkedPR,
   type LinkedPRClassification,
   type LinkedPRState,

--- a/packages/core/src/core/linked-pr-classification.test.ts
+++ b/packages/core/src/core/linked-pr-classification.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { classifyLinkedPR } from './linked-pr-classification.js';
+import { classifyLinkedPR, isLinkedPRStalled, STALLED_PR_THRESHOLD_DAYS } from './linked-pr-classification.js';
 
 describe('classifyLinkedPR', () => {
   it('returns none when there is no linked PR', () => {
@@ -119,5 +119,60 @@ describe('classifyLinkedPR', () => {
       });
       expect(result).toBe('other_open');
     });
+  });
+});
+
+describe('isLinkedPRStalled', () => {
+  // Fixed clock so the test is deterministic regardless of when it runs.
+  const now = new Date('2026-05-09T00:00:00Z');
+
+  it('exposes a 30-day threshold constant matching scout', () => {
+    expect(STALLED_PR_THRESHOLD_DAYS).toBe(30);
+  });
+
+  it('returns false when linkedPR is null or undefined', () => {
+    expect(isLinkedPRStalled(null, now)).toBe(false);
+    expect(isLinkedPRStalled(undefined, now)).toBe(false);
+  });
+
+  it('returns false when the PR is closed even if updatedAt is ancient', () => {
+    expect(isLinkedPRStalled({ author: { login: 'a' }, state: 'closed', updatedAt: '2020-01-01T00:00:00Z' }, now)).toBe(
+      false,
+    );
+  });
+
+  it('returns false when the PR is merged even if updatedAt is ancient', () => {
+    expect(isLinkedPRStalled({ author: { login: 'a' }, state: 'merged', updatedAt: '2020-01-01T00:00:00Z' }, now)).toBe(
+      false,
+    );
+  });
+
+  it('returns false when updatedAt is missing on an open PR (unknown age)', () => {
+    expect(isLinkedPRStalled({ author: { login: 'a' }, state: 'open' }, now)).toBe(false);
+  });
+
+  it('returns false for an open PR updated within the threshold', () => {
+    // 29 days before `now` — still fresh.
+    expect(isLinkedPRStalled({ author: { login: 'a' }, state: 'open', updatedAt: '2026-04-10T00:00:00Z' }, now)).toBe(
+      false,
+    );
+  });
+
+  it('returns true for an open PR last updated more than 30 days ago', () => {
+    // ~60 days before `now`.
+    expect(isLinkedPRStalled({ author: { login: 'a' }, state: 'open', updatedAt: '2026-03-09T00:00:00Z' }, now)).toBe(
+      true,
+    );
+  });
+
+  it('respects a custom thresholdDays override', () => {
+    // 10 days old: stalled at threshold=7 but not at threshold=30.
+    const linkedPR = { author: { login: 'a' }, state: 'open' as const, updatedAt: '2026-04-29T00:00:00Z' };
+    expect(isLinkedPRStalled(linkedPR, now, 7)).toBe(true);
+    expect(isLinkedPRStalled(linkedPR, now, 30)).toBe(false);
+  });
+
+  it('returns false when updatedAt is an unparseable string', () => {
+    expect(isLinkedPRStalled({ author: { login: 'a' }, state: 'open', updatedAt: 'not-a-date' }, now)).toBe(false);
   });
 });

--- a/packages/core/src/core/linked-pr-classification.ts
+++ b/packages/core/src/core/linked-pr-classification.ts
@@ -31,6 +31,48 @@ export interface LinkedPR {
    */
   author: { login: string } | null;
   state: LinkedPRState;
+  /**
+   * ISO timestamp of the linked PR's last update, surfaced from scout's
+   * timeline-event metadata when available (#97). Optional so existing
+   * callers and fixtures that don't carry the field continue to type-check.
+   * Used by `isLinkedPRStalled` to flag open PRs that haven't been touched
+   * in the last `STALLED_PR_THRESHOLD_DAYS` days.
+   */
+  updatedAt?: string;
+}
+
+/**
+ * Days of inactivity that classify an open linked PR as "stalled" — kept
+ * in sync with scout's `STALLED_PR_THRESHOLD_DAYS` so the autopilot helper
+ * and scout's own annotation use the same boundary.
+ */
+export const STALLED_PR_THRESHOLD_DAYS = 30;
+
+/**
+ * Determine whether an autopilot-shaped `LinkedPR` is stalled.
+ *
+ * True when:
+ *   - the PR is open, AND
+ *   - `updatedAt` is set, AND
+ *   - the elapsed time since `updatedAt` is at least `thresholdDays`.
+ *
+ * Returns false for closed/merged PRs, missing `updatedAt`, or invalid
+ * timestamps. Reimplemented locally rather than delegating to scout's
+ * helper so this module owns autopilot's `LinkedPR` shape contract end
+ * to end (avoids a runtime import dependency on scout's internal type).
+ */
+export function isLinkedPRStalled(
+  linkedPR: LinkedPR | null | undefined,
+  now: Date = new Date(),
+  thresholdDays: number = STALLED_PR_THRESHOLD_DAYS,
+): boolean {
+  if (!linkedPR) return false;
+  if (linkedPR.state !== 'open') return false;
+  if (!linkedPR.updatedAt) return false;
+  const updatedMs = Date.parse(linkedPR.updatedAt);
+  if (!Number.isFinite(updatedMs)) return false;
+  const ageDays = (now.getTime() - updatedMs) / (1000 * 60 * 60 * 24);
+  return ageDays >= thresholdDays;
 }
 
 /**

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -1116,8 +1116,14 @@ export interface CheckIntegrationOutput {
   unreferencedCount: number;
 }
 
-/** Status of a re-vetted issue from the curated list (#764). */
-export type VetListItemStatus = 'still_available' | 'claimed' | 'closed' | 'has_pr' | 'error';
+/**
+ * Status of a re-vetted issue from the curated list (#764).
+ *
+ * `has_stalled_pr` (scout 0.9.0 #97) distinguishes open-but-stalled linked
+ * PRs from cleanly-claimed `has_pr` issues — the issue is still actionable
+ * as a revive opportunity rather than something to drop.
+ */
+export type VetListItemStatus = 'still_available' | 'claimed' | 'closed' | 'has_pr' | 'has_stalled_pr' | 'error';
 
 /** Output of the vet-list command (#764). */
 export interface VetListOutput {
@@ -1133,6 +1139,8 @@ export interface VetListOutput {
     claimed: number;
     closed: number;
     hasPR: number;
+    /** Open linked PRs that haven't been touched in 30+ days (scout 0.9.0 #97). Surfaced as revive opportunities, not auto-dropped. */
+    hasStalledPR: number;
     errors: number;
   };
   pruneResult?: {

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -542,6 +542,24 @@ export const SearchOutputSchema = z.object({
   rateLimitWarning: z.string().optional(),
 });
 
+// ── Features output schema (scout 0.9.0 #97/#98/#99) ─────────────────
+//
+// `SearchCandidateSchema` augmented with the horizon literal that scout
+// stamps in features mode. Reusing the search candidate keeps the two
+// envelopes structurally identical apart from the bucket annotation.
+const FeaturesHorizonSchema = z.enum(['quick-win', 'bigger-bet']);
+const FeaturesCandidateSchema = SearchCandidateSchema.extend({
+  horizon: FeaturesHorizonSchema,
+});
+
+export const FeaturesOutputSchema = z.object({
+  quickWins: z.array(FeaturesCandidateSchema),
+  biggerBets: z.array(FeaturesCandidateSchema),
+  anchorRepos: z.array(z.string()),
+  message: z.string().nullable(),
+  rateLimitWarning: z.string().optional(),
+});
+
 // ── Doctor / skip-add / list-move-tier output schemas (#1148) ────────
 
 const DoctorCheckSchema = z.object({
@@ -866,44 +884,73 @@ export const LocalReposOutputSchema = z.object({
   fromCache: z.boolean(),
 });
 
+/**
+ * One candidate row in `SearchOutput`/`FeaturesOutput`. Extracted so the
+ * features command can reuse the exact contract `runSearch` already
+ * publishes — keeping the two outputs structurally identical for everything
+ * except the bucket-specific `horizon` annotation.
+ */
+export interface SearchCandidate {
+  issue: {
+    repo: string;
+    repoUrl: string;
+    number: number;
+    title: string;
+    url: string;
+    labels: string[];
+  };
+  recommendation: 'approve' | 'skip' | 'needs_review';
+  reasonsToApprove: string[];
+  reasonsToSkip: string[];
+  searchPriority: SearchPriority;
+  /** 0-100 scale composite viability score. Sanitized on the boundary (#1043): out-of-contract values are coerced to 0 and logged. */
+  viabilityScore: number;
+  /**
+   * Letter grade (A/B/C/F) computed from the autopilot-tracked repoScore.
+   * Scout's `search` does not emit per-candidate projectHealth, so scout-side
+   * signals are treated as unknown; unscored repos grade 'F'. See #1043.
+   */
+  grade: {
+    letter: 'A' | 'B' | 'C' | 'F';
+    reason: string;
+  };
+  repoScore?: {
+    /** 1-10 scale repository quality score */
+    score: number;
+    mergedPRCount: number;
+    closedWithoutMergeCount: number;
+    isResponsive: boolean;
+    lastMergedAt?: string;
+  };
+}
+
 export interface SearchOutput {
-  candidates: Array<{
-    issue: {
-      repo: string;
-      repoUrl: string;
-      number: number;
-      title: string;
-      url: string;
-      labels: string[];
-    };
-    recommendation: 'approve' | 'skip' | 'needs_review';
-    reasonsToApprove: string[];
-    reasonsToSkip: string[];
-    searchPriority: SearchPriority;
-    /** 0-100 scale composite viability score. Sanitized on the boundary (#1043): out-of-contract values are coerced to 0 and logged. */
-    viabilityScore: number;
-    /**
-     * Letter grade (A/B/C/F) computed from the autopilot-tracked repoScore.
-     * Scout's `search` does not emit per-candidate projectHealth, so scout-side
-     * signals are treated as unknown; unscored repos grade 'F'. See #1043.
-     */
-    grade: {
-      letter: 'A' | 'B' | 'C' | 'F';
-      reason: string;
-    };
-    repoScore?: {
-      /** 1-10 scale repository quality score */
-      score: number;
-      mergedPRCount: number;
-      closedWithoutMergeCount: number;
-      isResponsive: boolean;
-      lastMergedAt?: string;
-    };
-  }>;
+  candidates: SearchCandidate[];
   excludedRepos: string[];
   /** Repos with known anti-AI contribution policies, filtered from search results (#108). */
   aiPolicyBlocklist: string[];
   /** Present when rate limits affected the search — either low pre-flight quota or mid-search rate limit hits (#100). */
+  rateLimitWarning?: string;
+}
+
+/** Horizon classification stamped on each features-mode candidate. */
+export type FeaturesHorizon = 'quick-win' | 'bigger-bet';
+
+/** A `SearchCandidate` augmented with its features-mode horizon. */
+export type FeaturesCandidate = SearchCandidate & {
+  horizon: FeaturesHorizon;
+};
+
+export interface FeaturesOutput {
+  /** "Quick-win" bucket: feature-scoped issues without strong commitment markers (no milestone, no roadmap, no bigger-bet labels). */
+  quickWins: FeaturesCandidate[];
+  /** "Bigger-bet" bucket: feature-scoped issues that carry maintainer-commitment signals (milestone, roadmap, bigger-bet label). */
+  biggerBets: FeaturesCandidate[];
+  /** Repos that qualified as anchors for this run (3+ merged PRs, configurable). Empty when the user has no anchor repos yet. */
+  anchorRepos: string[];
+  /** Human-friendly explainer shown when neither bucket has results (no anchors, or anchors but no open feature opportunities). `null` on success. */
+  message: string | null;
+  /** Present when rate limits affected the search. Mirrors `SearchOutput.rateLimitWarning`. */
   rateLimitWarning?: string;
 }
 

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -506,6 +506,18 @@ export const CompactDailyOutputSchema = z.object({
 
 const SearchPrioritySchema = z.enum(['merged_pr', 'preferred_org', 'starred', 'normal']);
 
+/**
+ * Schema for the compact linked-PR annotation surfaced on candidate
+ * outputs (#97 / scout 0.9.0). Mirrors {@link CandidateLinkedPR}.
+ */
+const CandidateLinkedPRSchema = z.object({
+  number: z.number().int().positive(),
+  state: z.enum(['open', 'closed', 'merged']),
+  url: z.string(),
+  updatedAt: z.string().optional(),
+  isStalled: z.boolean(),
+});
+
 const SearchCandidateSchema = z.object({
   issue: z.object({
     repo: z.string(),
@@ -533,6 +545,7 @@ const SearchCandidateSchema = z.object({
       lastMergedAt: z.string().optional(),
     })
     .optional(),
+  linkedPR: CandidateLinkedPRSchema.optional(),
 });
 
 export const SearchOutputSchema = z.object({
@@ -885,6 +898,25 @@ export const LocalReposOutputSchema = z.object({
 });
 
 /**
+ * Compact summary of an issue's first linked PR, surfaced on candidate
+ * outputs (#97 / scout 0.9.0). `isStalled` is `true` when the PR is open
+ * and has not been updated for `STALLED_PR_THRESHOLD_DAYS` (default 30) —
+ * a revive-opportunity signal callers can render or filter on.
+ *
+ * `state` mirrors autopilot's existing tri-state classifier (`'merged'` is
+ * folded in from scout's `merged: true` boolean), not scout's raw enum.
+ */
+export interface CandidateLinkedPR {
+  number: number;
+  state: 'open' | 'closed' | 'merged';
+  url: string;
+  /** ISO timestamp of the PR's last update (when scout surfaces it). */
+  updatedAt?: string;
+  /** True when the PR is open AND `updatedAt` is more than 30 days old. */
+  isStalled: boolean;
+}
+
+/**
  * One candidate row in `SearchOutput`/`FeaturesOutput`. Extracted so the
  * features command can reuse the exact contract `runSearch` already
  * publishes — keeping the two outputs structurally identical for everything
@@ -922,6 +954,12 @@ export interface SearchCandidate {
     isResponsive: boolean;
     lastMergedAt?: string;
   };
+  /**
+   * First linked PR on the issue, when scout surfaced one. Optional —
+   * absent when no linked PR exists. `isStalled` flags revive
+   * opportunities (open PR + no updates for 30+ days, scout 0.9.0 #97).
+   */
+  linkedPR?: CandidateLinkedPR;
 }
 
 export interface SearchOutput {
@@ -1140,6 +1178,12 @@ export interface VetOutput {
     | 'other_open'
     | 'other_closed'
     | 'other_merged';
+  /**
+   * Compact linked-PR summary (#97 / scout 0.9.0). Present when the issue
+   * has a linked PR; absent otherwise. `isStalled` flags open PRs that
+   * haven't been touched in 30+ days as revive opportunities.
+   */
+  linkedPR?: CandidateLinkedPR;
   /**
    * Optional SLM pre-triage classification (#1122). Populated when the
    * user has set `slmTriageModel` and a local Ollama instance answered

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -10,7 +10,7 @@ MCP server for [OSS Autopilot](https://github.com/costajohnt/oss-autopilot) — 
 
 | Feature | Count | Description |
 |---------|-------|-------------|
-| **Tools** | 28 | `daily`, `status`, `search`, `vet`, `vet-list`, `track`, `compliance-score`, `repo-vet`, `comments`, `post`, `claim`, `config`, `init`, `setup`, `check-setup`, `startup`, `shelve`, `unshelve`, `dismiss`, `undismiss`, `move`, `state-show`, `state-sync`, `state-unlink`, `guidelines-get`, `guidelines-store`, `guidelines-reset`, `guidelines-fetch-corpus` |
+| **Tools** | 29 | `daily`, `status`, `search`, `features`, `vet`, `vet-list`, `track`, `compliance-score`, `repo-vet`, `comments`, `post`, `claim`, `config`, `init`, `setup`, `check-setup`, `startup`, `shelve`, `unshelve`, `dismiss`, `undismiss`, `move`, `state-show`, `state-sync`, `state-unlink`, `guidelines-get`, `guidelines-store`, `guidelines-reset`, `guidelines-fetch-corpus` |
 | **Resources** | 6 | `oss://status`, `oss://config`, `oss://prs`, `oss://prs/shelved`, `oss://pr/{owner}/{repo}/{number}`, `oss://repo/{owner}/{repo}/guidelines` |
 | **Prompts** | 4 | `triage` (PR prioritization), `respond-to-pr` (draft response), `find-issues` (discover issues), `extract-learnings` (distill per-repo guidance from past PR feedback) |
 
@@ -116,6 +116,7 @@ The token persists across restarts. To rotate, delete the file and restart — a
 | `daily` | Run daily PR monitoring check with prioritized summary | No |
 | `status` | Show current PR tracking status | Yes |
 | `search` | Search GitHub for contributable issues | Yes |
+| `features` | Find feature-scoped opportunities in repos with 3+ merged PRs (relationship-anchored) | Yes |
 | `vet` | Analyze an issue for contribution suitability | Yes |
 | `vet-list` | Re-vet all available issues in the curated issue list | No |
 | `track` | Fetch metadata for a pull request (informational; nothing persists) | No |

--- a/packages/mcp-server/src/index-main.test.ts
+++ b/packages/mcp-server/src/index-main.test.ts
@@ -21,7 +21,9 @@ vi.mock('@oss-autopilot/core/commands', () => ({
   runDismiss: vi.fn(),
   runUndismiss: vi.fn(),
   runMove: vi.fn(),
+  runFeatures: vi.fn(),
   MAX_SEARCH_RESULTS: 100,
+  MAX_FEATURES_RESULTS: 100,
 }));
 
 vi.mock('@oss-autopilot/core', () => ({

--- a/packages/mcp-server/src/index.test.ts
+++ b/packages/mcp-server/src/index.test.ts
@@ -161,10 +161,11 @@ describe('MCP server stdio transport', { timeout: 30_000 }, () => {
   it('lists tools via stdio', async () => {
     client = await createStdioClient();
     const { tools } = await client.listTools();
-    expect(tools.length).toBe(28);
+    expect(tools.length).toBe(29);
     expect(tools.some((t) => t.name === 'daily')).toBe(true);
     expect(tools.some((t) => t.name === 'compliance-score')).toBe(true);
     expect(tools.some((t) => t.name === 'repo-vet')).toBe(true);
+    expect(tools.some((t) => t.name === 'features')).toBe(true);
   });
 
   it('lists resources via stdio', async () => {

--- a/packages/mcp-server/src/prompts.test.ts
+++ b/packages/mcp-server/src/prompts.test.ts
@@ -62,7 +62,9 @@ vi.mock('@oss-autopilot/core/commands', () => ({
   runGuidelinesStore: vi.fn(),
   runGuidelinesReset: vi.fn(),
   runFetchCorpus: vi.fn(),
+  runFeatures: vi.fn(),
   MAX_SEARCH_RESULTS: 100,
+  MAX_FEATURES_RESULTS: 100,
 }));
 
 vi.mock('@oss-autopilot/core', () => ({

--- a/packages/mcp-server/src/resources.test.ts
+++ b/packages/mcp-server/src/resources.test.ts
@@ -32,7 +32,9 @@ vi.mock('@oss-autopilot/core/commands', () => ({
   runDismiss: vi.fn(),
   runUndismiss: vi.fn(),
   runMove: vi.fn(),
+  runFeatures: vi.fn(),
   MAX_SEARCH_RESULTS: 100,
+  MAX_FEATURES_RESULTS: 100,
 }));
 
 vi.mock('@oss-autopilot/core', () => ({

--- a/packages/mcp-server/src/tools-execution.test.ts
+++ b/packages/mcp-server/src/tools-execution.test.ts
@@ -45,7 +45,9 @@ vi.mock('@oss-autopilot/core/commands', () => ({
   runGuidelinesStore: mockRunGuidelinesStore,
   runGuidelinesReset: mockRunGuidelinesReset,
   runFetchCorpus: mockRunFetchCorpus,
+  runFeatures: vi.fn(),
   MAX_SEARCH_RESULTS: 100,
+  MAX_FEATURES_RESULTS: 100,
 }));
 
 vi.mock('@oss-autopilot/core', () => ({

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -15,6 +15,7 @@ const EXPECTED_TOOLS = [
   'daily',
   'status',
   'search',
+  'features',
   'vet',
   'vet-list',
   'track',
@@ -68,8 +69,8 @@ describe('MCP tool registrations', () => {
     await client.close();
   });
 
-  it('registers exactly 28 tools', () => {
-    expect(tools).toHaveLength(28);
+  it('registers exactly 29 tools', () => {
+    expect(tools).toHaveLength(29);
   });
 
   it('registers all expected tool names', () => {

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -12,6 +12,7 @@ import {
   runDaily,
   runStatus,
   runSearch,
+  runFeatures,
   runVet,
   runVetList,
   runTrack,
@@ -33,6 +34,7 @@ import {
   runGuidelinesReset,
   runFetchCorpus,
   MAX_SEARCH_RESULTS,
+  MAX_FEATURES_RESULTS,
 } from '@oss-autopilot/core/commands';
 import { errorMessage, getSetupKeys, getConfigKeys } from '@oss-autopilot/core';
 
@@ -175,6 +177,52 @@ export function registerTools(server: McpServer): void {
     wrapTool((args: { maxResults?: number }) => {
       const maxResults = args.maxResults ?? 5;
       return runSearch({ maxResults });
+    }),
+  );
+
+  // 3b. features — Surface feature-scoped opportunities in repos with 3+
+  // merged PRs. Sibling to `search` but ranks issues by maintainer-
+  // commitment signal (milestone, roadmap, label set). Returns two
+  // ranked buckets — quick wins and bigger bets. See scout 0.9.0
+  // #97/#98/#99 and oss-autopilot's runFeatures.
+  server.registerTool(
+    'features',
+    {
+      description:
+        'Surface feature-scoped contribution opportunities in repos where you already have 3+ merged PRs. Returns two ranked buckets: "quick wins" (low maintainer-commitment) and "bigger bets" (milestone / roadmap / accepted-RFC labels). Read-only.',
+      inputSchema: {
+        maxResults: z
+          .number()
+          .int()
+          .min(1)
+          .max(MAX_FEATURES_RESULTS)
+          .optional()
+          .describe(
+            `Total number of opportunities to return across both buckets (default: 10, max: ${MAX_FEATURES_RESULTS}).`,
+          ),
+        anchorThreshold: z
+          .number()
+          .int()
+          .min(1)
+          .max(50)
+          .optional()
+          .describe('Per-call override for the merged-PR threshold that qualifies a repo as an anchor (default 3).'),
+        splitRatio: z
+          .number()
+          .min(0)
+          .max(1)
+          .optional()
+          .describe('Per-call override for the quick-win share of results (default 0.6 = 60%).'),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    wrapTool((args: { maxResults?: number; anchorThreshold?: number; splitRatio?: number }) => {
+      const maxResults = args.maxResults ?? 10;
+      return runFeatures({
+        maxResults,
+        anchorThreshold: args.anchorThreshold,
+        splitRatio: args.splitRatio,
+      });
     }),
   );
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@oss-scout/core':
-        specifier: ^0.8.0
-        version: 0.8.0(@octokit/core@7.0.6)
+        specifier: ^0.9.0
+        version: 0.9.0(@octokit/core@7.0.6)
       commander:
         specifier: ^14.0.3
         version: 14.0.3
@@ -841,8 +841,8 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@oss-scout/core@0.8.0':
-    resolution: {integrity: sha512-9iZ150t6Ud1LkWwxRayDzs69LcIf9EJi/1tjOMoqjmydgBLVgIwEUXhMxdbZ6kfYonz0DOLrxgUpIqF9WMR50A==}
+  '@oss-scout/core@0.9.0':
+    resolution: {integrity: sha512-5BOXt9i1etqybGdMhk0xKY1s+r6rF76PKRpMP0KUFqg1qLQSEutnZc4/5wOfWVKR1XxE98mR1Q4O4+U7BiEv1w==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
@@ -3548,7 +3548,7 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@oss-scout/core@0.8.0(@octokit/core@7.0.6)':
+  '@oss-scout/core@0.9.0(@octokit/core@7.0.6)':
     dependencies:
       '@octokit/plugin-throttling': 11.0.3(@octokit/core@7.0.6)
       '@octokit/rest': 22.0.1

--- a/workflows/reference.md
+++ b/workflows/reference.md
@@ -36,6 +36,9 @@ Local-only commands (no GitHub token needed): `checkSetup`, `clear-override`, `c
 # Search for issues (n = number of results, default 5)
 <prefix> search [n] --json
 
+# Surface feature-scoped opportunities in repos with 3+ merged PRs (n = total, default 10)
+<prefix> features [n] --json [--anchor-threshold <1-50>] [--split-ratio <0-1>]
+
 # Deep-vet a specific issue
 <prefix> vet <issue-url> --json
 


### PR DESCRIPTION
## Summary

Bumps `@oss-scout/core` from `^0.8.0` to `^0.9.0` and integrates the new APIs end-to-end across the CLI, JSON output, and MCP tool surface.

## What changed

### Dep bump
- `@oss-scout/core` `^0.8.0` → `^0.9.0`. Lockfile resolves to `0.9.0`.

### New `oss-autopilot features` command
Wraps scout's new `OssScout.features()` (relationship-anchored feature-opportunity search). Mirrors the structure of `runSearch`:
- Sanitizes `viabilityScore` per the #1043 boundary contract.
- Grades each candidate via `gradeFromCandidate`.
- Returns `FeaturesOutput` with `quickWins`, `biggerBets`, `anchorRepos`, optional `message`.
- CLI flags: `--anchor-threshold <n>` (1-50), `--split-ratio <r>` (0-1), `--json`.
- `MAX_FEATURES_RESULTS = 100` cap with warning.
- New MCP tool `features` with the same parameters.

### Stalled-PR detection plumbed through
- `LinkedPR` interface in `core/linked-pr-classification.ts` gains optional `updatedAt`.
- `adaptScoutLinkedPR` propagates `updatedAt` when present (structural absence preserved when missing).
- New `isLinkedPRStalled(linkedPR)` in `core/linked-pr-classification.ts` reusing scout's 30-day threshold.
- `SearchOutput.candidates[].linkedPR`, `VetOutput.linkedPR`, `FeaturesOutput.{quickWins,biggerBets}[].linkedPR` all expose `{ number, state, url, updatedAt?, isStalled }`.
- CLI annotates lines with `(stalled PR, revive opportunity)` when applicable.

### Vet-list classification
- New `has_stalled_pr` status alongside `has_pr` and `has_linked_pr`.
- Stalled linked PRs surface as revive candidates instead of being dropped.
- Goldens updated for `vet-list.empty.json` / `vet-list.mixed.json`.

### Plugin contract
- `.claude-plugin/expected-cli-contract.json` lists the new `features` command (alphabetical).
- `workflows/reference.md` documents it.

## Test plan

- [x] All tests pass: 2591 core (+34 new) + 211 mcp (+2 new) + 256 dashboard (unchanged) = 3058 passing
- [x] `pnpm run lint`: 0 errors (1607 pre-existing warnings unaffected)
- [x] `pnpm run format:check`: clean
- [x] `tsc --noEmit`: clean for all 3 packages
- [x] Code review pass: no findings above threshold
- [ ] CI green