### PR TITLE
fix(startup): throttle dashboard browser re-open to avoid duplicate tabs

### DIFF
--- a/packages/core/src/commands/dashboard-lifecycle.ts
+++ b/packages/core/src/commands/dashboard-lifecycle.ts
@@ -22,6 +22,13 @@ export interface LaunchResult {
   url: string;
   port: number;
   alreadyRunning: boolean;
+  /**
+   * When `alreadyRunning` is true, the timestamp the running server most
+   * recently recorded a browser-open at (or undefined if never recorded).
+   * Used by startup to throttle duplicate browser tabs across `/oss` runs.
+   * Always undefined for fresh launches.
+   */
+  lastBrowserOpenedAt?: string;
 }
 
 function sleep(ms: number): Promise<void> {
@@ -75,11 +82,21 @@ export async function launchDashboardServer(options?: { port?: number }): Promis
       } else {
         // Could not kill old server (e.g. EPERM); return it rather than
         // attempting a doomed spawn on the same port.
-        return { url: existing.url, port: existing.port, alreadyRunning: true };
+        return {
+          url: existing.url,
+          port: existing.port,
+          alreadyRunning: true,
+          lastBrowserOpenedAt: info?.lastBrowserOpenedAt,
+        };
       }
       // Fall through to launch a new server
     } else {
-      return { url: existing.url, port: existing.port, alreadyRunning: true };
+      return {
+        url: existing.url,
+        port: existing.port,
+        alreadyRunning: true,
+        lastBrowserOpenedAt: info.lastBrowserOpenedAt,
+      };
     }
   }
 

--- a/packages/core/src/commands/dashboard-process.test.ts
+++ b/packages/core/src/commands/dashboard-process.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for dashboard-process.ts focused on PID file shape and the
+ * `recordBrowserOpened` helper added for #1339.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+vi.mock('../core/index.js', () => ({
+  getDataDir: () => process.env.__OSS_TEST_DATA_DIR ?? os.tmpdir(),
+}));
+
+const { writeDashboardServerInfo, readDashboardServerInfo, recordBrowserOpened, getDashboardPidPath } =
+  await import('./dashboard-process.js');
+
+describe('dashboard-process PID file', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oss-pidtest-'));
+    process.env.__OSS_TEST_DATA_DIR = tmpDir;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    delete process.env.__OSS_TEST_DATA_DIR;
+  });
+
+  it('round-trips lastBrowserOpenedAt through write/read', () => {
+    const ts = '2026-05-09T12:34:56.000Z';
+    writeDashboardServerInfo({
+      pid: 1234,
+      port: 3000,
+      startedAt: '2026-05-09T12:00:00.000Z',
+      version: '3.6.0',
+      lastBrowserOpenedAt: ts,
+    });
+
+    const info = readDashboardServerInfo();
+    expect(info?.lastBrowserOpenedAt).toBe(ts);
+  });
+
+  it('drops a non-string lastBrowserOpenedAt rather than rejecting the whole file', () => {
+    fs.writeFileSync(
+      getDashboardPidPath(),
+      JSON.stringify({
+        pid: 1234,
+        port: 3000,
+        startedAt: '2026-05-09T12:00:00.000Z',
+        lastBrowserOpenedAt: 12345, // wrong type
+      }),
+    );
+
+    const info = readDashboardServerInfo();
+    expect(info).not.toBeNull();
+    expect(info?.lastBrowserOpenedAt).toBeUndefined();
+    expect(info?.pid).toBe(1234);
+  });
+});
+
+describe('recordBrowserOpened', () => {
+  let tmpDir: string;
+  const fixedNow = new Date('2026-05-09T15:00:00.000Z');
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oss-pidtest-'));
+    process.env.__OSS_TEST_DATA_DIR = tmpDir;
+    vi.useFakeTimers();
+    vi.setSystemTime(fixedNow);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    delete process.env.__OSS_TEST_DATA_DIR;
+  });
+
+  it('stamps the PID file with the current ISO timestamp', () => {
+    writeDashboardServerInfo({
+      pid: 1234,
+      port: 3000,
+      startedAt: '2026-05-09T12:00:00.000Z',
+    });
+
+    recordBrowserOpened(3000);
+
+    const info = readDashboardServerInfo();
+    expect(info?.lastBrowserOpenedAt).toBe(fixedNow.toISOString());
+  });
+
+  it('no-ops when the PID file is missing', () => {
+    expect(() => recordBrowserOpened(3000)).not.toThrow();
+    expect(readDashboardServerInfo()).toBeNull();
+  });
+
+  it('no-ops when the recorded port does not match (stale read)', () => {
+    writeDashboardServerInfo({
+      pid: 1234,
+      port: 3000,
+      startedAt: '2026-05-09T12:00:00.000Z',
+    });
+
+    recordBrowserOpened(9999); // mismatched port
+
+    const info = readDashboardServerInfo();
+    expect(info?.lastBrowserOpenedAt).toBeUndefined();
+  });
+});

--- a/packages/core/src/commands/dashboard-process.ts
+++ b/packages/core/src/commands/dashboard-process.ts
@@ -18,6 +18,7 @@ export interface DashboardServerInfo {
   port: number;
   startedAt: string;
   version?: string;
+  lastBrowserOpenedAt?: string;
 }
 
 // ── PID File Management ────────────────────────────────────────────────────────
@@ -46,6 +47,9 @@ export function readDashboardServerInfo(): DashboardServerInfo | null {
       warn(MODULE, 'PID file has invalid structure, ignoring');
       return null;
     }
+    if (parsed.lastBrowserOpenedAt !== undefined && typeof parsed.lastBrowserOpenedAt !== 'string') {
+      delete parsed.lastBrowserOpenedAt;
+    }
     return parsed as DashboardServerInfo;
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
@@ -53,6 +57,22 @@ export function readDashboardServerInfo(): DashboardServerInfo | null {
       warn(MODULE, `Failed to read PID file: ${(err as Error).message}`);
     }
     return null;
+  }
+}
+
+/**
+ * Stamp the PID file with the current time as `lastBrowserOpenedAt`. Used by
+ * startup to throttle re-opening the dashboard tab — see the `shouldOpenBrowser`
+ * helper in `startup.ts`. No-ops if the PID file is missing or the recorded
+ * port doesn't match (server may have restarted between read and write).
+ */
+export function recordBrowserOpened(port: number): void {
+  const info = readDashboardServerInfo();
+  if (!info || info.port !== port) return;
+  try {
+    writeDashboardServerInfo({ ...info, lastBrowserOpenedAt: new Date().toISOString() });
+  } catch (err) {
+    warn(MODULE, `Failed to record browser-opened timestamp: ${(err as Error).message}`);
   }
 }
 

--- a/packages/core/src/commands/startup.test.ts
+++ b/packages/core/src/commands/startup.test.ts
@@ -30,6 +30,10 @@ vi.mock('./dashboard-lifecycle.js', () => ({
   launchDashboardServer: vi.fn(),
 }));
 
+vi.mock('./dashboard-process.js', () => ({
+  recordBrowserOpened: vi.fn(),
+}));
+
 // Mock fs so detectIssueList doesn't hit the real filesystem
 vi.mock('node:fs', async () => {
   const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
@@ -683,9 +687,9 @@ describe('runStartup behavior', () => {
       'http://127.0.0.1:3001/api/refresh',
       expect.objectContaining({ method: 'POST' }),
     );
-    // Should always call the OS browser-opener: native `open`/`xdg-open`/`start`
-    // focus an existing tab matching the URL instead of duplicating it, so
-    // surfacing the dashboard after /oss is safe here.
+    // No `lastBrowserOpenedAt` recorded yet → falls outside throttle window,
+    // so the OS browser-opener still runs to surface the dashboard for users
+    // who closed the tab between runs (#1100).
     expectBrowserOpenedWith('http://oss.localhost:3001');
     expect(result.daily?.briefSummary).toContain('Dashboard refreshed');
     expect(result.daily?.briefSummary).not.toContain('Dashboard opened in browser');
@@ -733,6 +737,123 @@ describe('runStartup behavior', () => {
     expect(result.daily?.briefSummary).toContain('Dashboard running');
     fetchSpy.mockRestore();
     consoleSpy.mockRestore();
+  });
+
+  it('skips browser-open when running server was opened within the throttle window (#1339)', async () => {
+    // Within the default 30-minute throttle: don't pile up duplicate tabs on
+    // back-to-back /oss runs. The SPA's existing /api/refresh keeps the
+    // already-open tab fresh; opening the URL again would surface a duplicate
+    // on browsers/setups where the OS-level "focus existing tab" doesn't fire.
+    const daily = makeDailyOutput(3);
+    executeDailyCheck.mockResolvedValue(daily);
+    launchDashboardServer.mockResolvedValue({
+      url: 'http://oss.localhost:3001',
+      port: 3001,
+      alreadyRunning: true,
+      lastBrowserOpenedAt: new Date(Date.now() - 60_000).toISOString(), // 1 minute ago
+    });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 200 }));
+
+    const result = await runStartup();
+
+    expect(result.dashboardUrl).toBe('http://oss.localhost:3001');
+    expect(execFile).not.toHaveBeenCalled();
+    // The data refresh still fires — the SPA tab gets fresh data.
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'http://127.0.0.1:3001/api/refresh',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    fetchSpy.mockRestore();
+  });
+
+  it('opens browser when last open is older than the throttle window (#1339)', async () => {
+    // Beyond the throttle: assume the user has closed the tab or moved on, so
+    // re-surface the dashboard.
+    const daily = makeDailyOutput(3);
+    executeDailyCheck.mockResolvedValue(daily);
+    launchDashboardServer.mockResolvedValue({
+      url: 'http://oss.localhost:3001',
+      port: 3001,
+      alreadyRunning: true,
+      lastBrowserOpenedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(), // 2 hours ago
+    });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await runStartup();
+
+    expect(execFile).toHaveBeenCalled();
+    expectBrowserOpenedWith('http://oss.localhost:3001');
+    fetchSpy.mockRestore();
+  });
+
+  it('honors OSS_NO_BROWSER=1 by skipping the browser open entirely (#1339)', async () => {
+    const daily = makeDailyOutput(3);
+    executeDailyCheck.mockResolvedValue(daily);
+    launchDashboardServer.mockResolvedValue({ url: 'http://oss.localhost:3000', port: 3000, alreadyRunning: false });
+    process.env.OSS_NO_BROWSER = '1';
+
+    try {
+      const result = await runStartup();
+      expect(result.dashboardUrl).toBe('http://oss.localhost:3000');
+      expect(execFile).not.toHaveBeenCalled();
+    } finally {
+      delete process.env.OSS_NO_BROWSER;
+    }
+  });
+
+  it('honors OSS_DASHBOARD_REOPEN_THROTTLE_MS=0 by always re-opening (#1339)', async () => {
+    const daily = makeDailyOutput(3);
+    executeDailyCheck.mockResolvedValue(daily);
+    launchDashboardServer.mockResolvedValue({
+      url: 'http://oss.localhost:3001',
+      port: 3001,
+      alreadyRunning: true,
+      lastBrowserOpenedAt: new Date(Date.now() - 5_000).toISOString(), // 5s ago — well within default
+    });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 200 }));
+    process.env.OSS_DASHBOARD_REOPEN_THROTTLE_MS = '0';
+
+    try {
+      await runStartup();
+      expect(execFile).toHaveBeenCalled();
+      expectBrowserOpenedWith('http://oss.localhost:3001');
+    } finally {
+      delete process.env.OSS_DASHBOARD_REOPEN_THROTTLE_MS;
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('records browser-opened timestamp after opening (#1339)', async () => {
+    const { recordBrowserOpened } = await import('./dashboard-process.js');
+    (recordBrowserOpened as ReturnType<typeof vi.fn>).mockClear();
+
+    const daily = makeDailyOutput(3);
+    executeDailyCheck.mockResolvedValue(daily);
+    launchDashboardServer.mockResolvedValue({ url: 'http://oss.localhost:3000', port: 3000, alreadyRunning: false });
+
+    await runStartup();
+
+    expect(recordBrowserOpened).toHaveBeenCalledWith(3000);
+  });
+
+  it('does not record browser-opened timestamp when open is throttled (#1339)', async () => {
+    const { recordBrowserOpened } = await import('./dashboard-process.js');
+    (recordBrowserOpened as ReturnType<typeof vi.fn>).mockClear();
+
+    const daily = makeDailyOutput(3);
+    executeDailyCheck.mockResolvedValue(daily);
+    launchDashboardServer.mockResolvedValue({
+      url: 'http://oss.localhost:3001',
+      port: 3001,
+      alreadyRunning: true,
+      lastBrowserOpenedAt: new Date(Date.now() - 60_000).toISOString(),
+    });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await runStartup();
+
+    expect(recordBrowserOpened).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
   });
 
   it('launches SPA even when totalActivePRs is 0 (covers misconfig + transient + between-PRs)', async () => {

--- a/packages/core/src/commands/startup.ts
+++ b/packages/core/src/commands/startup.ts
@@ -15,7 +15,8 @@ import { errorMessage } from '../core/errors.js';
 import { warn } from '../core/logger.js';
 import { type StartupOutput, type IssueListInfo } from '../formatters/json.js';
 import { executeDailyCheck } from './daily.js';
-import { launchDashboardServer } from './dashboard-lifecycle.js';
+import { launchDashboardServer, type LaunchResult } from './dashboard-lifecycle.js';
+import { recordBrowserOpened } from './dashboard-process.js';
 import { parseIssueList } from './parse-list.js';
 
 /**
@@ -190,6 +191,44 @@ export function openInBrowser(url: string): void {
  * Hits POST /api/refresh so the SPA picks up fresh data on its next poll.
  * Non-fatal: errors are logged but don't propagate (#830).
  */
+const DEFAULT_REOPEN_THROTTLE_MS = 30 * 60 * 1000; // 30 minutes
+
+/**
+ * Resolve the browser-reopen throttle window from `OSS_DASHBOARD_REOPEN_THROTTLE_MS`,
+ * falling back to {@link DEFAULT_REOPEN_THROTTLE_MS}. A value of `0` disables the
+ * throttle entirely, restoring the pre-#1339 behavior of always re-opening.
+ */
+function getReopenThrottleMs(): number {
+  const raw = process.env.OSS_DASHBOARD_REOPEN_THROTTLE_MS;
+  if (!raw) return DEFAULT_REOPEN_THROTTLE_MS;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : DEFAULT_REOPEN_THROTTLE_MS;
+}
+
+/**
+ * Decide whether `openInBrowser` should run. Throttles re-opens against an
+ * already-running server's `lastBrowserOpenedAt` timestamp so back-to-back
+ * `/oss` runs don't pile up duplicate tabs (#1339), while still re-surfacing
+ * the dashboard for users who closed the tab and came back later (#1100).
+ *
+ * Fresh launches (`alreadyRunning === false`) always open; the new server has
+ * no recorded open yet by definition.
+ *
+ * Set `OSS_NO_BROWSER=1` to skip opening unconditionally (e.g., headless / CI).
+ */
+function shouldOpenBrowser(spaResult: LaunchResult, throttleMs: number): boolean {
+  if (process.env.OSS_NO_BROWSER === '1') return false;
+  if (!spaResult.alreadyRunning) return true;
+  if (throttleMs === 0) return true;
+  const last = spaResult.lastBrowserOpenedAt;
+  if (!last) return true;
+  const lastMs = Date.parse(last);
+  if (!Number.isFinite(lastMs)) return true;
+  const elapsed = Date.now() - lastMs;
+  if (elapsed < 0) return true; // clock skew or future timestamp; treat as stale
+  return elapsed >= throttleMs;
+}
+
 async function triggerDashboardRefresh(port: number): Promise<boolean> {
   try {
     const res = await fetch(`http://127.0.0.1:${port}/api/refresh`, {
@@ -286,12 +325,15 @@ export async function runStartup(): Promise<StartupOutput> {
       } else {
         dashboardStatus = 'opened';
       }
-      // `open`/`xdg-open`/`start` focus an existing tab matching the URL
-      // instead of duplicating it, so this is safe whether the server was
-      // just started or was already running. Closes #830 properly — a user
-      // can close the dashboard tab while the daemon keeps running, leaving
-      // subsequent /oss runs with no visible dashboard if we didn't re-open.
-      openInBrowser(spaResult.url);
+      // Throttle re-opens against the running server's last-opened timestamp
+      // so back-to-back /oss runs don't pile up duplicate tabs (#1339), while
+      // still re-surfacing the dashboard for users who closed the tab and
+      // came back later (#1100). `OSS_NO_BROWSER=1` skips entirely;
+      // `OSS_DASHBOARD_REOPEN_THROTTLE_MS=0` restores always-open behavior.
+      if (shouldOpenBrowser(spaResult, getReopenThrottleMs())) {
+        openInBrowser(spaResult.url);
+        recordBrowserOpened(spaResult.port);
+      }
     } else {
       dashboardError = 'Dashboard SPA assets not found. Build with: cd packages/dashboard && pnpm run build';
       console.error(`[STARTUP] ${dashboardError}`);


### PR DESCRIPTION
## Summary
`/oss` opened a duplicate browser tab on every invocation in environments where the macOS `open` command does not focus an existing tab matching the URL. Tracked in #1339; this is the third pass on the same area (#834 → #1100 → here).

The boolean was flipping between "always open" (current) and "never open when alreadyRunning" (pre-#1100). Each fix was correct under different inputs. This PR adds a third dimension, time since last open, so both prior concerns hold:

- **#1339** (no duplicate tabs): within 30 minutes of the last open, skip.
- **#1100** (re-surface for users who close the tab): after the throttle expires, re-open.

## Implementation
- `DashboardServerInfo` gains an optional `lastBrowserOpenedAt` field (string or omitted). The validator gracefully drops a wrong-typed value rather than rejecting the whole file.
- `recordBrowserOpened(port)` stamps the PID file with the current time.
- `launchDashboardServer` surfaces `lastBrowserOpenedAt` on both `alreadyRunning: true` return sites.
- `startup.ts` gates `openInBrowser` on `shouldOpenBrowser()`, which returns `true` for fresh launches, `false` within the throttle, and `true` after it expires.

## Configuration
- `OSS_NO_BROWSER=1`: skip the browser open entirely (CI, headless).
- `OSS_DASHBOARD_REOPEN_THROTTLE_MS=<ms>`: override the default 30-minute window. `0` restores always-open behavior.

## Test plan
- [x] 6 new unit tests covering: within-throttle skip, beyond-throttle open, `OSS_NO_BROWSER=1`, `OSS_DASHBOARD_REOPEN_THROTTLE_MS=0`, timestamp recorded after open, timestamp not recorded when throttled.
- [x] New `dashboard-process.test.ts` covering PID file round-trip, validator drops wrong-typed `lastBrowserOpenedAt`, and `recordBrowserOpened` happy / no-PID / port-mismatch cases.
- [x] `pnpm typecheck`, `pnpm lint` (0 errors), `pnpm format:check` clean.
- [x] Full workspace test suite (core 2568, dashboard 256, mcp-server 209) green.
- [x] Manual smoke: bundled CLI run twice in succession does NOT re-open; forcing `OSS_DASHBOARD_REOPEN_THROTTLE_MS=0` re-opens and bumps the timestamp; `OSS_NO_BROWSER=1` records nothing.

## Future work
A truly correct fix would be server-side presence detection: have the dashboard track recent SPA polls and answer "is a tab connected right now?". The throttle here is a simpler approximation that solves the visible duplicate-tab regression without expanding the API surface.

Closes #1339.