### PR TITLE
feat(workflow): add upstream-drift check before push (closes #1345)

### DIFF
--- a/commands/pr-ready.md
+++ b/commands/pr-ready.md
@@ -14,6 +14,17 @@ For the diff currently uncommitted-and-staged or already on the local branch (wh
 
 1. **Verify branch hygiene** — confirm we're not on `main`, the working tree has work to evaluate, and main has been pulled recently. If the working tree is clean and the branch matches main, abort with "nothing to review".
 
+   **Upstream drift check (mandatory).** Re-fetch the upstream default branch and detect any commits since this branch diverged that touch files in this branch's diff:
+
+   ```bash
+   git fetch <remote> <default> 2>/dev/null
+   mergeBase=$(git merge-base <remote>/<default> HEAD)
+   touchedFiles=$(git diff --name-only "$mergeBase" HEAD)
+   overlappingCommits=$(git log "$mergeBase..<remote>/<default>" --oneline -- $touchedFiles)
+   ```
+
+   If `$overlappingCommits` is non-empty, surface the list and recommend re-vetting the issue before declaring READY. The same fix may have already merged; the CONTRIBUTING-style "no other open PRs" check passes vacuously when the duplicate has merged, so this drift check is the only safety net. Report as a Critical finding if any overlapping commits are found and the user hasn't acknowledged them.
+
 2. **Run the project's lint+format checks**:
    - `pnpm run lint`
    - `pnpm run format:check` (if the project's `package.json` defines it)

--- a/workflows/draft-first-workflow.md
+++ b/workflows/draft-first-workflow.md
@@ -480,7 +480,54 @@ Options:
 
 **CRITICAL: This step must NOT be reached without completing Steps 3 (review cycle), 4 (integration check), 5 (manual testing), 6 (human review), and 7 (squash, or explicitly skipped). If a PR is created before these steps, the workflow has been bypassed — this is a bug.**
 
-### 1. Show PR Summary
+### 1. Upstream Drift Check (Mandatory)
+
+The fix could have been merged upstream while this session was active. The CONTRIBUTING-style "no other open PRs" check that ran earlier passes vacuously when the duplicate has merged, so re-check the upstream history right before the irreversible push.
+
+```bash
+upstreamRepo=$(echo "{issueContext.url}" | sed -n 's|https://github.com/\([^/]*/[^/]*\)/.*|\1|p')
+upstreamDefault="${upstreamDefault:-$(gh repo view "$upstreamRepo" --json defaultBranchRef --jq '.defaultBranchRef.name')}"
+remote="${upstreamRemote:-upstream}"
+git remote get-url "$remote" >/dev/null 2>&1 || remote="origin"
+
+git fetch "$remote" "$upstreamDefault" 2>/dev/null
+
+mergeBase=$(git merge-base "$remote/$upstreamDefault" HEAD 2>/dev/null)
+touchedFiles=$(git diff --name-only "$mergeBase" HEAD 2>/dev/null)
+
+# Find commits on upstream main since mergeBase that touch any file we changed.
+overlappingCommits=""
+if [ -n "$touchedFiles" ]; then
+  overlappingCommits=$(git log "$mergeBase..$remote/$upstreamDefault" --oneline -- $touchedFiles 2>/dev/null)
+fi
+```
+
+**If `$overlappingCommits` is empty:** Proceed to "2. Show PR Summary".
+
+**If `$overlappingCommits` is non-empty:** Surface the commits inline:
+
+```
+## ⚠ Upstream drift detected
+
+`{remote}/{upstreamDefault}` has commits since this branch diverged that touch the same files as your diff:
+
+{overlappingCommits}
+
+The same fix may have already merged. Before pushing, re-vet the issue:
+  - Open the issue URL: {issueContext.url}
+  - Check the issue's state and any "Closed by" link
+  - Inspect the listed commits with `git show <sha>` to compare scope
+```
+
+Use AskUserQuestion:
+1. "Re-vet the issue" — run the issue-scout vet again on `{issueContext.url}`. If the vet returns "already fixed" / "closed", route to "Abandon this branch" below.
+2. "Show diff vs upstream" — `git diff $remote/$upstreamDefault..HEAD -- $touchedFiles`. Present and re-prompt with the same options.
+3. "Proceed anyway" — "I've verified the listed commits don't conflict with my fix or are unrelated." Continue to "2. Show PR Summary".
+4. "Abandon this branch" — Report: "Skipping PR creation. Branch `{branchName}` stays local; you can delete it with `git branch -D {branchName}` once you've confirmed the fix is duplicate." Return to the core router. Do NOT push or create a PR.
+
+**If the fetch fails** (no network, gh CLI error): Note "Could not verify upstream drift — proceeding with caution." Continue to "2. Show PR Summary".
+
+### 2. Show PR Summary
 
 ```
 ## Ready to create PR?
@@ -492,7 +539,7 @@ Files changed: {count}
 Issue: {issueContext.url}
 ```
 
-### 2. Confirm Push
+### 3. Confirm Push
 
 Push (remote, visible) is confirmed separately from PR creation so the user can verify exactly what is about to leave their machine before any irreversible action.
 
@@ -510,7 +557,7 @@ Options:
 
 **"Done for now":** Report: "Your changes are saved locally on branch `{branchName}`. Run `/oss` later to push and create the PR." Return to the core router.
 
-### 3. Push
+### 4. Push
 
 ```bash
 git push -u origin HEAD
@@ -518,7 +565,7 @@ git push -u origin HEAD
 
 **If push fails**, report the error and offer: "Retry" / "Done for now" — "Your changes are saved locally on branch `{branchName}`. You can push and create the PR later with `/oss`." Do NOT proceed to PR creation without a successful push.
 
-### 4. Confirm PR State and Create PR
+### 5. Confirm PR State and Create PR
 
 After the push succeeds, confirm the PR state separately:
 


### PR DESCRIPTION
## Summary

Adds a mandatory upstream-drift check at the top of Step 8 (Push + Create PR) in the draft-first workflow, plus the same signal in `/pr-ready`'s branch-hygiene step.

The current pre-PR gates verify state at session start (Step 1b's branch-base validation, the CONTRIBUTING-style "no other open PRs" check). They miss the case where another contributor opens *and merges* the same fix while the session is active — the CONTRIBUTING checkbox passes vacuously when the duplicate has already merged.

Closes #1345.

## What changed

- `workflows/draft-first-workflow.md` Step 8 gets a new sub-step "1. Upstream Drift Check" before "2. Show PR Summary". Renumbers the existing 2/3/4 sub-steps to 3/4/5.
- The check runs:

  ```bash
  git fetch "$remote" "$upstreamDefault"
  mergeBase=$(git merge-base "$remote/$upstreamDefault" HEAD)
  touchedFiles=$(git diff --name-only "$mergeBase" HEAD)
  overlappingCommits=$(git log "$mergeBase..$remote/$upstreamDefault" --oneline -- $touchedFiles)
  ```

  If `$overlappingCommits` is non-empty, the user gets four options: re-vet the issue, view the diff vs upstream, proceed anyway, or abandon the branch. Push is blocked unless the user picks one of the first three.

- `commands/pr-ready.md` step 1 (Verify branch hygiene) gets the same check so the drift signal also surfaces during the lint+tests+review loop, not only at push.

## Why this exists

Concrete recent incident on a third-party repo: the same fix landed on upstream main about 9 hours before our PR opened. Our session-initial fetch was hours before that merge; we never re-fetched. The PR was closed by the project lead within 2 hours of opening as a duplicate.

The remediation is one fetch and one git-log query, well under a second of runtime on any normally-sized repo, and the early-bailout saves the 5-30 minutes of push + PR-create + close cycle plus the maintainer-reputation cost.

## Verification

- Manually exercised the new check on this branch (no overlapping commits since mergeBase, as expected; check passes silently).
- `pnpm format:check` clean (pre-commit hook).
- Docs-only change: no TS/lint/test impact.

## Test plan

- [ ] Open another PR after this lands, simulate a session where upstream main moves ahead on the same files, verify the check surfaces the drift list and the four options work as documented.
- [ ] Run `/pr-ready` on a branch where upstream has overlapping commits, verify the drift is reported as a Critical finding.
