### PR TITLE
feat(strategy): expose on-demand snapshot via CLI/MCP, rewire agent (#1243 step 4)

### DIFF
--- a/.claude-plugin/expected-cli-contract.json
+++ b/.claude-plugin/expected-cli-contract.json
@@ -35,6 +35,7 @@
     "state",
     "stats",
     "status",
+    "strategy",
     "track",
     "undismiss",
     "unshelve",

--- a/agents/contribution-strategist.md
+++ b/agents/contribution-strategist.md
@@ -28,55 +28,45 @@ tools: ["Bash", "Read"]
 
 > **Input validation:** See "AskUserQuestion Validation Protocol" in `workflows/reference.md`.
 
-You are a Contribution Strategist who helps developers maximize the impact and growth of their open source journey.
-
-## Core Responsibilities
-
-1. Analyze contribution patterns and history
-2. Identify strengths and growth opportunities
-3. Recommend strategic repos and issue types
-4. Set meaningful, achievable goals
+You are a Contribution Strategist who synthesizes the typed `computeStrategy()` snapshot into actionable coaching for a single developer's open source path. Classification, capacity detection, and trajectory rules live in the core function (#1243); your job is the narrative on top.
 
 ## Data Access
 
-**Prefer MCP tool:** `mcp__plugin_oss-autopilot_oss-autopilot__status` — typed, no shell exec, no bundle dependency.
+**Prefer MCP tool:** `mcp__plugin_oss-autopilot_oss-autopilot__strategy` — runs the typed `computeStrategy()` function against local state and returns the structured snapshot.
 
 **CLI fallback** (only when MCP is unavailable):
 
 ```bash
-GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" status --json
+GITHUB_TOKEN=$(gh auth token) node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" strategy --json
 ```
 
-This returns PR history (merged/closed PRs with dates), active/dormant PRs with health indicators, configuration (languages, labels, preferences), and repository scores.
+The tool always runs — no cadence gate. When `strategy` is null (insufficient history below `STRATEGY_MIN_PRS`), `message` carries the explanation; report it verbatim and stop.
 
-**On failure:** Report the error and stop — do not improvise with raw `gh api` calls. If the CLI is missing, run `pnpm run bundle` or ask the user to reinstall.
+**On failure:** Report the error and stop — do not improvise with raw `gh api` calls or fall back to per-prompt categorization. If the CLI is missing, run `pnpm run bundle` or ask the user to reinstall.
 
-## Analysis Process
+## Snapshot Shape
 
-1. **Gather history** via the MCP tool / CLI above.
-2. **Identify patterns** — which repos have highest success rate, what types of PRs get merged fastest, which languages dominate, what times/days are most active.
-3. **Categorize strengths vs gaps vs opportunities.**
+```ts
+{
+  strategy: {
+    profile: { style, totalPRs, mergedCount, mergeRate, primaryLanguages, favoriteRepos },
+    capacity: { openPRCount, dormantPRCount, dormantRepoCount, overExtended, suggestedAction },
+    patterns: { prTypeDistribution, trajectoryDirection, averagePRSize },
+    recommendations: { languages, repos, issueTypes, avoidPatterns }
+  } | null,
+  message?: string
+}
+```
 
-## Strategic Framing
+`style`, `trajectoryDirection`, and `suggestedAction` are pre-classified by the core function. Read them; do not re-derive them from raw history.
 
-### Contribution profile
-Categorize contributions as bug fixes, features, documentation, testing, refactoring, or maintenance. Note success rate per category and per repo.
+## Synthesis Process
 
-### Growth trajectory
-Contribution frequency over time, increasing PR complexity, movement across types (docs → code → features), and relationship depth with specific projects.
-
-## Recommendations to Produce
-
-1. **Repo recommendations** — match user skills with repos that use their preferred languages, have good maintainer response, match their experience level, and offer growth.
-2. **Issue type recommendations** — beginners → docs/tests/good-first-issue; intermediate → bug fixes, small features; advanced → architecture, complex features.
-3. **Focus areas** — 2-3 specific areas (deepen one language, branch into new tech, build a relationship with one project).
-
-## Goal Setting
-
-Help set SMART goals across timeframes:
-- **Weekly:** respond to open PRs, commit X hours to OSS.
-- **Monthly:** open X PRs, get X merged, contribute to 1 new repo.
-- **Quarterly:** become regular contributor to 1-2 repos; complete a significant feature.
+1. **Fetch** the snapshot via the MCP tool. If `strategy === null`, surface `message` and stop.
+2. **Open with the headline** — style, merge rate, and one notable signal from `patterns` or `capacity`.
+3. **Call out capacity first when `capacity.overExtended === true`** — that's the highest-signal coaching moment. Surface `suggestedAction` as the next move.
+4. **Tie recommendations to patterns** — explain *why* a recommended language / repo / issue type matches what the developer has been doing.
+5. **Render `avoidPatterns` as cautions, not commands** — they're hints, not rules. Frame them as "watch for X" rather than "don't do X."
 
 ## Output Format
 
@@ -84,48 +74,45 @@ Help set SMART goals across timeframes:
 ## Contribution Strategy Report
 
 ### Your Profile
-- Contribution style: [Maintainer / Explorer / Specialist / Generalist]
-- Total tracked PRs: X (merged: X, active: X, rate: XX%)
-- Favorite repos: […]; primary languages: […]
+- Style: [profile.style]
+- Tracked PRs: [profile.totalPRs] (merged: [profile.mergedCount], merge rate: [mergeRate%])
+- Top languages: [profile.primaryLanguages.join(', ')]
+- Top repos: [profile.favoriteRepos.join(', ')]
 
-### Patterns & Insights
-**What's working:** [observation]
-**Growth opportunities:** [area for improvement]
+### Patterns & Capacity
+- Trajectory: [patterns.trajectoryDirection]
+- PR mix (recent): [prTypeDistribution → 1-line summary of dominant buckets]
+- Capacity: [openPRCount] open, [dormantPRCount] dormant across [dormantRepoCount] repo(s)
+- [Conditional: if overExtended] **Overextended.** Suggested next move: [suggestedAction].
 
 ### Strategic Recommendations
-1. **[Primary focus]** — Why: […]. How: [specific actions].
-2. **[Secondary focus]** — Why: […]. How: [specific actions].
+1. **Languages to lean into:** [recommendations.languages]. Why: [tie to profile / patterns].
+2. **Repos to deepen:** [recommendations.repos]. Why: [maintainer fit / existing relationship / language match].
+3. **Issue types that suit you:** [recommendations.issueTypes]. Why: [tie to recent PR mix].
 
-| Repo | Why | Issue types to target |
-|---|---|---|
-| repo1 | [reason] | [types] |
+### Watch For
+[For each entry in recommendations.avoidPatterns, render as `- [pattern]` with a brief 1-line elaboration.]
 
-### Suggested Goals
-- This week: [ ] [goal]
-- This month: [ ] [goal]
-- This quarter: [ ] [goal]
-
-### Action Items
-1. [Immediate]
-2. [Next]
-3. [Follow-up]
+### Suggested Next Action
+[One concrete next step grounded in `suggestedAction` if non-null, otherwise the strongest signal in patterns or recommendations.]
 ```
 
-## Coaching Tips
+When `recommendations.avoidPatterns` is empty, omit the "Watch For" section entirely rather than padding it.
 
-Personalize based on patterns:
-- **Low activity:** "Set a recurring time for OSS work — 2 hours/week adds up."
-- **High rejection rate:** "Engage in issue discussions before opening PRs to align with maintainer expectations."
-- **Single-repo focus:** "Diversify across 2-3 repos to reduce burnout risk."
-- **Documentation-only:** "Docs are valuable — when ready, convert a doc contribution into a related code fix."
+## Coaching Voice
 
-## Principles
-- Be encouraging but honest.
-- Focus on actionable advice.
-- Celebrate wins; recognize sustainable pace.
+- Be encouraging but honest. Do not soften a clear "overextended" signal into a hedge.
+- Stay grounded in the data — every claim should map back to a field in the snapshot. If the data doesn't support it, don't say it.
+- Celebrate maintainable pace; never push for more PRs when `capacity.overExtended === true`.
 - Never suggest AI attribution in contributions.
 
+## Principles
+
+- The deterministic compute is the source of truth. The agent's value is interpretation, not recomputation.
+- Prefer a short, useful synthesis over an exhaustive recap. If a section adds no insight beyond what the snapshot already says, drop it.
+- When the user asks a follow-up ("what about Rust specifically?"), ground your answer in the same snapshot rather than improvising from training data.
+
 ## Related Agents
-- **issue-scout** — find issues aligned with strategic recommendations.
+- **issue-scout** — find issues aligned with the recommendations the snapshot surfaces.
 - **repo-evaluator** — vet a recommended repo before committing.
-- **pr-health-checker** — diagnose PRs that need attention.
+- **pr-health-checker** — diagnose PRs flagged dormant in `capacity`.

--- a/packages/core/src/agents-contract.test.ts
+++ b/packages/core/src/agents-contract.test.ts
@@ -45,6 +45,7 @@ const REGISTERED_MCP_TOOLS = new Set([
   'track',
   'compliance-score',
   'repo-vet',
+  'strategy',
   'comments',
   'post',
   'claim',

--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -196,6 +196,67 @@ export const commands: CLICommandDef[] = [
     },
   },
 
+  // ── Strategy ───────────────────────────────────────────────────────────
+  {
+    name: 'strategy',
+    localOnly: true,
+    register(program) {
+      program
+        .command('strategy')
+        .description(
+          'On-demand contribution-strategy snapshot via the typed `computeStrategy` function (#1243). ' +
+            'Always runs against local state regardless of the auto-display cadence gate; returns ' +
+            'null + message when fewer than the minimum tracked PRs are available.',
+        )
+        .option('--json', 'Output as JSON')
+        .action(async (options) => {
+          const { StrategyOutputSchema } = await import('./formatters/json.js');
+          await executeAction(
+            options,
+            async () => (await import('./commands/strategy.js')).runStrategy(),
+            (data) => {
+              if (!data.strategy) {
+                console.log(`\n${data.message ?? 'Strategy unavailable.'}\n`);
+                return;
+              }
+              const { profile, capacity, patterns, recommendations } = data.strategy;
+              const mergeRatePct = Math.round(profile.mergeRate * 100);
+              console.log(`\nProfile: ${profile.style}`);
+              console.log(
+                `${profile.totalPRs} PRs tracked, ${profile.mergedCount} merged (${mergeRatePct}% merge rate).`,
+              );
+              if (profile.primaryLanguages.length > 0) {
+                console.log(`Top languages: ${profile.primaryLanguages.join(', ')}`);
+              }
+              if (profile.favoriteRepos.length > 0) {
+                console.log(`Top repos: ${profile.favoriteRepos.join(', ')}`);
+              }
+              console.log(
+                `\nCapacity: ${capacity.openPRCount} open, ${capacity.dormantPRCount} dormant across ${capacity.dormantRepoCount} repo(s).`,
+              );
+              if (capacity.overExtended) {
+                console.log(`Overextended — suggested action: ${capacity.suggestedAction ?? 'review dormant PRs'}.`);
+              }
+              console.log(`\nTrajectory: ${patterns.trajectoryDirection}`);
+              const dist = patterns.prTypeDistribution;
+              const parts: Array<[string, number]> = [];
+              for (const [k, v] of Object.entries(dist)) {
+                if (typeof v === 'number' && v > 0) parts.push([k, v]);
+              }
+              if (parts.length > 0) {
+                console.log(`PR types (recent): ${parts.map(([k, v]) => `${k}=${v}`).join(', ')}`);
+              }
+              if (recommendations.avoidPatterns.length > 0) {
+                console.log(`\nWatch for: ${recommendations.avoidPatterns.join('; ')}`);
+              }
+              console.log('\nRun with --json for structured output');
+            },
+            StrategyOutputSchema,
+          );
+        });
+    },
+  },
+
   // ── State ──────────────────────────────────────────────────────────────
   {
     name: 'state',

--- a/packages/core/src/cli.test.ts
+++ b/packages/core/src/cli.test.ts
@@ -106,6 +106,7 @@ const localOnlySet = new Set(LOCAL_ONLY_COMMANDS);
 describe('LOCAL_ONLY_COMMANDS (derived from registry)', () => {
   const expectedLocalOnly = [
     'status',
+    'strategy',
     'config',
     'setup',
     'checkSetup',
@@ -386,6 +387,7 @@ describe('Command registration', () => {
     const expectedCommands = [
       'daily',
       'status',
+      'strategy',
       'search',
       'features',
       'vet',

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -24,6 +24,8 @@ export { executeDailyCheck } from './daily.js';
 export { runStartup } from './startup.js';
 /** Return contribution statistics (merge rate, PR counts, repo breakdown) from local state. */
 export { runStatus } from './status.js';
+/** On-demand strategy snapshot via the typed `computeStrategy` core function (#1243 step 4). */
+export { runStrategy } from './strategy.js';
 /** Search GitHub for contributable issues using multi-strategy discovery. */
 export { runSearch, MAX_SEARCH_RESULTS } from './search.js';
 /** Surface feature-scoped opportunities in repos with 3+ merged PRs (scout 0.9.0). */

--- a/packages/core/src/commands/strategy.test.ts
+++ b/packages/core/src/commands/strategy.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for the `strategy` command (#1243 step 4).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../core/index.js', () => ({
+  getStateManager: vi.fn(),
+}));
+
+import { getStateManager } from '../core/index.js';
+import { runStrategy } from './strategy.js';
+import { STRATEGY_MIN_PRS } from '../core/strategy.js';
+
+const mockGetStateManager = vi.mocked(getStateManager);
+
+function makeMergedPR(repo: string, n: number, title = 'feat: ship something') {
+  return {
+    url: `https://github.com/${repo}/pull/${n}`,
+    title,
+    mergedAt: '2026-05-01T00:00:00Z',
+  };
+}
+
+function buildState(merged: ReturnType<typeof makeMergedPR>[], extras: Record<string, unknown> = {}) {
+  return {
+    mergedPRs: merged,
+    closedPRs: [],
+    repoScores: {},
+    lastDigest: null,
+    ...extras,
+  };
+}
+
+function setMockState(state: ReturnType<typeof buildState>) {
+  mockGetStateManager.mockReturnValue({
+    getState: vi.fn().mockReturnValue(state),
+  } as never);
+}
+
+describe('runStrategy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null with an explanatory message when below the merged-PR floor', async () => {
+    // Half the floor — gate should hold.
+    const merged = Array.from({ length: Math.floor(STRATEGY_MIN_PRS / 2) }, (_, i) =>
+      makeMergedPR('owner/repo', i + 1),
+    );
+    setMockState(buildState(merged));
+
+    const result = await runStrategy();
+
+    expect(result.strategy).toBeNull();
+    expect(result.message).toBeDefined();
+    expect(result.message).toContain(String(STRATEGY_MIN_PRS));
+    expect(result.message).toContain(String(merged.length));
+  });
+
+  it('returns null with message=0 when nothing is tracked yet', async () => {
+    setMockState(buildState([]));
+
+    const result = await runStrategy();
+
+    expect(result.strategy).toBeNull();
+    expect(result.message).toContain('currently tracking 0');
+  });
+
+  it('returns the typed strategy result when the floor is met', async () => {
+    const merged = Array.from({ length: STRATEGY_MIN_PRS + 2 }, (_, i) => makeMergedPR('owner/repo', i + 1));
+    setMockState(buildState(merged));
+
+    const result = await runStrategy();
+
+    expect(result.strategy).not.toBeNull();
+    expect(result.message).toBeUndefined();
+    expect(result.strategy?.profile.totalPRs).toBe(merged.length);
+    expect(result.strategy?.profile.mergedCount).toBe(merged.length);
+    expect(result.strategy?.profile.style).toMatch(/^(maintainer|explorer|specialist|generalist)$/);
+  });
+});

--- a/packages/core/src/commands/strategy.ts
+++ b/packages/core/src/commands/strategy.ts
@@ -1,0 +1,49 @@
+/**
+ * strategy command (#1243 step 4).
+ *
+ * Runs the typed `computeStrategy` core function against local state on
+ * demand. The daily auto-display already emits `strategySummary` under
+ * a cadence gate; this command is the *ungated* path used by the
+ * `contribution-strategist` agent so a user asking "how am I doing?"
+ * always gets an answer (or a clear "not enough data yet" message) even
+ * when the daily cadence has not fired.
+ *
+ * Read-only: no API calls, no state mutation.
+ */
+
+import { getStateManager } from '../core/index.js';
+import { computeStrategy, STRATEGY_MIN_PRS, type StrategyResult } from '../core/strategy.js';
+
+/**
+ * On-demand strategy snapshot. Mirrors `StrategyOutputSchema` in
+ * `formatters/json.ts` structurally — that schema uses `.passthrough()`
+ * for forward compatibility on the JSON-validation surface, so its
+ * inferred type carries an extra `unknown` index signature that does
+ * not match `StrategyResult`. The command's TypeScript shape is the
+ * exact structural form below.
+ */
+export interface StrategyCommandOutput {
+  strategy: StrategyResult | null;
+  message?: string;
+}
+
+/**
+ * Compute the on-demand strategy snapshot. Returns `{ strategy: null,
+ * message }` when state is below the merged-PR floor, and `{ strategy }`
+ * with the full typed result otherwise.
+ */
+export async function runStrategy(): Promise<StrategyCommandOutput> {
+  const stateManager = getStateManager();
+  const state = stateManager.getState();
+  const strategy = computeStrategy(state);
+  if (strategy === null) {
+    const merged = state.mergedPRs?.length ?? 0;
+    return {
+      strategy: null,
+      message:
+        `Strategy snapshot needs at least ${STRATEGY_MIN_PRS} merged PRs in local state; ` +
+        `currently tracking ${merged}. Keep contributing and the snapshot becomes available automatically.`,
+    };
+  }
+  return { strategy };
+}

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -419,7 +419,7 @@ const CompactRepoGroupSchema = z.object({
 // Mirrors {@link StrategyResult} in core/strategy.ts. Kept passthrough on the
 // inner objects so additive shape changes there don't break Zod validation
 // before the schema catches up — drift on required keys still fails.
-const StrategyResultSchema = z
+export const StrategyResultSchema = z
   .object({
     profile: z
       .object({
@@ -475,6 +475,20 @@ const StrategyResultSchema = z
       .passthrough(),
   })
   .passthrough();
+
+/**
+ * On-demand strategy snapshot output (#1243 step 4). Wraps the same
+ * `StrategyResult` shape consumed by the daily auto-display, but is
+ * always available — the cadence gate only governs the auto-display,
+ * not direct CLI/MCP calls. `strategy` is null when the minimum-data
+ * gate fails (fewer than `STRATEGY_MIN_PRS` merged PRs); `message`
+ * carries the human-readable explanation in that case.
+ */
+export const StrategyOutputSchema = z.object({
+  strategy: StrategyResultSchema.nullable(),
+  message: z.string().optional(),
+});
+export type StrategyCommandOutput = z.infer<typeof StrategyOutputSchema>;
 
 export const DailyOutputSchema = z.object({
   digest: DailyDigestCompactSchema,

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -10,7 +10,7 @@ MCP server for [OSS Autopilot](https://github.com/costajohnt/oss-autopilot) — 
 
 | Feature | Count | Description |
 |---------|-------|-------------|
-| **Tools** | 29 | `daily`, `status`, `search`, `features`, `vet`, `vet-list`, `track`, `compliance-score`, `repo-vet`, `comments`, `post`, `claim`, `config`, `init`, `setup`, `check-setup`, `startup`, `shelve`, `unshelve`, `dismiss`, `undismiss`, `move`, `state-show`, `state-sync`, `state-unlink`, `guidelines-get`, `guidelines-store`, `guidelines-reset`, `guidelines-fetch-corpus` |
+| **Tools** | 30 | `daily`, `status`, `search`, `features`, `vet`, `vet-list`, `track`, `compliance-score`, `repo-vet`, `strategy`, `comments`, `post`, `claim`, `config`, `init`, `setup`, `check-setup`, `startup`, `shelve`, `unshelve`, `dismiss`, `undismiss`, `move`, `state-show`, `state-sync`, `state-unlink`, `guidelines-get`, `guidelines-store`, `guidelines-reset`, `guidelines-fetch-corpus` |
 | **Resources** | 6 | `oss://status`, `oss://config`, `oss://prs`, `oss://prs/shelved`, `oss://pr/{owner}/{repo}/{number}`, `oss://repo/{owner}/{repo}/guidelines` |
 | **Prompts** | 4 | `triage` (PR prioritization), `respond-to-pr` (draft response), `find-issues` (discover issues), `extract-learnings` (distill per-repo guidance from past PR feedback) |
 
@@ -122,6 +122,7 @@ The token persists across restarts. To rotate, delete the file and restart — a
 | `track` | Fetch metadata for a pull request (informational; nothing persists) | No |
 | `compliance-score` | Score a PR against opensource.guide best practices (#1245) | Yes |
 | `repo-vet` | Compute the repo health rubric (1–10 + verdict) for `owner/repo` (#1271) | Yes |
+| `strategy` | On-demand contribution strategy snapshot via `computeStrategy()` (#1243) | No |
 | `comments` | Fetch and display PR comments | Yes |
 | `post` | Post a comment on an issue or PR | No |
 | `claim` | Claim an issue by posting a comment | No |

--- a/packages/mcp-server/src/index-main.test.ts
+++ b/packages/mcp-server/src/index-main.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach, afterEach, beforeAll, afterAll } 
 vi.mock('@oss-autopilot/core/commands', () => ({
   runDaily: vi.fn(),
   runStatus: vi.fn(),
+  runStrategy: vi.fn(),
   runSearch: vi.fn(),
   runVet: vi.fn(),
   runVetList: vi.fn(),

--- a/packages/mcp-server/src/index.test.ts
+++ b/packages/mcp-server/src/index.test.ts
@@ -161,11 +161,12 @@ describe('MCP server stdio transport', { timeout: 30_000 }, () => {
   it('lists tools via stdio', async () => {
     client = await createStdioClient();
     const { tools } = await client.listTools();
-    expect(tools.length).toBe(29);
+    expect(tools.length).toBe(30);
     expect(tools.some((t) => t.name === 'daily')).toBe(true);
     expect(tools.some((t) => t.name === 'compliance-score')).toBe(true);
     expect(tools.some((t) => t.name === 'repo-vet')).toBe(true);
     expect(tools.some((t) => t.name === 'features')).toBe(true);
+    expect(tools.some((t) => t.name === 'strategy')).toBe(true);
   });
 
   it('lists resources via stdio', async () => {

--- a/packages/mcp-server/src/prompts.test.ts
+++ b/packages/mcp-server/src/prompts.test.ts
@@ -41,6 +41,7 @@ vi.mock('@oss-autopilot/core/commands', () => ({
   }),
   // Stubs for tools.ts imports (not used by prompts but loaded via server.ts)
   runStatus: vi.fn(),
+  runStrategy: vi.fn(),
   runVet: vi.fn(),
   runVetList: vi.fn(),
   runTrack: vi.fn(),

--- a/packages/mcp-server/src/resources.test.ts
+++ b/packages/mcp-server/src/resources.test.ts
@@ -14,6 +14,7 @@ vi.mock('@oss-autopilot/core/commands', () => ({
   }),
   // Stubs for tools.ts imports (not used by resources but loaded via server.ts)
   runDaily: vi.fn(),
+  runStrategy: vi.fn(),
   runSearch: vi.fn(),
   runVet: vi.fn(),
   runVetList: vi.fn(),

--- a/packages/mcp-server/src/tools-execution.test.ts
+++ b/packages/mcp-server/src/tools-execution.test.ts
@@ -24,6 +24,7 @@ const {
 vi.mock('@oss-autopilot/core/commands', () => ({
   runDaily: mockRunDaily,
   runStatus: vi.fn(),
+  runStrategy: vi.fn(),
   runSearch: mockRunSearch,
   runVet: vi.fn(),
   runVetList: vi.fn(),

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -22,6 +22,7 @@ const EXPECTED_TOOLS = [
   'track',
   'compliance-score',
   'repo-vet',
+  'strategy',
   'comments',
   'post',
   'claim',
@@ -86,8 +87,8 @@ describe('MCP tool registrations', () => {
     await client.close();
   });
 
-  it('registers exactly 29 tools', () => {
-    expect(tools).toHaveLength(29);
+  it('registers exactly 30 tools', () => {
+    expect(tools).toHaveLength(30);
   });
 
   it('registers all expected tool names', () => {

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -11,6 +11,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import {
   runDaily,
   runStatus,
+  runStrategy,
   runSearch,
   runFeatures,
   runVet,
@@ -292,6 +293,23 @@ export function registerTools(server: McpServer): void {
       annotations: { readOnlyHint: true },
     },
     wrapTool(runComplianceScore),
+  );
+
+  // 5d. strategy — On-demand contribution strategy snapshot (#1243 step 4).
+  // Used by `contribution-strategist` to consume the typed `computeStrategy`
+  // output instead of doing its own categorization in the agent prompt.
+  server.registerTool(
+    'strategy',
+    {
+      description:
+        'Return the on-demand contribution strategy snapshot via the typed `computeStrategy` function. ' +
+        'Always runs against local state regardless of the auto-display cadence gate. ' +
+        'Returns `strategy: null` with a human-readable `message` when the merged-PR floor is not met. ' +
+        'Read-only; no API calls, no state mutation.',
+      inputSchema: {},
+      annotations: { readOnlyHint: true },
+    },
+    wrapTool(runStrategy),
   );
 
   // 5c. repo-vet — Run the typed repo-vet rubric against an `owner/repo`

--- a/workflows/reference.md
+++ b/workflows/reference.md
@@ -14,7 +14,7 @@ All commands support `--json` flag for structured output.
      `bash scripts/build-cli-if-stale.sh "$PWD" && pnpm run generate:reference`.
      CI fails if this line is out of sync with the registry. -->
 <!-- BEGIN AUTO:local-only-commands -->
-Local-only commands (no GitHub token needed): `checkSetup`, `clear-override`, `config`, `detect-formatters`, `dismiss`, `doctor`, `guidelines`, `list-mark-done`, `list-move-tier`, `local-repos`, `manifest`, `move`, `orphan-files`, `override`, `parse-issue-list`, `serve`, `setup`, `shelve`, `skip-add`, `startup`, `stats`, `status`, `undismiss`, `unshelve`.
+Local-only commands (no GitHub token needed): `checkSetup`, `clear-override`, `config`, `detect-formatters`, `dismiss`, `doctor`, `guidelines`, `list-mark-done`, `list-move-tier`, `local-repos`, `manifest`, `move`, `orphan-files`, `override`, `parse-issue-list`, `serve`, `setup`, `shelve`, `skip-add`, `startup`, `stats`, `status`, `strategy`, `undismiss`, `unshelve`.
 <!-- END AUTO:local-only-commands -->
 
 ### Core Workflow
@@ -28,6 +28,11 @@ Local-only commands (no GitHub token needed): `checkSetup`, `clear-override`, `c
 
 # Status overview (local-only)
 <prefix> status --json
+
+# On-demand contribution strategy snapshot (#1243). Always runs against local
+# state; returns null + message when fewer than the minimum tracked PRs are
+# available.
+<prefix> strategy --json
 ```
 
 ### Issue Discovery


### PR DESCRIPTION
## Summary

Completes the final step of #1243. Steps 1-3 are already shipped (typed `computeStrategy()` core function with full test coverage, cadence-gated `daily.strategySummary` auto-display, snapshot rendering in `commands/oss.md`). What was left: the `contribution-strategist` agent was still recomputing style / trajectory / capacity in its own prompt instead of consuming the typed output, and the only path to a snapshot was the gated daily auto-display.

This PR adds an ungated path (`strategy` CLI subcommand + MCP tool) and rewrites the agent to consume the typed result.

## Why an ungated path

`daily.ts` only emits `strategySummary` when the cadence gate opens (every 30 days OR 5+ PRs since last). That is correct for the auto-display surface, but an agent invocation ("how am I doing?") needs to answer every time, so it cannot share the gated path. The `strategy` command always runs `computeStrategy(state)` and returns `{ strategy: null, message }` when below the merged-PR floor.

## Changes

- `packages/core/src/commands/strategy.ts` — new `runStrategy()`. Read-only, no API calls, no state mutation. Returns the same `StrategyResult` shape consumed by the daily auto-display.
- `packages/core/src/commands/strategy.test.ts` — unit tests for the floor gate, the empty-state message, and the typed result shape.
- `packages/core/src/cli-registry.ts` — registers `strategy` as a `localOnly` command with text + JSON output renderers.
- `packages/core/src/commands/index.ts` — exports `runStrategy` for the MCP barrel.
- `packages/core/src/formatters/json.ts` — exports `StrategyResultSchema` (previously module-local) and adds `StrategyOutputSchema` for the new command.
- `packages/mcp-server/src/tools.ts` — registers `strategy` MCP tool, marked `readOnlyHint: true`.
- `agents/contribution-strategist.md` — rewritten to consume `computeStrategy()` output via the MCP tool, drop in-prompt categorization (the `style`, `trajectoryDirection`, and `suggestedAction` fields are pre-computed), and frame the agent's job as synthesis over typed data.

### Contract pins updated

- `.claude-plugin/expected-cli-contract.json` — adds `strategy`
- `workflows/reference.md` — adds `strategy` to local-only list and a new Core Workflow entry
- `packages/core/src/cli.test.ts` — pins `strategy` in `expectedLocalOnly` and `expectedCommands`
- `packages/core/src/agents-contract.test.ts` — pins `strategy` in `REGISTERED_MCP_TOOLS`
- `packages/mcp-server/src/tools.test.ts` — pins `strategy` in `EXPECTED_TOOLS`, bumps tool count 29 to 30
- `packages/mcp-server/src/index.test.ts` — bumps stdio tool count assertion 29 to 30, adds `strategy` presence check

### Test mocks

Four mcp-server test files mock `@oss-autopilot/core/commands`; each gets a `runStrategy: vi.fn()` stub to stay in sync.

## Test plan

- [x] `pnpm typecheck` clean (3 packages)
- [x] `pnpm lint` clean
- [x] `pnpm format:check` clean
- [x] Full suite: 2606 core + 256 dashboard + 214 mcp-server = **3076 passing**
- [x] New tests in `strategy.test.ts` cover the three logical branches (below floor with state, empty state, above floor)
- [ ] Smoke test the rewired agent against real local state before the next release

## Out of scope

Step 4 only touches the agent + the new CLI/MCP surface. The agent's coaching-tips library, the deferred `averagePRSize` field, and any further additions to `recommendations.avoidPatterns` heuristics are separate concerns.

Closes #1243.