### PR TITLE
feat(search): bias scout searches with computeStrategy() recommendations

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "@octokit/plugin-throttling": "^11.0.3",
     "@octokit/rest": "^22.0.1",
-    "@oss-scout/core": "^0.9.0",
+    "@oss-scout/core": "^0.10.0",
     "commander": "^14.0.3",
     "zod": "^4.4.3"
   },

--- a/packages/core/src/commands/search.contract.test.ts
+++ b/packages/core/src/commands/search.contract.test.ts
@@ -32,7 +32,13 @@ vi.mock('../core/index.js', async () => {
   const actual = await vi.importActual<typeof import('../core/index.js')>('../core/index.js');
   return {
     ...actual,
-    getStateManager: () => ({ getRepoScore: mocks.getRepoScore }),
+    getStateManager: () => ({
+      getRepoScore: mocks.getRepoScore,
+      // computeStrategy reads `mergedPRs`/`closedPRs`/`repoScores`/`lastDigest`.
+      // A minimal-merged-PR state ensures computeStrategy returns null and the
+      // search behaves exactly as before personalization (#1244).
+      getState: () => ({ mergedPRs: [], closedPRs: [], repoScores: {}, lastDigest: null }),
+    }),
   };
 });
 

--- a/packages/core/src/commands/search.ts
+++ b/packages/core/src/commands/search.ts
@@ -7,7 +7,8 @@ import { buildCandidateLinkedPR, createAutopilotScout } from './scout-bridge.js'
 import { getStateManager } from '../core/index.js';
 import { type SearchOutput } from '../formatters/json.js';
 import { gradeFromCandidate } from '../core/issue-grading.js';
-import { warn } from '../core/logger.js';
+import { computeStrategy } from '../core/strategy.js';
+import { debug, warn } from '../core/logger.js';
 
 export { type SearchOutput } from '../formatters/json.js';
 
@@ -58,9 +59,28 @@ function sanitizeViabilityScore(raw: unknown): number {
 
 export async function runSearch(options: SearchOptions): Promise<SearchOutput> {
   const scout = await createAutopilotScout();
-  const result = await scout.search({ maxResults: options.maxResults });
-
   const stateManager = getStateManager();
+
+  // Derive personalization from local history (#1244). `computeStrategy`
+  // returns null below the merged-PR floor — in that case we pass nothing
+  // and scout's sort behaves exactly as before. Once strategy data is
+  // available, scout boosts language/repo matches into a separate sort
+  // tier (still no filtering).
+  const strategy = computeStrategy(stateManager.getState());
+  const preferLanguages = strategy?.recommendations.languages ?? undefined;
+  const preferRepos = strategy?.recommendations.repos ?? undefined;
+  if (preferLanguages?.length || preferRepos?.length) {
+    debug(
+      MODULE,
+      `Applying strategy bias to search: preferLanguages=${JSON.stringify(preferLanguages ?? [])}, preferRepos=${JSON.stringify(preferRepos ?? [])}`,
+    );
+  }
+
+  const result = await scout.search({
+    maxResults: options.maxResults,
+    preferLanguages,
+    preferRepos,
+  });
 
   const searchOutput: SearchOutput = {
     candidates: result.candidates.map((c) => {
@@ -111,6 +131,8 @@ export async function runSearch(options: SearchOptions): Promise<SearchOutput> {
             }
           : undefined,
         ...(linkedPR ? { linkedPR } : {}),
+        ...(typeof c.boostScore === 'number' ? { boostScore: c.boostScore } : {}),
+        ...(c.boostReasons && c.boostReasons.length > 0 ? { boostReasons: c.boostReasons } : {}),
       };
     }),
     excludedRepos: result.excludedRepos,

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -560,6 +560,14 @@ const SearchCandidateSchema = z.object({
     })
     .optional(),
   linkedPR: CandidateLinkedPRSchema.optional(),
+  /**
+   * Personalization sort-tier signal threaded up from oss-scout (#1244).
+   * Present only when local strategy data biased the search and this
+   * candidate matched. `boostReasons` is the human-readable explanation
+   * (e.g. `"repo affinity: vercel/next.js"`, `"language match: TypeScript"`).
+   */
+  boostScore: z.number().optional(),
+  boostReasons: z.array(z.string()).optional(),
 });
 
 export const SearchOutputSchema = z.object({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@oss-scout/core':
-        specifier: ^0.9.0
-        version: 0.9.0(@octokit/core@7.0.6)
+        specifier: ^0.10.0
+        version: 0.10.0(@octokit/core@7.0.6)
       commander:
         specifier: ^14.0.3
         version: 14.0.3
@@ -841,8 +841,8 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@oss-scout/core@0.9.0':
-    resolution: {integrity: sha512-5BOXt9i1etqybGdMhk0xKY1s+r6rF76PKRpMP0KUFqg1qLQSEutnZc4/5wOfWVKR1XxE98mR1Q4O4+U7BiEv1w==}
+  '@oss-scout/core@0.10.0':
+    resolution: {integrity: sha512-hrKQKEOlPAhbNHBar9KgdLqoLTQusZxE1fzzZHqAgHiw9CPmEnZu989QAnjV8qpDDdo2DyeRYZSLEobJ2f5fMw==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
@@ -3526,7 +3526,7 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@oss-scout/core@0.9.0(@octokit/core@7.0.6)':
+  '@oss-scout/core@0.10.0(@octokit/core@7.0.6)':
     dependencies:
       '@octokit/plugin-throttling': 11.0.3(@octokit/core@7.0.6)
       '@octokit/rest': 22.0.1


### PR DESCRIPTION
## Summary

Wires the cross-plugin flow described in `#1244`. oss-autopilot's `search` command now feeds the user's actual contribution track record (via the typed `computeStrategy()` core function) into oss-scout as soft sort biases.

Combined with the just-shipped `@oss-scout/core@0.10.0` boost params (`preferLanguages` / `preferRepos`), running `oss-autopilot search` now reorders results to favor languages the user has actually merged in and repos where they have existing relationships, without filtering out anything.

## Flow

In `runSearch`:
1. Load local state via `getStateManager()`.
2. Run `computeStrategy(state)`. Returns `null` below the merged-PR floor (`STRATEGY_MIN_PRS = 10`) — call degrades to existing behavior with no boost.
3. When non-null, pass `recommendations.languages` and `recommendations.repos` to `scout.search({ preferLanguages, preferRepos })`.
4. Thread `boostScore` and `boostReasons` from each scout candidate up into the autopilot-side `SearchOutput` so consumers can render "why this result was boosted."

## Zero opt-in

Defaults to on. The user just runs `search` and personalization happens automatically once they have 10+ merged PRs tracked. Pre-floor users (new installs, fresh state) see exactly the same results as before. No flag, no config knob.

Rationale: this is the value proposition of the strategy work — without auto-application it would be a feature the user has to remember exists. Personalization is a soft boost, not a filter, so the worst case is "the order changes slightly," which is the intended outcome.

## Dependency

Bumps `@oss-scout/core` from `^0.9.0` to `^0.10.0` (just published).

## Schema additions

`SearchCandidateSchema` gains two optional fields:
- `boostScore?: number` — total boost applied (sum of matched weights, currently 0-30)
- `boostReasons?: string[]` — human-readable explanations like `["repo affinity: vercel/next.js", "language match: TypeScript"]`

Both omitted entirely when no match. No noise in output for unboosted candidates.

## Test plan

- [x] `pnpm typecheck` clean (3 packages)
- [x] `pnpm lint` clean (0 errors; warnings unchanged from baseline)
- [x] `pnpm format:check` clean
- [x] Full suite: 2606 core + 256 dashboard + 214 mcp-server = **3076 passing**
- [x] Search-contract test mock teaches `getStateManager` a `getState()` stub that returns empty merged/closed PRs, so `computeStrategy` short-circuits to null and the existing golden shapes don't change. Same shape as before for users without enough history; new behavior only kicks in past the floor.
- [ ] End-to-end smoke against real local state before tagging the next release

## Out of scope (still open on #1244)

- `boostIssueTypes` / `avoidRepos` MCP params (scout side)
- `diversityRatio` counterweight to prevent echo-chamber bias as boosts accumulate
- Pretty-printing `boostReasons` in the non-JSON CLI output (currently raw)

These three remain as follow-up PRs. The boost weighting in #1244's "Open Questions" section also stays open — current weights (repo +20, language +10) are first-pass tunings, expected to need real-data adjustment.

Closes part of `#1244`.