### PR TITLE
fix(dashboard): reflect SPA shelve/unshelve immediately

### DIFF
--- a/packages/core/src/commands/dashboard-data.ts
+++ b/packages/core/src/commands/dashboard-data.ts
@@ -120,6 +120,62 @@ export function buildDashboardStats(
 }
 
 /**
+ * A PR is shelved for display when the user explicitly shelved it, or the
+ * dormant-auto-shelve rule applies (dormant + not needing attention). Mirrors
+ * the partition built in fetchDashboardData (see the `freshShelved` filter).
+ */
+function isShelvedForDisplay(
+  pr: { url: string; stalenessTier?: string; status?: string },
+  explicitlyShelved: Set<string>,
+): boolean {
+  return explicitlyShelved.has(pr.url) || (pr.stalenessTier === 'dormant' && pr.status !== 'needs_addressing');
+}
+
+/**
+ * Re-derive `digest.shelvedPRs` and `summary.totalActivePRs` from the CURRENT
+ * `state.config.shelvedPRUrls` so a shelve/unshelve issued from the dashboard
+ * SPA is reflected immediately.
+ *
+ * Why this exists: POST /api/action → runMove only mutates
+ * `state.config.shelvedPRUrls`; it never touches the cached digest.
+ * buildDashboardJson derives both `shelvedPRUrls` and `stats.shelvedPRs` from
+ * `digest.shelvedPRs`, so without this reconciliation a dashboard shelve/unshelve
+ * appears to do nothing until the next full /api/refresh rebuilds the digest.
+ *
+ * Baked shelved entries that are NOT among the current open PRs (the daily-check
+ * dormant partition, #981) are preserved as-is — the SPA cannot act on those —
+ * while explicit shelve/unshelve of open PRs and the dormant-auto-shelve rule
+ * are honored.
+ */
+export function reconcileShelvePartition(digest: DailyDigest, state: Readonly<AgentState>): void {
+  const openPRs = (digest.openPRs || []) as Array<{ url: string; stalenessTier?: string; status?: string }>;
+  const openByUrl = new Map(openPRs.map((pr) => [pr.url, pr]));
+  const explicitlyShelved = new Set(state.config.shelvedPRUrls || []);
+
+  // Keep baked entries that are either off the open-PR list (daily dormant
+  // partition we can't recompute here) or still shelved under current state.
+  const reconciled = (digest.shelvedPRs || []).filter((ref) => {
+    const pr = openByUrl.get(ref.url);
+    return !pr || isShelvedForDisplay(pr, explicitlyShelved);
+  });
+  // Add open PRs that became shelved but aren't represented in the baked list yet.
+  const present = new Set(reconciled.map((ref) => ref.url));
+  for (const pr of openPRs) {
+    if (!present.has(pr.url) && isShelvedForDisplay(pr, explicitlyShelved)) {
+      reconciled.push(toShelvedPRRef(pr as Parameters<typeof toShelvedPRRef>[0]));
+    }
+  }
+
+  digest.shelvedPRs = reconciled;
+  // Only re-derive the active count when we actually have the open-PR list;
+  // some digests carry an authoritative summary with an empty openPRs fixture.
+  if (openPRs.length > 0) {
+    const shelvedOpen = reconciled.filter((ref) => openByUrl.has(ref.url)).length;
+    digest.summary.totalActivePRs = openPRs.length - shelvedOpen;
+  }
+}
+
+/**
  * Merge fresh API counts into existing stored counts.
  * Months present in the fresh data are updated; months only in the existing data are preserved.
  *

--- a/packages/core/src/commands/dashboard-server.test.ts
+++ b/packages/core/src/commands/dashboard-server.test.ts
@@ -79,30 +79,38 @@ vi.mock('../core/index.js', () => ({
   getDataDir: vi.fn(() => pidTestDir),
   getCLIVersion: vi.fn(() => '0.44.6'),
   applyStatusOverrides: vi.fn((prs: unknown[]) => prs),
+  // Used by the real reconcileShelvePartition (imported via importActual below).
+  toShelvedPRRef: vi.fn((pr: unknown) => pr),
 }));
 
-// Mock fetchDashboardData so we never call GitHub
-vi.mock('./dashboard-data.js', () => ({
-  fetchDashboardData: vi.fn(),
-  computePRsByRepo: vi.fn(() => ({
-    'owner/repo': { active: 2, merged: 5, closed: 1 },
-  })),
-  computeTopRepos: vi.fn(() => [['owner/repo', { active: 2, merged: 5, closed: 1 }]]),
-  getMonthlyData: vi.fn(() => ({
-    monthlyMerged: { '2026-01': 3 },
-    monthlyClosed: {},
-    monthlyOpened: {},
-  })),
-  buildDashboardStats: vi.fn(() => ({
-    activePRs: 2,
-    shelvedPRs: 0,
-    mergedPRs: 5,
-    closedPRs: 1,
-    mergeRate: '83.3%',
-  })),
-  storedToMergedPRs: vi.fn(() => []),
-  storedToClosedPRs: vi.fn(() => []),
-}));
+// Mock fetchDashboardData so we never call GitHub. reconcileShelvePartition is
+// the real implementation so the shelve/unshelve reconciliation is exercised;
+// everything else is stubbed to keep buildDashboardJson hermetic.
+vi.mock('./dashboard-data.js', async (importActual) => {
+  const actual = await importActual<typeof import('./dashboard-data.js')>();
+  return {
+    fetchDashboardData: vi.fn(),
+    computePRsByRepo: vi.fn(() => ({
+      'owner/repo': { active: 2, merged: 5, closed: 1 },
+    })),
+    computeTopRepos: vi.fn(() => [['owner/repo', { active: 2, merged: 5, closed: 1 }]]),
+    getMonthlyData: vi.fn(() => ({
+      monthlyMerged: { '2026-01': 3 },
+      monthlyClosed: {},
+      monthlyOpened: {},
+    })),
+    buildDashboardStats: vi.fn(() => ({
+      activePRs: 2,
+      shelvedPRs: 0,
+      mergedPRs: 5,
+      closedPRs: 1,
+      mergeRate: '83.3%',
+    })),
+    storedToMergedPRs: vi.fn(() => []),
+    storedToClosedPRs: vi.fn(() => []),
+    reconcileShelvePartition: actual.reconcileShelvePartition,
+  };
+});
 
 // Mock move command so dashboard-server's dynamic import resolves without side effects
 const mockRunMove = vi.fn().mockResolvedValue({ url: '', target: 'shelved', description: 'done' });
@@ -499,6 +507,97 @@ describe('dashboard-server', () => {
       const data = buildDashboardJson(digest, state, []);
 
       expect(data.shelvedPRUrls).toEqual(['https://github.com/o/r/pull/1', 'https://github.com/o/r/pull/2']);
+    });
+
+    it('reflects a live shelve: an open PR added to config.shelvedPRUrls appears in shelvedPRUrls', () => {
+      // Repro of the dashboard "shelve does nothing" bug. POST /api/action →
+      // runMove updates state.config.shelvedPRUrls but never the cached digest,
+      // and buildDashboardJson derived shelvedPRUrls purely from the stale
+      // digest.shelvedPRs — so a freshly-shelved PR never reached the SPA and
+      // stayed in the active list.
+      const pr = {
+        url: 'https://github.com/o/r/pull/7',
+        number: 7,
+        repo: 'o/r',
+        title: 'Active PR shelved via SPA',
+        status: 'waiting_on_maintainer',
+        stalenessTier: 'active',
+        daysSinceActivity: 2,
+      };
+      const digest = makeDigest({ openPRs: [pr], shelvedPRs: [] });
+      const state = makeState({
+        config: { shelvedPRUrls: [pr.url] },
+        lastDigest: digest,
+      });
+
+      const data = buildDashboardJson(digest, state, []);
+
+      expect(data.shelvedPRUrls).toContain(pr.url);
+    });
+
+    it('reflects a live unshelve: a baked shelved open PR dropped from config disappears from shelvedPRUrls', () => {
+      // The mirror bug: a PR shelved earlier (baked into digest.shelvedPRs) that
+      // the user unshelves via the SPA. runMove clears it from
+      // state.config.shelvedPRUrls, but the stale baked entry kept it shelved.
+      const pr = {
+        url: 'https://github.com/o/r/pull/8',
+        number: 8,
+        repo: 'o/r',
+        title: 'PR unshelved via SPA',
+        status: 'waiting_on_maintainer',
+        stalenessTier: 'active',
+        daysSinceActivity: 2,
+      };
+      const digest = makeDigest({
+        openPRs: [pr],
+        shelvedPRs: [
+          {
+            number: 8,
+            url: pr.url,
+            title: pr.title,
+            repo: 'o/r',
+            daysSinceActivity: 2,
+            status: 'waiting_on_maintainer',
+          },
+        ],
+      });
+      const state = makeState({ config: { shelvedPRUrls: [] }, lastDigest: digest });
+
+      const data = buildDashboardJson(digest, state, []);
+
+      expect(data.shelvedPRUrls).not.toContain(pr.url);
+    });
+
+    it('keeps a dormant-auto-shelved open PR shelved even when not in config', () => {
+      // Reconciliation must not undo the dormant-auto-shelve rule: a dormant,
+      // non-addressing PR stays shelved for display regardless of config.
+      const pr = {
+        url: 'https://github.com/o/r/pull/9',
+        number: 9,
+        repo: 'o/r',
+        title: 'Dormant auto-shelf',
+        status: 'waiting_on_maintainer',
+        stalenessTier: 'dormant',
+        daysSinceActivity: 60,
+      };
+      const digest = makeDigest({
+        openPRs: [pr],
+        shelvedPRs: [
+          {
+            number: 9,
+            url: pr.url,
+            title: pr.title,
+            repo: 'o/r',
+            daysSinceActivity: 60,
+            status: 'waiting_on_maintainer',
+          },
+        ],
+      });
+      const state = makeState({ config: { shelvedPRUrls: [] }, lastDigest: digest });
+
+      const data = buildDashboardJson(digest, state, []);
+
+      expect(data.shelvedPRUrls).toContain(pr.url);
     });
 
     it('should include repos with metadata and exclude repos without in repoMetadata (#677)', async () => {

--- a/packages/core/src/commands/dashboard-server.ts
+++ b/packages/core/src/commands/dashboard-server.ts
@@ -21,6 +21,7 @@ import {
   computeTopRepos,
   getMonthlyData,
   buildDashboardStats,
+  reconcileShelvePartition,
   storedToMergedPRs,
   storedToClosedPRs,
   type DashboardJsonData,
@@ -127,6 +128,11 @@ export function buildDashboardJson(
   allClosedPRs?: ClosedPR[],
   partialFailures?: string[],
 ): DashboardJsonData {
+  // Re-derive the shelve partition from the CURRENT state before reading it.
+  // The POST /api/action path rebuilds with a cached digest whose shelvedPRs
+  // predates the shelve/unshelve, so without this the SPA action appears to do
+  // nothing until the next full /api/refresh.
+  reconcileShelvePartition(digest, state);
   const prsByRepo = computePRsByRepo(digest, state);
   const topRepos = computeTopRepos(prsByRepo);
   const { monthlyMerged, monthlyOpened, monthlyClosed } = getMonthlyData(state);


### PR DESCRIPTION
## Summary
Shelving or unshelving a PR from the dashboard appeared to do nothing until the next full refresh. `POST /api/action` to `runMove` updates `state.config.shelvedPRUrls` and persists it, but `buildDashboardJson` derived `shelvedPRUrls` and `stats.shelvedPRs` solely from the cached `digest.shelvedPRs`, which the action never touches. Since the SPA filters the active list by `shelvedPRUrls`, the moved PR stayed in place.

## Fix
Add `reconcileShelvePartition()`, called at the top of `buildDashboardJson`, to re-derive the shelve partition from current state at JSON-build time. It:
- honors explicit shelve/unshelve of open PRs (fixes both directions),
- preserves the dormant-auto-shelve rule,
- preserves baked dormant-partition entries not among the open PRs (keeps the #981 behavior the SPA can't act on),
- keeps `stats.shelvedPRs` and `activePRs` consistent with the list.

## Tests
- 3 new tests in `dashboard-server.test.ts` (live shelve, live unshelve, dormant auto-shelf preserved).
- Existing #981 derivation test still passes.
- Full core suite: 2609 pass. Typecheck, eslint, prettier all clean.