### PR TITLE
ci: build the CLI bundle before tests so e2e suites actually run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,13 @@ jobs:
       - name: Type check
         run: pnpm run typecheck
 
+      # The CLI e2e suites (*.e2e.test.ts) execute dist/cli.bundle.cjs and
+      # skip when it is absent. The bundle must exist BEFORE tests run or
+      # all six suites silently skip — which is exactly what happened until
+      # #1366. The e2e-bundle-gate test enforces this ordering.
+      - name: Build CLI bundle (required by e2e suites, #1366)
+        run: pnpm --filter @oss-autopilot/core run bundle
+
       - name: Run tests
         run: pnpm run test
 
@@ -452,6 +459,12 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      # The e2e suites and the e2e-bundle-gate test (#1366) require the CLI
+      # bundle; without it the gate test fails (red noise behind the || true
+      # below) and the badge count silently excludes the e2e tests.
+      - name: Build CLI bundle (required by e2e suites, #1366)
+        run: pnpm --filter @oss-autopilot/core run bundle
 
       - name: Run tests and update badge
         run: |

--- a/packages/core/src/commands/e2e-bundle-gate.test.ts
+++ b/packages/core/src/commands/e2e-bundle-gate.test.ts
@@ -1,0 +1,27 @@
+/**
+ * CI gate: the CLI e2e suites must actually run in CI (#1366).
+ *
+ * Every *.e2e.test.ts suite executes dist/cli.bundle.cjs and gates on
+ * `describe.skipIf(!BUNDLE_EXISTS)` so plain local `vitest` runs don't
+ * require a build step. That skip is silent by design — and in CI it
+ * silently disabled all six suites for months because ci.yml ran tests
+ * before building the bundle.
+ *
+ * This test converts that silent skip into a loud failure: when CI is
+ * set, the bundle must exist by the time the test suite runs. If this
+ * fails, fix the workflow ordering (the "Build CLI bundle" step must
+ * precede "Run tests" in .github/workflows/ci.yml); do not delete or
+ * skip this test.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const BUNDLE_PATH = path.resolve(__dirname, '../../dist/cli.bundle.cjs');
+
+describe('CLI e2e bundle gate (#1366)', () => {
+  it.runIf(process.env.CI)('dist/cli.bundle.cjs exists in CI so e2e suites cannot silently skip', () => {
+    expect(fs.existsSync(BUNDLE_PATH), `expected CLI bundle at ${BUNDLE_PATH}`).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

The matrix job ran tests before any bundle build, and all six CLI e2e suites gate on `describe.skipIf(!BUNDLE_EXISTS)` keyed to the gitignored `dist/cli.bundle.cjs`, so every e2e suite silently skipped on every CI run (including the `AUTH_REQUIRED` envelope regression test for #1056).

Changes:
- Add a `Build CLI bundle` step before `Run tests` in the matrix job
- Same step in the `update-badge` job, whose badge count was also excluding the e2e tests
- New `e2e-bundle-gate.test.ts`: when `CI` is set, assert the bundle exists, so a future workflow reorder fails loudly instead of silently dropping 20 tests

## Test plan

- [x] Gate test verified in all three states locally: skips without CI, passes with CI + bundle, fails with CI + bundle removed
- [x] All six e2e suites pass locally against a fresh bundle (20 passed; 14 remain intentionally gated on GITHUB_TOKEN)
- [x] Full core suite green (2610 passed)
- [x] actionlint clean
- [x] This PR's own CI run is the live proof: the matrix jobs should now report ~20 more executed tests

Closes #1366