### PR TITLE
fix(mcp): retry Gist init after transient failure instead of latching done

### DIFF
--- a/packages/mcp-server/src/gist-init.test.ts
+++ b/packages/mcp-server/src/gist-init.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Regression tests for ensureGistInit retry semantics (#1368).
+ *
+ * The old implementation flipped a module-level `gistInitDone = true`
+ * BEFORE awaiting the token fetch and ensureGistPersistence(). One
+ * transient failure therefore permanently disabled Gist init for the
+ * process: every later tool call skipped initialization and gist-mode
+ * mutations silently landed in local state only.
+ *
+ * These tests drive real MCP tool calls through an in-memory transport
+ * and pin the intended semantics: failure surfaces as a tool error and
+ * clears the memo (next call retries), success is memoized, and
+ * concurrent first calls share a single init.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+const { mockGetGitHubTokenAsync, mockEnsureGistPersistence, mockRunStatus } = vi.hoisted(() => ({
+  mockGetGitHubTokenAsync: vi.fn(),
+  mockEnsureGistPersistence: vi.fn(),
+  mockRunStatus: vi.fn(),
+}));
+
+vi.mock('@oss-autopilot/core/commands', () => ({
+  runDaily: vi.fn(),
+  runStatus: mockRunStatus,
+  runStrategy: vi.fn(),
+  runSearch: vi.fn(),
+  runFeatures: vi.fn(),
+  runVet: vi.fn(),
+  runVetList: vi.fn(),
+  runTrack: vi.fn(),
+  runComplianceScore: vi.fn(),
+  runRepoVet: vi.fn(),
+  runComments: vi.fn(),
+  runPost: vi.fn(),
+  runClaim: vi.fn(),
+  runConfig: vi.fn(),
+  runInit: vi.fn(),
+  runSetup: vi.fn(),
+  runCheckSetup: vi.fn(),
+  runStartup: vi.fn(),
+  runDismiss: vi.fn(),
+  runUndismiss: vi.fn(),
+  runMove: vi.fn(),
+  runGuidelinesView: vi.fn(),
+  runGuidelinesStore: vi.fn(),
+  runGuidelinesReset: vi.fn(),
+  runFetchCorpus: vi.fn(),
+  MAX_SEARCH_RESULTS: 100,
+  MAX_FEATURES_RESULTS: 100,
+}));
+
+vi.mock('@oss-autopilot/core', () => ({
+  errorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
+  getStateManager: vi.fn().mockReturnValue({
+    getState: vi.fn().mockReturnValue({
+      lastDigest: { openPRs: [], shelvedPRs: [] },
+    }),
+  }),
+  getGitHubTokenAsync: mockGetGitHubTokenAsync,
+  ensureGistPersistence: mockEnsureGistPersistence,
+  getSetupKeys: () => ['username'],
+  getConfigKeys: () => ['username'],
+}));
+
+/**
+ * Build a fresh server + client pair from a fresh module graph so the
+ * module-level init memo in tools.ts starts clean for every test.
+ */
+async function freshClient(): Promise<Client> {
+  const { createServer } = await import('./server.js');
+  const server = createServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: 'gist-init-test', version: '0.0.0' });
+  await client.connect(clientTransport);
+  return client;
+}
+
+describe('ensureGistInit retry semantics (#1368)', () => {
+  let client: Client;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mockGetGitHubTokenAsync.mockReset().mockResolvedValue('test-token');
+    mockEnsureGistPersistence.mockReset().mockResolvedValue();
+    mockRunStatus.mockReset().mockResolvedValue({ ok: true });
+    client = await freshClient();
+  });
+
+  afterEach(async () => {
+    await client.close();
+  });
+
+  it('a transient init failure surfaces as a tool error and the next call retries init', async () => {
+    mockGetGitHubTokenAsync.mockRejectedValueOnce(new Error('transient token failure'));
+
+    const first = await client.callTool({ name: 'status', arguments: {} });
+    expect(first.isError).toBe(true);
+    expect(mockEnsureGistPersistence).not.toHaveBeenCalled();
+
+    const second = await client.callTool({ name: 'status', arguments: {} });
+    expect(second.isError).toBeFalsy();
+    expect(mockEnsureGistPersistence).toHaveBeenCalledTimes(1);
+    expect(mockEnsureGistPersistence).toHaveBeenCalledWith('test-token');
+  });
+
+  it('successful init is memoized: later calls do not re-run it', async () => {
+    await client.callTool({ name: 'status', arguments: {} });
+    await client.callTool({ name: 'status', arguments: {} });
+
+    expect(mockGetGitHubTokenAsync).toHaveBeenCalledTimes(1);
+    expect(mockEnsureGistPersistence).toHaveBeenCalledTimes(1);
+  });
+
+  it('concurrent first calls share a single init', async () => {
+    let release!: () => void;
+    mockGetGitHubTokenAsync.mockImplementationOnce(
+      () =>
+        new Promise<string>((resolve) => {
+          release = () => resolve('test-token');
+        }),
+    );
+
+    const a = client.callTool({ name: 'status', arguments: {} });
+    const b = client.callTool({ name: 'status', arguments: {} });
+    // Let both requests reach ensureGistInit before the token fetch resolves.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    release();
+
+    const [resultA, resultB] = await Promise.all([a, b]);
+    expect(resultA.isError).toBeFalsy();
+    expect(resultB.isError).toBeFalsy();
+    expect(mockGetGitHubTokenAsync).toHaveBeenCalledTimes(1);
+    expect(mockEnsureGistPersistence).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -72,18 +72,29 @@ const githubIssueOrPrUrlSchema = z
 const KNOWN_CONFIG_KEYS = Array.from(new Set([...getSetupKeys(), ...getConfigKeys()]));
 const configKeySchema = KNOWN_CONFIG_KEYS.length > 0 ? z.enum(KNOWN_CONFIG_KEYS as [string, ...string[]]) : z.string(); // defensive: if the registry is empty, fall back to the old shape
 
-/** One-shot Gist persistence activation (checked once per process). */
-let gistInitDone = false;
+/** One-shot Gist persistence activation (memoized per process, #1368). */
+let gistInitPromise: Promise<void> | null = null;
 async function ensureGistInit(): Promise<void> {
-  if (gistInitDone) return;
-  gistInitDone = true;
-
-  // Gist init errors (GistPermissionError, network) propagate to wrapTool's catch.
-  // Shared helper in core unifies the "peek at state file, check persistence mode,
-  // pre-set singleton" logic that was previously duplicated with cli.ts (#1000).
-  const { ensureGistPersistence, getGitHubTokenAsync } = await import('@oss-autopilot/core');
-  const token = await getGitHubTokenAsync();
-  await ensureGistPersistence(token);
+  // Memoize the in-flight promise instead of flipping a boolean up front:
+  // the old flag was set before the awaits, so one transient failure (token
+  // fetch, network) permanently skipped Gist init for the process and
+  // gist-mode mutations silently landed in local state only (#1368).
+  // Failure clears the memo so the next tool call retries; success stays
+  // memoized; concurrent first calls share the same promise.
+  if (!gistInitPromise) {
+    gistInitPromise = (async () => {
+      // Gist init errors (GistPermissionError, network) propagate to wrapTool's catch.
+      // Shared helper in core unifies the "peek at state file, check persistence mode,
+      // pre-set singleton" logic that was previously duplicated with cli.ts (#1000).
+      const { ensureGistPersistence, getGitHubTokenAsync } = await import('@oss-autopilot/core');
+      const token = await getGitHubTokenAsync();
+      await ensureGistPersistence(token);
+    })();
+    gistInitPromise.catch(() => {
+      gistInitPromise = null;
+    });
+  }
+  return gistInitPromise;
 }
 
 /** Standard MCP text content result. */


### PR DESCRIPTION
## Summary

`ensureGistInit` flipped `gistInitDone = true` before awaiting the token fetch and `ensureGistPersistence()`. One transient failure permanently disabled Gist init for the process: all subsequent tool calls skipped initialization and gist-mode mutations silently landed in local state only, diverging from the Gist until the next daily read clobbered them.

Now the in-flight promise is memoized instead: rejection clears the memo (next call retries), success stays memoized, concurrent first calls share one init.

## Test plan

- [x] New `gist-init.test.ts`: retry-after-failure (red before the fix), success memoization, concurrent-first-call dedupe, all through real MCP calls over InMemoryTransport
- [x] Full mcp-server suite green (217 tests)
- [x] tsc, eslint, prettier clean
- [x] Reviewed by code-reviewer and silent-failure-hunter agents: error still propagates to the MCP client (`isError: true`), no unhandled-rejection risk, no path where a tool runs against failed init

Closes #1368