### PR TITLE
fix(dashboard): hoist PR-list memos above early returns (Rules of Hooks)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,6 +8,7 @@ import * as regexp from 'eslint-plugin-regexp';
 import vitest from '@vitest/eslint-plugin';
 import unicorn from 'eslint-plugin-unicorn';
 import sonarjs from 'eslint-plugin-sonarjs';
+import reactHooks from 'eslint-plugin-react-hooks';
 
 // Helper: take a flat-config preset and downgrade every rule it sets to 'warn'.
 // Used to onboard opinionated plugins (unicorn, sonarjs) without gating CI
@@ -42,13 +43,7 @@ export default tseslint.config(
   downgradeToWarn(sonarjs.configs.recommended),
   eslintConfigPrettier,
   {
-    ignores: [
-      'packages/*/dist/**',
-      'packages/*/docs/**',
-      'packages/*/coverage/**',
-      'node_modules/**',
-      '*.cjs',
-    ],
+    ignores: ['packages/*/dist/**', 'packages/*/docs/**', 'packages/*/coverage/**', 'node_modules/**', '*.cjs'],
   },
   {
     languageOptions: {
@@ -146,6 +141,20 @@ export default tseslint.config(
       // false positive on Node globals (`process`, `Buffer`) — sonarjs
       // doesn't load @types/node
       'sonarjs/no-reference-error': 'off',
+    },
+  },
+  {
+    // Rules of Hooks for the Preact SPA (#1369). preact/hooks is positional
+    // (slot-indexed by call order), so a hook placed below a conditional
+    // return silently corrupts hook state on render paths that change the
+    // call count — that exact bug shipped in app.tsx. The plugin detects
+    // any `use*` call regardless of import source, so it works for
+    // preact/hooks without React. `exhaustive-deps` is intentionally not
+    // enabled: deps in this codebase are hand-tuned (see #1058 M37).
+    files: ['packages/dashboard/src/**/*.{ts,tsx}'],
+    plugins: { 'react-hooks': reactHooks },
+    rules: {
+      'react-hooks/rules-of-hooks': 'error',
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "eslint-plugin-import-x": "^4.16.2",
     "eslint-plugin-n": "^18.0.1",
     "eslint-plugin-promise": "^7.3.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-regexp": "^3.1.0",
     "eslint-plugin-sonarjs": "^4.0.3",
     "eslint-plugin-unicorn": "^64.0.0",

--- a/packages/dashboard/src/app.tsx
+++ b/packages/dashboard/src/app.tsx
@@ -17,7 +17,7 @@ import { SkeletonLoader } from './components/skeleton-loader';
 import { ThemeToggle } from './components/theme-toggle';
 import { CelebrationToast } from './components/celebration-toast';
 import { formatRelativeTime, refreshLabel } from './utils';
-import type { DashboardStats } from './types';
+import type { DashboardStats, FetchedPR } from './types';
 
 interface DashboardHeaderProps {
   stats: DashboardStats;
@@ -98,6 +98,10 @@ function DashboardHeader({
 // rather than silently falling through to the dashboard home.
 const KNOWN_ROUTES = new Set(['/', '/merged', '/closed', '/issues']);
 
+// Stable fallback for the pre-data render states so the hoisted memos below
+// keep referentially-equal deps while `data` is null (#1369).
+const EMPTY_ACTIVE_PRS: FetchedPR[] = [];
+
 function AppContent() {
   const { data, loading, refreshing, error, clearError, refresh, performAction, lastUpdated } = useDashboard();
   const { theme, toggleTheme } = useTheme();
@@ -147,6 +151,32 @@ function AppContent() {
   }, [triggerCelebration]);
 
   const shelvedUrls = useMemo(() => new Set(data?.shelvedPRUrls ?? []), [data?.shelvedPRUrls]);
+
+  // All hooks must run on every render path: preact/hooks is positional,
+  // so a hook below the early returns shifts slots whenever the component
+  // transitions between the loading/error states and the loaded tree, which
+  // silently corrupts memo state (#1369). These derivations therefore live
+  // above the guards and read from a stable empty fallback while `data` is
+  // null. Memoized so `filter` over hundreds of PRs doesn't rerun on
+  // unrelated state changes (#1058 M37).
+  const activePRList = data?.activePRs ?? EMPTY_ACTIVE_PRS;
+  const repos = useMemo(() => [...new Set(activePRList.map((pr) => pr.repo))].sort(), [activePRList]);
+  const statuses = useMemo(() => [...new Set(activePRList.map((pr) => pr.status))].sort(), [activePRList]);
+
+  const filteredPRs = useMemo(() => {
+    return activePRList.filter((pr) => {
+      if (filters.status !== 'all' && pr.status !== filters.status) return false;
+      if (filters.repo !== 'all' && pr.repo !== filters.repo) return false;
+      if (filters.search) {
+        const term = filters.search.toLowerCase();
+        const searchable = `${pr.title} ${pr.repo} ${pr.number}`.toLowerCase();
+        if (!searchable.includes(term)) return false;
+      }
+      return true;
+    });
+  }, [activePRList, filters.status, filters.repo, filters.search]);
+
+  const activePRs = useMemo(() => activePRList.filter((pr) => !shelvedUrls.has(pr.url)), [activePRList, shelvedUrls]);
 
   if (loading && !data) {
     return (
@@ -304,34 +334,10 @@ function AppContent() {
     );
   }
 
-  // Default route: dashboard home.
-  //
-  // These derivations were previously recomputed on every render — including
-  // every keystroke in the search input — even though they only depend on
-  // the stable PR list. Memoize so `filter` over hundreds of PRs doesn't
-  // rerun on unrelated state changes (#1058 M37).
-  const repos = useMemo(() => [...new Set(data.activePRs.map((pr) => pr.repo))].sort(), [data.activePRs]);
-  const statuses = useMemo(() => [...new Set(data.activePRs.map((pr) => pr.status))].sort(), [data.activePRs]);
-
-  const filteredPRs = useMemo(() => {
-    return data.activePRs.filter((pr) => {
-      if (filters.status !== 'all' && pr.status !== filters.status) return false;
-      if (filters.repo !== 'all' && pr.repo !== filters.repo) return false;
-      if (filters.search) {
-        const term = filters.search.toLowerCase();
-        const searchable = `${pr.title} ${pr.repo} ${pr.number}`.toLowerCase();
-        if (!searchable.includes(term)) return false;
-      }
-      return true;
-    });
-  }, [data.activePRs, filters.status, filters.repo, filters.search]);
-
+  // Default route: dashboard home. The PR-list derivations (repos, statuses,
+  // filteredPRs, activePRs) are memoized above the early returns (#1369).
   const selectedPR = selectedUrl ? (data.activePRs.find((pr) => pr.url === selectedUrl) ?? null) : null;
 
-  const activePRs = useMemo(
-    () => data.activePRs.filter((pr) => !shelvedUrls.has(pr.url)),
-    [data.activePRs, shelvedUrls],
-  );
   const needAttentionCount = activePRs.filter((pr) => pr.status === 'needs_addressing').length;
   const waitingCount = activePRs.filter((pr) => pr.status === 'waiting_on_maintainer').length;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       eslint-plugin-promise:
         specifier: ^7.3.0
         version: 7.3.0(eslint@10.4.1)
+      eslint-plugin-react-hooks:
+        specifier: ^7.1.1
+        version: 7.1.1(eslint@10.4.1)
       eslint-plugin-regexp:
         specifier: ^3.1.0
         version: 3.1.0(eslint@10.4.1)
@@ -1631,6 +1634,12 @@ packages:
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
 
+  eslint-plugin-react-hooks@7.1.1:
+    resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
+
   eslint-plugin-regexp@3.1.0:
     resolution: {integrity: sha512-qGXIC3DIKZHcK1H9A9+Byz9gmndY6TTSRkSMTZpNXdyCw2ObSehRgccJv35n9AdUakEjQp5VFNLas6BMXizCZg==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -1858,6 +1867,12 @@ packages:
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+
+  hermes-estree@0.25.1:
+    resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
+
+  hermes-parser@0.25.1:
+    resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
   hono@4.12.14:
     resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
@@ -2817,6 +2832,12 @@ packages:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
       zod: ^3.25.28 || ^4
+
+  zod-validation-error@4.0.2:
+    resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -4212,6 +4233,17 @@ snapshots:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1)
       eslint: 10.4.1
 
+  eslint-plugin-react-hooks@7.1.1(eslint@10.4.1):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/parser': 7.29.7
+      eslint: 10.4.1
+      hermes-parser: 0.25.1
+      zod: 4.4.3
+      zod-validation-error: 4.0.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-regexp@3.1.0(eslint@10.4.1):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1)
@@ -4494,6 +4526,12 @@ snapshots:
       function-bind: 1.1.2
 
   he@1.2.0: {}
+
+  hermes-estree@0.25.1: {}
+
+  hermes-parser@0.25.1:
+    dependencies:
+      hermes-estree: 0.25.1
 
   hono@4.12.14: {}
 
@@ -5425,6 +5463,10 @@ snapshots:
   zimmerframe@1.1.4: {}
 
   zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
+
+  zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
 


### PR DESCRIPTION
## Summary

`AppContent` called four `useMemo` hooks after the loading/error/null-data early returns. `preact/hooks` is positional, so render paths with different hook counts shift slots and silently corrupt memo state on loading-to-loaded (and refetch) transitions. `filteredPRs` is the direct input to `PRList`.

- Hoisted the four memos above the guards, deriving from a module-level `EMPTY_ACTIVE_PRS` fallback so deps stay referentially stable while `data` is null
- Added `eslint-plugin-react-hooks` with `rules-of-hooks: error` scoped to `packages/dashboard/src` (verified: the rule errors on all four old call sites, clean on the fixed file); `exhaustive-deps` deliberately not enabled since deps are hand-tuned (#1058 M37)

## Test plan

- [x] Full dashboard suite green under Node 22 (22 files, 256 tests), matching CI's matrix
- [x] Note: under local Node 26 three dashboard test files fail on pristine main too (jsdom env issue, unrelated to this diff); verified identical baseline before/after
- [x] tsc, eslint (0 react-hooks findings on new code), prettier, vite build clean
- [x] `pnpm install --frozen-lockfile` verified, lockfile in sync

Closes #1369