### PR TITLE
test(core): stop migration tests racing workers on the shared cwd data dir

### DIFF
--- a/packages/core/src/core/paths.ts
+++ b/packages/core/src/core/paths.ts
@@ -41,6 +41,24 @@ export function getStatePath(): string {
 }
 
 /**
+ * Returns the legacy (pre-`~/.oss-autopilot`) state file path: `./data/state.json`
+ * relative to the working directory.
+ *
+ * Functions rather than module constants so tests can mock them per-file:
+ * as constants in state-persistence.ts they resolved to the one shared
+ * `packages/core/data/` during vitest, and the migration tests racing
+ * parallel workers on that real directory caused CI flakes (#1382).
+ */
+export function getLegacyStatePath(): string {
+  return path.join(process.cwd(), 'data', 'state.json');
+}
+
+/** Legacy backup directory (`./data/backups`); see {@link getLegacyStatePath}. */
+export function getLegacyBackupDir(): string {
+  return path.join(process.cwd(), 'data', 'backups');
+}
+
+/**
  * Returns the backup directory path, creating it if it does not exist.
  *
  * Located at `~/.oss-autopilot/backups/`. Used for automatic state backups

--- a/packages/core/src/core/state-migration.test.ts
+++ b/packages/core/src/core/state-migration.test.ts
@@ -45,6 +45,19 @@ vi.mock('./paths.js', async (importOriginal) => {
       }
       return backupDir;
     },
+    // Legacy migration source, redirected into the per-test dir. The real
+    // implementation resolves to ./data under process.cwd(), which is one
+    // shared directory for every parallel vitest worker — tests that create
+    // real files there race against any concurrent StateManager load that
+    // migrates-and-unlinks them (#1382).
+    getLegacyStatePath: () => {
+      if (!mockTmpDir) throw new Error('mockTmpDir not set');
+      return path.join(mockTmpDir, 'legacy-data', 'state.json');
+    },
+    getLegacyBackupDir: () => {
+      if (!mockTmpDir) throw new Error('mockTmpDir not set');
+      return path.join(mockTmpDir, 'legacy-data', 'backups');
+    },
   };
 });
 
@@ -590,36 +603,33 @@ describe('issueListPath in config', () => {
 });
 
 // ── migrateFromLegacyLocation ───────────────────────────────────────────────
-// Legacy paths resolve to packages/core/data/ during vitest (process.cwd()).
-// Tests must create/cleanup this directory.
+// Legacy paths are mocked (getLegacyStatePath / getLegacyBackupDir in the
+// paths.js mock above) into a per-test directory under mockTmpDir. They used
+// to resolve to the real shared packages/core/data/ (process.cwd()), which
+// raced against every parallel vitest worker whose StateManager load ran
+// migration concurrently — the #1382 CI flake.
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('migrateFromLegacyLocation', () => {
-  const legacyDataDir = path.join(process.cwd(), 'data');
-  const legacyStatePath = path.join(legacyDataDir, 'state.json');
-  const legacyBackupDir = path.join(legacyDataDir, 'backups');
+  const legacyDataDir = () => path.join(mockTmpDir, 'legacy-data');
+  const legacyStatePath = () => path.join(legacyDataDir(), 'state.json');
+  const legacyBackupDir = () => path.join(legacyDataDir(), 'backups');
 
   function createLegacyState(data: Record<string, unknown>): void {
-    fs.mkdirSync(legacyDataDir, { recursive: true });
-    fs.writeFileSync(legacyStatePath, JSON.stringify(data), { mode: 0o600 });
+    fs.mkdirSync(legacyDataDir(), { recursive: true });
+    fs.writeFileSync(legacyStatePath(), JSON.stringify(data), { mode: 0o600 });
   }
 
   function createLegacyBackup(name: string, data: Record<string, unknown>): void {
-    fs.mkdirSync(legacyBackupDir, { recursive: true });
-    fs.writeFileSync(path.join(legacyBackupDir, name), JSON.stringify(data), { mode: 0o600 });
-  }
-
-  function cleanupLegacyDir(): void {
-    fs.rmSync(legacyDataDir, { recursive: true, force: true });
+    fs.mkdirSync(legacyBackupDir(), { recursive: true });
+    fs.writeFileSync(path.join(legacyBackupDir(), name), JSON.stringify(data), { mode: 0o600 });
   }
 
   beforeEach(() => {
     mockTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oss-state-legacy-'));
-    cleanupLegacyDir(); // ensure clean slate
   });
 
   afterEach(() => {
-    cleanupLegacyDir();
     fs.rmSync(mockTmpDir, { recursive: true, force: true });
     mockTmpDir = '';
   });
@@ -631,8 +641,8 @@ describe('migrateFromLegacyLocation', () => {
     expect(sm.getState().config.githubUsername).toBe('legacy-user');
 
     expect(fs.existsSync(path.join(mockTmpDir, 'state.json'))).toBe(true);
-    expect(fs.existsSync(legacyStatePath)).toBe(false);
-    expect(fs.existsSync(legacyDataDir)).toBe(false);
+    expect(fs.existsSync(legacyStatePath())).toBe(false);
+    expect(fs.existsSync(legacyDataDir())).toBe(false);
   });
 
   it('should migrate backup files from legacy location', () => {
@@ -650,18 +660,18 @@ describe('migrateFromLegacyLocation', () => {
     expect(backups).toContain('state-2024-01-02T00-00-00-000Z-def456.json');
 
     // Legacy backup dir should be removed
-    expect(fs.existsSync(legacyBackupDir)).toBe(false);
+    expect(fs.existsSync(legacyBackupDir())).toBe(false);
   });
 
   it('should not remove legacy data dir if other files remain', () => {
     createLegacyState(makeCurrentState());
-    fs.writeFileSync(path.join(legacyDataDir, 'other.txt'), 'keep me');
+    fs.writeFileSync(path.join(legacyDataDir(), 'other.txt'), 'keep me');
 
     new StateManager(false);
 
-    expect(fs.existsSync(legacyStatePath)).toBe(false);
-    expect(fs.existsSync(legacyDataDir)).toBe(true);
-    expect(fs.existsSync(path.join(legacyDataDir, 'other.txt'))).toBe(true);
+    expect(fs.existsSync(legacyStatePath())).toBe(false);
+    expect(fs.existsSync(legacyDataDir())).toBe(true);
+    expect(fs.existsSync(path.join(legacyDataDir(), 'other.txt'))).toBe(true);
   });
 
   it('should skip migration when new state already exists', () => {
@@ -676,19 +686,19 @@ describe('migrateFromLegacyLocation', () => {
     const sm = new StateManager(false);
 
     expect(sm.getState().config.githubUsername).toBe('new-user');
-    expect(fs.existsSync(legacyStatePath)).toBe(true);
+    expect(fs.existsSync(legacyStatePath())).toBe(true);
   });
 
   it('should handle migration failure gracefully', () => {
     createLegacyState(makeCurrentState());
-    fs.chmodSync(legacyStatePath, 0o000);
+    fs.chmodSync(legacyStatePath(), 0o000);
 
     const sm = new StateManager(false);
     expect(sm.getState().version).toBe(4);
 
     // Restore permissions so afterEach cleanup works
-    fs.chmodSync(legacyStatePath, 0o600);
-    expect(fs.existsSync(legacyStatePath)).toBe(true);
+    fs.chmodSync(legacyStatePath(), 0o600);
+    expect(fs.existsSync(legacyStatePath())).toBe(true);
   });
 });
 

--- a/packages/core/src/core/state-persistence.ts
+++ b/packages/core/src/core/state-persistence.ts
@@ -8,7 +8,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { AgentState } from './types.js';
 import { AgentStateSchema } from './state-schema.js';
-import { getStatePath, getBackupDir, getDataDir } from './paths.js';
+import { getStatePath, getBackupDir, getDataDir, getLegacyStatePath, getLegacyBackupDir } from './paths.js';
 import { errorMessage, ConcurrencyError } from './errors.js';
 import { debug, warn } from './logger.js';
 
@@ -16,10 +16,6 @@ const MODULE = 'state';
 
 // Lock file timeout: if a lock is older than this, it is considered stale
 const LOCK_TIMEOUT_MS = 30_000; // 30 seconds
-
-// Legacy path for migration
-const LEGACY_STATE_FILE = path.join(process.cwd(), 'data', 'state.json');
-const LEGACY_BACKUP_DIR = path.join(process.cwd(), 'data', 'backups');
 
 /**
  * Check whether an existing lock file is stale (expired or corrupt).
@@ -201,6 +197,10 @@ export function createFreshState(): AgentState {
  */
 function migrateFromLegacyLocation(): boolean {
   const newStatePath = getStatePath();
+  // Resolved via paths.js (not module constants) so tests can mock the
+  // legacy location into per-test temp dirs — see #1382.
+  const LEGACY_STATE_FILE = getLegacyStatePath();
+  const LEGACY_BACKUP_DIR = getLegacyBackupDir();
 
   // If new state already exists, no migration needed
   if (fs.existsSync(newStatePath)) {


### PR DESCRIPTION
## Summary

Root cause of the #1382 CI flake (seen twice across recent PRs, two different tests in `migrateFromLegacyLocation`): `LEGACY_STATE_FILE`/`LEGACY_BACKUP_DIR` were module constants on `process.cwd()/data`, the one shared directory for every parallel vitest worker. The migration tests created real fixtures there, and any concurrent test constructing a `StateManager` runs `migrateFromLegacyLocation` on load, migrates the fixture into its own mocked tmp dir, and unlinks the legacy files mid-test ('expected false to be true' on `existsSync(legacyStatePath)`, 'expected [] to include' on the backup listing).

Fix: lazy `getLegacyStatePath()`/`getLegacyBackupDir()` in `paths.ts` (call-time cwd, identical production value; nothing in the codebase chdirs), consumed by `state-persistence.ts`, mocked by the migration tests into `mockTmpDir/legacy-data`. The shared fixture is never created, so the race is structurally gone. Bonus: tests no longer write into the repo working tree.

## Test plan

- [x] Migration tests pass 4 consecutive runs
- [x] Full core suite green (2610 tests)
- [x] All 8 paths.js-mocking suites verified (306 tests); suites that spread `...actual` fall back to the real impl and no-op on a nonexistent dir
- [x] tsc, eslint, prettier clean

Closes #1382