### PR TITLE
fix(gist): surface corrupt-Gist, permission, and rate-limit errors from bootstrap

### DIFF
--- a/packages/core/src/core/gist-state-store.test.ts
+++ b/packages/core/src/core/gist-state-store.test.ts
@@ -8,6 +8,7 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import { GistStateStore, GIST_DESCRIPTION, STATE_FILE_NAME, type OctokitLike } from './gist-state-store.js';
 import { AgentStateSchema } from './state-schema.js';
+import { GistCorruptError } from './errors.js';
 import { createFreshState } from './state-persistence.js';
 
 // ── Mock utils.js to redirect path helpers to temp directories ────────────────
@@ -392,31 +393,62 @@ describe('GistStateStore', () => {
       expect(result.state.config.setupComplete).toBe(false);
     });
 
-    it('should preserve corrupt content and degrade rather than overwrite Gist (#1201)', async () => {
+    it('should preserve corrupt content and rethrow GistCorruptError rather than degrade (#1201, #1367)', async () => {
       const gistId = 'corrupt-gist';
       const corruptContent = 'not valid json';
 
       fs.writeFileSync(path.join(tmpDir, 'gist-id'), gistId);
       octokit.gists.get.mockResolvedValue(makeGistResponse(gistId, corruptContent));
-      // Force the search fallback to also fail so the bootstrap enters degraded mode
       octokit.gists.list.mockResolvedValue({ data: [] });
 
       const store = new GistStateStore(octokit);
-      const result = await store.bootstrap();
 
-      // Bootstrap recovers in degraded mode (gistId='') so push() can't run
-      // and silently overwrite the Gist with fresh state — that's the data-
-      // loss scenario #1201 was filed for.
-      expect(result.degraded).toBe(true);
-      expect(result.gistId).toBe('');
-      expect(result.state.version).toBe(4);
+      // A corrupt Gist must SURFACE, not degrade (#1367): by the time the
+      // parse throws, fetchAndCache has armed gistId + the ETag, so a
+      // degraded store could push() fresh state over the corrupt remote —
+      // the data-loss scenario #1201 was filed for. Degrading also risks
+      // silently abandoning the Gist and creating a fresh one via step 3.
+      await expect(store.bootstrap()).rejects.toThrow(GistCorruptError);
 
-      // The corrupt content should be preserved as `.rejected-<ts>` so the
+      // The corrupt content is still preserved as `.rejected-<ts>` so the
       // user can recover it.
       const rejectedFiles = fs.readdirSync(tmpDir).filter((f) => f.startsWith('state-cache.json.rejected-'));
       expect(rejectedFiles.length).toBeGreaterThanOrEqual(1);
       const preservedContent = fs.readFileSync(path.join(tmpDir, rejectedFiles[0]!), 'utf8');
       expect(preservedContent).toBe(corruptContent);
+    });
+
+    it('rethrows rate-limit errors instead of degrading (#1367)', async () => {
+      // The first gists.list call is checkGistScope's probe — let it succeed
+      // so the 429 hits the SEARCH step inside the outer try, exercising the
+      // new outer-catch rate-limit rethrow (checkGistScope has its own,
+      // pre-existing rethrow). errors.ts's contract is that rate-limit errors
+      // always propagate; degrading would present "you are rate-limited" as
+      // a stale local cache.
+      octokit.gists.list.mockResolvedValueOnce({ data: [] });
+      octokit.gists.list.mockRejectedValueOnce(Object.assign(new Error('API rate limit exceeded'), { status: 429 }));
+
+      const store = new GistStateStore(octokit);
+      await expect(store.bootstrap()).rejects.toThrow('API rate limit exceeded');
+    });
+
+    it('degraded bootstrap disarms the push path (#1367)', async () => {
+      // Genuine API unavailability still degrades — but the degraded store
+      // never verified its Gist, so it must not be able to push to one.
+      fs.writeFileSync(path.join(tmpDir, 'gist-id'), 'unreachable-gist');
+      octokit.gists.get.mockRejectedValue(new Error('Network error'));
+      octokit.gists.list.mockRejectedValue(new Error('Network error'));
+      octokit.gists.create.mockRejectedValue(new Error('Network error'));
+
+      const store = new GistStateStore(octokit);
+      const result = await store.bootstrap();
+
+      expect(result.degraded).toBe(true);
+      expect(store.getGistId()).toBeNull();
+
+      store.setState(createFreshState());
+      await expect(store.push()).rejects.toThrow(/cannot push before bootstrap/);
+      expect(octokit.gists.update).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/core/gist-state-store.ts
+++ b/packages/core/src/core/gist-state-store.ts
@@ -57,7 +57,13 @@ import {
 } from './state-persistence.js';
 import { getGistIdPath, getStateCachePath } from './paths.js';
 import { debug, warn } from './logger.js';
-import { GistPermissionError, GistConcurrencyError, GistCorruptError, isRateLimitError } from './errors.js';
+import {
+  ConfigurationError,
+  GistPermissionError,
+  GistConcurrencyError,
+  GistCorruptError,
+  isRateLimitError,
+} from './errors.js';
 
 const MODULE = 'gist-store';
 
@@ -217,6 +223,11 @@ export class GistStateStore {
           const state = await this.fetchAndCache(localId);
           return { gistId: localId, state, created: false };
         } catch (err) {
+          // A corrupt or permission-broken Gist must surface immediately
+          // (#1367): falling through to search would either re-find the same
+          // corrupt Gist or silently abandon it and create a fresh one.
+          if (err instanceof ConfigurationError) throw err;
+          if (isRateLimitError(err)) throw err;
           warn(MODULE, `Failed to fetch Gist ${localId}, will search/create`, err);
           // Fall through to search
         }
@@ -238,10 +249,21 @@ export class GistStateStore {
       this.writeLocalGistId(id);
       return { gistId: id, state, created: true };
     } catch (err) {
-      // Configuration errors (e.g. GistPermissionError) must surface, not degrade
-      if (err instanceof GistPermissionError) throw err;
+      // Configuration errors (GistPermissionError, GistCorruptError) and rate
+      // limits must surface, not degrade (#1367). A corrupt Gist especially:
+      // fetchAndCache arms this.gistId/lastFetchedEtag before the parse
+      // throws, so a degraded store could push() local or fresh state over
+      // the corrupt remote — the exact data loss #1201 exists to prevent.
+      // Rate limits propagate per the errors.ts contract; degrading would
+      // present "you are rate-limited" as a stale local cache.
+      if (err instanceof ConfigurationError) throw err;
+      if (isRateLimitError(err)) throw err;
 
-      // All API paths failed — enter degraded mode
+      // All API paths failed — enter degraded mode. Disarm the remote write
+      // path first: a degraded store never verified its Gist, so it must
+      // never be able to push to one (#1367).
+      this.gistId = null;
+      this.lastFetchedEtag = null;
       warn(MODULE, 'All Gist API paths failed, entering degraded mode', err);
 
       // Try reading from local cache file
@@ -307,6 +329,10 @@ export class GistStateStore {
           const state = await this.fetchAndCache(localId);
           return { gistId: localId, state, created: false, migrated: false };
         } catch (err) {
+          // See bootstrap(): corrupt/permission/rate-limit errors surface
+          // immediately rather than falling through (#1367).
+          if (err instanceof ConfigurationError) throw err;
+          if (isRateLimitError(err)) throw err;
           warn(MODULE, `bootstrapWithMigration: failed to fetch Gist ${localId}, will search/create`, err);
           // Fall through to search
         }
@@ -328,10 +354,15 @@ export class GistStateStore {
       this.writeLocalGistId(id);
       return { gistId: id, state, created: true, migrated: true };
     } catch (err) {
-      // Configuration errors (e.g. GistPermissionError) must surface, not degrade
-      if (err instanceof GistPermissionError) throw err;
+      // Same surfacing contract as bootstrap() (#1367): configuration errors
+      // and rate limits rethrow; only genuine API unavailability degrades.
+      if (err instanceof ConfigurationError) throw err;
+      if (isRateLimitError(err)) throw err;
 
-      // All API paths failed — enter degraded mode
+      // All API paths failed — enter degraded mode with the push path
+      // disarmed (see bootstrap()).
+      this.gistId = null;
+      this.lastFetchedEtag = null;
       warn(MODULE, 'bootstrapWithMigration: all Gist API paths failed, entering degraded mode', err);
 
       // Try reading from local cache file
@@ -740,6 +771,9 @@ export class GistStateStore {
         }
       }
     } catch (err) {
+      // A rate-limited search must not read as "no Gist found" — bootstrap
+      // would proceed to create a duplicate Gist while throttled (#1367).
+      if (isRateLimitError(err)) throw err;
       warn(MODULE, 'Failed to search Gists by description', err);
     }
     return null;


### PR DESCRIPTION
## Summary

Bootstrap swallowed everything except `GistPermissionError` into degraded mode. Three consequences, all fixed:

- **Corrupt Gist could be overwritten.** `GistCorruptError` degraded while `this.gistId`/`lastFetchedEtag` were already armed by `fetchAndCache`, so the next `checkpoint()` push overwrote the corrupt remote with local/fresh state (the exact data loss the #1201 protection was built for). Now `ConfigurationError` rethrows from both bootstrap catches and both step-1 inner catches.
- **Rate limits masqueraded as degraded mode / no-Gist.** 429s now propagate per the errors.ts contract, including from `searchForGist`, whose swallow-all catch previously turned a throttled search into 'no Gist found' followed by minting a duplicate Gist.
- **Degraded mode is now physically push-proof.** Entering it disarms `gistId`/`lastFetchedEtag`; `push()` refuses on null gistId and `refreshFromGist` reports `no-gist`.

Consumers verified: `getStateManagerAsync` rethrows `ConfigurationError` by design (#1202) and rate limits are not transient-network, so they surface; MCP wraps them as structured tool errors. The CLI `parse()` vs `parseAsync()` surfacing gap (raw unhandled-rejection stack) is pre-existing and tracked in #1386.

## Test plan

- [x] Rewritten #1201 test: bootstrap now rejects with `GistCorruptError` and still preserves the `.rejected-<ts>` copy
- [x] New: rate-limit rethrow test that genuinely exercises the search-step path (scope probe primed to succeed first)
- [x] New: degraded bootstrap disarm test (`getGistId()` null, `push()` rejects, `gists.update` never called)
- [x] Existing degraded tests (plain network errors) unchanged and passing
- [x] Full core suite green (2612 tests); gist + concurrency suites 60/60; tsc, eslint, prettier clean

Closes #1367