### PR TITLE
fix(state): surface Gist checkpoint push failures in structured output

### DIFF
--- a/packages/core/src/commands/comments.test.ts
+++ b/packages/core/src/commands/comments.test.ts
@@ -10,7 +10,7 @@ vi.mock('../core/index.js', () => ({
   parseGitHubUrl: vi.fn(),
   formatRelativeTime: vi.fn(),
   requireGitHubToken: vi.fn(),
-  maybeCheckpoint: vi.fn().mockResolvedValue(undefined),
+  maybeCheckpoint: vi.fn().mockResolvedValue(null),
 }));
 
 import { getStateManager, getOctokit, parseGitHubUrl, requireGitHubToken } from '../core/index.js';

--- a/packages/core/src/commands/comments.ts
+++ b/packages/core/src/commands/comments.ts
@@ -256,6 +256,7 @@ export async function runClaim(options: ClaimOptions): Promise<ClaimOutput> {
   }
 
   // Add to tracked issues — non-fatal if state save fails (comment already posted)
+  let gistSyncWarning: string | null = null;
   try {
     const stateManager = getStateManager();
     stateManager.addIssue({
@@ -270,10 +271,10 @@ export async function runClaim(options: ClaimOptions): Promise<ClaimOutput> {
       updatedAt: new Date().toISOString(),
       vetted: false,
     });
-    // Push state to Gist if in Gist mode. Best-effort — logs on failure
-    // rather than silently swallowing, so operators see the degraded-sync
-    // signal (#1036 audit H1).
-    await maybeCheckpoint(stateManager, MODULE);
+    // Push state to Gist if in Gist mode. Best-effort — the warning is
+    // threaded into the structured output so MCP/dashboard consumers see
+    // the degraded-sync signal, not just the stderr log (#1036 audit H1, #1370).
+    gistSyncWarning = await maybeCheckpoint(stateManager, MODULE);
   } catch (error) {
     // Structured warning instead of bare console.error so the breadcrumb shows
     // up in the plugin's log pipeline (#1056 M24).
@@ -286,5 +287,6 @@ export async function runClaim(options: ClaimOptions): Promise<ClaimOutput> {
   return {
     commentUrl: comment.html_url,
     issueUrl: options.issueUrl,
+    ...(gistSyncWarning ? { gistSyncWarning } : {}),
   };
 }

--- a/packages/core/src/commands/daily.ts
+++ b/packages/core/src/commands/daily.ts
@@ -794,10 +794,23 @@ async function executeDailyCheckInternal(token: string): Promise<DailyCheckResul
   // Checkpoint: push state to Gist if in Gist mode.
   // If getStateManagerAsync was not called before this command ran,
   // isGistMode() will be false and checkpoint is correctly skipped.
+  // `warnings` is the same array referenced by `result`, so warnings
+  // recorded here still reach the structured output.
   try {
     const sm = getStateManager();
     if (sm.isGistMode()) {
-      await sm.checkpoint();
+      // checkpoint() resolves false (no throw) when the push failed after
+      // its retry — previously discarded, reporting clean success while
+      // cross-machine state silently drifted (#1370).
+      const pushed = await sm.checkpoint();
+      if (!pushed) {
+        recordWarning(
+          warnings,
+          'gist-checkpoint',
+          'Gist checkpoint',
+          new Error('push failed after retry; state not synced to Gist this run'),
+        );
+      }
     }
   } catch (err) {
     recordWarning(warnings, 'gist-checkpoint', 'Gist checkpoint', err);

--- a/packages/core/src/commands/dismiss.test.ts
+++ b/packages/core/src/commands/dismiss.test.ts
@@ -8,7 +8,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Mock getStateManager for command-level tests
 vi.mock('../core/index.js', () => ({
   getStateManager: vi.fn(),
-  maybeCheckpoint: vi.fn().mockResolvedValue(undefined),
+  maybeCheckpoint: vi.fn().mockResolvedValue(null),
 }));
 
 import { getStateManager } from '../core/index.js';

--- a/packages/core/src/commands/dismiss.ts
+++ b/packages/core/src/commands/dismiss.ts
@@ -12,11 +12,15 @@ const MODULE = 'dismiss';
 export interface DismissOutput {
   dismissed: boolean;
   url: string;
+  /** Set when the post-mutation Gist checkpoint failed; the local mutation succeeded (#1370). */
+  gistSyncWarning?: string;
 }
 
 export interface UndismissOutput {
   undismissed: boolean;
   url: string;
+  /** Set when the post-mutation Gist checkpoint failed; the local mutation succeeded (#1370). */
+  gistSyncWarning?: string;
 }
 
 /**
@@ -34,9 +38,9 @@ export async function runDismiss(options: { url: string }): Promise<DismissOutpu
 
   const stateManager = getStateManager();
   const added = stateManager.dismissIssue(options.url, new Date().toISOString());
-  await maybeCheckpoint(stateManager, MODULE);
+  const gistSyncWarning = await maybeCheckpoint(stateManager, MODULE);
 
-  return { dismissed: added, url: options.url };
+  return { dismissed: added, url: options.url, ...(gistSyncWarning ? { gistSyncWarning } : {}) };
 }
 
 /**
@@ -53,7 +57,7 @@ export async function runUndismiss(options: { url: string }): Promise<UndismissO
 
   const stateManager = getStateManager();
   const removed = stateManager.undismissIssue(options.url);
-  await maybeCheckpoint(stateManager, MODULE);
+  const gistSyncWarning = await maybeCheckpoint(stateManager, MODULE);
 
-  return { undismissed: removed, url: options.url };
+  return { undismissed: removed, url: options.url, ...(gistSyncWarning ? { gistSyncWarning } : {}) };
 }

--- a/packages/core/src/commands/guidelines.ts
+++ b/packages/core/src/commands/guidelines.ts
@@ -50,12 +50,16 @@ export interface GuidelinesStoreOutput {
   repo: string;
   byteSize: number;
   stored: boolean;
+  /** Set when the post-mutation Gist checkpoint failed; the local mutation succeeded (#1370). */
+  gistSyncWarning?: string;
 }
 
 export interface GuidelinesResetOutput {
   repo: string;
   /** True when an existing file was tombstoned, false when no file existed. */
   deleted: boolean;
+  /** Set when the post-mutation Gist checkpoint failed; the local mutation succeeded (#1370). */
+  gistSyncWarning?: string;
 }
 
 export interface FetchCorpusOutput {
@@ -72,6 +76,8 @@ export interface FetchCorpusOutput {
    * succeeded. (#1209 L8)
    */
   failures: Array<{ prUrl: string; error: string }>;
+  /** Set when the post-mutation Gist checkpoint failed; the local mutation succeeded (#1370). */
+  gistSyncWarning?: string;
 }
 
 interface RepoOption {
@@ -125,11 +131,12 @@ export async function runGuidelinesStore(options: StoreOptions): Promise<Guideli
   // Push to Gist — autoSave only writes the local state-cache mirror in Gist
   // mode, so without this checkpoint the change never propagates across
   // machines (#1200).
-  await maybeCheckpoint(sm, MODULE);
+  const gistSyncWarning = await maybeCheckpoint(sm, MODULE);
   return {
     repo: options.repo,
     byteSize: Buffer.byteLength(options.content, 'utf8'),
     stored: true,
+    ...(gistSyncWarning ? { gistSyncWarning } : {}),
   };
 }
 
@@ -141,12 +148,13 @@ export async function runGuidelinesReset(options: RepoOption): Promise<Guideline
     throw new GuidelinesNotAvailableError();
   }
   const existed = sm.getGuidelines(options.repo) !== null;
+  let gistSyncWarning: string | null = null;
   if (existed) {
     sm.deleteGuidelines(options.repo);
     // Push to Gist — see runGuidelinesStore note (#1200).
-    await maybeCheckpoint(sm, MODULE);
+    gistSyncWarning = await maybeCheckpoint(sm, MODULE);
   }
-  return { repo: options.repo, deleted: existed };
+  return { repo: options.repo, deleted: existed, ...(gistSyncWarning ? { gistSyncWarning } : {}) };
 }
 
 /**
@@ -228,8 +236,9 @@ export async function runFetchCorpus(options: FetchCorpusOptions): Promise<Fetch
   // Push commentsFetchedAt stamps to Gist so other machines don't re-fetch
   // the same PRs forever. autoSave only writes the local mirror in Gist
   // mode (#1200).
+  let gistSyncWarning: string | null = null;
   if (bundles.length > 0) {
-    await maybeCheckpoint(sm, MODULE);
+    gistSyncWarning = await maybeCheckpoint(sm, MODULE);
   }
 
   return {
@@ -238,6 +247,7 @@ export async function runFetchCorpus(options: FetchCorpusOptions): Promise<Fetch
     prCount: bundles.length,
     skipped,
     failures,
+    ...(gistSyncWarning ? { gistSyncWarning } : {}),
   };
 }
 

--- a/packages/core/src/commands/move.test.ts
+++ b/packages/core/src/commands/move.test.ts
@@ -7,7 +7,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Mock getStateManager for command-level tests
 vi.mock('../core/index.js', () => ({
   getStateManager: vi.fn(),
-  maybeCheckpoint: vi.fn().mockResolvedValue(undefined),
+  maybeCheckpoint: vi.fn().mockResolvedValue(null),
 }));
 
 import { getStateManager } from '../core/index.js';

--- a/packages/core/src/commands/move.ts
+++ b/packages/core/src/commands/move.ts
@@ -18,6 +18,13 @@ export interface MoveOutput {
   target: MoveTarget;
   /** Human-readable description of what happened. */
   description: string;
+  /** Set when the post-mutation Gist checkpoint failed; the local mutation succeeded (#1370). */
+  gistSyncWarning?: string;
+}
+
+/** Attach the checkpoint warning only when present, keeping the key off the wire on clean runs (#1370). */
+function withGistSyncWarning(output: MoveOutput, gistSyncWarning: string | null): MoveOutput {
+  return gistSyncWarning ? { ...output, gistSyncWarning } : output;
 }
 
 /**
@@ -52,32 +59,38 @@ export async function runMove(options: { prUrl: string; target: string }): Promi
         stateManager.setStatusOverride(options.prUrl, status, lastActivityAt);
         stateManager.unshelvePR(options.prUrl);
       });
-      await maybeCheckpoint(stateManager, MODULE);
-      return { url: options.prUrl, target, description: `Moved to ${label}` };
+      const gistSyncWarning = await maybeCheckpoint(stateManager, MODULE);
+      return withGistSyncWarning({ url: options.prUrl, target, description: `Moved to ${label}` }, gistSyncWarning);
     }
     case 'shelved': {
       stateManager.batch(() => {
         stateManager.shelvePR(options.prUrl);
         stateManager.clearStatusOverride(options.prUrl);
       });
-      await maybeCheckpoint(stateManager, MODULE);
-      return {
-        url: options.prUrl,
-        target,
-        description: 'Shelved — excluded from capacity and actionable items',
-      };
+      const gistSyncWarning = await maybeCheckpoint(stateManager, MODULE);
+      return withGistSyncWarning(
+        {
+          url: options.prUrl,
+          target,
+          description: 'Shelved — excluded from capacity and actionable items',
+        },
+        gistSyncWarning,
+      );
     }
     case 'auto': {
       stateManager.batch(() => {
         stateManager.clearStatusOverride(options.prUrl);
         stateManager.unshelvePR(options.prUrl);
       });
-      await maybeCheckpoint(stateManager, MODULE);
-      return {
-        url: options.prUrl,
-        target,
-        description: 'Reset to computed status',
-      };
+      const gistSyncWarning = await maybeCheckpoint(stateManager, MODULE);
+      return withGistSyncWarning(
+        {
+          url: options.prUrl,
+          target,
+          description: 'Reset to computed status',
+        },
+        gistSyncWarning,
+      );
     }
     default: {
       const _exhaustive: never = target;

--- a/packages/core/src/commands/shelve.test.ts
+++ b/packages/core/src/commands/shelve.test.ts
@@ -35,7 +35,7 @@ describe('PR_URL_PATTERN', () => {
 // Mock getStateManager for command-level tests
 vi.mock('../core/index.js', () => ({
   getStateManager: vi.fn(),
-  maybeCheckpoint: vi.fn().mockResolvedValue(undefined),
+  maybeCheckpoint: vi.fn().mockResolvedValue(null),
 }));
 
 import { getStateManager, maybeCheckpoint } from '../core/index.js';
@@ -84,7 +84,27 @@ describe('runShelve', () => {
     // runShelve should still fail loud. Keep the assertion explicit.
     await expect(runShelve({ prUrl: TEST_PR_URL })).rejects.toThrow('network down');
     // Restore default for subsequent tests in this describe block.
-    mockMaybeCheckpoint.mockResolvedValue(undefined);
+    mockMaybeCheckpoint.mockResolvedValue(null);
+  });
+
+  it('threads the checkpoint warning into gistSyncWarning when the Gist push fails (#1370)', async () => {
+    mockShelvePR.mockReturnValue(true);
+    const warning = 'Gist checkpoint push failed after retry; the local mutation is saved';
+    mockMaybeCheckpoint.mockResolvedValueOnce(warning);
+
+    const result = await runShelve({ prUrl: TEST_PR_URL });
+
+    expect(result).toEqual({ shelved: true, url: TEST_PR_URL, gistSyncWarning: warning });
+  });
+
+  it('omits gistSyncWarning entirely when the checkpoint succeeds (#1370)', async () => {
+    mockShelvePR.mockReturnValue(true);
+    mockMaybeCheckpoint.mockResolvedValueOnce(null);
+
+    const result = await runShelve({ prUrl: TEST_PR_URL });
+
+    expect(result).not.toHaveProperty('gistSyncWarning');
+    expect(result).toEqual({ shelved: true, url: TEST_PR_URL });
   });
 
   it('should report not shelved when PR is already shelved', async () => {

--- a/packages/core/src/commands/shelve.ts
+++ b/packages/core/src/commands/shelve.ts
@@ -16,11 +16,15 @@ const MODULE = 'shelve';
 export interface ShelveOutput {
   shelved: boolean;
   url: string;
+  /** Set when the post-mutation Gist checkpoint failed; the local mutation succeeded (#1370). */
+  gistSyncWarning?: string;
 }
 
 export interface UnshelveOutput {
   unshelved: boolean;
   url: string;
+  /** Set when the post-mutation Gist checkpoint failed; the local mutation succeeded (#1370). */
+  gistSyncWarning?: string;
 }
 
 // Re-export for backward compatibility with tests
@@ -44,9 +48,9 @@ export async function runShelve(options: { prUrl: string }): Promise<ShelveOutpu
     added = stateManager.shelvePR(options.prUrl);
     stateManager.clearStatusOverride(options.prUrl);
   });
-  await maybeCheckpoint(stateManager, MODULE);
+  const gistSyncWarning = await maybeCheckpoint(stateManager, MODULE);
 
-  return { shelved: added, url: options.prUrl };
+  return { shelved: added, url: options.prUrl, ...(gistSyncWarning ? { gistSyncWarning } : {}) };
 }
 
 /**
@@ -67,7 +71,7 @@ export async function runUnshelve(options: { prUrl: string }): Promise<UnshelveO
     removed = stateManager.unshelvePR(options.prUrl);
     stateManager.clearStatusOverride(options.prUrl);
   });
-  await maybeCheckpoint(stateManager, MODULE);
+  const gistSyncWarning = await maybeCheckpoint(stateManager, MODULE);
 
-  return { unshelved: removed, url: options.prUrl };
+  return { unshelved: removed, url: options.prUrl, ...(gistSyncWarning ? { gistSyncWarning } : {}) };
 }

--- a/packages/core/src/core/state.test.ts
+++ b/packages/core/src/core/state.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { StateManager, getStateManager, resetStateManager } from './state.js';
+import { StateManager, getStateManager, resetStateManager, maybeCheckpoint } from './state.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
@@ -1087,5 +1087,45 @@ describe('StateManager Gist staleness marker (#1193)', () => {
 
     // Marker should not have been cleared by a throttle.
     expect(manager.getStateStaleness()).toEqual(before);
+  });
+});
+
+// StateManager-shaped stub for maybeCheckpoint tests (#1370). Outer scope to
+// satisfy unicorn/consistent-function-scoping.
+const makeCheckpointStub = (overrides: { isGistMode?: () => boolean; checkpoint?: ReturnType<typeof vi.fn> }) =>
+  ({
+    isGistMode: overrides.isGistMode ?? (() => true),
+    checkpoint: overrides.checkpoint ?? vi.fn(),
+  }) as unknown as StateManager;
+
+describe('maybeCheckpoint (#1370)', () => {
+  it('returns null without calling checkpoint when not in Gist mode', async () => {
+    const checkpoint = vi.fn();
+    const stub = makeCheckpointStub({ isGistMode: () => false, checkpoint });
+
+    await expect(maybeCheckpoint(stub, 'test')).resolves.toBeNull();
+    expect(checkpoint).not.toHaveBeenCalled();
+  });
+
+  it('returns the push-failed warning when checkpoint resolves false', async () => {
+    const stub = makeCheckpointStub({ checkpoint: vi.fn().mockResolvedValue(false) });
+
+    const warning = await maybeCheckpoint(stub, 'test');
+    expect(warning).toMatch(/push failed after retry/);
+    expect(warning).toMatch(/local mutation is saved/);
+  });
+
+  it('returns null when checkpoint resolves true', async () => {
+    const stub = makeCheckpointStub({ checkpoint: vi.fn().mockResolvedValue(true) });
+
+    await expect(maybeCheckpoint(stub, 'test')).resolves.toBeNull();
+  });
+
+  it('returns the failure warning (with the error message) when checkpoint throws', async () => {
+    const stub = makeCheckpointStub({ checkpoint: vi.fn().mockRejectedValue(new Error('socket hang up')) });
+
+    const warning = await maybeCheckpoint(stub, 'test');
+    expect(warning).toMatch(/Gist checkpoint failed/);
+    expect(warning).toMatch(/socket hang up/);
   });
 });

--- a/packages/core/src/core/state.ts
+++ b/packages/core/src/core/state.ts
@@ -70,16 +70,29 @@ function filterValidUrlEntries<T extends { url: string }>(
  * Intended for state-mutating PR-flow commands (shelve / unshelve / move /
  * dismiss / undismiss / claim) so Gist-sync users don't see day-long drift
  * between machines waiting for the next `daily` checkpoint. See issue #1036.
+ *
+ * @returns `null` when the push succeeded (or Gist mode is off); otherwise a
+ * human-readable warning the caller should surface in its structured output.
+ * `checkpoint()` resolves `false` without throwing when the push failed
+ * after its retry — previously that was discarded everywhere except
+ * `state --sync`, so a failed cross-machine sync reported clean success
+ * (#1370). stderr `warn()` alone is invisible to MCP/dashboard consumers.
  */
-export async function maybeCheckpoint(stateManager: StateManager, callerModule: string): Promise<void> {
-  if (!stateManager.isGistMode()) return;
+export async function maybeCheckpoint(stateManager: StateManager, callerModule: string): Promise<string | null> {
+  if (!stateManager.isGistMode()) return null;
   try {
-    await stateManager.checkpoint();
+    const pushed = await stateManager.checkpoint();
+    if (!pushed) {
+      const msg =
+        'Gist checkpoint push failed after retry; the local mutation is saved and will sync on the next successful push';
+      warn(callerModule, msg);
+      return msg;
+    }
+    return null;
   } catch (err) {
-    warn(
-      callerModule,
-      `Gist checkpoint failed (local mutation succeeded, will retry on next push): ${errorMessage(err)}`,
-    );
+    const msg = `Gist checkpoint failed (local mutation succeeded, will retry on next push): ${errorMessage(err)}`;
+    warn(callerModule, msg);
+    return msg;
   }
 }
 

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -654,6 +654,8 @@ export const PostOutputSchema = z.object({
 export const ClaimOutputSchema = z.object({
   commentUrl: z.string(),
   issueUrl: z.string(),
+  // Post-mutation Gist checkpoint failure (#1370). Optional: absent on clean runs.
+  gistSyncWarning: z.string().optional(),
 });
 
 export const InitOutputSchema = z.object({
@@ -746,6 +748,8 @@ export const MoveOutputSchema = z.object({
   url: z.string(),
   target: z.enum(['attention', 'waiting', 'shelved', 'auto']),
   description: z.string(),
+  // Post-mutation Gist checkpoint failure (#1370). Optional: absent on clean runs.
+  gistSyncWarning: z.string().optional(),
 });
 
 export const PRTemplateOutputSchema = z.object({
@@ -1278,6 +1282,8 @@ export interface PostOutput {
 export interface ClaimOutput {
   commentUrl: string;
   issueUrl: string;
+  /** Set when the post-mutation Gist checkpoint failed; the local mutation succeeded (#1370). */
+  gistSyncWarning?: string;
 }
 
 /** Info about a local git clone (#84) */


### PR DESCRIPTION
## Summary

`GistStateStore.push()` resolves `false` (no throw) when a push fails after its retry; only `state --sync` checked it. Mutating commands and the daily end-of-run checkpoint discarded the boolean, so gist-mode users got exit 0 and a clean JSON envelope while cross-machine state silently drifted (the failure existed only as a stderr `warn`, invisible to MCP and dashboard consumers).

- `maybeCheckpoint` returns `Promise<string | null>`: null on success/non-gist-mode, a human-readable warning on push-false or throw (still also `warn()`'d)
- All 11 call sites thread it into their results as optional `gistSyncWarning`: shelve/unshelve, move (x3 branches via a small helper), dismiss/undismiss, claim, guidelines store/reset, fetch-corpus
- `ClaimOutputSchema`/`MoveOutputSchema` accept the key (zod strips unknown keys in `formatJson`; the other outputs bypass schema validation, verified)
- daily records a `gist-checkpoint` warning into `warnings[]` on push-false (the array is shared by reference with the built result, verified)

## Test plan

- [x] New 4-case `maybeCheckpoint` unit suite (non-gist null, push-false message, success null, throw message)
- [x] Command-level: `runShelve` result carries `gistSyncWarning` on failure, key absent on success
- [x] Test mocks aligned to the new `string | null` contract
- [x] Full core suite green (2618 tests); core + mcp-server tsc clean; eslint 0 errors; prettier clean

Closes #1370