### PR TITLE
fix(state): preserve forensics and surface recovery when state.json is unparseable

### DIFF
--- a/packages/core/src/commands/daily-orchestration.test.ts
+++ b/packages/core/src/commands/daily-orchestration.test.ts
@@ -83,6 +83,7 @@ vi.mock('../core/index.js', async (importOriginal) => {
       undismissIssue: mockUndismissIssue,
       getStatusOverride: mockGetStatusOverride,
       getStateStaleness: vi.fn(() => null),
+      getLoadRecovery: vi.fn(() => null),
       batch: (fn: () => void) => fn(),
     })),
     requireGitHubToken: vi.fn(() => 'test-token'),

--- a/packages/core/src/commands/daily.ts
+++ b/packages/core/src/commands/daily.ts
@@ -708,6 +708,21 @@ async function executeDailyCheckInternal(token: string): Promise<DailyCheckResul
     warnings.push(buildStalenessWarning(staleness));
   }
 
+  // Surface a state-load recovery (corrupt state.json restored from backup or
+  // replaced with fresh state) so it's machine-visible, not just stderr (#1371).
+  const loadRecovery = getStateManager().getLoadRecovery();
+  if (loadRecovery) {
+    recordWarning(
+      warnings,
+      'state-load',
+      'State file recovery',
+      new Error(
+        `${loadRecovery.reason}; recovered from ${loadRecovery.source}` +
+          (loadRecovery.rejectedPath ? `; rejected file preserved at ${loadRecovery.rejectedPath}` : ''),
+      ),
+    );
+  }
+
   // Phase 1: Fetch all PR data from GitHub
   const {
     prs,

--- a/packages/core/src/core/state-persistence.test.ts
+++ b/packages/core/src/core/state-persistence.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { StateManager, acquireLock, releaseLock, atomicWriteFileSync, resetStateManager } from './state.js';
-import { saveState, createFreshState } from './state-persistence.js';
+import { saveState, createFreshState, loadState } from './state-persistence.js';
 import { ConcurrencyError } from './errors.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -703,6 +703,26 @@ describe('state recovery and backup edge cases', () => {
     expect(sm.getState().config.githubUsername).toBe('');
   });
 
+  it('should report recovery details when state has invalid structure (Zod path)', () => {
+    const statePath = path.join(mockTmpDir, 'state.json');
+    fs.writeFileSync(statePath, JSON.stringify({ version: 4, config: null, repoScores: {} }), { mode: 0o600 });
+
+    const backupDir = path.join(mockTmpDir, 'backups');
+    fs.mkdirSync(backupDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(backupDir, 'state-2024-01-01T00-00-00-000Z-abc123.json'),
+      JSON.stringify(makeCurrentState({ config: { ...makeBaseConfig(), githubUsername: 'backup-user' } })),
+      { mode: 0o600 },
+    );
+
+    const result = loadState();
+    expect(result.state.config.githubUsername).toBe('backup-user');
+    expect(result.recovery).toBeDefined();
+    expect(result.recovery?.source).toBe('backup');
+    expect(result.recovery?.rejectedPath).toMatch(/state\.json\.rejected-\d+$/);
+    expect(result.recovery?.reason).toContain('Invalid state file structure');
+  });
+
   it('should handle backup containing non-object JSON', () => {
     const statePath = path.join(mockTmpDir, 'state.json');
     fs.writeFileSync(statePath, 'CORRUPT', { mode: 0o600 });
@@ -715,6 +735,160 @@ describe('state recovery and backup edge cases', () => {
     const sm = new StateManager(false);
     expect(sm.getState().version).toBe(4);
     expect(sm.getState().config.githubUsername).toBe('');
+  });
+});
+
+// ── Rejected-file preservation and recovery metadata (#1371) ────────────────
+describe('loadState rejected-file preservation and recovery metadata (#1371)', () => {
+  beforeEach(() => {
+    mockTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oss-state-rejected-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(mockTmpDir, { recursive: true, force: true });
+    mockTmpDir = '';
+  });
+
+  function listRejectedFiles(): string[] {
+    return fs.readdirSync(mockTmpDir).filter((f) => f.startsWith('state.json.rejected-'));
+  }
+
+  it('preserves a .rejected copy with the corrupt content when restoring from backup', () => {
+    const statePath = path.join(mockTmpDir, 'state.json');
+    fs.writeFileSync(statePath, '{ this is not valid json }', { mode: 0o600 });
+
+    const backupDir = path.join(mockTmpDir, 'backups');
+    fs.mkdirSync(backupDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(backupDir, 'state-2024-01-01T00-00-00-000Z-abc123.json'),
+      JSON.stringify(makeCurrentState({ config: { ...makeBaseConfig(), githubUsername: 'rescued' } })),
+      { mode: 0o600 },
+    );
+
+    const result = loadState();
+
+    // Restored from backup
+    expect(result.state.config.githubUsername).toBe('rescued');
+    expect(result.recovery?.source).toBe('backup');
+
+    // The corrupt original is preserved verbatim before the overwrite
+    const rejected = listRejectedFiles();
+    expect(rejected.length).toBe(1);
+    expect(fs.readFileSync(path.join(mockTmpDir, rejected[0]), 'utf8')).toBe('{ this is not valid json }');
+    expect(result.recovery?.rejectedPath).toBe(path.join(mockTmpDir, rejected[0]));
+    expect(result.recovery?.reason).toContain('Error loading state');
+  });
+
+  it('preserves a .rejected copy and reports fresh recovery when no valid backup exists', () => {
+    const statePath = path.join(mockTmpDir, 'state.json');
+    fs.writeFileSync(statePath, 'CORRUPT', { mode: 0o600 });
+
+    const backupDir = path.join(mockTmpDir, 'backups');
+    fs.mkdirSync(backupDir, { recursive: true });
+    fs.writeFileSync(path.join(backupDir, 'state-2024-01-01T00-00-00-000Z-abc000.json'), 'ALSO CORRUPT', {
+      mode: 0o600,
+    });
+
+    const result = loadState();
+
+    expect(result.state.version).toBe(4);
+    expect(result.recovery?.source).toBe('fresh');
+
+    const rejected = listRejectedFiles();
+    expect(rejected.length).toBe(1);
+    expect(fs.readFileSync(path.join(mockTmpDir, rejected[0]), 'utf8')).toBe('CORRUPT');
+    expect(result.recovery?.rejectedPath).toBe(path.join(mockTmpDir, rejected[0]));
+  });
+
+  it('returns no recovery metadata for a healthy state file', () => {
+    const statePath = path.join(mockTmpDir, 'state.json');
+    fs.writeFileSync(statePath, JSON.stringify(makeCurrentState()), { mode: 0o600 });
+
+    const result = loadState();
+
+    expect(result.recovery).toBeUndefined();
+    expect(listRejectedFiles().length).toBe(0);
+  });
+
+  it('returns no recovery metadata when no state file exists (fresh start is not a recovery)', () => {
+    const result = loadState();
+
+    expect(result.state.version).toBe(4);
+    expect(result.recovery).toBeUndefined();
+    expect(listRejectedFiles().length).toBe(0);
+  });
+
+  // Root ignores file modes, so the chmod-000 setup cannot produce EACCES there.
+  const isRoot = process.getuid?.() === 0;
+
+  it.skipIf(isRoot)('throws an actionable error on EACCES instead of treating it as corruption', () => {
+    const statePath = path.join(mockTmpDir, 'state.json');
+    const original = JSON.stringify(makeCurrentState({ config: { ...makeBaseConfig(), githubUsername: 'keep-me' } }));
+    fs.writeFileSync(statePath, original, { mode: 0o600 });
+    fs.chmodSync(statePath, 0o000);
+
+    try {
+      expect(() => loadState()).toThrow(/permission/i);
+      expect(() => loadState()).toThrow(/state\.json/);
+
+      // No forensic copy, no clobbering — the file is untouched.
+      expect(listRejectedFiles().length).toBe(0);
+    } finally {
+      fs.chmodSync(statePath, 0o600);
+    }
+
+    // After restoring permissions the original content is intact.
+    expect(fs.readFileSync(statePath, 'utf8')).toBe(original);
+  });
+
+  it.skipIf(isRoot)('StateManager construction propagates the permission error', () => {
+    const statePath = path.join(mockTmpDir, 'state.json');
+    fs.writeFileSync(statePath, JSON.stringify(makeCurrentState()), { mode: 0o600 });
+    fs.chmodSync(statePath, 0o000);
+
+    try {
+      expect(() => new StateManager(false)).toThrow(/permission/i);
+    } finally {
+      fs.chmodSync(statePath, 0o600);
+    }
+  });
+});
+
+// ── StateManager.getLoadRecovery (#1371) ────────────────────────────────────
+describe('StateManager.getLoadRecovery', () => {
+  beforeEach(() => {
+    mockTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oss-state-loadrecovery-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(mockTmpDir, { recursive: true, force: true });
+    mockTmpDir = '';
+  });
+
+  it('returns recovery info after constructing against a corrupt state file', () => {
+    const statePath = path.join(mockTmpDir, 'state.json');
+    fs.writeFileSync(statePath, 'CORRUPT', { mode: 0o600 });
+
+    const sm = new StateManager(false);
+    const recovery = sm.getLoadRecovery();
+
+    expect(recovery).not.toBeNull();
+    expect(recovery?.source).toBe('fresh');
+    expect(recovery?.rejectedPath).toMatch(/state\.json\.rejected-\d+$/);
+    expect(recovery?.reason).toContain('Error loading state');
+  });
+
+  it('returns null against a healthy state file', () => {
+    const statePath = path.join(mockTmpDir, 'state.json');
+    fs.writeFileSync(statePath, JSON.stringify(makeCurrentState()), { mode: 0o600 });
+
+    const sm = new StateManager(false);
+    expect(sm.getLoadRecovery()).toBeNull();
+  });
+
+  it('returns null in in-memory mode', () => {
+    const sm = new StateManager(true);
+    expect(sm.getLoadRecovery()).toBeNull();
   });
 });
 

--- a/packages/core/src/core/state-persistence.ts
+++ b/packages/core/src/core/state-persistence.ts
@@ -359,12 +359,60 @@ function tryRestoreFromBackup(): AgentState | null {
 }
 
 /**
+ * Details about a recovery that happened during {@link loadState} — set when
+ * the main state file was unreadable (JSON parse error) or structurally
+ * invalid (Zod rejection) and the loader fell back to a backup or fresh state.
+ * Surfaced through StateManager.getLoadRecovery() so commands can include the
+ * event in structured output instead of only stderr warn() lines (#1371).
+ */
+export interface LoadRecoveryInfo {
+  /** Where the loaded state came from after the original file was rejected. */
+  source: 'backup' | 'fresh';
+  /** Path of the preserved `.rejected-<ts>` copy, or null if preservation failed. */
+  rejectedPath: string | null;
+  /** Short summary of why the original state file was rejected. */
+  reason: string;
+}
+
+/**
+ * Result of {@link loadState}: the loaded state, the file's mtime for change
+ * detection, and (only when the main file was rejected) recovery details.
+ */
+export interface LoadStateResult {
+  state: AgentState;
+  mtimeMs: number;
+  recovery?: LoadRecoveryInfo;
+}
+
+/**
+ * Copy a rejected state file to `<statePath>.rejected-<timestamp>` so the
+ * user can recover data manually before the file is overwritten by a backup
+ * restore or fresh state. Returns the preserved path, or null if the copy
+ * failed (preservation is best-effort and never throws).
+ */
+function preserveRejectedStateFile(statePath: string): string | null {
+  try {
+    const rejectedPath = statePath + '.rejected-' + Date.now();
+    fs.copyFileSync(statePath, rejectedPath);
+    warn(MODULE, `Previous state preserved at: ${rejectedPath}`);
+    return rejectedPath;
+  } catch (preserveErr) {
+    warn(MODULE, `Could not preserve rejected state file: ${errorMessage(preserveErr)}`);
+    return null;
+  }
+}
+
+/**
  * Load state from file, or create initial state if none exists.
  * If the main state file is corrupted, attempts to restore from the most recent backup.
  * Performs migration from legacy ./data/ location if needed.
- * @returns Object with the loaded state and the file's mtime (for change detection).
+ * @returns Object with the loaded state, the file's mtime (for change detection),
+ *   and recovery details when the main file was rejected.
+ * @throws Error when the state file exists but cannot be read due to a
+ *   permission error (EACCES/EPERM) — that is an environment problem, not
+ *   corruption, so restore-or-fresh would mask it and risk clobbering data.
  */
-export function loadState(): { state: AgentState; mtimeMs: number } {
+export function loadState(): LoadStateResult {
   // Try to migrate from legacy location first
   migrateFromLegacyLocation();
 
@@ -402,21 +450,17 @@ export function loadState(): { state: AgentState; mtimeMs: number } {
         debug(MODULE, 'Full validation errors:', parsed.error.issues);
 
         // Preserve the rejected state file so the user can recover
-        try {
-          const rejectedPath = statePath + '.rejected-' + Date.now();
-          fs.copyFileSync(statePath, rejectedPath);
-          warn(MODULE, `Previous state preserved at: ${rejectedPath}`);
-        } catch (preserveErr) {
-          warn(MODULE, `Could not preserve rejected state file: ${errorMessage(preserveErr)}`);
-        }
+        const rejectedPath = preserveRejectedStateFile(statePath);
+        const reason = `Invalid state file structure: ${summary}`;
 
         const restoredState = tryRestoreFromBackup();
         if (restoredState) {
           const mtimeMs = safeGetMtimeMs(statePath);
-          return { state: restoredState, mtimeMs };
+          const recovery: LoadRecoveryInfo = { source: 'backup', rejectedPath, reason };
+          return { state: restoredState, mtimeMs, recovery };
         }
         warn(MODULE, 'No valid backup found, starting fresh');
-        return { state: createFreshState(), mtimeMs: 0 };
+        return { state: createFreshState(), mtimeMs: 0, recovery: { source: 'fresh', rejectedPath, reason } };
       }
 
       // Save migrated state only after validation succeeds
@@ -458,14 +502,37 @@ export function loadState(): { state: AgentState; mtimeMs: number } {
       return { state, mtimeMs };
     }
   } catch (error) {
+    // Permission errors are environmental, not corruption — restoring a
+    // backup or starting fresh here would mask the real problem and risk
+    // clobbering a perfectly valid state file. Rethrow with guidance (#1371).
+    const code = (error as NodeJS.ErrnoException | null)?.code;
+    if (code === 'EACCES' || code === 'EPERM') {
+      throw new Error(
+        `Permission denied reading state file (${code}): ${errorMessage(error)}. ` +
+          'This is an environment problem, not state corruption. Check the ownership and ' +
+          'permissions of ~/.oss-autopilot/state.json (e.g. run `ls -l ~/.oss-autopilot/state.json` ' +
+          'and fix with chown/chmod), then retry.',
+        { cause: error },
+      );
+    }
+
     warn(MODULE, 'Error loading state:', error);
     warn(MODULE, 'Attempting to restore from backup...');
+
+    // Preserve the unparseable file before tryRestoreFromBackup() overwrites
+    // it with restored backup contents (#1371). Only attempt when the file
+    // actually exists — the error may have come from elsewhere in the block.
+    const rejectedPath = fs.existsSync(statePath) ? preserveRejectedStateFile(statePath) : null;
+    const reason = `Error loading state: ${errorMessage(error)}`;
+
     const restoredState = tryRestoreFromBackup();
     if (restoredState) {
       const mtimeMs = safeGetMtimeMs(statePath);
-      return { state: restoredState, mtimeMs };
+      const recovery: LoadRecoveryInfo = { source: 'backup', rejectedPath, reason };
+      return { state: restoredState, mtimeMs, recovery };
     }
     warn(MODULE, 'No valid backup found, starting fresh');
+    return { state: createFreshState(), mtimeMs: 0, recovery: { source: 'fresh', rejectedPath, reason } };
   }
 
   debug(MODULE, 'No existing state found, initializing...');
@@ -578,7 +645,7 @@ export function saveState(state: Readonly<AgentState>, expectedMtimeMs: number |
  * Uses mtime comparison (single statSync call) to avoid unnecessary JSON parsing.
  * @returns The new state and mtime if reloaded, or null if no change detected.
  */
-export function reloadStateIfChanged(lastLoadedMtimeMs: number): { state: AgentState; mtimeMs: number } | null {
+export function reloadStateIfChanged(lastLoadedMtimeMs: number): LoadStateResult | null {
   try {
     const statePath = getStatePath();
     const currentMtimeMs = fs.statSync(statePath).mtimeMs;

--- a/packages/core/src/core/state.ts
+++ b/packages/core/src/core/state.ts
@@ -24,6 +24,7 @@ import {
   reloadStateIfChanged,
   createFreshState,
   atomicWriteFileSync,
+  type LoadRecoveryInfo,
 } from './state-persistence.js';
 import * as repoScoring from './repo-score-manager.js';
 import type { Stats } from './repo-score-manager.js';
@@ -35,6 +36,7 @@ import { getStatePath, getStateCachePath } from './paths.js';
 import { parseGitHubUrl } from './urls.js';
 
 export { acquireLock, releaseLock, atomicWriteFileSync } from './state-persistence.js';
+export type { LoadRecoveryInfo } from './state-persistence.js';
 export type { Stats } from './repo-score-manager.js';
 
 const MODULE = 'state';
@@ -132,6 +134,7 @@ export class StateManager {
   protected gistDegraded = false;
   private staleness: StalenessInfo | null = null;
   private lastSuccessfulRefreshAt: string | null = null;
+  private loadRecovery: LoadRecoveryInfo | null = null;
 
   /**
    * Create a new StateManager instance.
@@ -147,6 +150,7 @@ export class StateManager {
       const result = loadState();
       this.state = result.state;
       this.lastLoadedMtimeMs = result.mtimeMs;
+      this.loadRecovery = result.recovery ?? null;
       this.tryReconcilePRCounts();
     }
   }
@@ -169,9 +173,11 @@ export class StateManager {
     // Check if local state exists for migration
     const statePath = getStatePath();
     let result;
+    let localRecovery: LoadRecoveryInfo | null = null;
     if (fs.existsSync(statePath)) {
       // Existing user: load local state and migrate it into the Gist if no Gist exists yet.
       const localStateResult = loadState();
+      localRecovery = localStateResult.recovery ?? null;
       const migrationResult = await gistStore.bootstrapWithMigration(localStateResult.state);
       result = migrationResult;
 
@@ -198,6 +204,9 @@ export class StateManager {
     manager.gistStore = gistStore;
     manager.gistDegraded = result.degraded ?? false;
     manager.inMemoryOnly = false; // re-enable persistence
+    // Surface a recovery that happened while loading the local file for Gist
+    // migration — the recovered (or fresh) state is what got migrated.
+    manager.loadRecovery = localRecovery;
 
     // Seed the staleness marker if bootstrap fell back to the local cache —
     // a `daily` running on a cron right after this start needs to know.
@@ -420,8 +429,19 @@ export class StateManager {
     if (!result) return false;
     this.state = result.state;
     this.lastLoadedMtimeMs = result.mtimeMs;
+    this.loadRecovery = result.recovery ?? null;
     this.tryReconcilePRCounts();
     return true;
+  }
+
+  /**
+   * Recovery details from the most recent state load, or null when the last
+   * load read the state file cleanly (or no load from disk has happened,
+   * e.g. in-memory mode). Set when loadState() fell back to a backup or
+   * fresh state because the main file was corrupt or invalid (#1371).
+   */
+  getLoadRecovery(): LoadRecoveryInfo | null {
+    return this.loadRecovery;
   }
 
   /**

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -110,7 +110,8 @@ export type DailyWarningPhase =
   | 'partition'
   | 'dismiss-filter'
   | 'gist-checkpoint'
-  | 'gist-staleness';
+  | 'gist-staleness'
+  | 'state-load';
 
 /**
  * A single non-fatal failure surfaced from the `daily` pipeline. Unlike
@@ -285,6 +286,7 @@ const DailyWarningPhaseSchema = z.enum([
   'dismiss-filter',
   'gist-checkpoint',
   'gist-staleness',
+  'state-load',
 ]);
 
 const DailyWarningSchema = z.object({


### PR DESCRIPTION
## Summary

Closes the asymmetry between the two state-corruption paths and makes recovery visible:

- **Forensics**: shared `preserveRejectedStateFile()` now runs before `tryRestoreFromBackup()` overwrites the corrupt file in BOTH the Zod-invalid and JSON.parse paths (previously parse corruption destroyed the evidence). Skipped cleanly when the file is genuinely absent.
- **Permission errors are not corruption**: EACCES/EPERM on initial load rethrow with an actionable message (ownership/permissions of `~/.oss-autopilot/state.json`) instead of silently restoring or starting fresh. `reloadStateIfChanged` keeps its documented degrade-to-in-memory semantics; every initial-load caller routes to `handleCommandError`/MCP `wrapTool` (verified across CLI, dashboard serve, MCP).
- **Visibility**: `loadState` returns `recovery: { source: 'backup' | 'fresh', rejectedPath, reason }` on all four recovery returns; `StateManager.getLoadRecovery()` exposes it; `daily` records a `state-load` warning into `warnings[]` (surfaced before Phase 1 so it survives early failures). `state-load` added to the `DailyWarningPhase` union and zod enum.

## Test plan

- [x] Parse-corrupt + valid backup: backup restored, `.rejected-<ts>` contains the corrupt bytes verbatim, `recovery.source === 'backup'`
- [x] Parse-corrupt + no valid backup: fresh state, forensics preserved, `recovery.source === 'fresh'`
- [x] EACCES: throws with the actionable message, no `.rejected` noise, original file untouched (skipIf root)
- [x] Zod path: existing tests unchanged, new recovery-field assertion
- [x] `getLoadRecovery()`: set after corrupt-file construction, null for healthy/in-memory
- [x] Full core suite green (2628); core + mcp tsc clean; eslint 0 errors; prettier clean

Closes #1371