### PR TITLE
fix(repo-vet): stop reporting rate-limited release fetches as no releases

### DIFF
--- a/packages/core/src/commands/compliance-score.test.ts
+++ b/packages/core/src/commands/compliance-score.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for the compliance-score command wrapper (#1373).
+ *
+ * Focused on the test-infrastructure probe's error-handling contract:
+ * rate-limit/auth errors abort the run; other failures keep the
+ * undefined-neutral fallback but emit a warning so "couldn't look" is
+ * distinguishable from "no test dir" in logs.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../core/index.js', () => ({
+  getOctokit: vi.fn(),
+  requireGitHubToken: vi.fn(),
+}));
+
+vi.mock('../core/logger.js', () => ({
+  warn: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+}));
+
+import { requireGitHubToken, getOctokit } from '../core/index.js';
+import { warn } from '../core/logger.js';
+import { runComplianceScore } from './compliance-score.js';
+
+const mockRequireGitHubToken = vi.mocked(requireGitHubToken);
+const mockGetOctokit = vi.mocked(getOctokit);
+const mockWarn = vi.mocked(warn);
+
+const TEST_PR_URL = 'https://github.com/owner/repo/pull/42';
+
+function httpError(status: number, message: string): Error {
+  return Object.assign(new Error(message), { status });
+}
+
+/** Minimal octokit stub; override `getContent` (the test-dir probe) per test. */
+function buildOctokit(getContent: ReturnType<typeof vi.fn>) {
+  return {
+    pulls: {
+      get: vi.fn().mockResolvedValue({
+        data: {
+          title: 'fix: something',
+          body: '',
+          head: { ref: 'fix/something' },
+          changed_files: 1,
+          additions: 5,
+          deletions: 2,
+        },
+      }),
+      listFiles: vi.fn().mockResolvedValue({ data: [{ filename: 'src/index.ts' }] }),
+    },
+    repos: { getContent },
+  } as unknown as ReturnType<typeof getOctokit>;
+}
+
+describe('runComplianceScore test-infrastructure probe (#1373)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireGitHubToken.mockReturnValue('ghp_test123');
+  });
+
+  it('rethrows a 429 rate-limit error from the test-dir probe', async () => {
+    mockGetOctokit.mockReturnValue(buildOctokit(vi.fn().mockRejectedValue(httpError(429, 'API rate limit exceeded'))));
+
+    await expect(runComplianceScore({ prUrl: TEST_PR_URL })).rejects.toThrow('API rate limit exceeded');
+  });
+
+  it('keeps undefined-neutral fallback on other probe errors and warns', async () => {
+    mockGetOctokit.mockReturnValue(buildOctokit(vi.fn().mockRejectedValue(httpError(500, 'Internal Server Error'))));
+
+    const result = await runComplianceScore({ prUrl: TEST_PR_URL });
+
+    // The run still completes and scores; the probe failure is only logged.
+    expect(result.pr.repo).toBe('owner/repo');
+    expect(typeof result.score).toBe('number');
+    expect(mockWarn).toHaveBeenCalledWith(
+      'compliance-score',
+      expect.stringMatching(/test-infrastructure probe for owner\/repo failed/),
+    );
+  });
+});

--- a/packages/core/src/commands/compliance-score.ts
+++ b/packages/core/src/commands/compliance-score.ts
@@ -12,7 +12,8 @@
  */
 
 import { getOctokit, requireGitHubToken } from '../core/index.js';
-import { ValidationError } from '../core/errors.js';
+import { ValidationError, errorMessage, isRateLimitOrAuthError } from '../core/errors.js';
+import { warn } from '../core/logger.js';
 import { validateUrl, PR_URL_PATTERN, validateGitHubUrl } from './validation.js';
 import { parseGitHubUrl } from '../core/urls.js';
 import {
@@ -23,11 +24,16 @@ import {
 } from '../core/compliance-score.js';
 import type { ComplianceScoreOutput } from '../formatters/json.js';
 
+const MODULE = 'compliance-score';
+
 /**
  * Detect whether the target repo has visible test infrastructure. Looks
  * for the well-known directories at the repo root in a single contents
- * call. Failures (missing repo, rate limit, network) surface as
- * `undefined` so the score function falls back to its strict default.
+ * call. Non-fatal failures (missing repo, 5xx, network) surface as
+ * `undefined` so the score function falls back to its strict default,
+ * with a warning so "couldn't look" is distinguishable from "no test
+ * dir" in logs. Rate-limit / auth errors propagate — swallowing them
+ * here would mask a systemic problem affecting the whole run (#1373).
  */
 async function detectTestInfrastructure(
   octokit: ReturnType<typeof getOctokit>,
@@ -39,7 +45,9 @@ async function detectTestInfrastructure(
     if (!Array.isArray(data)) return undefined;
     const TEST_DIR = /^(?:tests?|__tests__|spec)$/i;
     return data.some((entry) => entry.type === 'dir' && TEST_DIR.test(entry.name));
-  } catch {
+  } catch (err) {
+    if (isRateLimitOrAuthError(err)) throw err;
+    warn(MODULE, `test-infrastructure probe for ${owner}/${repo} failed: ${errorMessage(err)}`);
     return undefined;
   }
 }

--- a/packages/core/src/commands/repo-vet.test.ts
+++ b/packages/core/src/commands/repo-vet.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for the repo-vet command wrapper (#1373).
+ *
+ * Focused on the listReleases error-handling contract: rate-limit/auth
+ * errors abort the run, 404 is genuine absence, and 5xx/network errors
+ * degrade gracefully with the `releasesIncomplete` flag set so a vet
+ * batch under throttling can't silently report "no releases".
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../core/index.js', () => ({
+  getOctokit: vi.fn(),
+  requireGitHubToken: vi.fn(),
+}));
+
+vi.mock('../core/logger.js', () => ({
+  warn: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+}));
+
+import { requireGitHubToken, getOctokit } from '../core/index.js';
+import { warn } from '../core/logger.js';
+import { runRepoVet } from './repo-vet.js';
+import { RepoVetOutputSchema } from '../formatters/json.js';
+
+const mockRequireGitHubToken = vi.mocked(requireGitHubToken);
+const mockGetOctokit = vi.mocked(getOctokit);
+const mockWarn = vi.mocked(warn);
+
+function httpError(status: number, message: string): Error {
+  return Object.assign(new Error(message), { status });
+}
+
+const NOT_FOUND = httpError(404, 'Not Found');
+
+/** Minimal octokit stub; override `listReleases` per test. */
+function buildOctokit(listReleases: ReturnType<typeof vi.fn>) {
+  return {
+    repos: {
+      get: vi.fn().mockResolvedValue({
+        data: {
+          stargazers_count: 100,
+          forks_count: 10,
+          open_issues_count: 5,
+          subscribers_count: 8,
+          archived: false,
+          pushed_at: '2026-06-01T00:00:00Z',
+          created_at: '2020-01-01T00:00:00Z',
+        },
+      }),
+      listCommits: vi.fn().mockResolvedValue({ data: [] }),
+      listReleases,
+      // Community-health probes: every path 404s (definitive absence) so
+      // the release-path behavior under test is isolated.
+      getContent: vi.fn().mockRejectedValue(NOT_FOUND),
+    },
+    pulls: {
+      list: vi.fn().mockResolvedValue({ data: [] }),
+    },
+  } as unknown as ReturnType<typeof getOctokit>;
+}
+
+describe('runRepoVet release handling (#1373)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireGitHubToken.mockReturnValue('ghp_test123');
+  });
+
+  it('rethrows a 429 rate-limit error from listReleases', async () => {
+    mockGetOctokit.mockReturnValue(buildOctokit(vi.fn().mockRejectedValue(httpError(429, 'API rate limit exceeded'))));
+
+    await expect(runRepoVet({ repo: 'owner/repo' })).rejects.toThrow('API rate limit exceeded');
+  });
+
+  it('rethrows a 403 rate-limit error from listReleases', async () => {
+    mockGetOctokit.mockReturnValue(
+      buildOctokit(vi.fn().mockRejectedValue(httpError(403, 'API rate limit exceeded for installation'))),
+    );
+
+    await expect(runRepoVet({ repo: 'owner/repo' })).rejects.toThrow('rate limit');
+  });
+
+  it('treats a 404 as genuine absence: null lastReleaseISO, no incomplete flag, no warning', async () => {
+    mockGetOctokit.mockReturnValue(buildOctokit(vi.fn().mockRejectedValue(NOT_FOUND)));
+
+    const result = await runRepoVet({ repo: 'owner/repo' });
+
+    expect(result.maintainerActivity.lastReleaseISO).toBeNull();
+    expect(result.maintainerActivity.releasesIncomplete).toBe(false);
+    const warnMessages = mockWarn.mock.calls.map((c) => String(c[1]));
+    expect(warnMessages.some((m) => m.includes('release'))).toBe(false);
+  });
+
+  it('degrades gracefully on a 500: releasesIncomplete true, null lastReleaseISO, warning emitted', async () => {
+    mockGetOctokit.mockReturnValue(buildOctokit(vi.fn().mockRejectedValue(httpError(500, 'Internal Server Error'))));
+
+    const result = await runRepoVet({ repo: 'owner/repo' });
+
+    expect(result.maintainerActivity.lastReleaseISO).toBeNull();
+    expect(result.maintainerActivity.releasesIncomplete).toBe(true);
+    expect(mockWarn).toHaveBeenCalledWith(
+      'repo-vet',
+      expect.stringMatching(/owner\/repo.*release-recency signal is incomplete/),
+    );
+  });
+
+  it('degrades gracefully on a network error (no HTTP status)', async () => {
+    mockGetOctokit.mockReturnValue(
+      buildOctokit(vi.fn().mockRejectedValue(Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' }))),
+    );
+
+    const result = await runRepoVet({ repo: 'owner/repo' });
+
+    expect(result.maintainerActivity.releasesIncomplete).toBe(true);
+    expect(result.maintainerActivity.lastReleaseISO).toBeNull();
+  });
+
+  it('reports releasesIncomplete false on success and the flag survives the JSON schema', async () => {
+    mockGetOctokit.mockReturnValue(
+      buildOctokit(
+        vi
+          .fn()
+          .mockResolvedValue({ data: [{ published_at: '2026-05-01T00:00:00Z', created_at: '2026-05-01T00:00:00Z' }] }),
+      ),
+    );
+
+    const result = await runRepoVet({ repo: 'owner/repo' });
+
+    expect(result.maintainerActivity.lastReleaseISO).toBe('2026-05-01T00:00:00Z');
+    expect(result.maintainerActivity.releasesIncomplete).toBe(false);
+
+    // formatJson validates with RepoVetOutputSchema, which strips unknown
+    // keys — guard against the flag silently vanishing from --json output.
+    const parsed = RepoVetOutputSchema.parse(result);
+    expect(parsed.maintainerActivity.releasesIncomplete).toBe(false);
+  });
+});

--- a/packages/core/src/commands/repo-vet.ts
+++ b/packages/core/src/commands/repo-vet.ts
@@ -12,7 +12,7 @@
  */
 
 import { getOctokit, requireGitHubToken } from '../core/index.js';
-import { errorMessage } from '../core/errors.js';
+import { errorMessage, getHttpStatusCode, isRateLimitOrAuthError } from '../core/errors.js';
 import { warn } from '../core/logger.js';
 import { validateRepoIdentifier } from './validation.js';
 import { computeRepoVet, type RepoVetInput, type RepoVetResult } from '../core/repo-vet.js';
@@ -200,13 +200,32 @@ export async function runRepoVet(options: { repo: string }): Promise<RepoVetOutp
   const octokit = getOctokit(token);
   const now = new Date();
 
+  // Tracks the release-list analogue of communityHealth's `incomplete`:
+  // set when the listReleases call failed for a reason that does NOT
+  // prove absence (5xx, network), so the caller can distinguish "repo
+  // has no releases" from "couldn't check releases" (#1373).
+  let releasesIncomplete = false;
+
   const [repoMetaResp, closedPRsResp, commitsResp, releasesResp, communityHealthSummary] = await Promise.all([
     octokit.repos.get({ owner, repo }),
     octokit.pulls.list({ owner, repo, state: 'closed', sort: 'updated', direction: 'desc', per_page: 100 }),
     octokit.repos.listCommits({ owner, repo, per_page: 100 }),
-    octokit.repos
-      .listReleases({ owner, repo, per_page: 1 })
-      .catch(() => ({ data: [] as Array<{ published_at: string | null; created_at: string }> })),
+    octokit.repos.listReleases({ owner, repo, per_page: 1 }).catch((err: unknown) => {
+      // Rate-limit / auth failures must abort the run, same as every
+      // sibling fetch — under throttling, a blanket catch here would
+      // silently report "no releases" for the whole vet batch (#1373).
+      if (isRateLimitOrAuthError(err)) throw err;
+      const empty = { data: [] as Array<{ published_at: string | null; created_at: string }> };
+      // 404 is a definitive "nothing there" — genuine absence, not a gap.
+      if (getHttpStatusCode(err) === 404) return empty;
+      // 5xx / network: absence is unproven. Degrade gracefully but flag it.
+      releasesIncomplete = true;
+      warn(
+        MODULE,
+        `release listing for ${owner}/${repo} failed: ${errorMessage(err)} — release-recency signal is incomplete`,
+      );
+      return empty;
+    }),
     checkCommunityHealth(octokit, owner, repo),
   ]);
 
@@ -246,15 +265,20 @@ export async function runRepoVet(options: { repo: string }): Promise<RepoVetOutp
 
   // The core function names its metadata object `repo`. Rename to `repoMeta`
   // at the CLI boundary so the top-level slug doesn't collide with it.
-  // Also overlay the community-health `incomplete` flag the wrapper
-  // tracks (the core type doesn't carry it because computeRepoVet is
-  // pure — only the wrapper makes the API calls that can fail mid-probe).
-  const { repo: repoMeta, communityHealth, ...rest } = result;
+  // Also overlay the community-health `incomplete` and the
+  // `releasesIncomplete` flags the wrapper tracks (the core type doesn't
+  // carry them because computeRepoVet is pure — only the wrapper makes
+  // the API calls that can fail mid-probe). Like communityHealth's
+  // incomplete flag, releasesIncomplete deliberately does NOT alter the
+  // rubric score — the score reflects the fetched signals as-is and the
+  // flag tells consumers which signal was unverified.
+  const { repo: repoMeta, communityHealth, maintainerActivity, ...rest } = result;
   return {
     repoSlug: options.repo,
     fetchedAt: now.toISOString(),
     repoMeta,
     communityHealth: { ...communityHealth, incomplete: communityHealthSummary.incomplete },
+    maintainerActivity: { ...maintainerActivity, releasesIncomplete },
     ...rest,
   };
 }

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -797,6 +797,13 @@ export const RepoVetOutputSchema = z.object({
     lastCommitISO: z.string().nullable(),
     contributorsLast90d: z.number().int().nonnegative(),
     lastReleaseISO: z.string().nullable(),
+    /**
+     * True when the release listing failed for a non-404 reason (5xx,
+     * network), so a `null` lastReleaseISO means "could not determine"
+     * rather than "confirmed no releases". The release-list analogue of
+     * `communityHealth.incomplete` (#1373).
+     */
+    releasesIncomplete: z.boolean().optional(),
   }),
   communityHealth: z.object({
     contributing: z.boolean(),


### PR DESCRIPTION
## Summary

`listReleases(...).catch(() => ({data: []}))` converted every error into 'repo has no releases', which under rate limiting poisoned the release-recency signal for an entire vet batch. Now:

- rate-limit/auth errors rethrow and abort the run (identical to the unguarded `repos.get`/`pulls.list`/`listCommits` in the same `Promise.all`, so no asymmetry)
- 404 remains genuine absence (no flag, no warn)
- 5xx/network set `maintainerActivity.releasesIncomplete` + a warn, mirroring `communityHealth.incomplete` (always emitted, added to `RepoVetOutputSchema` so `--json` keeps it)
- scoring deliberately unchanged: the flag marks the null `lastReleaseISO` as unverified rather than mutating the score, consistent with how `communityHealth.incomplete` works
- sibling fix: `compliance-score`'s test-dir probe rethrows rate-limit/auth and warns on other failures, keeping undefined-neutral semantics

## Test plan

- [x] New command-level suites: 429 and rate-limit-403 reject; 404 = absence with no warn; 500 and ECONNRESET = flag true + warn; success = flag false and survives `RepoVetOutputSchema.parse`; compliance-score 429 rejects / 500 stays neutral with warn
- [x] Full core suite green (2636); core + mcp tsc clean; eslint 0 errors; prettier clean

Closes #1373