### PR TITLE
ci(dashboard): add coverage script and thresholds so the repo gate stops skipping it

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -11,7 +11,8 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint src --ext .ts,.tsx",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "exports": {
     "./package.json": "./package.json"
@@ -36,6 +37,7 @@
     "@preact/preset-vite": "^2.10.5",
     "@testing-library/preact": "^3.2.4",
     "@types/canvas-confetti": "^1.9.0",
+    "@vitest/coverage-v8": "^4.1.8",
     "jsdom": "^29.1.1",
     "typescript": "^5.9.3",
     "vite": "^8.0.16",

--- a/packages/dashboard/vitest.config.ts
+++ b/packages/dashboard/vitest.config.ts
@@ -7,5 +7,23 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./vitest.setup.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'text-summary'],
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: ['src/**/*.test.{ts,tsx}', 'src/index.tsx', 'src/test-helpers.ts', 'src/types.ts'],
+      // CI's coverage step runs `pnpm -r run test:coverage`, which silently
+      // skips packages without the script — this package had neither the
+      // script nor thresholds, so its coverage was unmeasured and ungated
+      // while core/mcp-server were enforced (#1375).
+      // Floors set ~5-10 points under measured reality (89.9/81.9/85.3/90.6
+      // at introduction) so the gate catches decay without being brittle.
+      thresholds: {
+        statements: 80,
+        branches: 75,
+        functions: 80,
+        lines: 80,
+      },
+    },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       '@types/canvas-confetti':
         specifier: ^1.9.0
         version: 1.9.0
+      '@vitest/coverage-v8':
+        specifier: ^4.1.8
+        version: 4.1.8(vitest@4.1.8)
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1


### PR DESCRIPTION
## Summary

`pnpm -r run test:coverage` (CI's coverage step) silently skips packages without the script. Dashboard had no `test:coverage` script and no coverage config, so its coverage could decay to zero with CI green while core and mcp-server were gated.

- Adds `test:coverage` + `@vitest/coverage-v8` (peer-matched to vitest 4.1.8) to the dashboard package
- Coverage block mirrors core's shape (v8, text reporters); includes `src/**/*.{ts,tsx}`, excludes tests, bootstrap (`index.tsx`), test helpers, and the type-only module
- Floors 80/75/80/80, set 5-10 points under measured reality (89.9 stmt / 81.9 branch / 85.3 func / 90.6 lines)
- Stale untracked `coverage/` artifact dirs (March/April runs referencing since-deleted files) were deleted locally; they were gitignored, so no repo diff

## Test plan

- [x] `vitest run --coverage` passes the gate under Node 22 (22 files, 256 tests, all thresholds met)
- [x] Reviewed: exclude list verified file-by-file, dep peer-matched, no CI double-run introduced
- [x] prettier + eslint clean

Closes #1375