### PR TITLE
fix(agents): align frontmatter tool grants with body instructions

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -19,18 +19,30 @@ advisory; both hard gates must be kept narrow.
 |---|---|
 | `mcp__plugin_oss-autopilot_oss-autopilot__post` | Writes a public GitHub comment. All posting goes through the `draft-review-post` skill so the user reviews the exact body before it ships. |
 | `mcp__plugin_oss-autopilot_oss-autopilot__claim` | Posts a claim comment on an issue. Same reason as `post`. |
-| `mcp__plugin_oss-autopilot_oss-autopilot__move`, `__track`, `__dismiss`, `__shelve` (and their inverses) | Mutate `~/.oss-autopilot/state.json`. Agents that need to influence state should produce a recommendation for the parent workflow to act on, not mutate directly. |
+| `mcp__plugin_oss-autopilot_oss-autopilot__move`, `__dismiss`, `__shelve` (and their inverses) | Mutate `~/.oss-autopilot/state.json`. Agents that need to influence state should produce a recommendation for the parent workflow to act on, not mutate directly. |
 | `mcp__linkedin__*`, `mcp__claude_ai_Gmail__*`, `mcp__puppeteer__*`, `mcp__plugin_serena_serena__execute_shell_command` | Out of scope — OSS Autopilot agents should never need cross-channel messaging, arbitrary web control, or sandbox escape. |
 
 ## Per-agent allowlists
 
-- `contribution-strategist` — `Bash`, `Read` (read-only analyzer; emits a markdown report in chat).
-- `issue-scout` — `Bash`, `Read`, `mcp__...__search`, `mcp__...__vet`, `mcp__...__vet-list`.
-- `pr-compliance-checker` — `Bash`, `Read`, `Glob`, `Grep`, `mcp__...__read`, `mcp__...__comments`.
-- `pr-health-checker` — `Bash`, `Read`, `Grep`, `mcp__...__read`, `mcp__...__comments`.
-- `pr-responder` — `Bash`, `Read`, `Write`, `Glob`, `Grep`, `mcp__...__read`, `mcp__...__comments` (keeps `Write` for drafting response files under `/tmp`; posting still routes through `draft-review-post`).
-- `pre-commit-reviewer` — `Bash`, `Read`, `Glob`, `Grep` (local git/diff review only).
-- `repo-evaluator` — `Bash`, `Read`, `Glob`, `mcp__...__vet`.
+Every agent additionally grants `AskUserQuestion` — each one runs a mandatory
+user-confirmation gate (see "AskUserQuestion Validation Protocol" in
+`workflows/reference.md`), so the tool is part of the design, not a
+convenience. The frontmatter `tools:` line in each agent file is the source of
+truth; `packages/core/src/agents-contract.test.ts` enforces that every tool an
+agent's body instructs with is actually granted (#1377).
+
+- `contribution-strategist` — `Bash`, `Read`, `mcp__...__strategy` (read-only analyzer; emits a markdown report in chat).
+- `issue-scout` — `Bash`, `Read`, `mcp__...__search`, `mcp__...__vet`, `mcp__...__vet-list`, `mcp__...__status`.
+- `pr-compliance-checker` — `Bash`, `Read`, `Glob`, `Grep`, `mcp__...__track`, `mcp__...__comments`, `mcp__...__compliance-score`, `mcp__...__guidelines-get`.
+- `pr-health-checker` — `Bash`, `Read`, `Grep`, `mcp__...__track`, `mcp__...__comments`. (Reads config via the CLI `config --json`; the MCP config tool is a get-or-set mutator and is deliberately not granted.)
+- `pr-responder` — `Bash`, `Read`, `Edit`, `Write`, `Glob`, `Grep`, `mcp__...__track`, `mcp__...__comments`, `mcp__...__guidelines-get` (keeps `Write` for drafting response files under `/tmp` and `Edit` for formatting reverts; posting still routes through `draft-review-post`).
+- `pre-commit-reviewer` — `Bash`, `Read`, `Glob`, `Grep`, `mcp__...__guidelines-get` (local git/diff review).
+- `repo-evaluator` — `Bash`, `Read`, `Glob`, `mcp__...__vet`, `mcp__...__repo-vet`, `mcp__...__status`.
+
+`track` here is the v2 read-only snapshot tool — it no longer mutates
+`~/.oss-autopilot/state.json`, which is why it can be granted despite the
+state-mutation exclusion above (the mutating tools — `move`, `dismiss`,
+`shelve` and inverses — remain excluded).
 
 ## Adding a tool
 

--- a/agents/contribution-strategist.md
+++ b/agents/contribution-strategist.md
@@ -23,7 +23,7 @@ User wants strategic guidance on where to contribute.
 purpose: Strategic OSS advice
 model: haiku
 color: magenta
-tools: ["Bash", "Read"]
+tools: ["Bash", "Read", "AskUserQuestion", "mcp__plugin_oss-autopilot_oss-autopilot__strategy"]
 ---
 
 > **Input validation:** See "AskUserQuestion Validation Protocol" in `workflows/reference.md`.

--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -23,7 +23,7 @@ User wants to evaluate a specific issue before investing time.
 purpose: Find and vet new issues
 model: sonnet
 color: green
-tools: ["Bash", "Read", "mcp__plugin_oss-autopilot_oss-autopilot__search", "mcp__plugin_oss-autopilot_oss-autopilot__vet", "mcp__plugin_oss-autopilot_oss-autopilot__vet-list"]
+tools: ["Bash", "Read", "AskUserQuestion", "mcp__plugin_oss-autopilot_oss-autopilot__search", "mcp__plugin_oss-autopilot_oss-autopilot__vet", "mcp__plugin_oss-autopilot_oss-autopilot__vet-list", "mcp__plugin_oss-autopilot_oss-autopilot__status"]
 ---
 
 > **Input validation:** See "AskUserQuestion Validation Protocol" in `workflows/reference.md`.

--- a/agents/pr-compliance-checker.md
+++ b/agents/pr-compliance-checker.md
@@ -23,7 +23,7 @@ User explicitly wants a PR compliance check.
 purpose: Validate PRs against opensource.guide
 model: haiku
 color: orange
-tools: ["Bash", "Read", "Glob", "Grep", "mcp__plugin_oss-autopilot_oss-autopilot__track", "mcp__plugin_oss-autopilot_oss-autopilot__comments", "mcp__plugin_oss-autopilot_oss-autopilot__compliance-score", "mcp__plugin_oss-autopilot_oss-autopilot__guidelines-get"]
+tools: ["Bash", "Read", "Glob", "Grep", "AskUserQuestion", "mcp__plugin_oss-autopilot_oss-autopilot__track", "mcp__plugin_oss-autopilot_oss-autopilot__comments", "mcp__plugin_oss-autopilot_oss-autopilot__compliance-score", "mcp__plugin_oss-autopilot_oss-autopilot__guidelines-get"]
 ---
 
 > **Input validation:** See "AskUserQuestion Validation Protocol" in `workflows/reference.md`.

--- a/agents/pr-health-checker.md
+++ b/agents/pr-health-checker.md
@@ -23,7 +23,7 @@ Rebase checking and execution is a core health check responsibility.
 purpose: Diagnose CI failures, merge conflicts, rebase status
 model: sonnet
 color: yellow
-tools: ["Bash", "Read", "Grep", "mcp__plugin_oss-autopilot_oss-autopilot__track", "mcp__plugin_oss-autopilot_oss-autopilot__comments"]
+tools: ["Bash", "Read", "Grep", "AskUserQuestion", "mcp__plugin_oss-autopilot_oss-autopilot__track", "mcp__plugin_oss-autopilot_oss-autopilot__comments"]
 ---
 
 > **Input validation:** See "AskUserQuestion Validation Protocol" in `workflows/reference.md`.
@@ -86,7 +86,7 @@ Use the MCP / CLI / gh path above.
 
 ### 2. Check Branch Freshness
 
-**Locate the local clone** by reading the user's configured scan paths. The default (`~/Documents/oss/<repo>`, `~/dev/<repo>`) is a fallback, NOT a fixed assumption. Check `config.localRepoScanPaths` first via `mcp__plugin_oss-autopilot_oss-autopilot__config` (or `cli.bundle.cjs config --json`); a user with clones in `~/code/` or `~/projects/` configures those paths once and avoids the silent-fallback footgun (#1247 Improvement 1).
+**Locate the local clone** by reading the user's configured scan paths. The default (`~/Documents/oss/<repo>`, `~/dev/<repo>`) is a fallback, NOT a fixed assumption. Check `config.localRepoScanPaths` first via `cli.bundle.cjs config --json` (the read-only CLI path below; the MCP config tool is a get-or-set mutator and is deliberately not granted to this agent); a user with clones in `~/code/` or `~/projects/` configures those paths once and avoids the silent-fallback footgun (#1247 Improvement 1).
 
 ```bash
 # Read configured scan paths (run once per session):
@@ -137,16 +137,15 @@ gh pr view NUMBER --repo OWNER/REPO --json reviews,reviewDecision
 
 `gh api repos/OWNER/REPO/issues/NUMBER/comments --jq '.[] | select(.user.login | endswith("[bot]")) | {author: .user.login, body: .body}'` — look for `changeset-bot` (missing changeset), `CLAassistant` (unsigned CLA), `codecov` (informational), `copilot` (automated suggestions).
 
-### 6. Cross-Repo Fan-Out and Same-Repo Coordination
+### 6. Multi-Repo Batches and Same-Repo Coordination
 
-PRs in **different repos** are independent — git working directories don't overlap, no shared lock state. When the caller hands you multiple PRs to check, group them by repo and **dispatch one parallel sub-agent per repo** (`Task` tool with this same agent-name, one call per repo, sent in a single message so they run concurrently). Wait for all to complete, then merge their reports for the user (#1272 Improvement 4).
+When the caller hands you multiple PRs to check, group them by repo and process the repos **one at a time** — run the full per-repo procedure (freshness, CI categorization, reviews, required files) for every PR in one repo before moving to the next, then merge the per-repo findings into a single report for the user. PRs in **different repos** are independent (git working directories don't overlap, no shared lock state), so the per-repo grouping is about keeping each repo's git operations coherent, not about shared state across repos.
 
-Within a **single repo**, handle multiple PRs **sequentially** in the same sub-agent — branches share the working tree, so checking two PR branches concurrently corrupts git state.
+Within a **single repo**, handle multiple PRs **sequentially** — branches share the working tree, so checking two PR branches concurrently corrupts git state.
 
 The split:
-- N PRs across M repos → M parallel sub-agents, each handling its repo's PRs sequentially.
-- Best speedup when PRs are spread across many repos (the common case for active contributors).
-- No speedup when all PRs are in one repo — the sequential rule still applies.
+- N PRs across M repos → process repo by repo, each repo's PRs handled sequentially.
+- Never interleave git operations for two PRs in the same repo.
 
 ## Output Format
 

--- a/agents/pr-responder.md
+++ b/agents/pr-responder.md
@@ -23,7 +23,7 @@ User needs help understanding and responding to a specific code review comment.
 purpose: Draft responses to maintainer feedback
 model: sonnet
 color: cyan
-tools: ["Bash", "Read", "Write", "Glob", "Grep", "mcp__plugin_oss-autopilot_oss-autopilot__track", "mcp__plugin_oss-autopilot_oss-autopilot__comments", "mcp__plugin_oss-autopilot_oss-autopilot__guidelines-get"]
+tools: ["Bash", "Read", "Edit", "Write", "Glob", "Grep", "AskUserQuestion", "mcp__plugin_oss-autopilot_oss-autopilot__track", "mcp__plugin_oss-autopilot_oss-autopilot__comments", "mcp__plugin_oss-autopilot_oss-autopilot__guidelines-get"]
 ---
 
 > **Input validation:** See "AskUserQuestion Validation Protocol" in `workflows/reference.md`.
@@ -93,7 +93,7 @@ When `daily --json` data is available, use the `isFromMaintainer` boolean on `ne
 | `approval_with_nit` | "LGTM, just fix X" | NO — fix and push |
 | `formatting_complaint` | "revert the formatting", "keep the diff focused" | NO — revert + brief ack only if they sound frustrated |
 
-When `formatting_complaint` is detected: identify formatting-only hunks via `git diff`, revert via `git checkout -- {file}` (for files where all changes are formatting) or the Edit tool (for mixed files), verify only functional changes remain, push.
+When `formatting_complaint` is detected: identify formatting-only hunks via `git diff`, revert via `git checkout -- {file}` (for files where all changes are formatting) or the `Edit` tool (for mixed files), verify only functional changes remain, push.
 
 ### 3. Comment Decision Logic (post-push)
 

--- a/agents/pre-commit-reviewer.md
+++ b/agents/pre-commit-reviewer.md
@@ -23,7 +23,7 @@ Post-conflict resolution is a critical moment where bugs can be introduced. Revi
 purpose: Review code changes before committing (fallback for PR review toolkit)
 model: sonnet
 color: red
-tools: ["Bash", "Read", "Glob", "Grep", "mcp__plugin_oss-autopilot_oss-autopilot__guidelines-get"]
+tools: ["Bash", "Read", "Glob", "Grep", "AskUserQuestion", "mcp__plugin_oss-autopilot_oss-autopilot__guidelines-get"]
 ---
 
 > **Input validation:** See "AskUserQuestion Validation Protocol" in `workflows/reference.md`.
@@ -43,9 +43,7 @@ Phase 1 ──► Phase 2 ──► Phase 3 ──► Phase 5 ──► Phase 6
 
 **Phase 1 must complete first** (every other phase reads its outputs). After Phase 1 is done, fan out: run **Phase 2, Phase 2.5, Phase 4, and Phase 4.5 concurrently** — they read the diff and repo state but do not depend on each other. **Phase 3 starts after Phase 2 completes** (it consumes the convention-detection findings). **Phase 5 waits on all of 2 / 2.5 / 3 / 4 / 4.5** before assembling the report. Phase 6 is sequential after Phase 5.
 
-Concrete tactics for the fan-out:
-- When invoked through the `Task` tool with sub-agent dispatch available: dispatch Phase 2, 2.5, 4, and 4.5 as parallel sub-tasks in a single message.
-- When constrained to inline reasoning: interleave the four phases in your context window rather than walking them strictly in order — read the diff once, then form findings for all four categories before producing Phase 5.
+Concrete tactic for the fan-out: interleave the four phases within this session rather than walking them strictly in order — read the diff once, then form findings for all four categories (conventions, security, tests, docs) before producing Phase 5.
 
 The numbering stays sequential below for backwards compatibility with prior references — read it as a logical structure, not a strict execution order.
 

--- a/agents/repo-evaluator.md
+++ b/agents/repo-evaluator.md
@@ -23,7 +23,7 @@ User wants to predict maintainer engagement before contributing.
 purpose: Analyze repository health
 model: sonnet
 color: blue
-tools: ["Bash", "Read", "Glob", "mcp__plugin_oss-autopilot_oss-autopilot__vet", "mcp__plugin_oss-autopilot_oss-autopilot__repo-vet"]
+tools: ["Bash", "Read", "Glob", "AskUserQuestion", "mcp__plugin_oss-autopilot_oss-autopilot__vet", "mcp__plugin_oss-autopilot_oss-autopilot__repo-vet", "mcp__plugin_oss-autopilot_oss-autopilot__status"]
 ---
 
 > **Input validation:** See "AskUserQuestion Validation Protocol" in `workflows/reference.md`.

--- a/packages/core/src/agents-contract.test.ts
+++ b/packages/core/src/agents-contract.test.ts
@@ -378,6 +378,68 @@ function validateInvocation(inv: CliInvocation, topLevel: Map<string, CommandInf
   return errors;
 }
 
+// ── Agent frontmatter tool grants ────────────────────────────────────────
+
+interface AgentDoc {
+  /** Path relative to the repo root. */
+  file: string;
+  /** Parsed frontmatter `tools:` allowlist; null when the agent declares no
+   * `tools:` key (unrestricted — every tool is implicitly granted). */
+  tools: Set<string> | null;
+  /** Markdown body (everything after the closing frontmatter fence). */
+  body: string;
+}
+
+function listAgentFiles(): string[] {
+  const abs = path.join(REPO_ROOT, 'agents');
+  return fs
+    .readdirSync(abs)
+    .filter((name) => name.endsWith('.md') && name !== 'README.md')
+    .map((name) => path.join(abs, name));
+}
+
+function parseAgentDoc(file: string): AgentDoc {
+  const rel = path.relative(REPO_ROOT, file);
+  const lines = fs.readFileSync(file, 'utf8').split('\n');
+  if (lines[0] !== '---') throw new Error(`${rel}: expected frontmatter to open on line 1`);
+  const end = lines.indexOf('---', 1);
+  if (end === -1) throw new Error(`${rel}: unterminated frontmatter`);
+  const toolsLine = lines.slice(1, end).find((l) => l.startsWith('tools:'));
+  let tools: Set<string> | null = null;
+  if (toolsLine) {
+    // Every agent declares tools as an inline JSON-style array of strings.
+    const parsed: unknown = JSON.parse(toolsLine.slice('tools:'.length).trim());
+    if (!Array.isArray(parsed) || !parsed.every((t): t is string => typeof t === 'string')) {
+      throw new Error(`${rel}: \`tools:\` frontmatter is not an array of strings`);
+    }
+    tools = new Set(parsed);
+  }
+  return { file: rel, tools, body: lines.slice(end + 1).join('\n') };
+}
+
+/**
+ * Built-in (non-MCP) tools detectable in agent bodies with near-zero
+ * false-positive risk (#1377):
+ *
+ *   - `AskUserQuestion` is a globally unique tool name; a word-boundary match
+ *     is always an instruction to use the tool.
+ *   - The phrase "Task tool" (name optionally backticked) only appears when
+ *     instructing sub-agent dispatch. Note: Claude Code subagents cannot nest
+ *     Task dispatch, so the usual fix is rewriting the instruction, not
+ *     granting the tool.
+ *   - `Edit` / `Write` are matched ONLY backtick-delimited; the bare words are
+ *     everyday English in review/drafting prose ("write a comment").
+ *
+ * If a pattern proves noisy on a future corpus, narrow the pattern — do not
+ * add a per-agent allowlist.
+ */
+const BUILTIN_TOOL_PATTERNS: ReadonlyArray<{ tool: string; pattern: RegExp }> = [
+  { tool: 'AskUserQuestion', pattern: /\bAskUserQuestion\b/ },
+  { tool: 'Task', pattern: /(?:`Task`|\bTask) tool\b/ },
+  { tool: 'Edit', pattern: /`Edit`/ },
+  { tool: 'Write', pattern: /`Write`/ },
+];
+
 // ── Tests ────────────────────────────────────────────────────────────────
 
 describe('REGISTERED_MCP_TOOLS mirror ↔ tools.ts source parity (#1374)', () => {
@@ -443,6 +505,60 @@ describe('prompt markdown ↔ CLI registry parity (#1245, #1376)', () => {
       offenders,
       `Prompt files invoke unregistered CLI commands/subcommands/flags — fix the ` +
         `markdown or register them in packages/core/src/cli-registry.ts:\n  ` +
+        offenders.join('\n  '),
+    ).toEqual([]);
+  });
+});
+
+describe('agent body tool references ↔ frontmatter tool grants (#1377)', () => {
+  const agents = listAgentFiles().map(parseAgentDoc);
+
+  it('sanity: the agent corpus parsed and carries restricted tool lists', () => {
+    expect(agents.length).toBeGreaterThan(5);
+    // Agents without a `tools:` key are unrestricted and skipped below by
+    // design; today every agent restricts its toolset, so a count of 0 here
+    // would mean the frontmatter parser broke.
+    expect(agents.filter((a) => a.tools !== null).length).toBeGreaterThan(5);
+  });
+
+  it('every MCP tool referenced in an agent body is granted in that agent frontmatter', () => {
+    const offenders: string[] = [];
+    for (const agent of agents) {
+      if (!agent.tools) continue; // unrestricted: everything is granted
+      const referenced = new Set([...agent.body.matchAll(MCP_TOOL_PATTERN)].map((m) => m[0]));
+      for (const tool of referenced) {
+        if (!agent.tools.has(tool)) {
+          offenders.push(`${agent.file} → body references ${tool} but frontmatter \`tools:\` does not grant it`);
+        }
+      }
+    }
+    expect(
+      offenders,
+      `Agent bodies instruct workflows with MCP tools their frontmatter never grants — ` +
+        `the instruction silently cannot execute. Add the tool to the agent's \`tools:\` ` +
+        `list or rewrite the instruction:\n  ` +
+        offenders.join('\n  '),
+    ).toEqual([]);
+  });
+
+  it('every built-in tool an agent body instructs with is granted in that agent frontmatter', () => {
+    const offenders: string[] = [];
+    for (const agent of agents) {
+      if (!agent.tools) continue; // unrestricted: everything is granted
+      for (const { tool, pattern } of BUILTIN_TOOL_PATTERNS) {
+        if (pattern.test(agent.body) && !agent.tools.has(tool)) {
+          offenders.push(
+            `${agent.file} → body instructs with ${tool} (matched ${String(pattern)}) ` +
+              `but frontmatter \`tools:\` does not grant it`,
+          );
+        }
+      }
+    }
+    expect(
+      offenders,
+      `Agent bodies instruct workflows with built-in tools their frontmatter never grants — ` +
+        `grant the tool or rewrite the instruction (for Task: subagents cannot nest Task ` +
+        `dispatch, so rewrite to sequential processing instead of granting):\n  ` +
         offenders.join('\n  '),
     ).toEqual([]);
   });


### PR DESCRIPTION
## Summary

Agents restricted their toolset via `tools:` frontmatter while their bodies instructed workflows requiring ungranted tools, so those instructions silently could not execute (#1377).

- **AskUserQuestion granted to all 7 agents**: every agent's confirmation-gate protocol is load-bearing design; none could fire
- **Read-only MCP grants where the body is designed around them**: `strategy` (contribution-strategist), `status` (issue-scout, repo-evaluator); `Edit` for pr-responder (body mention backticked so the gate pins it)
- **Impossible instructions rewritten instead of granted**: pr-health-checker's parallel Task-dispatch section → sequential per-repo processing (checklist and same-repo git-corruption rule intact); pre-commit-reviewer's Task sub-dispatch tactic → in-session phase interleaving
- **Deliberate non-grant**: pr-health-checker only *reads* config and the MCP config tool is a get-or-set mutator; the read-only CLI path covers it (noted in body + README)
- **agents/README.md allowlist table synced**: cited a never-existent `__read` tool and misstated `track` as excluded
- **New gate** in agents-contract.test.ts: per-agent MCP body refs ⊆ frontmatter grants, plus precise built-in checks (AskUserQuestion word boundary, 'Task tool' phrase, backticked Edit/Write); no allowlists

## Test plan

- [x] Gate revert-verified: removing grants or restoring the Task instruction produces exactly the expected offenders, restored to green
- [x] Full core suite green (2639); tsc clean; eslint 0 errors; prettier clean
- [x] generate-reference.mjs reports up-to-date (purpose lines untouched); CI frontmatter greps reproduced locally

Closes #1377