### PR TITLE
docs: fix README/ARCHITECTURE/ROADMAP drift and gate the counts in CI

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,7 +30,9 @@ The plugin layer consists of markdown files that Claude Code discovers and execu
 | `oss-search.md` | `/oss-search` | Issue discovery with multi-strategy search |
 | `oss-help.md` | `/oss-help` | Quick reference card for commands, agents, and workflows |
 | `oss-dashboard.md` | `/oss-dashboard` | Open the interactive SPA dashboard in the browser |
+| `oss-guidelines.md` | `/oss-guidelines` | View / edit / reset per-repo contribution guidelines stored by extract-learnings |
 | `pr-ready.md` | `/pr-ready` | Run the pre-commit review loop and signal when the branch is ready to push |
+| `plan-ready.md` | `/plan-ready` | Run a review-and-critique convergence loop on an implementation plan before code is written |
 
 Commands invoke the CLI via bash (`node packages/core/dist/cli.bundle.cjs <subcommand> --json`), parse the JSON response, and present results to the user through Claude Code's conversational interface.
 
@@ -49,6 +51,8 @@ Workflows contain delegated logic that commands read on demand. They are not sta
 | `dispatch-review.md` | On request | Dispatch a multi-specialist review of the current branch |
 | `dormant-pr-follow-up.md` | Dormant PR detected | Polite, escalating follow-up cadence with maintainers |
 | `extract-learnings.md` | After PR merge | Distill maintainer feedback into per-repo guidelines via `guidelines fetch-corpus` + extract-learnings prompt (#867) |
+| `edit-guidelines.md` | `/oss-guidelines` edit action | Manual edit path for stored per-repo guidelines (no corpus fetch or extraction) (#1283) |
+| `plan-review.md` | `/plan-ready` | Plan-phase review convergence loop — catches design problems before code exists (#1249) |
 | `reference.md` | Always loaded | Shared conventions and formatting rules |
 
 ### Agents (`agents/`)
@@ -85,7 +89,7 @@ A Commander program that loads command definitions from `cli-registry.ts`. Each 
 Key design:
 - **Lazy loading** — only the invoked command's module is evaluated (dynamic `import()` inside action handlers).
 - **Async token fetch** — the `preAction` hook fetches the GitHub token without blocking.
-- **`localOnly` registry flag** — 20 commands that skip the `preAction` GitHub token check. Note: some (like `startup`) still make GitHub API calls but handle auth internally, returning structured errors instead of calling `process.exit`.
+- **`localOnly` registry flag** — 25 commands that skip the `preAction` GitHub token check. Note: some (like `startup`) still make GitHub API calls but handle auth internally, returning structured errors instead of calling `process.exit`.
 
 ### JSON Contract
 
@@ -109,6 +113,9 @@ Debug and warning output goes to stderr via the logger, so it never contaminates
 | `startup` | `startup.ts` | Combined auth + setup + daily + dashboard (single CLI call) |
 | `daily` | `daily.ts` | Fetch all open PRs, compute digest, generate dashboard |
 | `search` | `search.ts` | Multi-strategy issue discovery |
+| `features` | `features.ts` | Feature-scoped opportunities in repos with 3+ merged PRs, split into quick-wins / bigger-bets |
+| `strategy` | `strategy.ts` | On-demand contribution-strategy snapshot from local state (#1243) |
+| `state` | `state-cmd.ts` | Manage state persistence: `--show`, `--sync`, `--unlink` (local/Gist) |
 | `track` | `track.ts` | Fetch PR metadata for inspection (no longer persists; `untrack` removed in v4 / #1133) |
 | `status` | `status.ts` | Show contribution stats from local state |
 | `config` | `config.ts` | Read/write user configuration |
@@ -116,10 +123,15 @@ Debug and warning output goes to stderr via the logger, so it never contaminates
 | `setup` / `checkSetup` | `setup.ts` | First-run setup and setup verification |
 | `vet` | `vet.ts` | Vet a single issue for claimability |
 | `vet-list` | `vet-list.ts` | Re-vet all issues in a curated issue list |
+| `repo-vet` | `repo-vet.ts` | Compute repo health rubric (1–10 score + verdict) for `owner/repo` (#1271) |
+| `compliance-score` | `compliance-score.ts` | Score a PR against opensource.guide best practices (#1245) |
+| `skip-add` | `skip-add.ts` | Append an issue URL to the skipped-issues file (idempotent) |
+| `list-move-tier` | `list-move-tier.ts` | Move an issue between Pursue / Maybe / Skip sections of a curated list (#1107) |
+| `list-mark-done` | `list-mark-done.ts` | Mark a curated-list issue line done with strikethrough + Done sub-bullet (#1299) |
 | `dashboard serve` | `dashboard.ts` | Launch interactive SPA dashboard (with `dashboard-data.ts`, `dashboard-lifecycle.ts`, `dashboard-process.ts`, `dashboard-server.ts`) |
 | `move` | `move.ts` | Transition a PR between states: attention, waiting, shelved, auto |
-| `shelve` / `unshelve` | `move.ts` (aliases) | Exclude PRs from capacity and actionable items |
-| `override` / `clear-override` | `move.ts` (aliases) | Backward-compatible status override commands |
+| `shelve` / `unshelve` | `shelve.ts` | Exclude/re-include PRs from capacity and actionable items (independent commands emitting `ShelveOutput`, see #1037) |
+| `override` / `clear-override` | `move.ts` (wrappers around `runMove`) | Backward-compatible status override commands |
 | `dismiss` / `undismiss` | `dismiss.ts` | Dismiss issue reply notifications (auto-resurfaces on new activity) |
 | `comments` / `post` / `claim` | `comments.ts` | Track issue conversations, post comments, claim issues |
 | `local-repos` | `local-repos.ts` | Scan for locally cloned repos |

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ A Preact SPA that auto-opens when you run `/oss` — PR management, charts, cont
 ```
 ┌──────────────────────────────────────────────────┐
 │  Claude Code Plugin Layer                        │
-│  /oss, /oss-search, /setup-oss, /oss-help        │
+│  8 slash commands (/oss, /oss-search, …)         │
 │  7 specialized agents, contribution skills       │
 ├──────────────────────────────────────────────────┤
 │                                                  │
@@ -74,7 +74,7 @@ A Preact SPA that auto-opens when you run `/oss` — PR management, charts, cont
 │  │ @oss-auto-   │  │ @oss-autopilot/dashboard │  │
 │  │ pilot/mcp    │  │ Preact + Vite             │  │
 │  │              │  │ PR management, charts,    │  │
-│  │ 27 tools     │  │ actions                   │  │
+│  │ 30 tools     │  │ actions                   │  │
 │  │ 6 resources  │  │                           │  │
 │  │ 4 prompts    │  │                           │  │
 │  └──────┬───────┘  └────────────┬─────────────┘  │
@@ -92,7 +92,7 @@ A Preact SPA that auto-opens when you run `/oss` — PR management, charts, cont
 
 **Three deployment models** — Claude Code plugin with 7 specialized agents, MCP server for Cursor/Claude Desktop/Codex/Windsurf, and a standalone CLI with `--json` structured output. Same core, different interfaces.
 
-**Deterministic core, AI orchestration layer** — Critical logic (PR status classification, CI failure analysis, state management) lives in tested TypeScript, not in prompts. The CLI returns structured JSON that agents consume. CI failures are categorized into a deterministic taxonomy — actionable vs. fork limitation vs. auth gate vs. infrastructure — rather than asking an LLM each time. 2,700+ tests validate the core independently of any LLM.
+**Deterministic core, AI orchestration layer** — Critical logic (PR status classification, CI failure analysis, state management) lives in tested TypeScript, not in prompts. The CLI returns structured JSON that agents consume. CI failures are categorized into a deterministic taxonomy — actionable vs. fork limitation vs. auth gate vs. infrastructure — rather than asking an LLM each time. 2,600+ tests validate the core independently of any LLM.
 
 **Production-grade GitHub API integration** — ETag-based HTTP caching, automatic rate limit backoff with retries, bounded concurrency pools, and paginated fetching. Handles the full complexity of fork-based contribution workflows: correct diff ranges, squash commit counting, and `--head` flag handling for cross-fork PRs. Designed to run daily without hitting API limits.
 
@@ -104,7 +104,7 @@ A Preact SPA that auto-opens when you run `/oss` — PR management, charts, cont
 
 **Security discipline** — State files written with `0o600` permissions, data directory created with `0o700`. Concurrent state write protection prevents corruption from parallel runs. Runtime schema validation via Zod on every state file read. XSS prevention tested. Input validation hardened across CLI arguments and API responses.
 
-**Automated release pipeline** — Conventional commits feed into release-please for automatic versioning and changelogs, with CI/CD publishing to npm on merge. 189+ changelog versions across both packages (core v0.1.0 → v3.2.0, mcp through v5.1.0) since the first release in January 2025.
+**Automated release pipeline** — Conventional commits feed into release-please for automatic versioning and changelogs, with CI/CD publishing to npm on merge. 200+ changelog versions across both packages (core v0.1.0 through v3.x, mcp through v5.x) since the first release in January 2025.
 
 Every feature in the list above was driven by real usage — capacity warnings came from overcommitting, "skip comment when code speaks for itself" came from over-commenting, diminishing returns detection came from spending too long searching. The tool is shaped by the contributions it manages.
 
@@ -143,7 +143,7 @@ Then add to your MCP client config:
 }
 ```
 
-The MCP server exposes 27 tools, 6 resources, and 4 prompts — the full OSS Autopilot feature set.
+The MCP server exposes 30 tools, 6 resources, and 4 prompts — the full OSS Autopilot feature set.
 
 </details>
 
@@ -179,7 +179,7 @@ All commands return `{ success, data, error, timestamp }` with `--json`.
 2. Work through critical issues (CI failures, maintainer comments, conflicts)
 3. Done for now
 
-**Commands:** `/oss` (daily check), `/oss-search` (find issues), `/setup-oss` (configure), `/oss-help` (reference)
+**Commands:** `/oss` (daily check), `/oss-search` (find issues), `/oss-dashboard` (interactive dashboard), `/oss-guidelines` (per-repo guidelines), `/pr-ready` (pre-push review loop), `/plan-ready` (plan review loop), `/setup-oss` (configure), `/oss-help` (reference)
 
 ---
 
@@ -187,8 +187,8 @@ All commands return `{ success, data, error, timestamp }` with `--json`.
 
 | Metric | Value |
 |--------|-------|
-| Releases | 189+ changelog versions (spanning core v0.1 through current v3.x; mcp through current v5.x) |
-| Tests | 2,700+ across 120+ files |
+| Releases | 200+ changelog versions (spanning core v0.1 through current v3.x; mcp through current v5.x) |
+| Tests | 3,000+ across 120+ files |
 | Issues + PRs | 1,200+ |
 | Time span | Jan 2025 → present |
 | npm packages | 3 |
@@ -320,7 +320,7 @@ pnpm run bundle              # Rebuild CLI bundle (esbuild)
 **Project structure:**
 
 ```
-├── commands/                    # Plugin slash commands (/oss, /oss-search, /setup-oss, /oss-help)
+├── commands/                    # 8 plugin slash commands (/oss, /oss-search, /pr-ready, …)
 ├── agents/                      # 7 specialized agents (PR responder, issue scout, etc.)
 ├── skills/                      # Contribution best practices
 ├── workflows/                   # Delegated logic loaded by commands on demand

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,30 +1,44 @@
 # Roadmap
 
+> **Maintenance note:** This file is hand-maintained. When an item under Now/Next closes on GitHub, move it to the Shipped section and pull the next item up from the open backlog.
+
 This roadmap reflects the current development priorities for oss-autopilot. Items are derived from [open issues](https://github.com/costajohnt/oss-autopilot/issues) and may shift as the project evolves.
 
 Have an idea? Open a [Discussion](https://github.com/costajohnt/oss-autopilot/discussions) or file an issue.
 
 ## Now (next 1-2 weeks)
 
-- [ ] Unify skip-list persistence — the `.md` file and `state.skippedIssues` currently drift ([#992](https://github.com/costajohnt/oss-autopilot/issues/992))
-- [ ] Audit-v2 follow-up sprint — close the 15 issues filed by the 2026-04-19 audit ([#993](https://github.com/costajohnt/oss-autopilot/issues/993)–[#1007](https://github.com/costajohnt/oss-autopilot/issues/1007))
+- [ ] Fix preAction bootstrap errors surfacing as unhandled rejections (`parse` vs `parseAsync`) ([#1386](https://github.com/costajohnt/oss-autopilot/issues/1386))
+- [ ] Stop three more catch sites from swallowing rate-limit errors into degraded results ([#1391](https://github.com/costajohnt/oss-autopilot/issues/1391))
+- [ ] Reconcile dashboard `needs_addressing` count with CLI `actionableIssues` — two independent classifiers diverge ([#1352](https://github.com/costajohnt/oss-autopilot/issues/1352))
+- [ ] Fix issue-scout hallucinating `Open` state and conflating cross-referenced PRs with closing PRs ([#1353](https://github.com/costajohnt/oss-autopilot/issues/1353))
+- [ ] Exclude issues the user already has open PRs for from search results ([#1354](https://github.com/costajohnt/oss-autopilot/issues/1354))
+- [ ] Fix `list-move-tier` silently no-opping on missing entries ([#1355](https://github.com/costajohnt/oss-autopilot/issues/1355))
+- [ ] Bring README/ARCHITECTURE/ROADMAP counts and status back in sync with the code ([#1379](https://github.com/costajohnt/oss-autopilot/issues/1379))
 
 ## Next (next 1-2 months)
 
-- [ ] Runtime `--json` contract enforcement — golden-file tests cover the happy path but nothing validates output shape at runtime ([#965](https://github.com/costajohnt/oss-autopilot/issues/965))
-- [ ] Per-repo learning from merged PR review feedback — adapt pursue-order signals based on what actually gets merged ([#867](https://github.com/costajohnt/oss-autopilot/issues/867))
-- [ ] Contract tests for mutating CLI commands (`track`, `dismiss`, `shelve`, `move`) ([#997](https://github.com/costajohnt/oss-autopilot/issues/997))
+- [ ] Move canonical issue-scout and repo-evaluator agents into oss-scout ([#1241](https://github.com/costajohnt/oss-autopilot/issues/1241))
+- [ ] Bias `oss-scout:issue-scout` searches with `strategy().recommendations`, with a diversity counterweight ([#1244](https://github.com/costajohnt/oss-autopilot/issues/1244))
+- [ ] Add a `guidelines list` subcommand backed by `listGuidelinesRepos()` ([#1393](https://github.com/costajohnt/oss-autopilot/issues/1393))
+- [ ] Surface `ConcurrencyError` in the dashboard as retryable instead of a generic 500 ([#1397](https://github.com/costajohnt/oss-autopilot/issues/1397))
 
 ## Later (no fixed timeline)
 
 - [ ] 1.0 launch content — blog post, social posts, competitive positioning ([#731](https://github.com/costajohnt/oss-autopilot/issues/731))
-- [ ] Dashboard live demo for non-dev audiences — 30-min visual walkthrough ([#940](https://github.com/costajohnt/oss-autopilot/issues/940))
+- [ ] Marketing video with Remotion ([#698](https://github.com/costajohnt/oss-autopilot/issues/698))
 - [ ] Co-maintainer recruitment — the project is currently solo-maintained (bus factor of 1)
 
 Have an idea? Open a [Discussion](https://github.com/costajohnt/oss-autopilot/discussions) or file an issue.
 
-## Completed (Recent)
+## Shipped
 
+- [x] Unify skip-list persistence — the `.md` file and `state.skippedIssues` no longer drift ([#992](https://github.com/costajohnt/oss-autopilot/issues/992))
+- [x] Audit-v2 follow-up sprint — closed the 15 issues filed by the 2026-04-19 audit ([#993](https://github.com/costajohnt/oss-autopilot/issues/993)–[#1007](https://github.com/costajohnt/oss-autopilot/issues/1007))
+- [x] Runtime `--json` contract enforcement — output shapes validated against Zod schemas at runtime ([#965](https://github.com/costajohnt/oss-autopilot/issues/965))
+- [x] Per-repo learning from merged PR review feedback ([#867](https://github.com/costajohnt/oss-autopilot/issues/867))
+- [x] Contract tests for mutating CLI commands (`track`, `dismiss`, `shelve`, `move`) ([#997](https://github.com/costajohnt/oss-autopilot/issues/997))
+- [x] Dashboard live demo for non-dev audiences — 30-min visual walkthrough ([#940](https://github.com/costajohnt/oss-autopilot/issues/940))
 - [x] Decompose `issue-discovery.ts` into focused modules ([#356](https://github.com/costajohnt/oss-autopilot/issues/356))
 - [x] Add SBOM generation to release workflow ([#359](https://github.com/costajohnt/oss-autopilot/issues/359))
 - [x] Add `/oss-help` quick reference command ([#360](https://github.com/costajohnt/oss-autopilot/issues/360))

--- a/commands/oss-help.md
+++ b/commands/oss-help.md
@@ -18,6 +18,9 @@ Print this reference card for the user. Do NOT run any commands — just display
 | `/oss-search` | **Find issues** — multi-strategy search across GitHub for contributable issues matching your language/label preferences |
 | `/setup-oss` | **Configure** — set GitHub username, languages, labels, PR limits, and other preferences |
 | `/oss-dashboard` | **Dashboard** — open the interactive SPA dashboard in your browser |
+| `/oss-guidelines` | **Guidelines** — view, edit, or reset per-repo contribution guidelines learned from past PRs |
+| `/pr-ready` | **Pre-push gate** — run the lint/test/review convergence loop to decide whether the current branch is ready to push |
+| `/plan-ready` | **Plan gate** — run the same review-and-critique convergence loop on an implementation plan before code is written |
 | `/oss-help` | **This card** — quick reference for all plugin capabilities |
 
 ## Agents

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -167,6 +167,10 @@ export default tseslint.config(
       '**/*.test.ts',
       '**/*.test.tsx',
       '**/*.e2e.test.ts',
+      // Test-support helpers shared between test files; excluded from the
+      // package tsconfig (they don't ship), so the type-aware projectService
+      // can't see them — disable type-checked rules like the tests they serve.
+      '**/src/test-lib/**/*.ts',
       '**/vitest.config.ts',
       '**/vitest.setup.ts',
       '**/vite.config.ts',

--- a/packages/core/src/agents-contract.test.ts
+++ b/packages/core/src/agents-contract.test.ts
@@ -34,6 +34,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { Command, type Option } from 'commander';
 import { commands } from './cli-registry.js';
+import { parseRegisteredTools } from './test-lib/registered-mcp-tools.js';
 
 const REPO_ROOT = path.resolve(__dirname, '../../..');
 
@@ -84,8 +85,8 @@ const REGISTERED_MCP_TOOLS = new Set([
   'guidelines-fetch-corpus',
 ]);
 
-const MCP_TOOLS_SOURCE = path.join(REPO_ROOT, 'packages/mcp-server/src/tools.ts');
-const REGISTER_TOOL_PATTERN = /registerTool\(\s*'([a-z][a-z0-9-]*)'/g;
+// Shared with docs-contract.test.ts via test-lib so the two parsers cannot
+// drift apart (#1374 mirror-drift class).
 
 // ── Markdown corpus ──────────────────────────────────────────────────────
 
@@ -449,8 +450,7 @@ describe('REGISTERED_MCP_TOOLS mirror ↔ tools.ts source parity (#1374)', () =>
     // false-failed the parity tests below. Parse the registrations out of
     // the source file (a file read, not a cross-package import) so drift
     // in either direction fails CI.
-    const source = fs.readFileSync(MCP_TOOLS_SOURCE, 'utf8');
-    const registered = [...source.matchAll(REGISTER_TOOL_PATTERN)].map((m) => m[1]).toSorted();
+    const registered = parseRegisteredTools().toSorted();
     expect(registered.length).toBeGreaterThan(0);
     expect([...REGISTERED_MCP_TOOLS].toSorted()).toEqual(registered);
   });

--- a/packages/core/src/docs-contract.test.ts
+++ b/packages/core/src/docs-contract.test.ts
@@ -1,0 +1,120 @@
+/**
+ * CI gate: the top-level docs (README.md, ARCHITECTURE.md) must not drift
+ * from the implementation (#1379).
+ *
+ * The 2026-06 audit found README claiming 27 MCP tools (actual: 30) and
+ * listing 4 slash commands (actual: 8), and ARCHITECTURE's command table
+ * missing /plan-ready and /oss-guidelines. These greps are cheap and keep
+ * the docs honest:
+ *
+ *   - README's slash-command list (the `**Commands:**` line) and every
+ *     "N slash commands" count must match the files in `commands/`.
+ *   - README's "N tools" claims must match the `registerTool()` calls in
+ *     `packages/mcp-server/src/tools.ts` (same source-parse approach as
+ *     `agents-contract.test.ts`).
+ *   - ARCHITECTURE's command table must have a row for every
+ *     `commands/*.md` file, and reference no file that does not exist.
+ *
+ * Parsers are tolerant of formatting (whitespace, surrounding prose) but
+ * strict on content (exact name sets, exact counts).
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { parseRegisteredTools } from './test-lib/registered-mcp-tools.js';
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const README = path.join(REPO_ROOT, 'README.md');
+const ARCHITECTURE = path.join(REPO_ROOT, 'ARCHITECTURE.md');
+const COMMANDS_DIR = path.join(REPO_ROOT, 'commands');
+
+/** Slash-command files shipped by the plugin (the source of truth). */
+function listCommandNames(): string[] {
+  return fs
+    .readdirSync(COMMANDS_DIR)
+    .filter((name) => name.endsWith('.md') && name !== 'README.md')
+    .map((name) => name.replace(/\.md$/, ''))
+    .toSorted();
+}
+
+describe('README.md ↔ commands/ parity (#1379)', () => {
+  const commandNames = listCommandNames();
+  const readme = fs.readFileSync(README, 'utf8');
+
+  it('sanity: the commands directory is non-trivial', () => {
+    expect(commandNames.length).toBeGreaterThan(3);
+  });
+
+  it('the `**Commands:**` line lists exactly the files in commands/', () => {
+    const line = readme.split('\n').find((l) => l.startsWith('**Commands:**'));
+    expect(
+      line,
+      'README.md no longer has a `**Commands:**` line — update this test to parse its replacement',
+    ).toBeDefined();
+    const listed = [...(line as string).matchAll(/`\/([a-z][\da-z-]*)`/g)].map((m) => m[1]).toSorted();
+    expect(listed, 'README `**Commands:**` line drifted from commands/*.md — add/remove the command entries').toEqual(
+      commandNames,
+    );
+  });
+
+  it('every "N slash commands" count in the README matches the number of commands/*.md files', () => {
+    const claims = [...readme.matchAll(/(\d+)\s+(?:plugin\s+)?slash commands/gi)].map((m) => Number(m[1]));
+    expect(claims.length, 'README no longer claims a slash-command count — update this test').toBeGreaterThan(0);
+    for (const claim of claims) {
+      expect(claim, `README claims ${claim} slash commands but commands/ has ${commandNames.length}`).toBe(
+        commandNames.length,
+      );
+    }
+  });
+});
+
+describe('README.md ↔ MCP tool registry parity (#1379)', () => {
+  it('every "N tools" count in the README matches the registerTool() calls in tools.ts', () => {
+    const registered = parseRegisteredTools();
+    expect(registered.length).toBeGreaterThan(0);
+
+    const readme = fs.readFileSync(README, 'utf8');
+    // Anchor to MCP-context lines only: a future prose edit like "added 5
+    // tools this release" must not be scooped into this assertion. Both
+    // guarded sites (the architecture-diagram cell and the MCP install
+    // section) live on lines that say "MCP" or use box-drawing characters.
+    const claims = readme
+      .split('\n')
+      .filter((line) => /MCP/i.test(line) || /[│┌└]/.test(line))
+      .flatMap((line) => [...line.matchAll(/(\d+)\s+tools\b/g)].map((m) => Number(m[1])));
+    expect(claims.length, 'README no longer claims an MCP tool count — update this test').toBeGreaterThan(0);
+    for (const claim of claims) {
+      expect(claim, `README claims ${claim} MCP tools but tools.ts registers ${registered.length}`).toBe(
+        registered.length,
+      );
+    }
+  });
+});
+
+describe('ARCHITECTURE.md command table ↔ commands/ parity (#1379)', () => {
+  const commandNames = listCommandNames();
+
+  /** Backticked `*.md` filenames in table rows of the "### Commands" section. */
+  function tableCommandNames(): string[] {
+    const lines = fs.readFileSync(ARCHITECTURE, 'utf8').split('\n');
+    const start = lines.findIndex((l) => /^###\s+Commands\b/.test(l));
+    expect(start, 'ARCHITECTURE.md no longer has a "### Commands" section — update this test').toBeGreaterThan(-1);
+    const names: string[] = [];
+    for (let i = start + 1; i < lines.length && !/^#{1,3}\s/.test(lines[i]); i++) {
+      if (!lines[i].trimStart().startsWith('|')) continue;
+      for (const m of lines[i].matchAll(/`([a-z][\da-z-]*)\.md`/g)) names.push(m[1]);
+    }
+    return names.toSorted();
+  }
+
+  it('the table has a row for every commands/*.md file and references no nonexistent file', () => {
+    const inTable = tableCommandNames();
+    const missing = commandNames.filter((n) => !inTable.includes(n));
+    const stale = inTable.filter((n) => !commandNames.includes(n));
+    expect(missing, `ARCHITECTURE.md command table is missing rows for: ${missing.join(', ')}`).toEqual([]);
+    expect(stale, `ARCHITECTURE.md command table references nonexistent command files: ${stale.join(', ')}`).toEqual(
+      [],
+    );
+  });
+});

--- a/packages/core/src/test-lib/registered-mcp-tools.ts
+++ b/packages/core/src/test-lib/registered-mcp-tools.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared source-parser for the MCP tool registry, used by the repo-contract
+ * tests (agents-contract.test.ts, docs-contract.test.ts).
+ *
+ * One definition instead of per-test copies: duplicated parsers are the
+ * mirror-drift class (#1374) — if tools.ts ever adopts a registration shape
+ * one copy matches and the other doesn't, the divergence is silent. This
+ * module lives under src/test-lib/, which is excluded from the package
+ * build (tsconfig) and from coverage (vitest config); it must never be
+ * imported by production code.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+export const REPO_ROOT = path.resolve(__dirname, '../../../..');
+
+export const MCP_TOOLS_SOURCE = path.join(REPO_ROOT, 'packages/mcp-server/src/tools.ts');
+
+export const REGISTER_TOOL_PATTERN = /registerTool\(\s*'([a-z][\da-z-]*)'/g;
+
+/**
+ * Parse the registered MCP tool names out of the tools.ts source.
+ * Throws (via the caller's assertions) being preferable to returning a
+ * silently-empty list, callers should assert `length > 0`.
+ */
+export function parseRegisteredTools(): string[] {
+  const source = fs.readFileSync(MCP_TOOLS_SOURCE, 'utf8');
+  return [...source.matchAll(REGISTER_TOOL_PATTERN)].map((m) => m[1]);
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -12,5 +12,5 @@
     "skipLibCheck": false
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/*.e2e.test.ts"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/*.e2e.test.ts", "src/test-lib/**"]
 }

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -7,7 +7,14 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'text-summary'],
       include: ['src/**/*.ts'],
-      exclude: ['src/**/*.test.ts', 'src/**/*.e2e.test.ts', 'src/cli.ts', 'src/cli-registry.ts', 'src/**/index.ts'],
+      exclude: [
+        'src/**/*.test.ts',
+        'src/**/*.e2e.test.ts',
+        'src/cli.ts',
+        'src/cli-registry.ts',
+        'src/**/index.ts',
+        'src/test-lib/**',
+      ],
       thresholds: {
         statements: 80,
         branches: 80,


### PR DESCRIPTION
## Summary

Final issue of the audit batch (#1379). Every count re-verified against current code:

- **README**: 27→30 MCP tools (x2), 4→8 slash commands (x3), 189+→200+ changelog versions, exact-version claims → v3.x/v5.x style, '2,700+ tests validate the core' overclaim → 2,600+ (actual 2,669), table → 3,000+ across 120+ files (actual 3,142/128)
- **ARCHITECTURE**: command table completed (all 8 commands), shelve/unshelve corrected from 'aliases' to independent `shelve.ts` commands, localOnly 20→25, 8 missing subcommand rows + 2 workflow rows added
- **ROADMAP**: hand-maintained note added; all closed Now/Next items (`gh`-verified) moved to a Shipped section; Now/Next rebuilt from the 13 actually-open issues; Later keeps the marketing items
- **commands/oss-help.md**: same 4-of-8 drift in its command table, completed
- **Drift guards** (new `docs-contract.test.ts`, 5 tests, revert-verified on three reintroduced drifts): README Commands line ⊆⊇ `commands/`, count claims match the sources (tool counts anchored to MCP-context lines so future prose can't false-trip), ARCHITECTURE table bidirectional. The registerTool parser is extracted to `src/test-lib/` (tsconfig + coverage excluded, test-only imports verified) and shared with agents-contract so the parsers can't drift apart (the #1374 lesson applied to ourselves)

## Test plan

- [x] 11 contract tests green; guards fail on reintroduced drift (27 tools, dropped command, renamed table row), pass after restore
- [x] Full core suite green (2651) including the coverage gate with the test-lib exclusion
- [x] tsc clean; eslint 0 errors; generate-reference.mjs reports no interference

Closes #1379