### PR TITLE
feat(guidelines): add guidelines list subcommand and MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ A Preact SPA that auto-opens when you run `/oss` — PR management, charts, cont
 │  │ @oss-auto-   │  │ @oss-autopilot/dashboard │  │
 │  │ pilot/mcp    │  │ Preact + Vite             │  │
 │  │              │  │ PR management, charts,    │  │
-│  │ 30 tools     │  │ actions                   │  │
+│  │ 31 tools     │  │ actions                   │  │
 │  │ 6 resources  │  │                           │  │
 │  │ 4 prompts    │  │                           │  │
 │  └──────┬───────┘  └────────────┬─────────────┘  │
@@ -143,7 +143,7 @@ Then add to your MCP client config:
 }
 ```
 
-The MCP server exposes 30 tools, 6 resources, and 4 prompts — the full OSS Autopilot feature set.
+The MCP server exposes 31 tools, 6 resources, and 4 prompts — the full OSS Autopilot feature set.
 
 </details>
 

--- a/commands/oss-guidelines.md
+++ b/commands/oss-guidelines.md
@@ -21,14 +21,12 @@ the full extraction.
 
 1. **Resolve the target repo.**
    - If an argument was passed, use it verbatim.
-   - Otherwise, enumerate repos with stored guidelines by listing the
-     MCP `repo-guidelines` resources (`ListMcpResourcesTool` on the
-     oss-autopilot server; each stored repo appears as an
-     `oss://repo/{owner}/{repo}/guidelines` resource) and present the
-     list via `AskUserQuestion`. The CLI has no enumeration subcommand
-     (`guidelines` only supports `view`/`store`/`reset`/`fetch-corpus`,
-     all repo-scoped), so when MCP resources are unavailable, ask the
-     user for the `owner/repo` directly.
+   - Otherwise, enumerate repos with stored guidelines via the
+     `mcp__plugin_oss-autopilot_oss-autopilot__guidelines-list` tool
+     when the MCP server is available, or
+     `cli.bundle.cjs guidelines list --json` otherwise. Both return
+     `{ repos, count, storageMode }`. Present the list via
+     `AskUserQuestion`.
    - If no guidelines exist for any repo, surface a one-line nudge
      toward `extract-learnings` and exit.
 

--- a/packages/core/src/agents-contract.test.ts
+++ b/packages/core/src/agents-contract.test.ts
@@ -79,6 +79,7 @@ const REGISTERED_MCP_TOOLS = new Set([
   'state-show',
   'state-sync',
   'state-unlink',
+  'guidelines-list',
   'guidelines-get',
   'guidelines-store',
   'guidelines-reset',

--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -1616,6 +1616,25 @@ export const commands: CLICommandDef[] = [
         .description('Manage per-repo learning guidelines extracted from PR feedback (#867)');
 
       group
+        .command('list')
+        .description('List repos with stored guidelines (always empty in local mode)')
+        .option('--json', 'Output as JSON')
+        .action(async (options) => {
+          await executeAction(
+            options,
+            async () => (await import('./commands/guidelines.js')).runGuidelinesList(),
+            (data) => {
+              if (data.count === 0) {
+                console.log(`No guidelines stored for any repo (storage: ${data.storageMode}).`);
+              } else {
+                console.log(`${data.count} repo(s) with stored guidelines:`);
+                for (const repo of data.repos) console.log(`  ${repo}`);
+              }
+            },
+          );
+        });
+
+      group
         .command('view')
         .description('Read the per-repo guidelines file (returns null when none exists or in local mode)')
         .requiredOption('--repo <owner/repo>', 'Repository identifier')

--- a/packages/core/src/commands/__golden__/guidelines.list-local.json
+++ b/packages/core/src/commands/__golden__/guidelines.list-local.json
@@ -1,0 +1,5 @@
+{
+  "repos": [],
+  "count": 0,
+  "storageMode": "local-unavailable"
+}

--- a/packages/core/src/commands/__golden__/guidelines.list.json
+++ b/packages/core/src/commands/__golden__/guidelines.list.json
@@ -1,0 +1,8 @@
+{
+  "repos": [
+    "owner/repo-a",
+    "owner/repo-b"
+  ],
+  "count": 2,
+  "storageMode": "gist"
+}

--- a/packages/core/src/commands/guidelines.contract.test.ts
+++ b/packages/core/src/commands/guidelines.contract.test.ts
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   setGuidelines: vi.fn(),
   deleteGuidelines: vi.fn(),
   isGuidelinesAvailable: vi.fn(),
+  listGuidelinesRepos: vi.fn(),
   getMergedPRs: vi.fn(),
   getClosedPRs: vi.fn(),
   markPRCommentsFetched: vi.fn(),
@@ -37,6 +38,7 @@ vi.mock('../core/index.js', async () => {
       setGuidelines: mocks.setGuidelines,
       deleteGuidelines: mocks.deleteGuidelines,
       isGuidelinesAvailable: mocks.isGuidelinesAvailable,
+      listGuidelinesRepos: mocks.listGuidelinesRepos,
       getMergedPRs: mocks.getMergedPRs,
       getClosedPRs: mocks.getClosedPRs,
       markPRCommentsFetched: mocks.markPRCommentsFetched,
@@ -48,7 +50,13 @@ vi.mock('../core/index.js', async () => {
   };
 });
 
-import { runGuidelinesView, runGuidelinesStore, runGuidelinesReset, runFetchCorpus } from './guidelines.js';
+import {
+  runGuidelinesList,
+  runGuidelinesView,
+  runGuidelinesStore,
+  runGuidelinesReset,
+  runFetchCorpus,
+} from './guidelines.js';
 
 describe('guidelines --json contract', () => {
   beforeEach(() => {
@@ -56,6 +64,19 @@ describe('guidelines --json contract', () => {
     mocks.isGuidelinesAvailable.mockReturnValue(true);
     mocks.getMergedPRs.mockReturnValue([]);
     mocks.getClosedPRs.mockReturnValue([]);
+  });
+
+  it('list: stored repos matches the golden shape', async () => {
+    mocks.listGuidelinesRepos.mockReturnValue(['owner/repo-a', 'owner/repo-b']);
+    const result = await runGuidelinesList();
+    await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/guidelines.list.json');
+  });
+
+  it('list: empty in local-unavailable mode matches the golden shape', async () => {
+    mocks.listGuidelinesRepos.mockReturnValue([]);
+    mocks.isGuidelinesAvailable.mockReturnValue(false);
+    const result = await runGuidelinesList();
+    await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/guidelines.list-local.json');
   });
 
   it('view: existing guidelines matches the golden shape', async () => {

--- a/packages/core/src/commands/guidelines.test.ts
+++ b/packages/core/src/commands/guidelines.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   setGuidelines: vi.fn(),
   deleteGuidelines: vi.fn(),
   isGuidelinesAvailable: vi.fn(),
+  listGuidelinesRepos: vi.fn(),
   getMergedPRs: vi.fn(),
   getClosedPRs: vi.fn(),
   markPRCommentsFetched: vi.fn(),
@@ -28,6 +29,7 @@ vi.mock('../core/index.js', async () => {
       setGuidelines: mocks.setGuidelines,
       deleteGuidelines: mocks.deleteGuidelines,
       isGuidelinesAvailable: mocks.isGuidelinesAvailable,
+      listGuidelinesRepos: mocks.listGuidelinesRepos,
       getMergedPRs: mocks.getMergedPRs,
       getClosedPRs: mocks.getClosedPRs,
       markPRCommentsFetched: mocks.markPRCommentsFetched,
@@ -44,12 +46,19 @@ const mockGetGuidelines = mocks.getGuidelines;
 const mockSetGuidelines = mocks.setGuidelines;
 const mockDeleteGuidelines = mocks.deleteGuidelines;
 const mockIsGuidelinesAvailable = mocks.isGuidelinesAvailable;
+const mockListGuidelinesRepos = mocks.listGuidelinesRepos;
 const mockGetMergedPRs = mocks.getMergedPRs;
 const mockGetClosedPRs = mocks.getClosedPRs;
 const mockMarkPRCommentsFetched = mocks.markPRCommentsFetched;
 const mockMaybeCheckpoint = mocks.maybeCheckpoint;
 
-import { runGuidelinesView, runGuidelinesStore, runGuidelinesReset, runFetchCorpus } from './guidelines.js';
+import {
+  runGuidelinesList,
+  runGuidelinesView,
+  runGuidelinesStore,
+  runGuidelinesReset,
+  runFetchCorpus,
+} from './guidelines.js';
 import { GuidelinesNotAvailableError } from '../core/index.js';
 
 beforeEach(() => {
@@ -57,6 +66,34 @@ beforeEach(() => {
   mockGetMergedPRs.mockReturnValue([]);
   mockGetClosedPRs.mockReturnValue([]);
   mockIsGuidelinesAvailable.mockReturnValue(true);
+});
+
+describe('runGuidelinesList', () => {
+  it('returns an empty list when no guidelines are stored', async () => {
+    mockListGuidelinesRepos.mockReturnValue([]);
+    const out = await runGuidelinesList();
+    expect(out.repos).toEqual([]);
+    expect(out.count).toBe(0);
+    expect(out.storageMode).toBe('gist');
+  });
+
+  it('returns the sorted repo list with a count', async () => {
+    // StateManager.listGuidelinesRepos() returns alphabetically sorted repos
+    // (sorting is owned by guidelines-store and covered there).
+    mockListGuidelinesRepos.mockReturnValue(['apple-org/repo-b', 'zebra-org/repo-a']);
+    const out = await runGuidelinesList();
+    expect(out.repos).toEqual(['apple-org/repo-b', 'zebra-org/repo-a']);
+    expect(out.count).toBe(2);
+    expect(out.storageMode).toBe('gist');
+  });
+
+  it("reports 'local-unavailable' with an empty list when not in Gist mode", async () => {
+    mockListGuidelinesRepos.mockReturnValue([]);
+    mockIsGuidelinesAvailable.mockReturnValue(false);
+    const out = await runGuidelinesList();
+    expect(out.repos).toEqual([]);
+    expect(out.storageMode).toBe('local-unavailable');
+  });
 });
 
 describe('runGuidelinesView', () => {

--- a/packages/core/src/commands/guidelines.ts
+++ b/packages/core/src/commands/guidelines.ts
@@ -1,6 +1,7 @@
 /**
  * Guidelines CLI commands (#867 PR 4).
  *
+ * `guidelines list`        — list repos with stored guidelines.
  * `guidelines view`        — read the per-repo guidelines file from the Gist.
  * `guidelines store`       — overwrite the per-repo guidelines file.
  * `guidelines reset`       — tombstone the file so subsequent reads return null.
@@ -43,6 +44,14 @@ export interface GuidelinesViewOutput {
   /** Whether a guidelines file exists for this repo. */
   exists: boolean;
   /** Where the guidelines would be persisted if a write happened now. */
+  storageMode: 'gist' | 'local-unavailable';
+}
+
+export interface GuidelinesListOutput {
+  /** Repos with non-empty guidelines stored, sorted alphabetically. Always empty in local mode. */
+  repos: string[];
+  count: number;
+  /** Where guidelines are persisted. `local-unavailable` always yields an empty list. */
   storageMode: 'gist' | 'local-unavailable';
 }
 
@@ -111,6 +120,21 @@ export async function runGuidelinesView(options: RepoOption): Promise<Guidelines
     content,
     byteSize: content === null ? 0 : Buffer.byteLength(content, 'utf8'),
     exists: content !== null,
+    storageMode: sm.isGuidelinesAvailable() ? 'gist' : 'local-unavailable',
+  };
+}
+
+/**
+ * List every repo with non-empty stored guidelines. Never throws in local
+ * mode — returns an empty list with `storageMode: 'local-unavailable'` so
+ * hosts can distinguish "nothing stored" from "storage not configured".
+ */
+export async function runGuidelinesList(): Promise<GuidelinesListOutput> {
+  const sm = getStateManager();
+  const repos = sm.listGuidelinesRepos();
+  return {
+    repos,
+    count: repos.length,
     storageMode: sm.isGuidelinesAvailable() ? 'gist' : 'local-unavailable',
   };
 }

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -75,6 +75,8 @@ export { runCheckSetup } from './setup.js';
 
 // ── Per-Repo Guidelines (#867) ──────────────────────────────────────────────
 
+/** List repos with stored guidelines (empty in local mode). */
+export { runGuidelinesList } from './guidelines.js';
 /** Read the guidelines file for a repo. */
 export { runGuidelinesView } from './guidelines.js';
 /** Persist a guidelines file for a repo (overwrites on subsequent calls). */
@@ -162,6 +164,7 @@ export type {
 export type { ShelveOutput, UnshelveOutput } from './shelve.js';
 export type { MoveOutput, MoveTarget } from './move.js';
 export type {
+  GuidelinesListOutput,
   GuidelinesViewOutput,
   GuidelinesStoreOutput,
   GuidelinesResetOutput,

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -10,7 +10,7 @@ MCP server for [OSS Autopilot](https://github.com/costajohnt/oss-autopilot) — 
 
 | Feature | Count | Description |
 |---------|-------|-------------|
-| **Tools** | 30 | `daily`, `status`, `search`, `features`, `vet`, `vet-list`, `track`, `compliance-score`, `repo-vet`, `strategy`, `comments`, `post`, `claim`, `config`, `init`, `setup`, `check-setup`, `startup`, `shelve`, `unshelve`, `dismiss`, `undismiss`, `move`, `state-show`, `state-sync`, `state-unlink`, `guidelines-get`, `guidelines-store`, `guidelines-reset`, `guidelines-fetch-corpus` |
+| **Tools** | 31 | `daily`, `status`, `search`, `features`, `vet`, `vet-list`, `track`, `compliance-score`, `repo-vet`, `strategy`, `comments`, `post`, `claim`, `config`, `init`, `setup`, `check-setup`, `startup`, `shelve`, `unshelve`, `dismiss`, `undismiss`, `move`, `state-show`, `state-sync`, `state-unlink`, `guidelines-list`, `guidelines-get`, `guidelines-store`, `guidelines-reset`, `guidelines-fetch-corpus` |
 | **Resources** | 6 | `oss://status`, `oss://config`, `oss://prs`, `oss://prs/shelved`, `oss://pr/{owner}/{repo}/{number}`, `oss://repo/{owner}/{repo}/guidelines` |
 | **Prompts** | 4 | `triage` (PR prioritization), `respond-to-pr` (draft response), `find-issues` (discover issues), `extract-learnings` (distill per-repo guidance from past PR feedback) |
 
@@ -139,6 +139,7 @@ The token persists across restarts. To rotate, delete the file and restart — a
 | `state-show` | Show current state persistence mode (local or Gist) and sync status | Yes |
 | `state-sync` | Force push current state to the backing Gist | No |
 | `state-unlink` | Disconnect from Gist persistence and switch to local-only mode | No |
+| `guidelines-list` | List repos that have stored guidelines (always empty in local mode) | Yes |
 | `guidelines-get` | Read per-repo learning guidelines extracted from past PR feedback | Yes |
 | `guidelines-store` | Persist per-repo guidelines (8 KB cap; requires Gist mode) | No |
 | `guidelines-reset` | Tombstone the guidelines file for a repo | No |

--- a/packages/mcp-server/src/index.test.ts
+++ b/packages/mcp-server/src/index.test.ts
@@ -161,7 +161,7 @@ describe('MCP server stdio transport', { timeout: 30_000 }, () => {
   it('lists tools via stdio', async () => {
     client = await createStdioClient();
     const { tools } = await client.listTools();
-    expect(tools.length).toBe(30);
+    expect(tools.length).toBe(31);
     expect(tools.some((t) => t.name === 'daily')).toBe(true);
     expect(tools.some((t) => t.name === 'compliance-score')).toBe(true);
     expect(tools.some((t) => t.name === 'repo-vet')).toBe(true);

--- a/packages/mcp-server/src/tools-execution.test.ts
+++ b/packages/mcp-server/src/tools-execution.test.ts
@@ -7,6 +7,7 @@ const {
   mockRunDaily,
   mockRunSearch,
   mockRunMove,
+  mockRunGuidelinesList,
   mockRunGuidelinesView,
   mockRunGuidelinesStore,
   mockRunGuidelinesReset,
@@ -15,6 +16,7 @@ const {
   mockRunDaily: vi.fn(),
   mockRunSearch: vi.fn(),
   mockRunMove: vi.fn(),
+  mockRunGuidelinesList: vi.fn(),
   mockRunGuidelinesView: vi.fn(),
   mockRunGuidelinesStore: vi.fn(),
   mockRunGuidelinesReset: vi.fn(),
@@ -42,6 +44,7 @@ vi.mock('@oss-autopilot/core/commands', () => ({
   runDismiss: vi.fn(),
   runUndismiss: vi.fn(),
   runMove: mockRunMove,
+  runGuidelinesList: mockRunGuidelinesList,
   runGuidelinesView: mockRunGuidelinesView,
   runGuidelinesStore: mockRunGuidelinesStore,
   runGuidelinesReset: mockRunGuidelinesReset,
@@ -192,6 +195,25 @@ describe('tool execution', () => {
   // Previously only `tools.test.ts` checked these were registered; nothing
   // verified that callTool actually delegates to the right run* function or
   // that the input schemas reject malformed args at the MCP boundary.
+
+  describe('guidelines-list tool', () => {
+    it('delegates to runGuidelinesList and returns the repo list', async () => {
+      mockRunGuidelinesList.mockResolvedValueOnce({
+        repos: ['owner/repo-a', 'owner/repo-b'],
+        count: 2,
+        storageMode: 'gist',
+      });
+
+      const result = await client.callTool({ name: 'guidelines-list', arguments: {} });
+
+      expect(result.isError).toBeFalsy();
+      expect(mockRunGuidelinesList).toHaveBeenCalledOnce();
+      const content = result.content[0] as { type: string; text: string };
+      const parsed = JSON.parse(content.text);
+      expect(parsed.repos).toEqual(['owner/repo-a', 'owner/repo-b']);
+      expect(parsed.count).toBe(2);
+    });
+  });
 
   describe('guidelines-get tool', () => {
     it('delegates to runGuidelinesView and returns content', async () => {

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -39,6 +39,7 @@ const EXPECTED_TOOLS = [
   'state-show',
   'state-sync',
   'state-unlink',
+  'guidelines-list',
   'guidelines-get',
   'guidelines-store',
   'guidelines-reset',
@@ -87,8 +88,8 @@ describe('MCP tool registrations', () => {
     await client.close();
   });
 
-  it('registers exactly 30 tools', () => {
-    expect(tools).toHaveLength(30);
+  it('registers exactly 31 tools', () => {
+    expect(tools).toHaveLength(31);
   });
 
   it('registers all expected tool names', () => {

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -30,6 +30,7 @@ import {
   runDismiss,
   runUndismiss,
   runMove,
+  runGuidelinesList,
   runGuidelinesView,
   runGuidelinesStore,
   runGuidelinesReset,
@@ -572,6 +573,18 @@ export function registerTools(server: McpServer): void {
   );
 
   // ── Per-Repo Guidelines (#867) ──────────────────────────────────────
+  // guidelines-list
+  server.registerTool(
+    'guidelines-list',
+    {
+      description:
+        'List repos that have stored per-repo learning guidelines. Returns an empty list when nothing is stored or when running in local mode without Gist persistence (storageMode distinguishes the two).',
+      inputSchema: {},
+      annotations: { readOnlyHint: true },
+    },
+    wrapTool(() => runGuidelinesList()),
+  );
+
   // 23. guidelines-get
   server.registerTool(
     'guidelines-get',

--- a/workflows/reference.md
+++ b/workflows/reference.md
@@ -69,6 +69,9 @@ Local-only commands (no GitHub token needed): `checkSetup`, `clear-override`, `c
 ### Per-Repo Guidelines (#867)
 
 ```bash
+# List repos with stored guidelines
+<prefix> guidelines list --json
+
 # Read stored guidelines for a repo
 <prefix> guidelines view --repo <owner/repo> --json
 


### PR DESCRIPTION
## Summary

Implements #1393 (filed during the audit batch): `guidelines list --json` returning `{ repos, count, storageMode }` backed by `StateManager.listGuidelinesRepos()`, plus the read-only `guidelines-list` MCP tool, and `commands/oss-guidelines.md` step 1 simplified from the MCP-resource enumeration dance to the new tool/CLI path.

- `storageMode` mirrors `guidelines view` ('gist' | 'local-unavailable') so hosts distinguish nothing-stored from gist-not-configured
- All count gates this repo now enforces fired and were satisfied: tools.test EXPECTED_TOOLS (31), agents-contract mirror + source parity, README tool counts x2, mcp-server README table/summary, stdio transport count, Commander-introspection validation of the new doc invocations

## Test plan

- [x] 3 unit tests (empty state, stored repos, local mode) + 2 contract goldens + MCP delegation test
- [x] core 2656 / mcp 220 green; tsc both clean; eslint 0 errors; generate-reference.mjs harmonious
- [x] Smoke: `guidelines list --json` returns the local-mode shape on a real machine

Closes #1393