### PR TITLE
fix(cli): parse asynchronously so bootstrap errors surface actionably

### DIFF
--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -23,8 +23,13 @@ interface CLICommandDef {
   register(program: Command): void;
 }
 
-/** Shared error handler for CLI action catch blocks. */
-function handleCommandError(err: unknown, json?: boolean): never {
+/**
+ * Shared error handler for CLI action catch blocks. Exported so cli.ts can
+ * route preAction-hook rejections (corrupt Gist, missing gist scope, rate
+ * limit during bootstrap) through the same formatting instead of letting
+ * them surface as raw unhandled rejections (#1386).
+ */
+export function handleCommandError(err: unknown, json?: boolean): never {
   const msg = errorMessage(err);
   if (json) {
     outputJsonError(msg, resolveErrorCode(err));

--- a/packages/core/src/cli.test.ts
+++ b/packages/core/src/cli.test.ts
@@ -25,6 +25,7 @@ vi.mock('./core/index.js', () => ({
 
 vi.mock('./core/errors.js', () => ({
   errorMessage: vi.fn((err: unknown) => String(err)),
+  resolveErrorCode: vi.fn(() => 'UNKNOWN'),
 }));
 
 vi.mock('./formatters/json.js', () => ({
@@ -669,5 +670,57 @@ describe('CLI argument parsing', () => {
     const baseOpt = cmd!.options.find((o) => o.long === '--base');
     expect(baseOpt).toBeDefined();
     expect(baseOpt!.defaultValue).toBe('main');
+  });
+});
+
+// ─── handleCommandError + parseAsync wiring (#1386) ──────────────────────────
+
+describe('handleCommandError (#1386)', () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit called');
+    }) as never) as unknown as ReturnType<typeof vi.spyOn>;
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {}) as unknown as ReturnType<typeof vi.spyOn>;
+    const { outputJsonError } = await import('./formatters/json.js');
+    vi.mocked(outputJsonError).mockClear();
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('json mode: emits the error envelope with the resolved code and exits 1', async () => {
+    const { handleCommandError } = await import('./cli-registry.js');
+    const { outputJsonError } = await import('./formatters/json.js');
+
+    expect(() => handleCommandError(new Error('gist corrupt'), true)).toThrow('process.exit called');
+    expect(vi.mocked(outputJsonError)).toHaveBeenCalledWith('Error: gist corrupt', 'UNKNOWN');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('text mode: prints the message to stderr and exits 1', async () => {
+    const { handleCommandError } = await import('./cli-registry.js');
+
+    expect(() => handleCommandError(new Error('gist corrupt'), false)).toThrow('process.exit called');
+    expect(errorSpy).toHaveBeenCalledWith('Error: Error: gist corrupt');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});
+
+describe('cli.ts parses asynchronously (#1386)', () => {
+  it('uses program.parseAsync() with a handleCommandError catch, not bare parse()', () => {
+    // Source pin in the style of the lazy-import checks above: the preAction
+    // hook is async, so a synchronous parse() turns hook rejections (corrupt
+    // Gist, missing scope, rate limit during bootstrap) into raw
+    // UnhandledPromiseRejection stacks instead of actionable messages.
+    const source = readFileSync(join(__dirname, 'cli.ts'), 'utf8');
+    expect(source).toContain('program.parseAsync()');
+    expect(source).toMatch(/parseAsync\(\)\s*\.catch\(/s);
+    expect(source).toContain('handleCommandError(err');
+    expect(source).not.toMatch(/^program\.parse\(\);/m);
   });
 });

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -11,7 +11,7 @@
 
 import { Command } from 'commander';
 import { getGitHubTokenAsync, enableDebug, debug, getCLIVersion, stateFileExists } from './core/index.js';
-import { commands } from './cli-registry.js';
+import { commands, handleCommandError } from './cli-registry.js';
 
 const VERSION = getCLIVersion();
 
@@ -115,5 +115,13 @@ Run oss-autopilot --help for all commands.
   process.exit(0);
 }
 
-// Parse and execute
-program.parse();
+// Parse and execute. parseAsync, not parse: the preAction hook is async, so
+// with synchronous parse() a rejected hook promise (corrupt Gist, missing
+// gist scope, rate limit during bootstrap — all of which ensureGistPersistence
+// now propagates) became an UnhandledPromiseRejection and the user saw a raw
+// stack instead of the actionable message (#1386). Command actions already
+// route their errors through executeAction/handleCommandError, so this catch
+// covers exactly the hook path (plus any handler that escapes the wrapper).
+program.parseAsync().catch((err: unknown) => {
+  handleCommandError(err, process.argv.includes('--json'));
+});


### PR DESCRIPTION
## Summary

`program.parse()` is synchronous but the preAction hook is async, so hook rejections (corrupt Gist, missing gist scope, bootstrap rate limits — all propagated since #1387) surfaced as raw `UnhandledPromiseRejection` stacks. Now `program.parseAsync().catch()` routes them through the shared `handleCommandError` (newly exported), with `--json` detected via argv exactly like the hook's own fallback. The MCP path was already clean; this closes the CLI half.

- Action errors are still single-handled: `executeAction` exits before the outer catch can see them (verified)
- Success path unchanged: the parse call is the file's final statement, nothing depended on sync completion

## Test plan

- [x] New unit tests: json-mode envelope with resolved error code + exit 1, text-mode stderr + exit 1 (mocked process.exit)
- [x] Source-pin test: cli.ts must use parseAsync-with-catch, bare parse() fails the suite
- [x] Full core suite green (2659) including the e2e suites against a freshly built bundle; smoke test of the bundle (--version, real `status --json` exit 0)
- [x] tsc, eslint, prettier clean

Closes #1386