### PR TITLE
feat(dashboard): retry once then return 409 on state-write conflicts

### DIFF
--- a/packages/core/src/commands/dashboard-server.test.ts
+++ b/packages/core/src/commands/dashboard-server.test.ts
@@ -143,6 +143,7 @@ import {
 } from './dashboard-server.js';
 import { fetchDashboardData, storedToMergedPRs } from './dashboard-data.js';
 import { getGitHubToken } from '../core/index.js';
+import { ConcurrencyError } from '../core/errors.js';
 
 // ── Test Data ────────────────────────────────────────────────────────
 
@@ -883,6 +884,92 @@ describe('dashboard-server', () => {
       expect(data.error).toBe('Action failed');
     });
 
+    // ── Concurrency conflicts (#1397) ───────────────────────────────
+    // An external CLI write landing between the handler's reload and save
+    // surfaces as ConcurrencyError from the mutation (see
+    // state-concurrency.test.ts). The handler retries once via
+    // reload-reapply; a second conflict becomes a retryable 409.
+
+    it('retries once on ConcurrencyError and returns 200 when the retry succeeds (move)', async () => {
+      mockStateManager.reloadIfChanged.mockClear();
+      mockRunMove.mockClear();
+      mockRunMove.mockRejectedValueOnce(new ConcurrencyError(1000, 2000));
+
+      const result = await sendRequest(
+        'POST',
+        '/api/action',
+        JSON.stringify({ action: 'move', url: 'https://github.com/owner/repo/pull/1', target: 'shelved' }),
+      );
+
+      expect(result.statusCode).toBe(200);
+      const data = JSON.parse(result.body);
+      expect(data).toHaveProperty('stats');
+      // Mutation re-applied once after a fresh reload: two reloads, two attempts.
+      expect(mockRunMove).toHaveBeenCalledTimes(2);
+      expect(mockStateManager.reloadIfChanged).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries once on ConcurrencyError and returns 200 when the retry succeeds (dismiss)', async () => {
+      mockStateManager.dismissIssue.mockImplementationOnce(() => {
+        throw new ConcurrencyError(1000, 2000);
+      });
+
+      const result = await sendRequest(
+        'POST',
+        '/api/action',
+        JSON.stringify({ action: 'dismiss_issue_response', url: 'https://github.com/owner/repo/issues/42' }),
+      );
+
+      expect(result.statusCode).toBe(200);
+      expect(mockStateManager.dismissIssue).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns a machine-readable 409 when the retry also hits ConcurrencyError', async () => {
+      mockRunMove
+        .mockRejectedValueOnce(new ConcurrencyError(1000, 2000))
+        .mockRejectedValueOnce(new ConcurrencyError(2000, 3000));
+
+      const result = await sendRequest(
+        'POST',
+        '/api/action',
+        JSON.stringify({ action: 'move', url: 'https://github.com/owner/repo/pull/1', target: 'shelved' }),
+      );
+
+      expect(result.statusCode).toBe(409);
+      const data = JSON.parse(result.body);
+      expect(data.code).toBe('CONCURRENCY_ERROR');
+      expect(data.retryable).toBe(true);
+      expect(typeof data.error).toBe('string');
+    });
+
+    it('returns 500 (not 409) when the retry fails with a non-concurrency error', async () => {
+      mockRunMove.mockRejectedValueOnce(new ConcurrencyError(1000, 2000)).mockRejectedValueOnce(new Error('disk full'));
+
+      const result = await sendRequest(
+        'POST',
+        '/api/action',
+        JSON.stringify({ action: 'move', url: 'https://github.com/owner/repo/pull/1', target: 'shelved' }),
+      );
+
+      expect(result.statusCode).toBe(500);
+      expect(JSON.parse(result.body).error).toBe('Action failed');
+    });
+
+    it('does not reload state for a request that fails validation (#1397)', async () => {
+      // The reload was moved AFTER body parsing/validation to shrink the
+      // read-modify-write window — invalid requests must not touch state.
+      mockStateManager.reloadIfChanged.mockClear();
+
+      const result = await sendRequest(
+        'POST',
+        '/api/action',
+        JSON.stringify({ action: 'invalid_action', url: 'https://github.com/owner/repo/pull/1' }),
+      );
+
+      expect(result.statusCode).toBe(400);
+      expect(mockStateManager.reloadIfChanged).not.toHaveBeenCalled();
+    });
+
     it('should accept a valid dismiss_issue_response action', async () => {
       const result = await sendRequest(
         'POST',
@@ -1205,6 +1292,18 @@ describe('dashboard-server', () => {
       expect(result.statusCode).toBe(500);
       const data = JSON.parse(result.body);
       expect(data.error).toContain('Refresh failed');
+    });
+
+    it('returns a machine-readable 409 on ConcurrencyError (#1397)', async () => {
+      vi.mocked(getGitHubToken).mockReturnValue('test-token');
+      vi.mocked(fetchDashboardData).mockRejectedValueOnce(new ConcurrencyError(1000, 2000));
+
+      const result = await sendRequest('POST', '/api/refresh');
+      expect(result.statusCode).toBe(409);
+      const data = JSON.parse(result.body);
+      expect(data.code).toBe('CONCURRENCY_ERROR');
+      expect(data.retryable).toBe(true);
+      expect(typeof data.error).toBe('string');
     });
 
     it('should reject refresh with invalid origin', async () => {

--- a/packages/core/src/commands/dashboard-server.ts
+++ b/packages/core/src/commands/dashboard-server.ts
@@ -11,7 +11,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as crypto from 'node:crypto';
 import { getStateManager, getGitHubToken, getCLIVersion, applyStatusOverrides } from '../core/index.js';
-import { errorMessage, ValidationError } from '../core/errors.js';
+import { errorMessage, ValidationError, ConcurrencyError, GistConcurrencyError } from '../core/errors.js';
 import { warn } from '../core/logger.js';
 import { validateUrl, validateGitHubUrl, PR_URL_PATTERN, ISSUE_URL_PATTERN } from './validation.js';
 import type { MoveTarget } from './move.js';
@@ -309,6 +309,29 @@ function sendError(res: http.ServerResponse, statusCode: number, message: string
   sendJson(res, statusCode, { error: message });
 }
 
+/**
+ * True when an error is an optimistic-concurrency conflict on state.json
+ * (local mtime CAS) or the state Gist (ETag CAS). Both carry the
+ * CONCURRENCY_ERROR code and the same recovery contract: reload, re-apply,
+ * save. See state-concurrency.test.ts (#1378) and errors.ts.
+ */
+function isConcurrencyConflict(error: unknown): boolean {
+  return error instanceof ConcurrencyError || error instanceof GistConcurrencyError;
+}
+
+/**
+ * Send the machine-readable 409 for a concurrency conflict (#1397).
+ * `retryable: true` tells the SPA it can re-prime via GET /api/data and
+ * retry the POST; `code` matches the structured code on ConcurrencyError.
+ */
+function sendConflict(res: http.ServerResponse): void {
+  sendJson(res, 409, {
+    error: 'Another process wrote state concurrently — retry the request',
+    code: 'CONCURRENCY_ERROR',
+    retryable: true,
+  });
+}
+
 // ── Server ─────────────────────────────────────────────────────────────────────
 
 export async function startDashboardServer(options: DashboardServerOptions): Promise<void> {
@@ -498,14 +521,17 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
   server.requestTimeout = REQUEST_TIMEOUT_MS;
 
   // ── POST /api/action handler ─────────────────────────────────────────────
-  async function handleAction(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
-    // Reload state before mutating to avoid overwriting external CLI changes
+
+  /** Re-read state written by external processes (CLI) before mutating. */
+  async function reloadState(): Promise<void> {
     if (stateManager.isGistMode()) {
       await stateManager.refreshFromGist();
     } else {
       stateManager.reloadIfChanged();
     }
+  }
 
+  async function handleAction(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
     let body: ActionRequest;
     try {
       const raw = await readBody(req);
@@ -541,22 +567,61 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
       return;
     }
 
+    // Resolve the mutation up-front so target validation happens before the
+    // state reload — keeps the reload-to-save freshness window minimal.
+    let applyMutation: () => Promise<void> | void;
+    if (body.action === 'move') {
+      const { VALID_TARGETS, runMove } = await import('./move.js');
+      if (!body.target || !VALID_TARGETS.includes(body.target as MoveTarget)) {
+        sendError(res, 400, `move requires a valid "target" field (${VALID_TARGETS.join(', ')})`);
+        return;
+      }
+      const target = body.target;
+      applyMutation = async () => {
+        await runMove({ prUrl: body.url, target });
+      };
+    } else {
+      // dismiss_issue_response
+      applyMutation = () => {
+        stateManager.dismissIssue(body.url, new Date().toISOString());
+      };
+    }
+
+    // Reload state before mutating to avoid overwriting external CLI changes.
+    // Runs AFTER body parsing/validation (which only inspects the request,
+    // never the loaded state) so the read-modify-write window excludes the
+    // body-streaming time (#1397).
+    await reloadState();
+
     try {
-      if (body.action === 'move') {
-        const { VALID_TARGETS, runMove } = await import('./move.js');
-        if (!body.target || !VALID_TARGETS.includes(body.target as MoveTarget)) {
-          sendError(res, 400, `move requires a valid "target" field (${VALID_TARGETS.join(', ')})`);
+      await applyMutation();
+    } catch (error) {
+      if (!isConcurrencyConflict(error)) {
+        warn(MODULE, `Action failed: ${body.action} ${body.url} ${errorMessage(error)}`);
+        sendError(res, 500, 'Action failed');
+        return;
+      }
+      // Concurrency conflict: an external write landed between our reload and
+      // save. Decision (#1397): retry ONCE server-side instead of bouncing the
+      // first conflict to the client. Both mutations (move targets, dismiss)
+      // are absolute set operations, so re-applying them on a freshly reloaded
+      // baseline is safe — exactly the reload-reapply recovery contract pinned
+      // in state-concurrency.test.ts. A second consecutive conflict means
+      // sustained contention; surface it as a retryable 409 and let the SPA
+      // re-prime and retry.
+      try {
+        await reloadState();
+        await applyMutation();
+      } catch (retryError) {
+        if (isConcurrencyConflict(retryError)) {
+          warn(MODULE, `Action conflicted twice: ${body.action} ${body.url} ${errorMessage(retryError)}`);
+          sendConflict(res);
           return;
         }
-        await runMove({ prUrl: body.url, target: body.target });
-      } else {
-        // dismiss_issue_response
-        stateManager.dismissIssue(body.url, new Date().toISOString());
+        warn(MODULE, `Action failed on conflict retry: ${body.action} ${body.url} ${errorMessage(retryError)}`);
+        sendError(res, 500, 'Action failed');
+        return;
       }
-    } catch (error) {
-      warn(MODULE, `Action failed: ${body.action} ${body.url} ${errorMessage(error)}`);
-      sendError(res, 500, 'Action failed');
-      return;
     }
 
     // Rebuild dashboard data from cached digest + updated state. Persist
@@ -585,11 +650,7 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
     }
 
     try {
-      if (stateManager.isGistMode()) {
-        await stateManager.refreshFromGist();
-      } else {
-        stateManager.reloadIfChanged();
-      }
+      await reloadState();
       warn(MODULE, 'Refreshing dashboard data from GitHub...');
       const result = await fetchDashboardData(currentToken);
       cachedDigest = result.digest;
@@ -608,6 +669,14 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
       cachedIssueListMtimeMs = getIssueListMtimeMs();
       sendJson(res, 200, cachedJsonData);
     } catch (error) {
+      // No server-side retry here (unlike handleAction): a refresh re-run is a
+      // full GitHub fetch — expensive and rate-limited. The 409 is retryable
+      // by the client, which re-POSTs /api/refresh on its own schedule (#1397).
+      if (isConcurrencyConflict(error)) {
+        warn(MODULE, `Dashboard refresh hit a concurrent state write: ${errorMessage(error)}`);
+        sendConflict(res);
+        return;
+      }
       warn(MODULE, `Dashboard refresh failed: ${errorMessage(error)}`);
       sendError(res, 500, 'Refresh failed');
     }

--- a/packages/core/src/core/state-concurrency.test.ts
+++ b/packages/core/src/core/state-concurrency.test.ts
@@ -167,8 +167,9 @@ describe('local state contention: CLI + dashboard on one state.json (#1378)', ()
   // (c) The dashboard action-handler pattern (dashboard-server.ts
   //     handleAction): reloadIfChanged() → mutate → save(), with an external
   //     CLI write landing inside the window. The conflict must surface as
-  //     ConcurrencyError (handleAction's catch turns it into a 500 to the
-  //     SPA) — never silent loss of the CLI's write.
+  //     ConcurrencyError (handleAction retries once via reload-reapply, then
+  //     returns a retryable 409 to the SPA, #1397) — never silent loss of
+  //     the CLI's write.
   it('surfaces ConcurrencyError when an external write lands between the dashboard’s reload and save', () => {
     seedStateFile();
 

--- a/packages/dashboard/src/hooks/use-dashboard.test.ts
+++ b/packages/dashboard/src/hooks/use-dashboard.test.ts
@@ -383,6 +383,103 @@ describe('useDashboard', () => {
     });
   });
 
+  // ── 409 concurrency conflict retry (#1397) ────────────────────────────
+
+  describe('409 conflict handling', () => {
+    // Real timers, same as the CSRF retry tests — the auto-refresh cascade
+    // under fake timers consumed mocks unpredictably.
+    beforeEach(() => {
+      vi.useRealTimers();
+    });
+
+    const conflictBody = {
+      error: 'Another process wrote state concurrently — retry the request',
+      code: 'CONCURRENCY_ERROR',
+      retryable: true,
+    };
+
+    function mockFetchConflict() {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        headers: new Headers(),
+        json: () => Promise.resolve(conflictBody),
+      });
+    }
+
+    it('recovers from a 409 by re-priming via /api/data and retrying the POST once', async () => {
+      // Scenario: an external CLI write collided with the action server-side
+      // (twice, since the server itself retries once). The hook re-fetches
+      // /api/data to pick up the fresh state baseline and retries the POST,
+      // which now succeeds.
+      const data = makeDashboardData();
+      const updated = makeDashboardData({ shelvedPRUrls: ['https://github.com/o/r/pull/1'] });
+
+      // Mock 1: mount GET /api/data
+      mockFetchOk(data, 'test-token');
+      // Mock 2: first POST /api/action → 409 conflict
+      mockFetchConflict();
+      // Mock 3: re-prime GET /api/data
+      mockFetchOk(data, 'test-token');
+      // Mock 4: retry POST /api/action → success
+      mockFetchOk(updated, 'test-token');
+
+      const { result } = renderHook(() => useDashboard());
+      await vi.waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => {
+        await result.current.performAction({
+          action: 'move',
+          url: 'https://github.com/o/r/pull/1',
+          target: 'shelved',
+        });
+      });
+
+      const calls = mockFetch.mock.calls as Array<[string, RequestInit?]>;
+      const actionPosts = calls.filter((c) => c[0] === '/api/action');
+      expect(actionPosts).toHaveLength(2);
+
+      // Retry's response wins — data state reflects the successful POST.
+      expect(result.current.data?.shelvedPRUrls).toEqual(['https://github.com/o/r/pull/1']);
+      expect(result.current.error).toBe(null);
+    });
+
+    it('surfaces the conflict error when the retried POST 409s again', async () => {
+      const data = makeDashboardData();
+
+      // Mock 1: mount GET /api/data
+      mockFetchOk(data, 'test-token');
+      // Mock 2: first POST /api/action → 409
+      mockFetchConflict();
+      // Mock 3: re-prime GET /api/data
+      mockFetchOk(data, 'test-token');
+      // Mock 4: retry POST /api/action → 409 again (sustained contention)
+      mockFetchConflict();
+      // Mock 5: performAction's post-failure re-sync GET /api/data
+      mockFetchOk(data, 'test-token');
+
+      const { result } = renderHook(() => useDashboard());
+      await vi.waitFor(() => expect(result.current.loading).toBe(false));
+
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      await expect(
+        act(async () => {
+          await result.current.performAction({
+            action: 'move',
+            url: 'https://github.com/o/r/pull/1',
+            target: 'shelved',
+          });
+        }),
+      ).rejects.toThrow(conflictBody.error);
+      errorSpy.mockRestore();
+
+      const calls = mockFetch.mock.calls as Array<[string, RequestInit?]>;
+      const actionPosts = calls.filter((c) => c[0] === '/api/action');
+      // Exactly one retry — no infinite loop on sustained contention.
+      expect(actionPosts).toHaveLength(2);
+    });
+  });
+
   // ── #1050 runtime schema validation ───────────────────────────────────
 
   describe('schema validation (#1050)', () => {

--- a/packages/dashboard/src/hooks/use-dashboard.ts
+++ b/packages/dashboard/src/hooks/use-dashboard.ts
@@ -25,6 +25,17 @@ class CsrfRejectedError extends Error {
   }
 }
 
+/** Sentinel thrown from fetchJsonWithToken on a 409 concurrency conflict
+ * (#1397) — the server lost an optimistic compare-and-swap on state.json to
+ * an external writer. Retryable: re-prime via /api/data and retry once. */
+const CONFLICT = Symbol('conflict');
+class ConflictError extends Error {
+  readonly kind = CONFLICT;
+  constructor(message: string) {
+    super(message);
+  }
+}
+
 async function fetchJsonWithToken(url: string, init?: RequestInit): Promise<JsonResult> {
   const res = await fetch(url, init);
   if (!res.ok) {
@@ -34,6 +45,12 @@ async function fetchJsonWithToken(url: string, init?: RequestInit): Promise<Json
     // re-fetch /api/data to pick up the current token and retry once.
     if (res.status === 403 && typeof message === 'string' && /csrf token/i.test(message)) {
       throw new CsrfRejectedError(message);
+    }
+    // 409 means a concurrent state write — the server already retried once
+    // (#1397). Recoverable the same way as a stale CSRF token: re-fetch
+    // /api/data for a fresh baseline and retry the POST once.
+    if (res.status === 409) {
+      throw new ConflictError(typeof message === 'string' ? message : `HTTP ${res.status}`);
     }
     throw new Error(message);
   }
@@ -83,11 +100,15 @@ export function useDashboard() {
       try {
         return await fetchJsonWithToken(url, buildPostInit(body));
       } catch (err) {
-        if (!(err instanceof CsrfRejectedError)) throw err;
-        // Stale-tab recovery: the server rotated tokens (e.g. after upgrade)
-        // or the client never captured one. Re-prime via /api/data, then
-        // retry the POST exactly once. If the retry also fails we surface
-        // the original server message so the user sees "please refresh".
+        if (!(err instanceof CsrfRejectedError) && !(err instanceof ConflictError)) throw err;
+        // Recoverable rejections, both retried the same way:
+        // - CsrfRejectedError: stale-tab recovery — the server rotated tokens
+        //   (e.g. after upgrade) or the client never captured one.
+        // - ConflictError (409, #1397): a concurrent state write beat us;
+        //   re-priming picks up the fresh state baseline.
+        // Re-prime via /api/data, then retry the POST exactly once. If the
+        // retry also fails we surface the server's message via the normal
+        // error path (a second 409 propagates from fetchJsonWithToken).
         try {
           const primed = await fetchJsonWithToken('/api/data');
           if (primed.csrfToken) csrfTokenRef.current = primed.csrfToken;


### PR DESCRIPTION
## Summary

Implements #1397 (filed from the #1378 contention work). `ConcurrencyError` was mapped to a generic 500, so the SPA couldn't distinguish a transient lost-the-race conflict (retry succeeds) from a real failure.

- **handleAction**: validate → reload (moved after parsing; nothing in validation reads loaded state, pinned by a test) → mutate → save; on conflict, ONE server-side reload-reapply retry (all carried mutations are absolute set/clear operations, matching the recovery contract pinned in `state-concurrency.test.ts`), then `409 { error, code: 'CONCURRENCY_ERROR', retryable: true }`
- **handleRefresh**: plain 409 on conflict (no server retry; refresh is a full rate-limited GitHub fetch, documented at the catch site)
- **SPA**: 409 handled exactly like the CSRF-403 retry (re-prime via `/api/data`, retry once, surface on second conflict); `startup.ts`'s refresh trigger treats any non-ok uniformly, so the shape change is additive everywhere

## Test plan

- [x] Server: retry-success (move + dismiss), double-conflict → 409 body, conflict-then-other-error → 500, validation-failure-does-not-reload (pins the reorder), refresh 409
- [x] SPA: 409-then-success retry, 409-twice surfaces error with exactly 2 POSTs
- [x] core 2665 green; dashboard 258 green under Node 22; tsc both clean; eslint 0 errors
- [x] Reviewed: re-apply idempotency verified per mutation type; CAS baseline left stale on throw so the retry genuinely reloads; worst case 4 bounded idempotent applies

Closes #1397