### PR TITLE
fix(core): stop three per-item catches from swallowing rate-limit errors

### DIFF
--- a/packages/core/src/commands/comments.test.ts
+++ b/packages/core/src/commands/comments.test.ts
@@ -292,7 +292,7 @@ describe('runClaim', () => {
     const mockCreateComment = vi.fn().mockResolvedValue({
       data: { html_url: 'https://github.com/owner/repo/issues/10#issuecomment-1' },
     });
-    const mockIssuesGet = vi.fn().mockRejectedValue(new Error('403 from GitHub'));
+    const mockIssuesGet = vi.fn().mockRejectedValue(new Error('Server Error'));
     mockGetOctokit.mockReturnValue({
       issues: { createComment: mockCreateComment, get: mockIssuesGet },
     } as any);
@@ -306,9 +306,54 @@ describe('runClaim', () => {
     const result = await runClaim({ issueUrl: TEST_ISSUE_URL });
 
     expect(result.commentUrl).toBe('https://github.com/owner/repo/issues/10#issuecomment-1');
+    expect(mockCreateComment).toHaveBeenCalled();
     expect(mockAddIssue).toHaveBeenCalledWith(expect.objectContaining({ title: '(claimed)', labels: [] }));
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[WARN] [comments] Claimed'));
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[WARN] [comments] Failed to enrich issue metadata'),
+    );
     consoleSpy.mockRestore();
+  });
+
+  it('should abort before posting the claim comment when enrichment hits a rate limit (#1391)', async () => {
+    mockRequireGitHubToken.mockReturnValue('ghp_test123');
+    mockParseGitHubUrl.mockReturnValue({ owner: 'owner', repo: 'repo', number: 10, type: 'issues' });
+
+    const mockCreateComment = vi.fn();
+    const mockIssuesGet = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error('API rate limit exceeded'), { status: 429 }));
+    mockGetOctokit.mockReturnValue({
+      issues: { createComment: mockCreateComment, get: mockIssuesGet },
+    } as any);
+    const mockAddIssue = vi.fn();
+    mockGetStateManager.mockReturnValue({
+      addIssue: mockAddIssue,
+    } as any);
+
+    await expect(runClaim({ issueUrl: TEST_ISSUE_URL })).rejects.toThrow('API rate limit exceeded');
+    // Enrichment runs before the comment post, so a rate-limit abort leaves
+    // no orphaned claim comment and no half-saved state.
+    expect(mockCreateComment).not.toHaveBeenCalled();
+    expect(mockAddIssue).not.toHaveBeenCalled();
+  });
+
+  it('should abort before posting the claim comment when enrichment hits an auth error (401) (#1391)', async () => {
+    mockRequireGitHubToken.mockReturnValue('ghp_test123');
+    mockParseGitHubUrl.mockReturnValue({ owner: 'owner', repo: 'repo', number: 10, type: 'issues' });
+
+    const mockCreateComment = vi.fn();
+    const mockIssuesGet = vi.fn().mockRejectedValue(Object.assign(new Error('Bad credentials'), { status: 401 }));
+    mockGetOctokit.mockReturnValue({
+      issues: { createComment: mockCreateComment, get: mockIssuesGet },
+    } as any);
+    const mockAddIssue = vi.fn();
+    mockGetStateManager.mockReturnValue({
+      addIssue: mockAddIssue,
+    } as any);
+
+    await expect(runClaim({ issueUrl: TEST_ISSUE_URL })).rejects.toThrow('Bad credentials');
+    expect(mockCreateComment).not.toHaveBeenCalled();
+    expect(mockAddIssue).not.toHaveBeenCalled();
   });
 
   it('should still return success when state save fails (comment already posted)', async () => {
@@ -347,8 +392,11 @@ describe('runClaim', () => {
     mockParseGitHubUrl.mockReturnValue({ owner: 'owner', repo: 'repo', number: 10, type: 'issues' });
 
     const mockCreateComment = vi.fn().mockRejectedValue(new Error('Permission denied'));
+    const mockIssuesGet = vi.fn().mockResolvedValue({
+      data: { title: 'x', labels: [], created_at: '2026-04-20T10:00:00Z' },
+    });
     mockGetOctokit.mockReturnValue({
-      issues: { createComment: mockCreateComment },
+      issues: { createComment: mockCreateComment, get: mockIssuesGet },
     } as any);
 
     await expect(runClaim({ issueUrl: TEST_ISSUE_URL })).rejects.toThrow('Permission denied');

--- a/packages/core/src/commands/comments.ts
+++ b/packages/core/src/commands/comments.ts
@@ -5,7 +5,7 @@
 
 import { getStateManager, getOctokit, parseGitHubUrl, requireGitHubToken, maybeCheckpoint } from '../core/index.js';
 import { wrapUntrustedContent } from '../core/untrusted-content.js';
-import { ValidationError } from '../core/errors.js';
+import { ValidationError, isRateLimitOrAuthError } from '../core/errors.js';
 import { warn } from '../core/logger.js';
 
 const MODULE = 'comments';
@@ -236,17 +236,15 @@ export async function runClaim(options: ClaimOptions): Promise<ClaimOutput> {
 
   const octokit = getOctokit(token);
 
-  const { data: comment } = await octokit.issues.createComment({
-    owner,
-    repo,
-    issue_number: number,
-    body: message,
-  });
-
   // Fetch the real issue title + labels so the tracked entry has useful metadata
   // rather than a permanent "(claimed)" placeholder that never gets backfilled
   // (#1056 M24). Best-effort: if the fetch fails, fall back to the placeholder
   // so state still records the claim.
+  //
+  // Ordering matters: enrichment runs BEFORE the claim comment is posted
+  // (#1391). Rate-limit / auth failures rethrow here, and aborting after the
+  // comment landed would leave an orphaned claim on GitHub that local state
+  // never tracked — aborting before it means a clean no-op the user can retry.
   let issueTitle = '(claimed)';
   let issueLabels: string[] = [];
   let issueCreatedAt = new Date().toISOString();
@@ -258,11 +256,19 @@ export async function runClaim(options: ClaimOptions): Promise<ClaimOutput> {
       .filter((name): name is string => Boolean(name));
     if (issue.created_at) issueCreatedAt = issue.created_at;
   } catch (error) {
+    if (isRateLimitOrAuthError(error)) throw error;
     warn(
       MODULE,
-      `Claimed ${options.issueUrl} but failed to enrich issue metadata (title/labels): ${error instanceof Error ? error.message : error}`,
+      `Failed to enrich issue metadata (title/labels) for ${options.issueUrl}; claiming with placeholder: ${error instanceof Error ? error.message : error}`,
     );
   }
+
+  const { data: comment } = await octokit.issues.createComment({
+    owner,
+    repo,
+    issue_number: number,
+    body: message,
+  });
 
   // Add to tracked issues — non-fatal if state save fails (comment already posted)
   let gistSyncWarning: string | null = null;

--- a/packages/core/src/commands/guidelines.test.ts
+++ b/packages/core/src/commands/guidelines.test.ts
@@ -391,4 +391,15 @@ describe('runFetchCorpus', () => {
   it('throws on a malformed repo identifier', async () => {
     await expect(runFetchCorpus({ repo: 'just-a-name' })).rejects.toThrow(/Invalid repo identifier/);
   });
+
+  it('rejects when the batch fetch aborts on a rate limit, without stamping or checkpointing (#1391)', async () => {
+    mockGetMergedPRs.mockReturnValue([{ url: PR_RECENT, title: 't', mergedAt: recentTimestamp() }]);
+    mockFetchPRCommentBundlesBatch.mockRejectedValue(
+      Object.assign(new Error('API rate limit exceeded'), { status: 429 }),
+    );
+
+    await expect(runFetchCorpus({ repo: 'owner/repo' })).rejects.toThrow('API rate limit exceeded');
+    expect(mockMarkPRCommentsFetched).not.toHaveBeenCalled();
+    expect(mockMaybeCheckpoint).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/core/issue-conversation.test.ts
+++ b/packages/core/src/core/issue-conversation.test.ts
@@ -647,7 +647,7 @@ describe('IssueConversationMonitor', () => {
     mockOctokitInstance.issues.listComments.mockImplementation(() => {
       callCount++;
       if (callCount === 1) {
-        return Promise.reject(new Error('API rate limit exceeded'));
+        return Promise.reject(Object.assign(new Error('Internal Server Error'), { status: 500 }));
       }
       return Promise.resolve({
         data: [
@@ -664,7 +664,39 @@ describe('IssueConversationMonitor', () => {
     expect(issues).toHaveLength(1);
     expect(issues[0].status).toBe('new_response');
     expect(failures).toHaveLength(1);
-    expect(failures[0].error).toContain('rate limit');
+    expect(failures[0].error).toContain('Internal Server Error');
+  });
+
+  it('should reject when a per-issue analysis hits a rate limit instead of degrading to fewer results (#1391)', async () => {
+    mockOctokitInstance.search.issuesAndPullRequests.mockResolvedValue({
+      data: {
+        items: [
+          makeSearchItem({ html_url: 'https://github.com/owner/repo/issues/1', number: 1 }),
+          makeSearchItem({ html_url: 'https://github.com/owner/repo/issues/2', number: 2 }),
+        ],
+        total_count: 2,
+      },
+    });
+
+    mockOctokitInstance.issues.listComments.mockRejectedValue(
+      Object.assign(new Error('API rate limit exceeded'), { status: 429 }),
+    );
+
+    const monitor = new IssueConversationMonitor('fake-token');
+    await expect(monitor.fetchCommentedIssues()).rejects.toThrow('API rate limit exceeded');
+  });
+
+  it('should reject when a per-issue analysis hits an auth error (401) (#1391)', async () => {
+    mockOctokitInstance.search.issuesAndPullRequests.mockResolvedValue({
+      data: { items: [makeSearchItem()], total_count: 1 },
+    });
+
+    mockOctokitInstance.issues.listComments.mockRejectedValue(
+      Object.assign(new Error('Bad credentials'), { status: 401 }),
+    );
+
+    const monitor = new IssueConversationMonitor('fake-token');
+    await expect(monitor.fetchCommentedIssues()).rejects.toThrow('Bad credentials');
   });
 
   it('should filter out excludeRepos', async () => {

--- a/packages/core/src/core/issue-conversation.ts
+++ b/packages/core/src/core/issue-conversation.ts
@@ -15,7 +15,7 @@ import { daysBetween } from './dates.js';
 import { splitRepo, extractOwnerRepo, isOwnRepo } from './urls.js';
 import { runWorkerPool, DEFAULT_CONCURRENCY } from './concurrency.js';
 import type { CommentedIssue, IssueConversationStatus } from './types.js';
-import { ConfigurationError, errorMessage } from './errors.js';
+import { ConfigurationError, errorMessage, isRateLimitOrAuthError } from './errors.js';
 import { debug, warn } from './logger.js';
 
 const MODULE = 'issue-conversation';
@@ -136,6 +136,13 @@ export class IssueConversationMonitor {
             });
           }
         } catch (error) {
+          // Rate-limit / auth failures must propagate, not degrade to "fewer
+          // results" — under throttling every sibling analysis fails the same
+          // way and the partial result silently looks like a quiet day (#1391).
+          // runWorkerPool aborts remaining workers and rejects; daily.ts and
+          // dashboard-data.ts rethrow rate-limit/auth from their phase catches,
+          // aborting the run just like PRMonitor's 429s do.
+          if (isRateLimitOrAuthError(error)) throw error;
           const msg = errorMessage(error);
           failures.push({ issueUrl: item.html_url, error: msg });
           warn(MODULE, `Error analyzing issue ${item.html_url}: ${msg}`);
@@ -150,7 +157,7 @@ export class IssueConversationMonitor {
     if (failures.length === candidates.length && candidates.length > 0) {
       warn(
         MODULE,
-        `All ${candidates.length} issue analysis call(s) failed. Possible systemic issue (rate limit, auth, network).`,
+        `All ${candidates.length} issue analysis call(s) failed. Possible systemic issue (network, GitHub availability).`,
       );
     }
 

--- a/packages/core/src/core/pr-comments-fetcher.test.ts
+++ b/packages/core/src/core/pr-comments-fetcher.test.ts
@@ -263,7 +263,7 @@ describe('fetchPRCommentBundlesBatch', () => {
     expect(bundles).toHaveLength(3);
   });
 
-  it('skips PRs that fail to fetch (404, rate limit) without aborting', async () => {
+  it('skips PRs that fail to fetch (404, transient errors) without aborting', async () => {
     let call = 0;
     const octokit = {
       pulls: {
@@ -360,5 +360,83 @@ describe('fetchPRCommentBundlesBatch', () => {
       prUrl: 'https://github.com/owner/repo/pull/2',
       error: expect.stringContaining('Not Found'),
     });
+  });
+
+  it('rejects the whole batch on a rate-limit error instead of degrading to a skip (#1391)', async () => {
+    const rateLimitError = Object.assign(new Error('API rate limit exceeded'), { status: 429 });
+    const octokit = {
+      pulls: {
+        get: vi.fn(async ({ pull_number }: { pull_number: number }) => {
+          if (pull_number === 2) throw rateLimitError;
+          return { data: makePR() };
+        }),
+        listReviews: vi.fn(async () => ({ data: [] })),
+        listReviewComments: vi.fn(async () => ({ data: [] })),
+      },
+      issues: {
+        listComments: vi.fn(async () => ({ data: [] })),
+      },
+    } as unknown as Octokit;
+
+    const urls = [
+      'https://github.com/owner/repo/pull/1',
+      'https://github.com/owner/repo/pull/2',
+      'https://github.com/owner/repo/pull/3',
+    ];
+    await expect(fetchPRCommentBundlesBatch(octokit, urls, 'me', 1)).rejects.toThrow('API rate limit exceeded');
+    // Abort flag stops the queue: PR 3 is never attempted after the 429.
+    const getCalls = (octokit.pulls.get as ReturnType<typeof vi.fn>).mock.calls as Array<[{ pull_number: number }]>;
+    expect(getCalls.map(([args]) => args.pull_number)).toEqual([1, 2]);
+  });
+
+  it('rejects the whole batch on an auth error (401) instead of degrading to a skip (#1391)', async () => {
+    const authError = Object.assign(new Error('Bad credentials'), { status: 401 });
+    const octokit = {
+      pulls: {
+        get: vi.fn(async () => {
+          throw authError;
+        }),
+        listReviews: vi.fn(async () => ({ data: [] })),
+        listReviewComments: vi.fn(async () => ({ data: [] })),
+      },
+      issues: {
+        listComments: vi.fn(async () => ({ data: [] })),
+      },
+    } as unknown as Octokit;
+
+    await expect(
+      fetchPRCommentBundlesBatch(octokit, ['https://github.com/owner/repo/pull/1'], 'me', 1),
+    ).rejects.toThrow('Bad credentials');
+  });
+
+  it('keeps the degrade-to-failures behavior for a 500 server error (#1391)', async () => {
+    const serverError = Object.assign(new Error('Internal Server Error'), { status: 500 });
+    const octokit = {
+      pulls: {
+        get: vi.fn(async ({ pull_number }: { pull_number: number }) => {
+          if (pull_number === 2) throw serverError;
+          return { data: makePR() };
+        }),
+        listReviews: vi.fn(async () => ({ data: [] })),
+        listReviewComments: vi.fn(async () => ({ data: [] })),
+      },
+      issues: {
+        listComments: vi.fn(async () => ({ data: [] })),
+      },
+    } as unknown as Octokit;
+
+    const urls = [
+      'https://github.com/owner/repo/pull/1',
+      'https://github.com/owner/repo/pull/2',
+      'https://github.com/owner/repo/pull/3',
+    ];
+    const result = await fetchPRCommentBundlesBatch(octokit, urls, 'me', 1);
+    expect(result.bundles).toHaveLength(2);
+    expect(result.failures).toEqual([
+      {
+        prUrl: 'https://github.com/owner/repo/pull/2',
+        error: expect.stringContaining('Internal Server Error'),
+      },
+    ]);
   });
 });

--- a/packages/core/src/core/pr-comments-fetcher.ts
+++ b/packages/core/src/core/pr-comments-fetcher.ts
@@ -16,7 +16,7 @@ import { paginateAll } from './pagination.js';
 import { wrapUntrustedContent } from './untrusted-content.js';
 import { isBotAuthor } from './comment-utils.js';
 import { parseGitHubUrl } from './urls.js';
-import { ValidationError, errorMessage } from './errors.js';
+import { ValidationError, errorMessage, isRateLimitOrAuthError } from './errors.js';
 import { debug, warn } from './logger.js';
 
 const MODULE = 'pr-comments-fetcher';
@@ -184,8 +184,13 @@ export async function fetchPRCommentBundle(
  * `{ bundles, failures }` so the caller can decide whether to retry, surface
  * a partial-data banner, or proceed. Rationale: extraction quality is already
  * a partial-information problem (users contribute to many repos and many PRs),
- * so a single 404 / rate limit on one PR should not deny the host the corpus
- * from the other 4 — but the failure should still be visible (#1209 L8).
+ * so a single 404 / transient failure on one PR should not deny the host the
+ * corpus from the other 4 — but the failure should still be visible (#1209 L8).
+ *
+ * Rate-limit / auth errors are the exception: they reject the whole batch
+ * (#1391). Under throttling every remaining PR would fail the same way, so
+ * degrading to "skipped N PRs" silently masks a systemic failure the caller
+ * needs to surface (the CLI/MCP error envelope on `guidelines fetch-corpus`).
  */
 export interface PRCommentBundlesBatchResult {
   bundles: PRCommentBundle[];
@@ -201,15 +206,25 @@ export async function fetchPRCommentBundlesBatch(
   const bundles: PRCommentBundle[] = [];
   const failures: Array<{ prUrl: string; error: string }> = [];
   const queue = [...prUrls];
+  let aborted = false;
 
   async function worker(): Promise<void> {
     while (queue.length > 0) {
+      if (aborted) return;
       const url = queue.shift();
       if (!url) return;
       try {
         const bundle = await fetchPRCommentBundle(octokit, url, githubUsername);
         bundles.push(bundle);
       } catch (err) {
+        // Rate-limit / auth failures abort the batch instead of degrading to
+        // a per-PR skip — see the doc comment above (#1391). The abort flag
+        // stops sibling workers from burning more rate-limited requests on
+        // results that will be discarded when Promise.all rejects.
+        if (isRateLimitOrAuthError(err)) {
+          aborted = true;
+          throw err;
+        }
         const errorMsg = errorMessage(err);
         failures.push({ prUrl: url, error: errorMsg });
         warn(MODULE, `Skipping ${url}: ${errorMsg}`);


### PR DESCRIPTION
## Summary

Closes #1391 (filed from the #1373 sweep). Three per-item catches kept batch resilience but also swallowed 429/401, so throttled runs degraded silently. All three now rethrow `isRateLimitOrAuthError` per the established pattern (pr-monitor, ci-analysis, nonFatalCatch, #1373):

- **pr-comments-fetcher batch worker**: rethrows + aborts queued siblings (runWorkerPool's pattern); the rejection propagates through `runFetchCorpus` to the CLI/MCP error envelopes, and neither `markPRCommentsFetched` nor the checkpoint runs on abort
- **issue-conversation per-issue catch**: rethrows into the callers' existing rate-limit-first catches (daily, dashboard-data), so a 429 aborts the run exactly like pr-monitor's; stale 'possible systemic issue' warning text corrected
- **runClaim enrichment**: reordered to enrich BEFORE posting, so a throttled enrichment is a clean retryable no-op (no orphaned GitHub comment, no state write); the posted comment never depended on enrichment data, so the success path is observably unchanged (review-verified); generic failures keep today's placeholder degrade

## Test plan

- [x] Per site: 429 and 401 reject through the PUBLIC entry points (runFetchCorpus, fetchCommentedIssues, runClaim with createComment+addIssue uncalled); 500/network keeps the degrade behavior; batch abort stops the queue (call-order asserted)
- [x] Two existing tests corrected, not weakened (status-less fixtures that never exercised real rate limits; one now additionally asserts the posted-comment path)
- [x] Core suite green (2673); core+mcp tsc clean; eslint 0 errors; prettier clean

Closes #1391