### PR TITLE
fix(core): list-move-tier errors on URL not found instead of quiet success

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,20 +8,14 @@ Have an idea? Open a [Discussion](https://github.com/costajohnt/oss-autopilot/di
 
 ## Now (next 1-2 weeks)
 
-- [ ] Fix preAction bootstrap errors surfacing as unhandled rejections (`parse` vs `parseAsync`) ([#1386](https://github.com/costajohnt/oss-autopilot/issues/1386))
-- [ ] Stop three more catch sites from swallowing rate-limit errors into degraded results ([#1391](https://github.com/costajohnt/oss-autopilot/issues/1391))
 - [ ] Reconcile dashboard `needs_addressing` count with CLI `actionableIssues` — two independent classifiers diverge ([#1352](https://github.com/costajohnt/oss-autopilot/issues/1352))
 - [ ] Fix issue-scout hallucinating `Open` state and conflating cross-referenced PRs with closing PRs ([#1353](https://github.com/costajohnt/oss-autopilot/issues/1353))
 - [ ] Exclude issues the user already has open PRs for from search results ([#1354](https://github.com/costajohnt/oss-autopilot/issues/1354))
-- [ ] Fix `list-move-tier` silently no-opping on missing entries ([#1355](https://github.com/costajohnt/oss-autopilot/issues/1355))
-- [ ] Bring README/ARCHITECTURE/ROADMAP counts and status back in sync with the code ([#1379](https://github.com/costajohnt/oss-autopilot/issues/1379))
 
 ## Next (next 1-2 months)
 
 - [ ] Move canonical issue-scout and repo-evaluator agents into oss-scout ([#1241](https://github.com/costajohnt/oss-autopilot/issues/1241))
 - [ ] Bias `oss-scout:issue-scout` searches with `strategy().recommendations`, with a diversity counterweight ([#1244](https://github.com/costajohnt/oss-autopilot/issues/1244))
-- [ ] Add a `guidelines list` subcommand backed by `listGuidelinesRepos()` ([#1393](https://github.com/costajohnt/oss-autopilot/issues/1393))
-- [ ] Surface `ConcurrencyError` in the dashboard as retryable instead of a generic 500 ([#1397](https://github.com/costajohnt/oss-autopilot/issues/1397))
 
 ## Later (no fixed timeline)
 
@@ -33,6 +27,12 @@ Have an idea? Open a [Discussion](https://github.com/costajohnt/oss-autopilot/di
 
 ## Shipped
 
+- [x] Fix `list-move-tier` silently no-opping on missing entries — a URL absent from the list is now an explicit error ([#1355](https://github.com/costajohnt/oss-autopilot/issues/1355))
+- [x] Fix preAction bootstrap errors surfacing as unhandled rejections (`parse` vs `parseAsync`) ([#1386](https://github.com/costajohnt/oss-autopilot/issues/1386))
+- [x] Stop three more catch sites from swallowing rate-limit errors into degraded results ([#1391](https://github.com/costajohnt/oss-autopilot/issues/1391))
+- [x] Add a `guidelines list` subcommand backed by `listGuidelinesRepos()` ([#1393](https://github.com/costajohnt/oss-autopilot/issues/1393))
+- [x] Surface `ConcurrencyError` in the dashboard as retryable instead of a generic 500 ([#1397](https://github.com/costajohnt/oss-autopilot/issues/1397))
+- [x] Bring README/ARCHITECTURE/ROADMAP counts and status back in sync with the code ([#1379](https://github.com/costajohnt/oss-autopilot/issues/1379))
 - [x] Unify skip-list persistence — the `.md` file and `state.skippedIssues` no longer drift ([#992](https://github.com/costajohnt/oss-autopilot/issues/992))
 - [x] Audit-v2 follow-up sprint — closed the 15 issues filed by the 2026-04-19 audit ([#993](https://github.com/costajohnt/oss-autopilot/issues/993)–[#1007](https://github.com/costajohnt/oss-autopilot/issues/1007))
 - [x] Runtime `--json` contract enforcement — output shapes validated against Zod schemas at runtime ([#965](https://github.com/costajohnt/oss-autopilot/issues/965))

--- a/commands/oss-search.md
+++ b/commands/oss-search.md
@@ -165,7 +165,7 @@ Use AskUserQuestion:
      --json
    ```
 
-   The command preserves blank lines and sub-bullets between entries, is idempotent (re-running with the same tier is a no-op), and creates the target tier section if it doesn't already exist.
+   The command preserves blank lines and sub-bullets between entries, is idempotent (re-running with the same tier is a no-op), and creates the target tier section if it doesn't already exist. It does NOT create list entries: if the issue URL is missing from the list (e.g. step 1 was skipped or wrote a different URL), the command exits non-zero with `success: false` (#1355) — add the entry under `## Pending Vet` first, then re-run the move.
 
 5. Track round scores: `searchRoundScores.push(mean of all scores)` (unfiltered — includes scores below threshold)
 

--- a/packages/core/src/commands/list-move-tier.test.ts
+++ b/packages/core/src/commands/list-move-tier.test.ts
@@ -162,17 +162,27 @@ describe('runListMoveTier (filesystem)', () => {
     await expect(runListMoveTier({ issueUrl: URL_A, tier: 'skip', listPath })).rejects.toThrow(/File not found/);
   });
 
-  it('does not touch the file when the URL is not present', async () => {
+  it('throws ValidationError and does not touch the file when the URL is not present (#1355)', async () => {
     const original = '## Pursue\n\n- [Other](https://github.com/x/y/issues/9)\n';
     fs.writeFileSync(listPath, original);
     const before = fs.statSync(listPath).mtimeMs;
     // small delay to allow mtime resolution
     await new Promise((resolve) => setTimeout(resolve, 10));
-    const out = await runListMoveTier({ issueUrl: URL_A, tier: 'pursue', listPath });
-    expect(out.moved).toBe(false);
-    expect(out.count).toBe(0);
+    const promise = runListMoveTier({ issueUrl: URL_A, tier: 'pursue', listPath });
+    await expect(promise).rejects.toThrow(/not found in the list/);
+    await expect(promise).rejects.toMatchObject({ name: 'ValidationError', code: 'VALIDATION_ERROR' });
     const after = fs.statSync(listPath).mtimeMs;
     expect(after).toBe(before); // no write happened
+    expect(fs.readFileSync(listPath, 'utf8')).toBe(original);
+  });
+
+  it('still resolves (no error) when the entry is already in the target tier', async () => {
+    const original = ['## Pursue', '', `- [A](${URL_A})`, ''].join('\n');
+    fs.writeFileSync(listPath, original);
+    const out = await runListMoveTier({ issueUrl: URL_A, tier: 'pursue', listPath });
+    expect(out.moved).toBe(false);
+    expect(out.count).toBe(1);
+    expect(out.reason).toMatch(/already/);
     expect(fs.readFileSync(listPath, 'utf8')).toBe(original);
   });
 });

--- a/packages/core/src/commands/list-move-tier.ts
+++ b/packages/core/src/commands/list-move-tier.ts
@@ -6,14 +6,16 @@
  * issue-list markdown file. Replaces the model-driven prose rewrite that
  * lived in /oss-search with a deterministic file manipulation.
  *
- * Idempotent: re-running with the same target tier is a no-op.
+ * Idempotent: re-running with the same target tier is a no-op. A URL that is
+ * not in the list at all is an error (#1355) — the command does not create
+ * entries, and callers must add the entry before moving it.
  *
  * No GitHub calls — pure read/transform/write of a local file.
  */
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { errorMessage } from '../core/errors.js';
+import { errorMessage, ValidationError } from '../core/errors.js';
 
 export type Tier = 'pursue' | 'maybe' | 'skip';
 
@@ -30,7 +32,8 @@ export interface ListMoveTierOptions {
 }
 
 export interface ListMoveTierOutput {
-  /** Whether anything moved (false when the URL isn't in the list, or it was already in the target tier). */
+  /** Whether anything moved (false only when the entry was already in the
+   * target tier — a URL missing from the list entirely throws instead, #1355). */
   moved: boolean;
   /** Fully-resolved file path that was inspected. */
   filePath: string;
@@ -38,7 +41,8 @@ export interface ListMoveTierOutput {
   url: string;
   /** The target tier (always normalized to one of pursue/maybe/skip). */
   toTier: Tier;
-  /** The tier the issue was moved out of, if it had one. Absent when not found or already in target. */
+  /** The tier the issue was moved out of, if it had one. Also populated on the
+   * already-in-target no-op; absent when the source block sat under no tier header. */
   fromTier?: string;
   /** Number of matching entries moved. Should normally be 1; >1 means the list contained duplicate entries (all moved). */
   count: number;
@@ -124,18 +128,35 @@ function findTierInsertionIndex(lines: string[], headerIndex: number): number {
  * Pure transform — accepts the file content and returns the rewritten content
  * plus a summary of what changed. Exported for unit testing.
  */
+/** Discriminates the two `moved: false` outcomes of {@link moveIssueToTier}. */
+export type MoveNoOpReason = 'not-found' | 'already-in-target';
+
 export function moveIssueToTier(
   content: string,
   issueUrl: string,
   targetTier: Tier,
-): { content: string; moved: boolean; fromTier?: string; count: number; reason?: string } {
+): {
+  content: string;
+  moved: boolean;
+  fromTier?: string;
+  count: number;
+  reason?: string;
+  /** Set only when `moved` is false — why nothing changed. */
+  reasonCode?: MoveNoOpReason;
+} {
   // Preserve the trailing newline if present so we don't accidentally strip it.
   const hadTrailingNewline = content.endsWith('\n');
   const lines = (hadTrailingNewline ? content.slice(0, -1) : content).split('\n');
 
   const blocks = findIssueBlocks(lines, issueUrl);
   if (blocks.length === 0) {
-    return { content, moved: false, count: 0, reason: 'issue URL not found in the list' };
+    return {
+      content,
+      moved: false,
+      count: 0,
+      reason: 'issue URL not found in the list',
+      reasonCode: 'not-found',
+    };
   }
 
   const targetHeader = TIER_HEADERS[targetTier];
@@ -147,6 +168,7 @@ export function moveIssueToTier(
       fromTier: blocks[0].tier,
       count: blocks.length,
       reason: 'already in target tier',
+      reasonCode: 'already-in-target',
     };
   }
 
@@ -223,6 +245,15 @@ export async function runListMoveTier(options: ListMoveTierOptions): Promise<Lis
   }
 
   const result = moveIssueToTier(content, options.issueUrl, options.tier);
+
+  // #1355: a missing entry is a caller error, not a quiet success. Idempotent
+  // re-runs (already-in-target) still resolve normally.
+  if (result.reasonCode === 'not-found') {
+    throw new ValidationError(
+      `Issue URL not found in the list: ${options.issueUrl} (${filePath}). ` +
+        'Add the entry to the list first, then re-run list-move-tier.',
+    );
+  }
 
   if (result.moved) {
     try {

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -630,7 +630,10 @@ export const ListMoveTierOutputSchema = z.object({
   toTier: z.enum(['pursue', 'maybe', 'skip']),
   fromTier: z.string().optional(),
   count: z.number().int().nonnegative(),
-  reason: z.string().optional(),
+  // #1355: not-found now throws before reaching the success envelope, so the
+  // only reachable no-op reason is the idempotent one. Pinned so a new quiet
+  // no-op path trips the #1105 runtime validator instead of shipping silently.
+  reason: z.literal('already in target tier').optional(),
 });
 
 // list-mark-done (#1299): mirrors {@link MarkDoneOutput} from the command


### PR DESCRIPTION
## Summary

Closes #1355. `list-move-tier` returned `moved: false` inside a `success: true` envelope when the target URL was not in the curated list, so agent callers (the `/oss-search` tier-assignment step) proceeded as if the move landed while the list stayed unchanged.

- `runListMoveTier` now throws `ValidationError` on the not-found path — `success: false` envelope, `VALIDATION` error code, exit 1, file untouched.
- The idempotent already-in-target no-op still resolves normally (`moved: false`, `reason: 'already in target tier'`).
- The pure transform returns an explicit `reasonCode: 'not-found' | 'already-in-target'` discriminator; the wrapper branches on that instead of the `count === 0` structural invariant.
- `ListMoveTierOutputSchema.reason` pinned to the one reachable literal so any future quiet no-op path trips the runtime output validator.
- `commands/oss-search.md` documents the no-create semantics (entries must be added under `## Pending Vet` before moving).
- ROADMAP: #1355 plus five already-closed rows (#1386, #1391, #1393, #1397, #1379 — all verified CLOSED) moved to Shipped per the file's maintenance note.

Sibling command `list-mark-done` has the same bug class, including a workflow doc that documents the throwing contract it doesn't have; filed as #1406 rather than widening this PR.

## Test plan

- [x] New test: not-found rejects with `ValidationError` (`VALIDATION_ERROR`), file mtime + content untouched
- [x] New test: already-in-target still resolves with `moved: false` + reason, no write
- [x] Full core suite: 2674 passed, lint + typecheck clean
- [x] Convergence review pass: no Critical/Recommended findings