### PR TITLE
feat(core,dashboard): unified attention taxonomy shared by CLI brief and dashboard

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,14 +8,10 @@ Have an idea? Open a [Discussion](https://github.com/costajohnt/oss-autopilot/di
 
 ## Now (next 1-2 weeks)
 
-- [ ] Reconcile dashboard `needs_addressing` count with CLI `actionableIssues` — two independent classifiers diverge ([#1352](https://github.com/costajohnt/oss-autopilot/issues/1352))
-- [ ] Fix issue-scout hallucinating `Open` state and conflating cross-referenced PRs with closing PRs ([#1353](https://github.com/costajohnt/oss-autopilot/issues/1353))
-- [ ] Exclude issues the user already has open PRs for from search results ([#1354](https://github.com/costajohnt/oss-autopilot/issues/1354))
-
-## Next (next 1-2 months)
-
 - [ ] Move canonical issue-scout and repo-evaluator agents into oss-scout ([#1241](https://github.com/costajohnt/oss-autopilot/issues/1241))
 - [ ] Bias `oss-scout:issue-scout` searches with `strategy().recommendations`, with a diversity counterweight ([#1244](https://github.com/costajohnt/oss-autopilot/issues/1244))
+
+## Next (next 1-2 months)
 
 ## Later (no fixed timeline)
 
@@ -27,6 +23,8 @@ Have an idea? Open a [Discussion](https://github.com/costajohnt/oss-autopilot/di
 
 ## Shipped
 
+- [x] Unify the attention taxonomy — one classifier for CLI brief and dashboard, with `stuck_ci` / `dormant_followup` buckets ([#1352](https://github.com/costajohnt/oss-autopilot/issues/1352))
+- [x] Deterministic `verify-issue` — real open/closed state and closing-vs-mention PR classification, wired into issue-scout ([#1353](https://github.com/costajohnt/oss-autopilot/issues/1353), [#1354](https://github.com/costajohnt/oss-autopilot/issues/1354))
 - [x] Fix `list-move-tier` silently no-opping on missing entries — a URL absent from the list is now an explicit error ([#1355](https://github.com/costajohnt/oss-autopilot/issues/1355))
 - [x] Fix preAction bootstrap errors surfacing as unhandled rejections (`parse` vs `parseAsync`) ([#1386](https://github.com/costajohnt/oss-autopilot/issues/1386))
 - [x] Stop three more catch sites from swallowing rate-limit errors into degraded results ([#1391](https://github.com/costajohnt/oss-autopilot/issues/1391))

--- a/packages/core/src/commands/daily-render.ts
+++ b/packages/core/src/commands/daily-render.ts
@@ -23,6 +23,7 @@ import type {
   DailyDigest,
   MaintainerActionHint,
 } from '../core/types.js';
+import type { AttentionSummary } from '../core/pr-attention.js';
 
 /**
  * Format a maintainer action hint as a human-readable label.
@@ -52,11 +53,23 @@ export function formatActionHint(hint: MaintainerActionHint): string {
  *
  * @returns One-line status string (e.g., "3 Active PRs | 1 needs attention | 2 issue replies")
  */
-export function formatBriefSummary(digest: DailyDigest, issueCount: number, issueResponseCount: number = 0): string {
+export function formatBriefSummary(
+  digest: DailyDigest,
+  issueCount: number,
+  issueResponseCount: number = 0,
+  attention?: Pick<AttentionSummary, 'stuckCI' | 'dormantFollowup'>,
+): string {
   const attentionText = issueCount > 0 ? `${issueCount} need${issueCount === 1 ? 's' : ''} attention` : 'all on track';
   const issueReplyText =
     issueResponseCount > 0 ? ` | ${issueResponseCount} issue repl${issueResponseCount === 1 ? 'y' : 'ies'}` : '';
-  return `\u{1F4CA} ${digest.summary.totalActivePRs} Active PRs | ${attentionText}${issueReplyText}`;
+  // #1352: the watch-style buckets are appended only when non-zero — they're
+  // ping/nudge workflows, not part of the headline "need attention" count.
+  const stuckText = attention && attention.stuckCI > 0 ? ` | ${attention.stuckCI} stuck CI` : '';
+  const dormantText =
+    attention && attention.dormantFollowup > 0
+      ? ` | ${attention.dormantFollowup} dormant follow-up${attention.dormantFollowup === 1 ? '' : 's'}`
+      : '';
+  return `\u{1F4CA} ${digest.summary.totalActivePRs} Active PRs | ${attentionText}${issueReplyText}${stuckText}${dormantText}`;
 }
 
 /**

--- a/packages/core/src/commands/daily.ts
+++ b/packages/core/src/commands/daily.ts
@@ -22,6 +22,8 @@ import {
   toShelvedPRRef,
   formatBriefSummary,
   formatSummary,
+  summarizeAttentionBuckets,
+  type AttentionSummary,
   type DailyDigest,
   type FetchedPR,
   type ShelvedPRRef,
@@ -123,6 +125,8 @@ export interface DailyCheckResult {
   summary: string;
   briefSummary: string;
   actionableIssues: ActionableIssue[];
+  /** Unified attention-bucket counts over active PRs (#1352). */
+  attention: AttentionSummary;
   actionMenu: ActionMenu;
   commentedIssues: CommentedIssue[];
   repoGroups: RepoGroup[];
@@ -605,7 +609,10 @@ function generateDigestOutput(
   // Auto-undismiss mutations are auto-saved by undismissIssue()
   const actionableIssues = collectActionableIssues(activePRs, previousLastDigestAt);
   digest.summary.totalNeedingAttention = actionableIssues.length;
-  const briefSummary = formatBriefSummary(digest, actionableIssues.length, issueResponses.length);
+  // #1352: one classifier for all attention surfaces — the dashboard stamps
+  // the same buckets per-PR, so the headline counts cannot diverge.
+  const attention = summarizeAttentionBuckets(activePRs);
+  const briefSummary = formatBriefSummary(digest, actionableIssues.length, issueResponses.length, attention);
   const actionMenu = computeActionMenu(actionableIssues, capacity, filteredCommentedIssues);
   const repoGroups = groupPRsByRepo(activePRs);
 
@@ -633,6 +640,7 @@ function generateDigestOutput(
     summary,
     briefSummary,
     actionableIssues,
+    attention,
     actionMenu,
     commentedIssues: filteredCommentedIssues,
     repoGroups,
@@ -691,6 +699,7 @@ export function toDailyOutput(result: DailyCheckResult): DailyOutput {
     summary: result.summary,
     briefSummary: result.briefSummary,
     actionableIssues: compactActionableIssues(result.actionableIssues),
+    attention: result.attention,
     actionMenu: result.actionMenu,
     commentedIssues: result.commentedIssues.map(fenceCommentedIssue),
     repoGroups: compactRepoGroups(result.repoGroups),

--- a/packages/core/src/commands/dashboard-data.ts
+++ b/packages/core/src/commands/dashboard-data.ts
@@ -4,7 +4,7 @@
  * Consumed by the dashboard HTTP server (dashboard-server.ts) for the SPA API.
  */
 
-import { getStateManager, PRMonitor, IssueConversationMonitor, getOctokit } from '../core/index.js';
+import { getStateManager, PRMonitor, IssueConversationMonitor, getOctokit, CRITICAL_STATUSES } from '../core/index.js';
 import { errorMessage, isRateLimitOrAuthError } from '../core/errors.js';
 import { warn } from '../core/logger.js';
 import { emptyPRCountsResult, fetchMergedPRsSince, fetchClosedPRsSince } from '../core/github-stats.js';
@@ -123,12 +123,18 @@ export function buildDashboardStats(
  * A PR is shelved for display when the user explicitly shelved it, or the
  * dormant-auto-shelve rule applies (dormant + not needing attention). Mirrors
  * the partition built in fetchDashboardData (see the `freshShelved` filter).
+ *
+ * #1352: an explicitly shelved PR that turns critical is NOT shelved for
+ * display — the daily check auto-unshelves it (`CRITICAL_STATUSES`), so the
+ * dashboard must agree immediately rather than diverging from the CLI's
+ * headline count until the next daily run.
  */
 function isShelvedForDisplay(
   pr: { url: string; stalenessTier?: string; status?: string },
   explicitlyShelved: Set<string>,
 ): boolean {
-  return explicitlyShelved.has(pr.url) || (pr.stalenessTier === 'dormant' && pr.status !== 'needs_addressing');
+  if (CRITICAL_STATUSES.has(pr.status as FetchedPR['status'])) return false;
+  return explicitlyShelved.has(pr.url) || pr.stalenessTier === 'dormant';
 }
 
 /**
@@ -390,11 +396,13 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
 
       const digest = prMonitor.generateDigest(prs, recentlyClosedPRs, recentlyMergedPRs);
 
-      // Apply shelve partitioning for display (auto-unshelve only runs in daily check)
-      // Dormant PRs are treated as shelved unless they need addressing
+      // Apply shelve partitioning for display (auto-unshelve only runs in daily check).
+      // Dormant PRs are treated as shelved unless they need addressing, and a
+      // critical PR is never display-shelved (#1352) — mirrors the daily
+      // check's CRITICAL_STATUSES auto-unshelve so headline counts agree.
       const shelvedUrls = new Set(stateManager.getState().config.shelvedPRUrls || []);
       const freshShelved = prs.filter(
-        (pr) => shelvedUrls.has(pr.url) || (pr.stalenessTier === 'dormant' && pr.status !== 'needs_addressing'),
+        (pr) => !CRITICAL_STATUSES.has(pr.status) && (shelvedUrls.has(pr.url) || pr.stalenessTier === 'dormant'),
       );
       digest.shelvedPRs = freshShelved.map(toShelvedPRRef);
       digest.autoUnshelvedPRs = [];

--- a/packages/core/src/commands/dashboard-server.test.ts
+++ b/packages/core/src/commands/dashboard-server.test.ts
@@ -73,15 +73,22 @@ const mockStateManager = {
 // Create a temp dir for PID file tests (needs to exist before mock is evaluated)
 const pidTestDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dashboard-pid-test-'));
 
-vi.mock('../core/index.js', () => ({
-  getStateManager: vi.fn(() => mockStateManager),
-  getGitHubToken: vi.fn(() => null),
-  getDataDir: vi.fn(() => pidTestDir),
-  getCLIVersion: vi.fn(() => '0.44.6'),
-  applyStatusOverrides: vi.fn((prs: unknown[]) => prs),
-  // Used by the real reconcileShelvePartition (imported via importActual below).
-  toShelvedPRRef: vi.fn((pr: unknown) => pr),
-}));
+vi.mock('../core/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../core/index.js')>();
+  return {
+    getStateManager: vi.fn(() => mockStateManager),
+    getGitHubToken: vi.fn(() => null),
+    getDataDir: vi.fn(() => pidTestDir),
+    getCLIVersion: vi.fn(() => '0.44.6'),
+    applyStatusOverrides: vi.fn((prs: unknown[]) => prs),
+    // Real pure classifier + status set (#1352) so /api/data responses carry
+    // genuine buckets and the shelve partition mirrors the daily check.
+    classifyAttentionBucket: actual.classifyAttentionBucket,
+    CRITICAL_STATUSES: actual.CRITICAL_STATUSES,
+    // Used by the real reconcileShelvePartition (imported via importActual below).
+    toShelvedPRRef: vi.fn((pr: unknown) => pr),
+  };
+});
 
 // Mock fetchDashboardData so we never call GitHub. reconcileShelvePartition is
 // the real implementation so the shelve/unshelve reconciliation is exercised;
@@ -567,6 +574,32 @@ describe('dashboard-server', () => {
       const data = buildDashboardJson(digest, state, []);
 
       expect(data.shelvedPRUrls).not.toContain(pr.url);
+    });
+
+    it('never display-shelves a critical PR, even when explicitly shelved (#1352)', () => {
+      // The daily check auto-unshelves a shelved PR the moment it turns
+      // needs_addressing (CRITICAL_STATUSES). The dashboard partition must
+      // agree immediately, or its headline count diverges from the CLI brief
+      // until the next daily run — the exact class #1352 closes.
+      const pr = {
+        url: 'https://github.com/o/r/pull/12',
+        number: 12,
+        repo: 'o/r',
+        title: 'Shelved PR that turned critical',
+        status: 'needs_addressing',
+        stalenessTier: 'dormant',
+        daysSinceActivity: 40,
+      };
+      const digest = makeDigest({ openPRs: [pr], shelvedPRs: [] });
+      const state = makeState({
+        config: { shelvedPRUrls: [pr.url] },
+        lastDigest: digest,
+      });
+
+      const data = buildDashboardJson(digest, state, []);
+
+      expect(data.shelvedPRUrls).not.toContain(pr.url);
+      expect(data.activePRs.map((p) => p.url)).toContain(pr.url);
     });
 
     it('keeps a dormant-auto-shelved open PR shelved even when not in config', () => {

--- a/packages/core/src/commands/dashboard-server.ts
+++ b/packages/core/src/commands/dashboard-server.ts
@@ -10,7 +10,13 @@ import * as http from 'node:http';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as crypto from 'node:crypto';
-import { getStateManager, getGitHubToken, getCLIVersion, applyStatusOverrides } from '../core/index.js';
+import {
+  getStateManager,
+  getGitHubToken,
+  getCLIVersion,
+  applyStatusOverrides,
+  classifyAttentionBucket,
+} from '../core/index.js';
 import { errorMessage, ValidationError, ConcurrencyError, GistConcurrencyError } from '../core/errors.js';
 import { warn } from '../core/logger.js';
 import { validateUrl, validateGitHubUrl, PR_URL_PATTERN, ISSUE_URL_PATTERN } from './validation.js';
@@ -172,7 +178,12 @@ export function buildDashboardJson(
     monthlyMerged,
     monthlyOpened,
     monthlyClosed,
-    activePRs: applyStatusOverrides(digest.openPRs || [], state),
+    // #1352: stamp the unified attention bucket so the SPA renders the same
+    // taxonomy the CLI brief counts (single classifier, no second opinion).
+    activePRs: applyStatusOverrides(digest.openPRs || [], state).map((pr) => ({
+      ...pr,
+      attentionBucket: classifyAttentionBucket(pr),
+    })),
     // Source of truth is digest.shelvedPRs (union of explicitly-shelved URLs
     // and dormant-non-addressing PRs auto-shelved for display). Returning
     // only state.config.shelvedPRUrls would under-count and desync from

--- a/packages/core/src/core/daily-logic.test.ts
+++ b/packages/core/src/core/daily-logic.test.ts
@@ -21,6 +21,7 @@ import {
   CRITICAL_STATUSES,
   STALE_STATUSES,
 } from './daily-logic.js';
+import { summarizeAttentionBuckets } from './pr-attention.js';
 import type { FetchedPR, MaintainerActionHint, AgentState } from './types.js';
 import {
   makeFetchedPR,
@@ -178,6 +179,26 @@ describe('assessCapacity', () => {
 // ---------------------------------------------------------------------------
 
 describe('collectActionableIssues', () => {
+  it('covers every needs_addressing PR — count matches the needs_attention bucket by construction (#1352)', () => {
+    const prs = [
+      makePR({ repo: 'o/r', number: 1, status: 'needs_addressing', actionReason: 'needs_changes' }),
+      // Unmapped reason (not in reasonOrder) must still produce an entry, sorted last.
+      makePR({ repo: 'o/r', number: 2, status: 'needs_addressing', actionReason: 'needs_rebase' }),
+      // Missing actionReason (e.g. a hand-rolled override payload) falls back to needs_response.
+      makePR({ repo: 'o/r', number: 3, status: 'needs_addressing', actionReason: undefined }),
+      makePR({ repo: 'o/r', number: 4, status: 'waiting_on_maintainer' }),
+    ];
+
+    const result = collectActionableIssues(prs);
+
+    expect(result).toHaveLength(3);
+    // Known reasons sort by priority; unmapped/missing reasons sort last in stable order.
+    expect(result.map((i) => i.pr.number)).toEqual([1, 2, 3]);
+    expect(result[1].label).toBe('[needs_rebase]');
+    expect(result[2].label).toBe('[Needs Response]'); // missing reason falls back
+    expect(result).toHaveLength(summarizeAttentionBuckets(prs).needsAttention);
+  });
+
   it('should return empty array for empty PR list', () => {
     const result = collectActionableIssues([]);
     expect(result).toEqual([]);
@@ -401,6 +422,22 @@ describe('formatBriefSummary', () => {
     const digest = makeDigest();
     const result = formatBriefSummary(digest, 0, 1);
     expect(result).toContain('1 issue reply');
+  });
+
+  it('appends stuck CI and dormant follow-up counts when non-zero (#1352)', () => {
+    const digest = makeDigest();
+    const result = formatBriefSummary(digest, 2, 0, { stuckCI: 1, dormantFollowup: 2 });
+    expect(result).toContain('2 need attention');
+    expect(result).toContain('1 stuck CI');
+    expect(result).toContain('2 dormant follow-ups');
+  });
+
+  it('uses singular dormant follow-up for count of 1 and omits zero buckets', () => {
+    const digest = makeDigest();
+    const result = formatBriefSummary(digest, 0, 0, { stuckCI: 0, dormantFollowup: 1 });
+    expect(result).not.toContain('stuck CI');
+    expect(result).toContain('1 dormant follow-up');
+    expect(result).toContain('all on track');
   });
 
   it('should omit issue reply text when count is 0', () => {

--- a/packages/core/src/core/daily-logic.ts
+++ b/packages/core/src/core/daily-logic.ts
@@ -293,63 +293,78 @@ export function collectActionableIssues(prs: FetchedPR[], lastDigestAt?: string)
     'incomplete_checklist',
   ];
 
-  for (const reason of reasonOrder) {
-    for (const pr of actionPRs) {
-      if (pr.actionReason !== reason) continue;
+  // #1352: every needs_addressing PR produces exactly one entry, including
+  // PRs whose actionReason is missing or outside reasonOrder (the defensive
+  // default below). This keeps the CLI brief's count equal to the dashboard's
+  // needs_attention bucket by construction — previously an unmapped reason
+  // silently dropped the PR from the brief while the dashboard still counted
+  // it. Unmapped reasons sort last.
+  const sortedPRs = [...actionPRs].sort((a, b) => {
+    const rank = (pr: FetchedPR) => {
+      const i = reasonOrder.indexOf(pr.actionReason as ActionReason);
+      return i === -1 ? reasonOrder.length : i;
+    };
+    return rank(a) - rank(b);
+  });
 
-      let label: string;
-      let type: ActionableIssueType;
-      switch (reason) {
-        case 'needs_response': {
-          label = '[Needs Response]';
-          type = 'needs_response';
-          break;
-        }
-        case 'needs_changes': {
-          label = '[Needs Changes]';
-          type = 'needs_changes';
-          break;
-        }
-        case 'failing_ci': {
-          const checkInfo = pr.failingCheckNames.length > 0 ? ` (${pr.failingCheckNames.join(', ')})` : '';
-          label = `[CI Failing${checkInfo}]`;
-          type = 'ci_failing';
-          break;
-        }
-        case 'merge_conflict': {
-          label = '[Merge Conflict]';
-          type = 'merge_conflict';
-          break;
-        }
-        case 'incomplete_checklist': {
-          const stats = pr.checklistStats ? ` (${pr.checklistStats.checked}/${pr.checklistStats.total})` : '';
-          label = `[Incomplete Checklist${stats}]`;
-          type = 'incomplete_checklist';
-          break;
-        }
-        default: {
-          // Defensive fallback for ActionReason values not explicitly handled
-          // above (e.g. ci_not_running, needs_rebase, missing_required_files).
-          // These aren't in reasonOrder today but this guards future additions.
-          warn('daily-logic', `Unhandled ActionReason "${reason}" for PR ${pr.url} — falling back to needs_response`);
-          label = `[${reason}]`;
-          type = 'needs_response';
-        }
-      }
-
-      // A PR is "new" if it was created after the last daily digest (first time seen).
-      // If there's no previous digest (first run) or createdAt is invalid, assume new.
-      const createdTime = new Date(pr.createdAt).getTime();
-      let isNewContribution: boolean;
-      if (isNaN(createdTime)) {
-        warn('daily-logic', `Invalid createdAt "${pr.createdAt}" for PR ${pr.url}, assuming new contribution`);
-        isNewContribution = true;
-      } else {
-        isNewContribution = isNaN(lastDigestTime) || createdTime > lastDigestTime;
-      }
-
-      issues.push({ type, pr, label, isNewContribution });
+  for (const pr of sortedPRs) {
+    if (pr.actionReason === undefined) {
+      warn('daily-logic', `needs_addressing PR ${pr.url} has no actionReason — defaulting to needs_response`);
     }
+    const reason: ActionReason = pr.actionReason ?? 'needs_response';
+
+    let label: string;
+    let type: ActionableIssueType;
+    switch (reason) {
+      case 'needs_response': {
+        label = '[Needs Response]';
+        type = 'needs_response';
+        break;
+      }
+      case 'needs_changes': {
+        label = '[Needs Changes]';
+        type = 'needs_changes';
+        break;
+      }
+      case 'failing_ci': {
+        const checkInfo = pr.failingCheckNames.length > 0 ? ` (${pr.failingCheckNames.join(', ')})` : '';
+        label = `[CI Failing${checkInfo}]`;
+        type = 'ci_failing';
+        break;
+      }
+      case 'merge_conflict': {
+        label = '[Merge Conflict]';
+        type = 'merge_conflict';
+        break;
+      }
+      case 'incomplete_checklist': {
+        const stats = pr.checklistStats ? ` (${pr.checklistStats.checked}/${pr.checklistStats.total})` : '';
+        label = `[Incomplete Checklist${stats}]`;
+        type = 'incomplete_checklist';
+        break;
+      }
+      default: {
+        // Defensive fallback for ActionReason values not explicitly handled
+        // above (e.g. ci_not_running, needs_rebase, missing_required_files).
+        // These aren't in reasonOrder today but this guards future additions.
+        warn('daily-logic', `Unhandled ActionReason "${reason}" for PR ${pr.url} — falling back to needs_response`);
+        label = `[${reason}]`;
+        type = 'needs_response';
+      }
+    }
+
+    // A PR is "new" if it was created after the last daily digest (first time seen).
+    // If there's no previous digest (first run) or createdAt is invalid, assume new.
+    const createdTime = new Date(pr.createdAt).getTime();
+    let isNewContribution: boolean;
+    if (isNaN(createdTime)) {
+      warn('daily-logic', `Invalid createdAt "${pr.createdAt}" for PR ${pr.url}, assuming new contribution`);
+      isNewContribution = true;
+    } else {
+      isNewContribution = isNaN(lastDigestTime) || createdTime > lastDigestTime;
+    }
+
+    issues.push({ type, pr, label, isNewContribution });
   }
 
   return issues;

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -101,6 +101,15 @@ export {
   type VerifyIssueParams,
 } from './issue-verification.js';
 export {
+  classifyAttentionBucket,
+  summarizeAttentionBuckets,
+  STUCK_CI_THRESHOLD_DAYS,
+  DORMANT_FOLLOWUP_THRESHOLD_DAYS,
+  type AttentionBucket,
+  type AttentionInput,
+  type AttentionSummary,
+} from './pr-attention.js';
+export {
   scanForAntiLLMPolicy,
   type AntiLLMCategory,
   type AntiLLMMatch,

--- a/packages/core/src/core/pr-attention.test.ts
+++ b/packages/core/src/core/pr-attention.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for the unified PR attention taxonomy (#1352).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  classifyAttentionBucket,
+  summarizeAttentionBuckets,
+  STUCK_CI_THRESHOLD_DAYS,
+  DORMANT_FOLLOWUP_THRESHOLD_DAYS,
+  type AttentionInput,
+} from './pr-attention.js';
+
+function input(overrides: Partial<AttentionInput> = {}): AttentionInput {
+  return {
+    status: 'waiting_on_maintainer',
+    ciStatus: 'passing',
+    reviewDecision: 'review_required',
+    daysSinceActivity: 0,
+    ...overrides,
+  };
+}
+
+describe('classifyAttentionBucket', () => {
+  it('needs_addressing is always needs_attention, regardless of CI or staleness', () => {
+    expect(
+      classifyAttentionBucket(input({ status: 'needs_addressing', ciStatus: 'pending', daysSinceActivity: 99 })),
+    ).toBe('needs_attention');
+  });
+
+  it('pending CI past the threshold is stuck_ci', () => {
+    expect(classifyAttentionBucket(input({ ciStatus: 'pending', daysSinceActivity: STUCK_CI_THRESHOLD_DAYS }))).toBe(
+      'stuck_ci',
+    );
+  });
+
+  it('pending CI within the threshold is just waiting (fresh runs are normal)', () => {
+    expect(
+      classifyAttentionBucket(input({ ciStatus: 'pending', daysSinceActivity: STUCK_CI_THRESHOLD_DAYS - 1 })),
+    ).toBe('waiting');
+  });
+
+  it('review_required past the follow-up threshold is dormant_followup', () => {
+    expect(
+      classifyAttentionBucket(
+        input({ reviewDecision: 'review_required', daysSinceActivity: DORMANT_FOLLOWUP_THRESHOLD_DAYS }),
+      ),
+    ).toBe('dormant_followup');
+  });
+
+  it('review_required within the threshold is waiting', () => {
+    expect(
+      classifyAttentionBucket(
+        input({ reviewDecision: 'review_required', daysSinceActivity: DORMANT_FOLLOWUP_THRESHOLD_DAYS - 1 }),
+      ),
+    ).toBe('waiting');
+  });
+
+  it('approved dormant PRs are waiting, not dormant_followup (nothing to nudge for review)', () => {
+    expect(classifyAttentionBucket(input({ reviewDecision: 'approved', daysSinceActivity: 40 }))).toBe('waiting');
+  });
+
+  it('stuck_ci wins over dormant_followup when both apply', () => {
+    expect(
+      classifyAttentionBucket(input({ ciStatus: 'pending', reviewDecision: 'review_required', daysSinceActivity: 30 })),
+    ).toBe('stuck_ci');
+  });
+
+  it('the issue #1352 examples land in the new buckets, not needs_attention', () => {
+    // "ciStatus: pending and 12 days since activity. CI looks stuck."
+    expect(classifyAttentionBucket(input({ ciStatus: 'pending', daysSinceActivity: 12 }))).toBe('stuck_ci');
+    // "reviewDecision: review_required, ciStatus: passing, 15 days dormant."
+    expect(
+      classifyAttentionBucket(input({ ciStatus: 'passing', reviewDecision: 'review_required', daysSinceActivity: 15 })),
+    ).toBe('dormant_followup');
+  });
+});
+
+describe('summarizeAttentionBuckets', () => {
+  it('counts every bucket', () => {
+    const summary = summarizeAttentionBuckets([
+      input({ status: 'needs_addressing' }),
+      input({ status: 'needs_addressing' }),
+      input({ ciStatus: 'pending', daysSinceActivity: 12 }),
+      input({ reviewDecision: 'review_required', daysSinceActivity: 15 }),
+      input({ reviewDecision: 'approved', daysSinceActivity: 1 }),
+    ]);
+    expect(summary).toEqual({ needsAttention: 2, stuckCI: 1, dormantFollowup: 1, waiting: 1 });
+  });
+
+  it('returns all zeros for an empty list', () => {
+    expect(summarizeAttentionBuckets([])).toEqual({
+      needsAttention: 0,
+      stuckCI: 0,
+      dormantFollowup: 0,
+      waiting: 0,
+    });
+  });
+});

--- a/packages/core/src/core/pr-attention.ts
+++ b/packages/core/src/core/pr-attention.ts
@@ -1,0 +1,94 @@
+/**
+ * Unified PR attention taxonomy (#1352).
+ *
+ * The headline "needs attention" number used to be computed twice — the CLI
+ * brief counted `collectActionableIssues()` output while the dashboard
+ * counted raw `status === 'needs_addressing'` — and the cases the CLI
+ * deliberately excludes (stuck CI, dormant maintainer waits) sat
+ * undifferentiated inside `waiting_on_maintainer`. This module is the single
+ * classifier both surfaces consume.
+ *
+ * Buckets (mutually exclusive, first match wins):
+ * - `needs_attention` — the contributor has a concrete code-related next
+ *   step today (`status === 'needs_addressing'`: response, changes, CI fix,
+ *   conflict, checklist). This is the headline count on BOTH surfaces.
+ * - `stuck_ci` — waiting PRs whose CI has been `pending` long past any
+ *   normal run time. A "ping / investigate" workflow, not a coding one.
+ * - `dormant_followup` — waiting PRs with `review_required` and no activity
+ *   past the follow-up threshold. A "draft a nudge" workflow.
+ * - `waiting` — everything else that's healthy to leave alone.
+ */
+
+import type { AttentionBucket, FetchedPR } from './types.js';
+
+export type { AttentionBucket } from './types.js';
+
+/**
+ * Days of inactivity after which a `pending` CI status reads as stuck rather
+ * than in-flight. Real CI runs finish in minutes-to-hours; multiple days of
+ * `pending` means a webhook was lost, a runner died, or a required check
+ * never started.
+ */
+export const STUCK_CI_THRESHOLD_DAYS = 3;
+
+/**
+ * Days of inactivity after which a `review_required` PR becomes a follow-up
+ * candidate. Matches the middle step of the 7/14/30 dormant-PR follow-up
+ * cadence — early enough to nudge before the PR goes fully dormant
+ * (default `dormantThresholdDays` is 30).
+ */
+export const DORMANT_FOLLOWUP_THRESHOLD_DAYS = 14;
+
+/** The minimal slice of {@link FetchedPR} the classifier reads. */
+export type AttentionInput = Pick<FetchedPR, 'status' | 'ciStatus' | 'reviewDecision' | 'daysSinceActivity'>;
+
+/**
+ * Classify one PR into its attention bucket. Pure — both the CLI daily path
+ * and the dashboard `/api/data` path call this, so the two surfaces cannot
+ * diverge on what a count means.
+ */
+export function classifyAttentionBucket(pr: AttentionInput): AttentionBucket {
+  if (pr.status === 'needs_addressing') return 'needs_attention';
+
+  // From here on the PR is waiting_on_maintainer — subdivide the wait.
+  if (pr.ciStatus === 'pending' && pr.daysSinceActivity >= STUCK_CI_THRESHOLD_DAYS) {
+    return 'stuck_ci';
+  }
+  if (pr.reviewDecision === 'review_required' && pr.daysSinceActivity >= DORMANT_FOLLOWUP_THRESHOLD_DAYS) {
+    return 'dormant_followup';
+  }
+  return 'waiting';
+}
+
+export interface AttentionSummary {
+  needsAttention: number;
+  stuckCI: number;
+  dormantFollowup: number;
+  waiting: number;
+}
+
+/** Count PRs per bucket — the shape both headline surfaces render from. */
+export function summarizeAttentionBuckets(prs: readonly AttentionInput[]): AttentionSummary {
+  const summary: AttentionSummary = { needsAttention: 0, stuckCI: 0, dormantFollowup: 0, waiting: 0 };
+  for (const pr of prs) {
+    switch (classifyAttentionBucket(pr)) {
+      case 'needs_attention': {
+        summary.needsAttention++;
+        break;
+      }
+      case 'stuck_ci': {
+        summary.stuckCI++;
+        break;
+      }
+      case 'dormant_followup': {
+        summary.dormantFollowup++;
+        break;
+      }
+      case 'waiting': {
+        summary.waiting++;
+        break;
+      }
+    }
+  }
+  return summary;
+}

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -201,6 +201,9 @@ export type MaintainerActionHint =
  * This is never persisted in local state — it represents a point-in-time snapshot
  * of a PR's current condition.
  */
+/** Unified attention bucket (#1352) — see core/pr-attention.ts for the classifier. */
+export type AttentionBucket = 'needs_attention' | 'stuck_ci' | 'dormant_followup' | 'waiting';
+
 export interface FetchedPR {
   // Identity
   id: number;
@@ -219,6 +222,11 @@ export interface FetchedPR {
   actionReasons?: ActionReason[];
   /** How stale the PR is based on activity age. Independent of status — a PR can be both needs_addressing and dormant. */
   stalenessTier: StalenessTier;
+  /** Unified attention bucket (#1352), computed by `classifyAttentionBucket()`
+   * from status/ciStatus/reviewDecision/daysSinceActivity. Stamped by the
+   * dashboard data path so the SPA renders the same taxonomy the CLI brief
+   * counts. Optional: absent on payloads from older producers. */
+  attentionBucket?: AttentionBucket;
 
   /** Human-readable status label for consistent display (#79). E.g., "[CI Failing]", "[Needs Response]". */
   displayLabel: string;

--- a/packages/core/src/formatters/json.test.ts
+++ b/packages/core/src/formatters/json.test.ts
@@ -184,6 +184,7 @@ function makeMockDailyOutput(): DailyOutput {
     },
     summary: 'This is a long markdown summary that takes up ~8KB...',
     briefSummary: '5 Active PRs | 2 need attention',
+    attention: { needsAttention: 2, stuckCI: 1, dormantFollowup: 0, waiting: 2 },
     actionableIssues: [
       {
         type: 'ci_failing',

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -4,6 +4,7 @@
  */
 
 import { z, type ZodType } from 'zod';
+import type { AttentionSummary } from '../core/pr-attention.js';
 import type {
   FetchedPR,
   DailyDigest,
@@ -162,6 +163,8 @@ export interface DailyOutput {
   summary: string; // Pre-formatted markdown for Claude to display verbatim
   briefSummary: string; // One-liner for action-first flow
   actionableIssues: CompactActionableIssue[]; // Structured list referencing PRs by URL
+  /** Unified attention-bucket counts (#1352) — same classifier the dashboard stamps per-PR. */
+  attention: AttentionSummary;
   actionMenu: ActionMenu; // Pre-computed action menu for Action Menu section
   commentedIssues: CommentedIssue[]; // Issues user commented on with conversation state
   repoGroups: CompactRepoGroup[]; // PRs grouped by repo for safe parallel dispatch (#80)
@@ -195,6 +198,8 @@ export interface CompactDailyOutput {
   capacity: CapacityAssessment;
   briefSummary: string;
   actionableIssues: CompactActionableIssue[];
+  /** Unified attention-bucket counts (#1352), retained under --compact. */
+  attention: AttentionSummary;
   actionMenu: ActionMenu;
   commentedIssues: CommentedIssue[];
   /** Number of PRs that failed to fetch. Non-zero indicates partial results. */
@@ -220,6 +225,7 @@ export function toCompactDailyOutput(output: DailyOutput): CompactDailyOutput {
     capacity: output.capacity,
     briefSummary: output.briefSummary,
     actionableIssues: output.actionableIssues,
+    attention: output.attention,
     actionMenu: output.actionMenu,
     commentedIssues: output.commentedIssues,
     failureCount: output.failures.length,
@@ -492,12 +498,20 @@ export const StrategyOutputSchema = z.object({
 });
 export type StrategyCommandOutput = z.infer<typeof StrategyOutputSchema>;
 
+export const AttentionSummarySchema = z.object({
+  needsAttention: z.number().int().nonnegative(),
+  stuckCI: z.number().int().nonnegative(),
+  dormantFollowup: z.number().int().nonnegative(),
+  waiting: z.number().int().nonnegative(),
+});
+
 export const DailyOutputSchema = z.object({
   digest: DailyDigestCompactSchema,
   capacity: CapacityAssessmentSchema,
   summary: z.string(),
   briefSummary: z.string(),
   actionableIssues: z.array(CompactActionableIssueSchema),
+  attention: AttentionSummarySchema,
   actionMenu: ActionMenuSchema,
   commentedIssues: z.array(CommentedIssuePassthroughSchema),
   repoGroups: z.array(CompactRepoGroupSchema),
@@ -511,6 +525,7 @@ export const CompactDailyOutputSchema = z.object({
   capacity: CapacityAssessmentSchema,
   briefSummary: z.string(),
   actionableIssues: z.array(CompactActionableIssueSchema),
+  attention: AttentionSummarySchema,
   actionMenu: ActionMenuSchema,
   commentedIssues: z.array(CommentedIssuePassthroughSchema),
   failureCount: z.number().int().nonnegative(),

--- a/packages/dashboard/src/app.tsx
+++ b/packages/dashboard/src/app.tsx
@@ -16,7 +16,7 @@ import { VettedIssueList } from './components/vetted-issue-list';
 import { SkeletonLoader } from './components/skeleton-loader';
 import { ThemeToggle } from './components/theme-toggle';
 import { CelebrationToast } from './components/celebration-toast';
-import { formatRelativeTime, refreshLabel } from './utils';
+import { attentionBucketOf, formatRelativeTime, refreshLabel } from './utils';
 import type { DashboardStats, FetchedPR } from './types';
 
 interface DashboardHeaderProps {
@@ -128,9 +128,16 @@ function AppContent() {
   // users with a backgrounded tab can see "(2) OSS Autopilot" and react.
   // Counting here instead of memoing because the dep list is already minimal.
   useEffect(() => {
-    const needCount = data?.activePRs?.filter((pr) => pr.status === 'needs_addressing').length ?? 0;
+    // Counts the shelved-filtered set so the tab prefix matches the StatsBar
+    // headline (#1352) — digest.openPRs deliberately includes shelved PRs.
+    // Derived inline (not from the activePRs memo) because this effect sits
+    // above the memo declarations and hook order must stay stable (#1369).
+    const shelved = new Set(data?.shelvedPRUrls ?? []);
+    const needCount = (data?.activePRs ?? []).filter(
+      (pr) => !shelved.has(pr.url) && attentionBucketOf(pr) === 'needs_attention',
+    ).length;
     document.title = needCount > 0 ? `(${needCount}) OSS Autopilot` : 'OSS Autopilot Dashboard';
-  }, [data?.activePRs]);
+  }, [data?.activePRs, data?.shelvedPRUrls]);
 
   // Global Shift+C fires a celebration (#940). Ignored when the user is
   // typing into an input/textarea/contenteditable so the shortcut doesn't
@@ -338,8 +345,12 @@ function AppContent() {
   // filteredPRs, activePRs) are memoized above the early returns (#1369).
   const selectedPR = selectedUrl ? (data.activePRs.find((pr) => pr.url === selectedUrl) ?? null) : null;
 
-  const needAttentionCount = activePRs.filter((pr) => pr.status === 'needs_addressing').length;
-  const waitingCount = activePRs.filter((pr) => pr.status === 'waiting_on_maintainer').length;
+  // #1352: counts come from the same attention-bucket classifier the CLI
+  // brief uses, so the headline number matches `N need attention` exactly.
+  const needAttentionCount = activePRs.filter((pr) => attentionBucketOf(pr) === 'needs_attention').length;
+  const stuckCICount = activePRs.filter((pr) => attentionBucketOf(pr) === 'stuck_ci').length;
+  const dormantFollowupCount = activePRs.filter((pr) => attentionBucketOf(pr) === 'dormant_followup').length;
+  const waitingCount = activePRs.filter((pr) => attentionBucketOf(pr) === 'waiting').length;
 
   const scrollTo = (id: string) => {
     const el = document.getElementById(id);
@@ -369,8 +380,12 @@ function AppContent() {
           <StatsBar
             stats={data.stats}
             needAttentionCount={needAttentionCount}
+            stuckCICount={stuckCICount}
+            dormantFollowupCount={dormantFollowupCount}
             waitingCount={waitingCount}
             onNeedAttentionClick={() => scrollTo('section-action')}
+            onStuckCIClick={() => scrollTo('section-stuck')}
+            onDormantFollowupClick={() => scrollTo('section-dormant')}
             onWaitingClick={() => scrollTo('section-waiting')}
             onShelvedClick={() => {
               setShelvedOpen(true);

--- a/packages/dashboard/src/components/pr-list.test.tsx
+++ b/packages/dashboard/src/components/pr-list.test.tsx
@@ -201,3 +201,64 @@ describe('statusClass', () => {
     expect(statusClass('unknown_status' as FetchedPRStatus)).toBe('');
   });
 });
+
+describe('attention bucket sections (#1352)', () => {
+  const noop = () => {};
+  it('renders Stuck CI and Dormant Follow-up sections from server-stamped buckets', () => {
+    const prs = [
+      makePR({ url: 'https://github.com/o/r/pull/1', number: 1, status: 'needs_addressing' }),
+      makePR({
+        url: 'https://github.com/o/r/pull/2',
+        number: 2,
+        status: 'waiting_on_maintainer',
+        attentionBucket: 'stuck_ci',
+      }),
+      makePR({
+        url: 'https://github.com/o/r/pull/3',
+        number: 3,
+        status: 'waiting_on_maintainer',
+        attentionBucket: 'dormant_followup',
+      }),
+      makePR({
+        url: 'https://github.com/o/r/pull/4',
+        number: 4,
+        status: 'waiting_on_maintainer',
+        attentionBucket: 'waiting',
+      }),
+    ];
+    const { container, getByText } = render(
+      <PRList
+        prs={prs}
+        selectedUrl={null}
+        onSelect={noop}
+        shelvedUrls={new Set()}
+        shelvedOpen={false}
+        onShelvedToggle={noop}
+      />,
+    );
+    expect(getByText('Stuck CI')).toBeTruthy();
+    expect(getByText('Dormant Follow-up')).toBeTruthy();
+    expect(container.querySelector('#section-stuck')).toBeTruthy();
+    expect(container.querySelector('#section-dormant')).toBeTruthy();
+    // Each section holds exactly one PR
+    expect(container.querySelector('#section-stuck')?.querySelectorAll('.pr-row')).toHaveLength(1);
+    expect(container.querySelector('#section-dormant')?.querySelectorAll('.pr-row')).toHaveLength(1);
+  });
+
+  it('omits bucket sections that are empty and falls back by status for unstamped PRs', () => {
+    const prs = [makePR({ url: 'https://github.com/o/r/pull/1', number: 1, status: 'waiting_on_maintainer' })];
+    const { container, queryByText } = render(
+      <PRList
+        prs={prs}
+        selectedUrl={null}
+        onSelect={noop}
+        shelvedUrls={new Set()}
+        shelvedOpen={false}
+        onShelvedToggle={noop}
+      />,
+    );
+    expect(queryByText('Stuck CI')).toBeNull();
+    expect(queryByText('Dormant Follow-up')).toBeNull();
+    expect(container.querySelector('#section-waiting')?.querySelectorAll('.pr-row')).toHaveLength(1);
+  });
+});

--- a/packages/dashboard/src/components/pr-list.tsx
+++ b/packages/dashboard/src/components/pr-list.tsx
@@ -1,5 +1,5 @@
-import type { FetchedPR, FetchedPRStatus } from '../types';
-import { truncate, statusColor, stripBrackets, pillColorClass } from '../utils';
+import type { AttentionBucket, FetchedPR, FetchedPRStatus } from '../types';
+import { truncate, statusColor, stripBrackets, pillColorClass, attentionBucketOf } from '../utils';
 
 interface PRListProps {
   prs: FetchedPR[];
@@ -10,11 +10,17 @@ interface PRListProps {
   onShelvedToggle: () => void;
 }
 
-/** Statuses that belong in the "Need Attention" section. */
-const NEED_ATTENTION: Set<FetchedPRStatus> = new Set(['needs_addressing']);
-
-/** Statuses that belong in the "Waiting on Others" section. */
-const WAITING: Set<FetchedPRStatus> = new Set(['waiting_on_maintainer']);
+/**
+ * Section order for the unified attention taxonomy (#1352). Buckets are
+ * stamped server-side by the shared core classifier; `attentionBucketOf`
+ * falls back to the coarse status split for older payloads.
+ */
+const SECTION_ORDER: Array<{ bucket: AttentionBucket; id: string; title: string; dotClass: string }> = [
+  { bucket: 'needs_attention', id: 'action', title: 'Need Attention', dotClass: 'red' },
+  { bucket: 'stuck_ci', id: 'stuck', title: 'Stuck CI', dotClass: 'amber' },
+  { bucket: 'dormant_followup', id: 'dormant', title: 'Dormant Follow-up', dotClass: 'amber' },
+  { bucket: 'waiting', id: 'waiting', title: 'Waiting on Others', dotClass: 'blue' },
+];
 
 interface SectionDef {
   id: string;
@@ -94,20 +100,12 @@ export function PRList({ prs, selectedUrl, onSelect, shelvedUrls, shelvedOpen, o
   const activePRs = prs.filter((pr) => !shelvedUrls.has(pr.url));
   const shelvedPRs = prs.filter((pr) => shelvedUrls.has(pr.url));
 
-  const sections: SectionDef[] = [
-    {
-      id: 'action',
-      title: 'Need Attention',
-      dotClass: 'red',
-      prs: activePRs.filter((pr) => NEED_ATTENTION.has(pr.status)),
-    },
-    {
-      id: 'waiting',
-      title: 'Waiting on Others',
-      dotClass: 'blue',
-      prs: activePRs.filter((pr) => WAITING.has(pr.status)),
-    },
-  ].filter((s) => s.prs.length > 0);
+  const sections: SectionDef[] = SECTION_ORDER.map(({ bucket, id, title, dotClass }) => ({
+    id,
+    title,
+    dotClass,
+    prs: activePRs.filter((pr) => attentionBucketOf(pr) === bucket),
+  })).filter((s) => s.prs.length > 0);
 
   return (
     <div class="pr-list">

--- a/packages/dashboard/src/components/stats-bar.test.tsx
+++ b/packages/dashboard/src/components/stats-bar.test.tsx
@@ -20,6 +20,34 @@ describe('StatsBar', () => {
     expect(cards).toHaveLength(5);
   });
 
+  it('renders Stuck CI and Dormant Follow-up cards only when non-zero (#1352)', () => {
+    const { container } = render(<StatsBar {...baseProps} stuckCICount={2} dormantFollowupCount={1} />);
+    const labels = [...container.querySelectorAll('.stat-label')].map((el) => el.textContent);
+    expect(labels).toContain('Stuck CI');
+    expect(labels).toContain('Dormant Follow-up');
+    // Inserted between Need Attention and Waiting on Others
+    expect(labels.indexOf('Stuck CI')).toBeGreaterThan(labels.indexOf('Need Attention'));
+    expect(labels.indexOf('Dormant Follow-up')).toBeLessThan(labels.indexOf('Waiting on Others'));
+  });
+
+  it('fires the bucket click handlers (#1352)', () => {
+    const onStuckCIClick = vi.fn();
+    const onDormantFollowupClick = vi.fn();
+    const { getByText } = render(
+      <StatsBar
+        {...baseProps}
+        stuckCICount={1}
+        dormantFollowupCount={1}
+        onStuckCIClick={onStuckCIClick}
+        onDormantFollowupClick={onDormantFollowupClick}
+      />,
+    );
+    fireEvent.click(getByText('Stuck CI'));
+    fireEvent.click(getByText('Dormant Follow-up'));
+    expect(onStuckCIClick).toHaveBeenCalledOnce();
+    expect(onDormantFollowupClick).toHaveBeenCalledOnce();
+  });
+
   it('displays correct values after animation', () => {
     const { container } = render(<StatsBar {...baseProps} />);
     act(() => {

--- a/packages/dashboard/src/components/stats-bar.tsx
+++ b/packages/dashboard/src/components/stats-bar.tsx
@@ -4,8 +4,13 @@ import { AnimatedValue } from './animated-value';
 interface StatsBarProps {
   stats: DashboardStats;
   needAttentionCount: number;
+  /** Unified attention buckets (#1352); the cards render only when non-zero. */
+  stuckCICount?: number;
+  dormantFollowupCount?: number;
   waitingCount: number;
   onNeedAttentionClick?: () => void;
+  onStuckCIClick?: () => void;
+  onDormantFollowupClick?: () => void;
   onWaitingClick?: () => void;
   onShelvedClick?: () => void;
   onMergedClick?: () => void;
@@ -23,8 +28,12 @@ interface StatCardDef {
 export function StatsBar({
   stats,
   needAttentionCount,
+  stuckCICount = 0,
+  dormantFollowupCount = 0,
   waitingCount,
   onNeedAttentionClick,
+  onStuckCIClick,
+  onDormantFollowupClick,
   onWaitingClick,
   onShelvedClick,
   onMergedClick,
@@ -33,6 +42,20 @@ export function StatsBar({
 }: StatsBarProps) {
   const cards: StatCardDef[] = [
     { label: 'Need Attention', value: needAttentionCount, colorClass: 'red', onClick: onNeedAttentionClick },
+    // #1352 watch buckets — shown only when non-zero so the bar stays compact.
+    ...(stuckCICount > 0
+      ? [{ label: 'Stuck CI', value: stuckCICount, colorClass: 'amber', onClick: onStuckCIClick }]
+      : []),
+    ...(dormantFollowupCount > 0
+      ? [
+          {
+            label: 'Dormant Follow-up',
+            value: dormantFollowupCount,
+            colorClass: 'amber',
+            onClick: onDormantFollowupClick,
+          },
+        ]
+      : []),
     { label: 'Waiting on Others', value: waitingCount, colorClass: 'blue', onClick: onWaitingClick },
     { label: 'Shelved', value: stats.shelvedPRs, colorClass: 'muted', onClick: onShelvedClick },
     { label: 'Merged PRs', value: stats.mergedPRs, colorClass: 'purple', onClick: onMergedClick },

--- a/packages/dashboard/src/styles.css
+++ b/packages/dashboard/src/styles.css
@@ -769,6 +769,10 @@ a:hover {
   background: var(--text-muted);
 }
 
+.pr-section-dot.amber {
+  background: var(--amber, #d97706);
+}
+
 .pr-section-count {
   font-size: 0.6875rem;
   font-weight: 600;

--- a/packages/dashboard/src/types.ts
+++ b/packages/dashboard/src/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type {
+  AttentionBucket,
   FetchedPRStatus,
   ShelvedPRRef,
   FetchedPR,
@@ -26,6 +27,7 @@ import type {
 
 // Re-export shared types so consumers keep using `import { X } from '../types'`
 export type {
+  AttentionBucket,
   FetchedPRStatus,
   ShelvedPRRef,
   FetchedPR,

--- a/packages/dashboard/src/utils.test.ts
+++ b/packages/dashboard/src/utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  attentionBucketOf,
   stripBrackets,
   pillColorClass,
   truncate,
@@ -11,6 +12,17 @@ import {
   formatRelativeTime,
   refreshLabel,
 } from './utils';
+
+describe('attentionBucketOf (#1352)', () => {
+  it('prefers the server-stamped bucket', () => {
+    expect(attentionBucketOf({ status: 'waiting_on_maintainer', attentionBucket: 'stuck_ci' })).toBe('stuck_ci');
+  });
+
+  it('falls back to the coarse status split for older payloads', () => {
+    expect(attentionBucketOf({ status: 'needs_addressing' })).toBe('needs_attention');
+    expect(attentionBucketOf({ status: 'waiting_on_maintainer' })).toBe('waiting');
+  });
+});
 
 describe('stripBrackets', () => {
   it('removes surrounding brackets from a label', () => {

--- a/packages/dashboard/src/utils.ts
+++ b/packages/dashboard/src/utils.ts
@@ -1,4 +1,4 @@
-import type { FetchedPRStatus } from './types';
+import type { AttentionBucket, FetchedPR, FetchedPRStatus } from './types';
 
 /** Strip brackets from core display labels, e.g. "[CI Failing]" → "CI Failing". */
 export function stripBrackets(label: string): string {
@@ -49,6 +49,15 @@ export function formatDate(iso: string): string {
   } catch {
     return iso;
   }
+}
+
+/**
+ * Resolve a PR's unified attention bucket (#1352). The server stamps
+ * `attentionBucket` via the shared core classifier; payloads from older
+ * servers fall back to the coarse status split so the SPA stays usable.
+ */
+export function attentionBucketOf(pr: Pick<FetchedPR, 'status' | 'attentionBucket'>): AttentionBucket {
+  return pr.attentionBucket ?? (pr.status === 'needs_addressing' ? 'needs_attention' : 'waiting');
 }
 
 export function statusColor(status: FetchedPRStatus | string): string {


### PR DESCRIPTION
## Summary

Closes #1352. The headline "needs attention" number was computed by two independent classifiers (CLI brief via `collectActionableIssues()`, dashboard via a raw `status === 'needs_addressing'` filter), and the cases the CLI deliberately excludes — stuck CI, dormant maintainer waits — sat undifferentiated inside `waiting_on_maintainer`.

### One classifier, all surfaces
- NEW `core/pr-attention.ts`: `classifyAttentionBucket()` → `needs_attention` | `stuck_ci` (CI `pending` ≥ 3 days) | `dormant_followup` (`review_required`, ≥ 14 days idle — matches the middle step of the 7/14/30 follow-up cadence) | `waiting`, plus `summarizeAttentionBuckets()`.
- Dashboard server stamps `attentionBucket` on every PR in `/api/data`; the SPA renders sections (Stuck CI / Dormant Follow-up with amber accents), conditional StatsBar cards, and the tab-title prefix from the stamped buckets, with a coarse status-split fallback for payloads from older servers.
- Daily output carries an `attention` summary through `DailyOutput` and `CompactDailyOutput` (+ Zod schemas); the brief appends `N stuck CI | N dormant follow-ups` when non-zero.

### Parity by construction
- `collectActionableIssues()` now emits exactly one entry per `needs_addressing` PR. Previously a PR whose `actionReason` fell outside the five mapped reasons (or was missing) was silently dropped from the brief while the dashboard still counted it — the exact divergence the issue reported. Unmapped reasons warn and sort last; a test pins `brief count === needs_attention bucket count`.
- The dashboard shelve partitions now honor `CRITICAL_STATUSES`: an explicitly shelved PR that turns critical is never display-shelved (the daily check auto-unshelves it, so the dashboard must agree within the same refresh instead of diverging until the next daily run). Regression test added.
- The SPA tab-title count uses the same shelved-filtered population as the StatsBar headline.

### Deliberately out of scope
- The MCP `oss://prs` resource serves the raw digest un-stamped (consumers get bucket counts via the `daily` tool's `attention` field); stamping it can ride along with a future resource-shape change.
- The action menu's existing "Follow up on dormant PRs" item already covers the `dormant_followup` workflow; no new menu entries.

## Test plan

- [x] 10 classifier tests including the two concrete examples from the issue (pending CI 12 days → `stuck_ci`; `review_required` passing 15 days → `dormant_followup`)
- [x] Parity test: `collectActionableIssues().length === summarizeAttentionBuckets().needsAttention` over mixed inputs incl. unmapped/missing reasons
- [x] Dashboard partition regression: shelved-but-critical PR is active, not shelved
- [x] SPA tests: bucket sections render, empty buckets omitted, legacy fallback, conditional StatsBar cards + click handlers
- [x] Full monorepo suite: 3210 tests passing; lint, typecheck, format, coverage gates (incl. dashboard 80/75/80/80) green
- [x] Two review passes + convergence: no Critical/Recommended findings remaining