### PR TITLE
fix(core): list-mark-done errors on URL not found instead of quiet success

### DIFF
--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -703,19 +703,9 @@ export const commands: CLICommandDef[] = [
                 prStatus: options.prStatus,
                 listPath: options.listPath,
               });
-              // Convert "URL not in list" into a real CLI error so the JSON
-              // envelope reports `success: false` and the process exits non-zero.
-              // The pure transform's success-shaped not-found return is fine for
-              // library consumers, but as a CLI command "I asked you to mark X
-              // and you couldn't find X" is a failure the caller must see.
-              // The "already marked done" case stays as a success-shape return
-              // (it's idempotent — the caller's intent was achieved).
-              if (!result.marked && result.reason === 'issue URL not found in the list') {
-                throw new Error(
-                  `Issue URL not found in ${result.filePath}: ${result.url}. ` +
-                    `Verify --list-path and the issue URL.`,
-                );
-              }
+              // Not-found now throws ValidationError inside the command (#1406),
+              // so library and CLI consumers see the same failure — no CLI-layer
+              // re-throw needed (mirrors list-move-tier after #1355).
               return result;
             },
             (data) => {

--- a/packages/core/src/commands/list-mark-done.test.ts
+++ b/packages/core/src/commands/list-mark-done.test.ts
@@ -219,11 +219,29 @@ describe('runMarkIssueListItemDone (filesystem)', () => {
     ).rejects.toThrow(/File not found/);
   });
 
-  it('does not write when the URL is not present', async () => {
+  it('throws ValidationError and does not write when the URL is not present (#1406)', async () => {
     const original = `### foo/bar\n- [#9](https://github.com/foo/bar/issues/9) — other\n`;
     fs.writeFileSync(listPath, original);
     const before = fs.statSync(listPath).mtimeMs;
     await new Promise((resolve) => setTimeout(resolve, 10));
+    const promise = runMarkIssueListItemDone({
+      issueUrl: ISSUE_A,
+      prUrl: PR_A,
+      prStatus: 'merged',
+      listPath,
+    });
+    // The exact phrase "Issue URL not found" is load-bearing: the consumer
+    // branch in workflows/draft-first-workflow.md matches on it.
+    await expect(promise).rejects.toThrow(/Issue URL not found in the list/);
+    await expect(promise).rejects.toMatchObject({ name: 'ValidationError', code: 'VALIDATION_ERROR' });
+    const after = fs.statSync(listPath).mtimeMs;
+    expect(after).toBe(before);
+    expect(fs.readFileSync(listPath, 'utf8')).toBe(original);
+  });
+
+  it('still resolves (no error) when the entry is already marked done', async () => {
+    const original = `### foo/bar\n- ~~[#1](${ISSUE_A}) — x~~\n  - **Done** — PR [#2](${PR_A}) submitted, merged.\n`;
+    fs.writeFileSync(listPath, original);
     const out = await runMarkIssueListItemDone({
       issueUrl: ISSUE_A,
       prUrl: PR_A,
@@ -231,8 +249,7 @@ describe('runMarkIssueListItemDone (filesystem)', () => {
       listPath,
     });
     expect(out.marked).toBe(false);
-    const after = fs.statSync(listPath).mtimeMs;
-    expect(after).toBe(before);
+    expect(out.reason).toMatch(/already/);
     expect(fs.readFileSync(listPath, 'utf8')).toBe(original);
   });
 

--- a/packages/core/src/commands/list-mark-done.ts
+++ b/packages/core/src/commands/list-mark-done.ts
@@ -1,6 +1,9 @@
 /**
  * list-mark-done command (#1299).
  *
+ * A URL that is not in the list at all is an error (#1406) — marking done
+ * requires an existing entry; only the already-marked re-run is a quiet no-op.
+ *
  * Mark an issue line in a curated list as done by wrapping it in
  * `~~strikethrough~~` and appending a `**Done** — PR [#N](url) ...` sub-bullet.
  * If every issue under the same `### repo/name` heading is now struck through,
@@ -14,7 +17,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { errorMessage } from '../core/errors.js';
+import { errorMessage, ValidationError } from '../core/errors.js';
 
 export interface MarkDoneOptions {
   issueUrl: string;
@@ -25,7 +28,8 @@ export interface MarkDoneOptions {
 }
 
 export interface MarkDoneOutput {
-  /** True if the line was found and updated. False on already-marked or not-found. */
+  /** True if the line was found and updated. False only when already marked
+   * done — a URL missing from the list entirely throws instead (#1406). */
   marked: boolean;
   /** Fully-resolved file path that was inspected. */
   filePath: string;
@@ -139,6 +143,9 @@ function countOpenIssues(lines: string[], section: RepoSection): number {
   return open;
 }
 
+/** Discriminates the two `marked: false` outcomes of {@link markIssueAsDone}. */
+export type MarkDoneNoOpReason = 'not-found' | 'already-marked';
+
 /** Pure transform — exposed for unit testing. */
 export function markIssueAsDone(
   content: string,
@@ -149,6 +156,8 @@ export function markIssueAsDone(
   repoHeadingStruck: boolean;
   remainingUnderRepo: number;
   reason?: string;
+  /** Set only when `marked` is false — why nothing changed. */
+  reasonCode?: MarkDoneNoOpReason;
 } {
   const hadTrailingNewline = content.endsWith('\n');
   const lines = (hadTrailingNewline ? content.slice(0, -1) : content).split('\n');
@@ -161,6 +170,7 @@ export function markIssueAsDone(
       repoHeadingStruck: false,
       remainingUnderRepo: 0,
       reason: 'issue URL not found in the list',
+      reasonCode: 'not-found',
     };
   }
 
@@ -176,6 +186,7 @@ export function markIssueAsDone(
       repoHeadingStruck: false,
       remainingUnderRepo: section ? countOpenIssues(lines, section) : 0,
       reason: 'already marked done',
+      reasonCode: 'already-marked',
     };
   }
 
@@ -243,6 +254,17 @@ export async function runMarkIssueListItemDone(options: MarkDoneOptions): Promis
     prUrl: options.prUrl,
     prStatus: options.prStatus,
   });
+
+  // #1406: a missing entry is a caller error, not a quiet success — the
+  // consumer branch in workflows/draft-first-workflow.md already documents
+  // this contract (STOP on success:false mentioning "Issue URL not found").
+  // Idempotent re-runs (already marked done) still resolve normally.
+  if (result.reasonCode === 'not-found') {
+    throw new ValidationError(
+      `Issue URL not found in the list: ${options.issueUrl} (${filePath}). ` +
+        'Check the URL and --list-path; the entry must exist before it can be marked done.',
+    );
+  }
 
   if (result.marked) {
     const tmp = `${filePath}.tmp-${process.pid}-${Date.now()}`;

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -662,7 +662,10 @@ export const ListMarkDoneOutputSchema = z.object({
   url: z.string(),
   repoHeadingStruck: z.boolean(),
   remainingUnderRepo: z.number().int().nonnegative(),
-  reason: z.string().optional(),
+  // #1406: not-found now throws before the success envelope, so the only
+  // reachable no-op reason is the idempotent one. Pinned so a new quiet
+  // no-op path trips the #1105 runtime validator instead of shipping silently.
+  reason: z.literal('already marked done').optional(),
 });
 
 // verify-issue (#1353, #1354): mirrors {@link IssueVerification} from


### PR DESCRIPTION
## Summary

Closes #1406. Mirrors #1355 onto the sibling command. `runMarkIssueListItemDone` returned `marked: false` inside a `success: true` envelope when the URL wasn't in the list; only a CLI-layer string-matched re-throw converted it to a failure, leaving library/MCP consumers with the silent no-op.

- The throw now lives in the command: `ValidationError` on a typed `reasonCode: 'not-found'` discriminator, before any write. The unreachable CLI-layer guard is removed (matching list-move-tier's post-#1355 shape).
- `already marked done` stays a resolving idempotent no-op.
- `ListMarkDoneOutputSchema.reason` pinned to the one reachable literal.
- `workflows/draft-first-workflow.md` documented this exact contract before the code had it — all three of its branches (`marked: true`, already-done, `success: false` mentioning "Issue URL not found") are now reachable as written; the error message preserves that load-bearing phrase, pinned by a test.

## Test plan

- [x] New test: not-found rejects with `ValidationError` (`VALIDATION_ERROR`), message contains the doc's match phrase, file mtime + content untouched
- [x] New test: already-marked still resolves with `marked: false` + reason, no write
- [x] Full monorepo suite: 3211 tests passing; lint, typecheck clean
- [x] Review pass: discriminant verified airtight; dead-code finding fixed