### PR TITLE
feat(core): diversity counterweight + surfaced bias annotations for strategy-biased search

### DIFF
--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -89,7 +89,7 @@ Hidden signals (policy PRs, hidden comments) aren't document-scannable — note 
 ## Search Process
 
 1. **Run `search`** (MCP tool or CLI) — it automatically loads user preferences, applies multi-strategy search (merged repos, orgs, starred, broad, maintained), scores by viability (0–100), filters to active/available, and returns structured candidates.
-2. **Parse results.** Each candidate has `issue`, `recommendation`, `reasonsToApprove`, `reasonsToSkip`, `viabilityScore`, `grade`, `searchPriority`, optional `repoScore`.
+2. **Parse results.** Each candidate has `issue`, `recommendation`, `reasonsToApprove`, `reasonsToSkip`, `viabilityScore`, `grade`, `searchPriority`, optional `repoScore`. Strategy-biased searches (#1244) also carry optional `boostReasons` (why this result was boosted, e.g. repo affinity or language match) and `diversitySlot: true` (deliberately outside the user's usual languages/repos — the echo-chamber counterweight). Quote these in your summary so the user sees why each result surfaced; do not treat a diversity slot as a lower-quality result.
 3. **Manual context** via `status --json`: preferences, open PRs with health, history, cached repo scores.
 
 ### gh fallback

--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -386,6 +386,14 @@ export const commands: CLICommandDef[] = [
                 console.log(`[${recommendation.toUpperCase()}] ${issue.repo}#${issue.number}: ${issue.title}`);
                 console.log(`  URL: ${issue.url}`);
                 console.log(`  Viability: ${viabilityScore}/100`);
+                // #1244: say WHY a result surfaced so the user can calibrate
+                // trust in the strategy bias — and see the counterweight work.
+                if (candidate.boostReasons && candidate.boostReasons.length > 0) {
+                  console.log(`  Why surfaced: ${candidate.boostReasons.join(', ')}`);
+                }
+                if (candidate.diversitySlot) {
+                  console.log('  Diversity slot: outside your usual languages/repos');
+                }
                 if (reasonsToApprove.length > 0) console.log(`  Approve: ${reasonsToApprove.join(', ')}`);
                 if (reasonsToSkip.length > 0) console.log(`  Skip: ${reasonsToSkip.join(', ')}`);
                 console.log('---');

--- a/packages/core/src/commands/search.test.ts
+++ b/packages/core/src/commands/search.test.ts
@@ -43,6 +43,53 @@ describe('runSearch', () => {
     } as any);
   });
 
+  it('passes the diversity counterweight ratio to scout (#1244)', async () => {
+    mockSearch.mockResolvedValue({
+      candidates: [],
+      excludedRepos: [],
+      aiPolicyBlocklist: [],
+      strategiesUsed: ['broad'],
+    });
+
+    await runSearch({ maxResults: 5 });
+
+    expect(mockSearch).toHaveBeenCalledWith(expect.objectContaining({ diversityRatio: 0.2 }));
+  });
+
+  it('surfaces diversitySlot on candidates and omits it when absent (#1244)', async () => {
+    const base = {
+      recommendation: 'approve',
+      reasonsToApprove: [],
+      reasonsToSkip: [],
+      searchPriority: 'normal',
+      viabilityScore: 50,
+    };
+    mockSearch.mockResolvedValue({
+      candidates: [
+        {
+          ...base,
+          issue: { repo: 'a/b', number: 1, title: 'slot', url: 'https://github.com/a/b/issues/1', labels: [] },
+          diversitySlot: true,
+        },
+        {
+          ...base,
+          issue: { repo: 'a/b', number: 2, title: 'boosted', url: 'https://github.com/a/b/issues/2', labels: [] },
+          boostScore: 3,
+          boostReasons: ['language match: TypeScript'],
+        },
+      ],
+      excludedRepos: [],
+      aiPolicyBlocklist: [],
+      strategiesUsed: ['broad'],
+    });
+
+    const result = await runSearch({ maxResults: 5 });
+
+    expect(result.candidates[0].diversitySlot).toBe(true);
+    expect('diversitySlot' in result.candidates[1]).toBe(false);
+    expect(result.candidates[1].boostReasons).toEqual(['language match: TypeScript']);
+  });
+
   it('should search and return candidates', async () => {
     mockSearch.mockResolvedValue({
       candidates: [
@@ -68,7 +115,7 @@ describe('runSearch', () => {
 
     const result = await runSearch({ maxResults: 10 });
 
-    expect(mockSearch).toHaveBeenCalledWith({ maxResults: 10 });
+    expect(mockSearch).toHaveBeenCalledWith(expect.objectContaining({ maxResults: 10, diversityRatio: 0.2 }));
     expect(result).toEqual(
       expect.objectContaining({
         candidates: expect.arrayContaining([

--- a/packages/core/src/commands/search.ts
+++ b/packages/core/src/commands/search.ts
@@ -21,6 +21,15 @@ const MODULE = 'search';
  */
 export const MAX_SEARCH_RESULTS = 100;
 
+/**
+ * Fraction of search slots reserved for candidates that matched neither
+ * strategy-preferred languages nor repos (#1244). Counterweight against
+ * echo-chamber bias: without it, strategy-boosted searches return more of
+ * what already merged, which merges more of the same, and the profile
+ * narrows over time. Scout clamps to [0, 1]; 0.2 is the issue's proposal.
+ */
+export const SEARCH_DIVERSITY_RATIO = 0.2;
+
 interface SearchOptions {
   maxResults: number;
 }
@@ -80,6 +89,7 @@ export async function runSearch(options: SearchOptions): Promise<SearchOutput> {
     maxResults: options.maxResults,
     preferLanguages,
     preferRepos,
+    diversityRatio: SEARCH_DIVERSITY_RATIO,
   });
 
   // #1354: never surface issues the user already has an open PR for. Uses
@@ -149,6 +159,7 @@ export async function runSearch(options: SearchOptions): Promise<SearchOutput> {
         ...(linkedPR ? { linkedPR } : {}),
         ...(typeof c.boostScore === 'number' ? { boostScore: c.boostScore } : {}),
         ...(c.boostReasons && c.boostReasons.length > 0 ? { boostReasons: c.boostReasons } : {}),
+        ...(c.diversitySlot === true ? { diversitySlot: true } : {}),
       };
     }),
     excludedRepos: result.excludedRepos,

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -585,6 +585,9 @@ const SearchCandidateSchema = z.object({
    */
   boostScore: z.number().optional(),
   boostReasons: z.array(z.string()).optional(),
+  /** True when this candidate filled a diversity slot (#1244) — surfaced so
+   * the user can see the counterweight working, not just its absence. */
+  diversitySlot: z.boolean().optional(),
 });
 
 export const SearchOutputSchema = z.object({
@@ -1049,6 +1052,12 @@ export interface SearchCandidate {
    * opportunities (open PR + no updates for 30+ days, scout 0.9.0 #97).
    */
   linkedPR?: CandidateLinkedPR;
+  /** Strategy-bias sort boost from scout (#1244); absent when unboosted. */
+  boostScore?: number;
+  /** Human-readable boost explanations, e.g. "repo affinity: vercel/next.js". */
+  boostReasons?: string[];
+  /** True when this candidate filled a diversity slot (#1244). */
+  diversitySlot?: boolean;
 }
 
 export interface SearchOutput {


### PR DESCRIPTION
## Summary

Closes #1244. The strategy-bias engine already exists on both sides (scout 0.11.0 boosts `preferLanguages`/`preferRepos` matches and implements `diversityRatio` slot reservation; `runSearch` already passes the preference fields). This PR wires the two remaining pieces from the issue:

**Diversity counterweight.** `runSearch` passes `diversityRatio: 0.2` (the issue's proposed 20%), so each round reserves roughly a fifth of its slots for candidates that matched neither preference list. Without it, biased search returns more of what already merged, which merges more of the same, and the profile narrows.

**Bias transparency.** Candidates surface scout's `diversitySlot` flag alongside `boostScore`/`boostReasons` (the latter two were Zod-schema-only; the hand-written `SearchCandidate` interface now declares all three). Text mode prints `Why surfaced: <boost reasons>` and a `Diversity slot: outside your usual languages/repos` line; the issue-scout agent guidance instructs quoting both and never treating a diversity slot as lower quality.

**Out of scope, matching scout's own #1244 scope note in `personalization.ts`:** `boostIssueTypes` and `avoidRepos` MCP fields.

## Test plan

- [x] New test: `scout.search` receives `diversityRatio: 0.2`
- [x] New test: `diversitySlot` surfaced when scout sets it, omitted when absent; `boostReasons` pass through
- [x] Verified the pinned `@oss-scout/core` 0.11.0 d.ts actually accepts `diversityRatio` and emits `diversitySlot` (not just the local scout repo HEAD)
- [x] Full monorepo suite: 3213 tests passing; lint, typecheck clean
- [x] Review pass: clean, no Critical/Recommended findings