### PR TITLE
fix(core): pin contract goldens to their output schemas and typecheck tests

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,7 +34,7 @@
     "bundle": "esbuild src/cli.ts --bundle --platform=node --target=node22 --format=cjs --minify --sourcemap --outfile=dist/cli.bundle.cjs",
     "start": "tsx src/cli.ts",
     "dev": "tsx watch src/cli.ts",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.tests.json",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",

--- a/packages/core/src/commands/__golden__/daily.degraded.json
+++ b/packages/core/src/commands/__golden__/daily.degraded.json
@@ -96,6 +96,12 @@
       "isNewContribution": false
     }
   ],
+  "attention": {
+    "needsAttention": 1,
+    "stuckCI": 0,
+    "dormantFollowup": 0,
+    "waiting": 1
+  },
   "actionMenu": {
     "items": [
       {

--- a/packages/core/src/commands/__golden__/daily.empty.json
+++ b/packages/core/src/commands/__golden__/daily.empty.json
@@ -26,6 +26,12 @@
   "summary": "No open PRs.",
   "briefSummary": "No open PRs",
   "actionableIssues": [],
+  "attention": {
+    "needsAttention": 0,
+    "stuckCI": 0,
+    "dormantFollowup": 0,
+    "waiting": 0
+  },
   "actionMenu": {
     "items": [
       {

--- a/packages/core/src/commands/__golden__/daily.typical.json
+++ b/packages/core/src/commands/__golden__/daily.typical.json
@@ -96,6 +96,12 @@
       "isNewContribution": false
     }
   ],
+  "attention": {
+    "needsAttention": 1,
+    "stuckCI": 0,
+    "dormantFollowup": 0,
+    "waiting": 1
+  },
   "actionMenu": {
     "items": [
       {

--- a/packages/core/src/commands/daily.contract.test.ts
+++ b/packages/core/src/commands/daily.contract.test.ts
@@ -18,7 +18,25 @@
 
 import { describe, it, expect } from 'vitest';
 import { toDailyOutput, type DailyCheckResult } from './daily.js';
-import { makeFetchedPR, makeDailyDigest, makeCapacityAssessment } from '../core/test-utils.js';
+import { summarizeAttentionBuckets } from '../core/pr-attention.js';
+import {
+  DailyOutputSchema,
+  CompactDailyOutputSchema,
+  toCompactDailyOutput,
+  type DailyOutput,
+} from '../formatters/json.js';
+import { makeFetchedPR, makeDailyDigest, makeCapacityAssessment, schemaIssues } from '../core/test-utils.js';
+
+/**
+ * Goldens pin the serialized shape; this pins the goldens to the exported
+ * schemas. Without it a fixture missing a required field (tests are excluded
+ * from tsc) produces goldens that match yet fail `DailyOutputSchema` for
+ * every real consumer (#1418).
+ */
+function expectSchemaValid(result: DailyOutput): void {
+  expect(schemaIssues(DailyOutputSchema, result)).toEqual([]);
+  expect(schemaIssues(CompactDailyOutputSchema, toCompactDailyOutput(result))).toEqual([]);
+}
 
 function makeFixture(overrides: Partial<DailyCheckResult> = {}): DailyCheckResult {
   const pr1 = makeFetchedPR({
@@ -46,6 +64,9 @@ function makeFixture(overrides: Partial<DailyCheckResult> = {}): DailyCheckResul
     summary: 'One PR needs attention; one waiting on review.',
     briefSummary: '2 active PRs: 1 needs attention',
     actionableIssues: [{ type: 'ci_failing', pr: pr1, label: '[CI Failing]', isNewContribution: false }],
+    // Mirrors production wiring: executeDailyCheckInternal computes
+    // `attention` with this same classifier over the active PRs (#1352).
+    attention: summarizeAttentionBuckets([pr1, pr2]),
     actionMenu: {
       items: [
         {
@@ -75,6 +96,7 @@ function makeFixture(overrides: Partial<DailyCheckResult> = {}): DailyCheckResul
 describe('daily --json contract', () => {
   it('typical-day output matches the golden shape', async () => {
     const result = toDailyOutput(makeFixture());
+    expectSchemaValid(result);
     await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/daily.typical.json');
   });
 
@@ -86,6 +108,7 @@ describe('daily --json contract', () => {
         summary: 'No open PRs.',
         briefSummary: 'No open PRs',
         actionableIssues: [],
+        attention: summarizeAttentionBuckets([]),
         actionMenu: {
           items: [
             { key: 'search', label: 'Search for new issues', description: 'Find a new contribution' },
@@ -102,6 +125,7 @@ describe('daily --json contract', () => {
         repoGroups: [],
       }),
     );
+    expectSchemaValid(result);
     await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/daily.empty.json');
   });
 
@@ -115,6 +139,7 @@ describe('daily --json contract', () => {
         ],
       }),
     );
+    expectSchemaValid(result);
     await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/daily.degraded.json');
   });
 });

--- a/packages/core/src/commands/daily.test.ts
+++ b/packages/core/src/commands/daily.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect } from 'vitest';
 import { computeRepoSignals, computeActionMenu, groupPRsByRepo, toShelvedPRRef } from './daily.js';
 import { deduplicateDigest, compactActionableIssues, compactRepoGroups } from '../formatters/json.js';
-import type { DailyDigest, CommentedIssue } from '../core/types.js';
+import type { DailyDigest, CommentedIssue, FetchedPR } from '../core/types.js';
 import type { ActionableIssue } from '../formatters/json.js';
 import { makeFetchedPR, makeCapacityAssessment as makeCapacity } from '../core/test-utils.js';
 

--- a/packages/core/src/commands/dashboard-data.test.ts
+++ b/packages/core/src/commands/dashboard-data.test.ts
@@ -113,7 +113,7 @@ vi.mock('../core/index.js', async (importOriginal) => {
     // Override here so the existing mockBuildStarFilter / mockToShelvedPRRef
     // wiring keeps working.
     buildStarFilter: (...args: unknown[]) => mockBuildStarFilter(...args),
-    toShelvedPRRef: (...args: unknown[]) => mockToShelvedPRRef(...args),
+    toShelvedPRRef: (pr: unknown) => mockToShelvedPRRef(pr),
   };
 });
 
@@ -151,7 +151,7 @@ vi.mock('../core/github-stats.js', () => ({
 }));
 
 vi.mock('./daily.js', () => ({
-  toShelvedPRRef: (...args: unknown[]) => mockToShelvedPRRef(...args),
+  toShelvedPRRef: (pr: unknown) => mockToShelvedPRRef(pr),
   buildStarFilter: (...args: unknown[]) => mockBuildStarFilter(...args),
 }));
 

--- a/packages/core/src/commands/dashboard-server.test.ts
+++ b/packages/core/src/commands/dashboard-server.test.ts
@@ -17,7 +17,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import type { DailyDigest } from '../core/types.js';
-import { makeAgentState as makeState } from '../core/test-utils.js';
+import { makeAgentState as makeState, makeRepoScore } from '../core/test-utils.js';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 
 // ── Captured request handler ──────────────────────────────────────────
@@ -226,7 +226,7 @@ function createMockRes(): { res: ServerResponse; result: Promise<MockResponseRes
     statusCode = code;
     if (hdrs) Object.assign(headers, hdrs);
     return res;
-  });
+  }) as unknown as ServerResponse['writeHead'];
 
   res.end = vi.fn((data?: string | Buffer) => {
     if (data) {
@@ -638,30 +638,10 @@ describe('dashboard-server', () => {
       const state = makeState({
         lastDigest: makeDigest(),
         repoScores: {
-          'has/both': {
-            score: 5,
-            mergedPRCount: 1,
-            closedWithoutMergeCount: 0,
-            signals: {},
-            stargazersCount: 500,
-            language: 'TypeScript',
-          },
-          'has/stars-only': {
-            score: 5,
-            mergedPRCount: 1,
-            closedWithoutMergeCount: 0,
-            signals: {},
-            stargazersCount: 100,
-          },
-          'has/null-language': {
-            score: 5,
-            mergedPRCount: 1,
-            closedWithoutMergeCount: 0,
-            signals: {},
-            stargazersCount: 200,
-            language: null,
-          },
-          'no/metadata': { score: 5, mergedPRCount: 2, closedWithoutMergeCount: 0, signals: {} },
+          'has/both': makeRepoScore({ repo: 'has/both', stargazersCount: 500, language: 'TypeScript' }),
+          'has/stars-only': makeRepoScore({ repo: 'has/stars-only', stargazersCount: 100 }),
+          'has/null-language': makeRepoScore({ repo: 'has/null-language', stargazersCount: 200, language: null }),
+          'no/metadata': makeRepoScore({ repo: 'no/metadata', mergedPRCount: 2 }),
         },
       });
       mockStateManager.getState.mockReturnValue(state);

--- a/packages/core/src/commands/doctor.test.ts
+++ b/packages/core/src/commands/doctor.test.ts
@@ -54,7 +54,9 @@ const mockGetStatePath = vi.mocked(getStatePath);
  * single `{stdout, stderr}` object, matching what the real Node child
  * process helper yields when promisified.
  */
-function stubExecFile(responses: Array<{ stdout?: string; stderr?: string; error?: Error & { code?: number } }>): void {
+function stubExecFile(
+  responses: Array<{ stdout?: string; stderr?: string; error?: Error & { code?: string | number } }>,
+): void {
   let i = 0;
   mockExecFile.mockImplementation(((_cmd: string, _args: string[], _opts: unknown, cb: unknown) => {
     const callback = cb as (err: Error | null, value?: { stdout: string; stderr: string }) => void;

--- a/packages/core/src/commands/move.contract.test.ts
+++ b/packages/core/src/commands/move.contract.test.ts
@@ -32,6 +32,8 @@ vi.mock('../core/index.js', async () => {
 });
 
 import { runMove } from './move.js';
+import { MoveOutputSchema } from '../formatters/json.js';
+import { schemaIssues } from '../core/test-utils.js';
 
 const TEST_PR_URL = 'https://github.com/owner/repo/pull/42';
 
@@ -43,21 +45,25 @@ describe('move --json contract', () => {
 
   it('target=attention output matches the golden shape', async () => {
     const result = await runMove({ prUrl: TEST_PR_URL, target: 'attention' });
+    expect(schemaIssues(MoveOutputSchema, result)).toEqual([]);
     await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/move.attention.json');
   });
 
   it('target=waiting output matches the golden shape', async () => {
     const result = await runMove({ prUrl: TEST_PR_URL, target: 'waiting' });
+    expect(schemaIssues(MoveOutputSchema, result)).toEqual([]);
     await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/move.waiting.json');
   });
 
   it('target=shelved output matches the golden shape', async () => {
     const result = await runMove({ prUrl: TEST_PR_URL, target: 'shelved' });
+    expect(schemaIssues(MoveOutputSchema, result)).toEqual([]);
     await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/move.shelved.json');
   });
 
   it('target=auto output matches the golden shape', async () => {
     const result = await runMove({ prUrl: TEST_PR_URL, target: 'auto' });
+    expect(schemaIssues(MoveOutputSchema, result)).toEqual([]);
     await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/move.auto.json');
   });
 });

--- a/packages/core/src/commands/scout-bridge.test.ts
+++ b/packages/core/src/commands/scout-bridge.test.ts
@@ -40,12 +40,12 @@ describe('buildScoutState', () => {
         githubUsername: 'octocat',
         languages: ['TypeScript', 'Rust'],
         labels: ['good first issue', 'help wanted'],
-        scope: ['all'],
+        scope: ['beginner'],
         excludeRepos: ['owner/excluded'],
         excludeOrgs: ['bad-org'],
         aiPolicyBlocklist: ['matplotlib/matplotlib'],
         preferredOrgs: ['microsoft', 'vercel'],
-        projectCategories: ['web', 'cli'],
+        projectCategories: ['devtools', 'infrastructure'],
         minStars: 100,
         maxIssueAgeDays: 30,
         includeDocIssues: false,
@@ -75,11 +75,11 @@ describe('buildScoutState', () => {
     expect(result.preferences.githubUsername).toBe('octocat');
     expect(result.preferences.languages).toEqual(['TypeScript', 'Rust']);
     expect(result.preferences.labels).toEqual(['good first issue', 'help wanted']);
-    expect(result.preferences.scope).toEqual(['all']);
+    expect(result.preferences.scope).toEqual(['beginner']);
     expect(result.preferences.excludeRepos).toEqual(['owner/excluded']);
     expect(result.preferences.excludeOrgs).toEqual(['bad-org']);
     expect(result.preferences.aiPolicyBlocklist).toEqual(['matplotlib/matplotlib']);
-    expect(result.preferences.projectCategories).toEqual(['web', 'cli']);
+    expect(result.preferences.projectCategories).toEqual(['devtools', 'infrastructure']);
     expect(result.preferences.minStars).toBe(100);
     expect(result.preferences.maxIssueAgeDays).toBe(30);
     expect(result.preferences.includeDocIssues).toBe(false);
@@ -92,17 +92,17 @@ describe('buildScoutState', () => {
     expect(result.savedResults).toEqual([]);
   });
 
-  it.each([
-    ['excludeOrgs', 'excludeOrgs'],
-    ['projectCategories', 'projectCategories'],
-  ] as const)('should default %s to [] when undefined in config', (field) => {
-    const state = makeAgentState({ config: { [field]: undefined } });
-    mockGetStateManager.mockReturnValue(makeStateManagerMock({ state, config: state.config }));
+  it.each(['excludeOrgs', 'projectCategories'] as const)(
+    'should default %s to [] when undefined in config',
+    (field) => {
+      const state = makeAgentState({ config: { [field]: undefined } });
+      mockGetStateManager.mockReturnValue(makeStateManagerMock({ state, config: state.config }));
 
-    const result = buildScoutState();
+      const result = buildScoutState();
 
-    expect(result.preferences[field]).toEqual([]);
-  });
+      expect(result.preferences[field]).toEqual([]);
+    },
+  );
 
   it('should correctly project mergedPRs to url, title, mergedAt', () => {
     const state = makeAgentState({

--- a/packages/core/src/commands/search.contract.test.ts
+++ b/packages/core/src/commands/search.contract.test.ts
@@ -43,6 +43,8 @@ vi.mock('../core/index.js', async () => {
 });
 
 import { runSearch } from './search.js';
+import { SearchOutputSchema } from '../formatters/json.js';
+import { schemaIssues } from '../core/test-utils.js';
 
 describe('search --json contract', () => {
   beforeEach(() => {
@@ -129,6 +131,7 @@ describe('search --json contract', () => {
       expect(candidate.grade.letter).toMatch(/^[A-CF]$/);
     }
 
+    expect(schemaIssues(SearchOutputSchema, result)).toEqual([]);
     await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/search.json');
   });
 
@@ -141,6 +144,7 @@ describe('search --json contract', () => {
     });
 
     const result = await runSearch({ maxResults: 5 });
+    expect(schemaIssues(SearchOutputSchema, result)).toEqual([]);
     await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/search.rate-limited.json');
   });
 });

--- a/packages/core/src/commands/state-cmd.test.ts
+++ b/packages/core/src/commands/state-cmd.test.ts
@@ -119,9 +119,9 @@ describe('runStateShow', () => {
     const sm = {
       ...makeStateManagerMock({ state: { lastRunAt: undefined } }),
       isGistDegraded: vi.fn().mockReturnValue(false),
+      // Patch getState to return a state with no lastRunAt
+      getState: () => ({ ...makeAgentState(), lastRunAt: undefined }),
     };
-    // Patch getState to return a state with no lastRunAt
-    sm.getState = () => ({ ...makeAgentState(), lastRunAt: undefined }) as any;
     mockGetStateManager.mockReturnValue(sm as any);
 
     const result = await runStateShow();

--- a/packages/core/src/commands/status.contract.test.ts
+++ b/packages/core/src/commands/status.contract.test.ts
@@ -20,6 +20,8 @@ vi.mock('../core/index.js', () => ({
 
 import { getStateManager } from '../core/index.js';
 import { runStatus } from './status.js';
+import { StatusOutputSchema } from '../formatters/json.js';
+import { schemaIssues } from '../core/test-utils.js';
 
 const mockGetStateManager = vi.mocked(getStateManager);
 
@@ -51,11 +53,13 @@ describe('status --json contract', () => {
 
   it('online mode output matches the golden shape', async () => {
     const result = await runStatus({});
+    expect(schemaIssues(StatusOutputSchema, result)).toEqual([]);
     await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/status.online.json');
   });
 
   it('offline mode output matches the golden shape', async () => {
     const result = await runStatus({ offline: true });
+    expect(schemaIssues(StatusOutputSchema, result)).toEqual([]);
     await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/status.offline.json');
   });
 });

--- a/packages/core/src/core/daily-logic.test.ts
+++ b/packages/core/src/core/daily-logic.test.ts
@@ -607,7 +607,7 @@ describe('computeActionMenu (core)', () => {
         isNewContribution: false,
       },
       {
-        type: 'changes_requested' as const,
+        type: 'needs_changes' as const,
         pr: makePR({ repo: 'owner/repo-b' }),
         label: '[Changes Requested]',
         isNewContribution: false,
@@ -685,7 +685,10 @@ describe('applyStatusOverrides', () => {
   });
 
   function makeState(
-    statusOverrides: Record<string, { status: string; setAt: string; lastActivityAt: string }> = {},
+    statusOverrides: Record<
+      string,
+      { status: 'needs_addressing' | 'waiting_on_maintainer'; setAt: string; lastActivityAt: string }
+    > = {},
   ): Readonly<AgentState> {
     return makeAgentState({ config: { statusOverrides } });
   }

--- a/packages/core/src/core/gist-state-store.concurrency.test.ts
+++ b/packages/core/src/core/gist-state-store.concurrency.test.ts
@@ -141,22 +141,32 @@ function makeStatefulGistMock(gistId: string, initialStateJson: string): Statefu
         getCalls++;
         return buildResponse();
       }),
-      update: vi.fn(async ({ gist_id, files: incoming, headers }) => {
-        if (gist_id !== gistId) {
-          throw new Error(`gist mock received unexpected gist_id: got ${gist_id}, expected ${gistId}`);
-        }
-        updateCalls++;
-        const ifMatch = headers?.['if-match'];
-        if (ifMatch !== undefined && ifMatch !== currentEtag) {
-          throw Object.assign(new Error('Precondition failed'), { status: 412 });
-        }
-        for (const [filename, file] of Object.entries(incoming)) {
-          files[filename] = file.content;
-        }
-        etagCounter++;
-        currentEtag = `W/"e${etagCounter}"`;
-        return buildResponse();
-      }),
+      update: vi.fn(
+        async ({
+          gist_id,
+          files: incoming,
+          headers,
+        }: {
+          gist_id: string;
+          files: Record<string, { content: string }>;
+          headers?: Record<string, string>;
+        }) => {
+          if (gist_id !== gistId) {
+            throw new Error(`gist mock received unexpected gist_id: got ${gist_id}, expected ${gistId}`);
+          }
+          updateCalls++;
+          const ifMatch = headers?.['if-match'];
+          if (ifMatch !== undefined && ifMatch !== currentEtag) {
+            throw Object.assign(new Error('Precondition failed'), { status: 412 });
+          }
+          for (const [filename, file] of Object.entries(incoming)) {
+            files[filename] = file.content;
+          }
+          etagCounter++;
+          currentEtag = `W/"e${etagCounter}"`;
+          return buildResponse();
+        },
+      ),
       create: vi.fn(),
     },
   };

--- a/packages/core/src/core/gist-state-store.test.ts
+++ b/packages/core/src/core/gist-state-store.test.ts
@@ -95,14 +95,18 @@ function makeGistResponse(gistId: string, stateJson?: string) {
 }
 
 /** Create a mock Octokit with gists methods as vi.fn(). */
-function makeMockOctokit(): OctokitLike & {
+type MockOctokit = OctokitLike & {
   gists: {
     get: ReturnType<typeof vi.fn>;
     list: ReturnType<typeof vi.fn>;
     create: ReturnType<typeof vi.fn>;
     update: ReturnType<typeof vi.fn>;
   };
-} {
+};
+
+function makeMockOctokit(): MockOctokit {
+  // The cast is load-bearing: a bare vi.fn() satisfies the Mock side of the
+  // intersection but not OctokitLike's concrete call signatures.
   return {
     gists: {
       get: vi.fn(),
@@ -110,7 +114,7 @@ function makeMockOctokit(): OctokitLike & {
       create: vi.fn(),
       update: vi.fn(),
     },
-  };
+  } as unknown as MockOctokit;
 }
 
 // ── Test suite ───────────────────────────────────────────────────────────────
@@ -446,7 +450,7 @@ describe('GistStateStore', () => {
       expect(result.degraded).toBe(true);
       expect(store.getGistId()).toBeNull();
 
-      store.setState(createFreshState());
+      store.setState(JSON.stringify(createFreshState()));
       await expect(store.push()).rejects.toThrow(/cannot push before bootstrap/);
       expect(octokit.gists.update).not.toHaveBeenCalled();
     });

--- a/packages/core/src/core/linked-pr-classification.test.ts
+++ b/packages/core/src/core/linked-pr-classification.test.ts
@@ -83,8 +83,8 @@ describe('classifyLinkedPR', () => {
 
   describe('state casing and normalization', () => {
     it('accepts uppercase state values (GraphQL PullRequestState enum)', () => {
-      // @ts-expect-error — runtime test for uppercase input
       const result = classifyLinkedPR({
+        // @ts-expect-error — runtime test for uppercase input
         linkedPR: { author: { login: 'contributor' }, state: 'OPEN' },
         userLogin: 'costajohnt',
       });
@@ -92,8 +92,8 @@ describe('classifyLinkedPR', () => {
     });
 
     it('accepts uppercase MERGED from GraphQL', () => {
-      // @ts-expect-error — runtime test for uppercase input
       const result = classifyLinkedPR({
+        // @ts-expect-error — runtime test for uppercase input
         linkedPR: { author: { login: 'costajohnt' }, state: 'MERGED' },
         userLogin: 'costajohnt',
       });
@@ -104,7 +104,6 @@ describe('classifyLinkedPR', () => {
   describe('ghost author handling', () => {
     it('treats a null author (deleted GitHub account) as other_X', () => {
       const result = classifyLinkedPR({
-        // @ts-expect-error — runtime test: GitHub returns null author for deleted accounts
         linkedPR: { author: null, state: 'closed' },
         userLogin: 'costajohnt',
       });

--- a/packages/core/src/core/pr-comments-fetcher.test.ts
+++ b/packages/core/src/core/pr-comments-fetcher.test.ts
@@ -241,7 +241,7 @@ describe('fetchPRCommentBundle', () => {
     expect(extractFromFence(bundle.reviews[0].body)).toBe('review 1');
     expect(extractFromFence(bundle.reviews[100].body)).toBe('final review');
     // listReviews called exactly twice — page 1 (full), page 2 (short → stop).
-    expect((octokit.pulls.listReviews as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
+    expect((octokit.pulls.listReviews as unknown as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
   });
 });
 
@@ -385,7 +385,9 @@ describe('fetchPRCommentBundlesBatch', () => {
     ];
     await expect(fetchPRCommentBundlesBatch(octokit, urls, 'me', 1)).rejects.toThrow('API rate limit exceeded');
     // Abort flag stops the queue: PR 3 is never attempted after the 429.
-    const getCalls = (octokit.pulls.get as ReturnType<typeof vi.fn>).mock.calls as Array<[{ pull_number: number }]>;
+    const getCalls = (octokit.pulls.get as unknown as ReturnType<typeof vi.fn>).mock.calls as Array<
+      [{ pull_number: number }]
+    >;
     expect(getCalls.map(([args]) => args.pull_number)).toEqual([1, 2]);
   });
 

--- a/packages/core/src/core/prompt-injection-corpus.test.ts
+++ b/packages/core/src/core/prompt-injection-corpus.test.ts
@@ -288,6 +288,7 @@ describe('end-to-end: toDailyOutput emits fenced commentedIssues bodies (#1372)'
       summary: '',
       briefSummary: '',
       actionableIssues: [],
+      attention: { needsAttention: 0, stuckCI: 0, dormantFollowup: 0, waiting: 0 },
       actionMenu: {
         items: [],
         context: {

--- a/packages/core/src/core/test-utils.ts
+++ b/packages/core/src/core/test-utils.ts
@@ -6,6 +6,7 @@
  * callers only specify the fields relevant to their test.
  */
 
+import type { z } from 'zod';
 import type {
   FetchedPR,
   DailyDigest,
@@ -98,7 +99,9 @@ export function makeCapacityAssessment(overrides: Partial<CapacityAssessment> = 
 // RepoScore
 // ---------------------------------------------------------------------------
 
-export function makeRepoScore(overrides: Partial<RepoScore> = {}): RepoScore {
+export function makeRepoScore(
+  overrides: Partial<Omit<RepoScore, 'signals'>> & { signals?: Partial<RepoScore['signals']> } = {},
+): RepoScore {
   const { signals: signalOverrides, ...rest } = overrides;
   return {
     repo: 'owner/repo',
@@ -280,4 +283,19 @@ export function makeIssueCandidate(overrides: Partial<IssueCandidate> = {}): Iss
     searchPriority: 'normal',
     ...overrides,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Schema validation (contract tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the Zod issues from validating `value` against `schema` — empty
+ * when it parses. Contract tests assert this equals `[]` so a golden that
+ * drifts from its exported output schema fails loudly with the exact paths,
+ * instead of passing on golden equality alone (#1418).
+ */
+export function schemaIssues(schema: z.ZodTypeAny, value: unknown): z.ZodIssue[] {
+  const result = schema.safeParse(value);
+  return result.success ? [] : result.error.issues;
 }

--- a/packages/core/tsconfig.tests.json
+++ b/packages/core/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "lib": ["ES2023"],
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Fixes #1418. The daily contract fixture omitted the now-required `attention` field, so `toDailyOutput` emitted `attention: undefined`, `JSON.stringify` dropped it, and the three daily goldens kept matching while failing `DailyOutputSchema.safeParse` for every real consumer.

## Changes

- **Fixture + goldens**: `attention` computed via `summarizeAttentionBuckets` (mirrors `executeDailyCheckInternal`); all three daily goldens regenerated and now parse under `DailyOutputSchema`.
- **Schema-validity assertions**: new `schemaIssues` helper in `test-utils`; every contract test with an exported Zod output schema now asserts validity before snapshotting: daily (full + compact via `toCompactDailyOutput`), move, search, status. verify-issue already round-trips its schema. The remaining 10 contract tests have TS-interface outputs only, so there is no schema to assert against.
- **Tooling gate**: new `packages/core/tsconfig.tests.json` (includes tests + test-lib, lib ES2023); core `typecheck` script now chains it, so CI's existing `pnpm run typecheck` step type-checks test files. This closes the gap that let the fixture omission ship.
- **41 pre-existing test type errors fixed** across 15 files, surfaced by the new gate. Several were real instances of the same bug class: `prompt-injection-corpus` also omitted `attention`; `daily-logic` used the nonexistent `ActionableIssueType` value `changes_requested`; `scout-bridge` used scope/category values the schemas reject; `gist-state-store` passed an object where `setState` takes a JSON string. `makeRepoScore` now accepts partial `signals` overrides (same pattern as `makeAgentState` config).

## Acceptance criteria

- [x] All daily goldens parse under DailyOutputSchema/CompactDailyOutputSchema (asserted in-test)
- [x] Contract tests assert schema validity, not just golden equality
- [x] Fixture omissions of required fields are caught by tooling (mutation-verified: deleting `attention` fails both the schema assertion and `typecheck`)

## Test plan

- [x] `tsc --noEmit` and `tsc --noEmit -p tsconfig.tests.json` both clean
- [x] Full core suite: 2727 passed / 15 skipped / 3 todo
- [x] eslint + prettier clean
- [x] Mutation check: removing `attention` from the fixture fails the typecheck gate (TS2322) and 2/3 contract tests with `invalid_type` at path `attention`