### PR TITLE
fix(core): dashboard partitions on post-override status, matching the CLI

### DIFF
--- a/packages/core/src/commands/dashboard-data.test.ts
+++ b/packages/core/src/commands/dashboard-data.test.ts
@@ -33,6 +33,7 @@ const {
   mockFetchClosedPRsSince,
   mockBuildStarFilter,
   mockToShelvedPRRef,
+  mockApplyStatusOverrides,
   mockIsRateLimitOrAuthError,
   mockWarn,
 } = vi.hoisted(() => ({
@@ -60,6 +61,12 @@ const {
   mockFetchMergedPRsSince: vi.fn().mockResolvedValue([]),
   mockFetchClosedPRsSince: vi.fn().mockResolvedValue([]),
   mockBuildStarFilter: vi.fn().mockReturnValue(undefined),
+  // Identity by default (also re-installed in beforeEach after clearAllMocks);
+  // #1416 ordering tests swap in a status-flipping implementation to prove
+  // overrides are applied before partitioning. An undefined-returning default
+  // would crash fetchDashboardData inside its swallow-and-warn persistence
+  // guard — a false green.
+  mockApplyStatusOverrides: vi.fn((prs: unknown, _state?: unknown) => prs),
   mockToShelvedPRRef: vi.fn((pr: any) => ({
     number: pr.number,
     url: pr.url,
@@ -114,6 +121,7 @@ vi.mock('../core/index.js', async (importOriginal) => {
     // wiring keeps working.
     buildStarFilter: (...args: unknown[]) => mockBuildStarFilter(...args),
     toShelvedPRRef: (pr: unknown) => mockToShelvedPRRef(pr),
+    applyStatusOverrides: (prs: unknown, state: unknown) => mockApplyStatusOverrides(prs, state),
   };
 });
 
@@ -924,6 +932,7 @@ describe('fetchDashboardData', () => {
 
     mockIsRateLimitOrAuthError.mockReturnValue(false);
     mockBuildStarFilter.mockReturnValue(undefined);
+    mockApplyStatusOverrides.mockImplementation((prs: unknown) => prs);
   });
 
   it('fetches and returns dashboard data successfully (happy path)', async () => {
@@ -942,6 +951,64 @@ describe('fetchDashboardData', () => {
     expect(mockFetchUserOpenPRs).toHaveBeenCalled();
     expect(mockGenerateDigest).toHaveBeenCalled();
     expect(mockSetLastDigest).toHaveBeenCalled();
+  });
+
+  describe('partitions on post-override status (#1416)', () => {
+    const PR_URL = 'https://github.com/owner/repo/pull/7';
+
+    /** Dormant PR — the class where overrides survive until new activity. */
+    function makeDormantPR(status: 'needs_addressing' | 'waiting_on_maintainer') {
+      return makeFetchedPR({
+        repo: 'owner/repo',
+        number: 7,
+        status,
+        stalenessTier: 'dormant',
+        daysSinceActivity: 40,
+      });
+    }
+
+    /** Simulate a live override the way the real applyStatusOverrides reports it. */
+    function flipStatusTo(status: 'needs_addressing' | 'waiting_on_maintainer') {
+      mockApplyStatusOverrides.mockImplementation((prs: unknown) =>
+        (prs as Array<{ url: string }>).map((p) => (p.url === PR_URL ? { ...p, status } : p)),
+      );
+    }
+
+    beforeEach(() => {
+      // Build the digest from whatever PR list the partition hands over, so
+      // the test observes which statuses generateDigest actually consumed.
+      mockGenerateDigest.mockImplementation((prs: never[]) => makeMockDigest(prs));
+    });
+
+    it('shelves a dormant PR whose override flips needs_addressing -> waiting_on_maintainer', async () => {
+      mockFetchUserOpenPRs.mockResolvedValue({ prs: [makeDormantPR('needs_addressing')], failures: [] });
+      flipStatusTo('waiting_on_maintainer');
+
+      const result = await fetchDashboardData('test-token');
+
+      // The cached/persisted digest keeps RAW statuses so a later override
+      // CLEAR takes effect on rebuild instead of being baked in…
+      const digestInput = mockGenerateDigest.mock.calls[0][0] as Array<{ status: string }>;
+      expect(digestInput[0].status).toBe('needs_addressing');
+      // …while the shelve partition uses the post-override status, agreeing
+      // with the CLI rule: dormant + non-critical => shelved.
+      expect((result.digest.shelvedPRs ?? []).map((ref) => ref.url)).toContain(PR_URL);
+      expect(result.digest.summary.totalActivePRs).toBe(0);
+    });
+
+    it('keeps active a dormant PR whose override flips waiting_on_maintainer -> needs_addressing', async () => {
+      mockFetchUserOpenPRs.mockResolvedValue({ prs: [makeDormantPR('waiting_on_maintainer')], failures: [] });
+      flipStatusTo('needs_addressing');
+
+      const result = await fetchDashboardData('test-token');
+
+      // Raw status persisted; partition derived from the overridden status.
+      const digestInput = mockGenerateDigest.mock.calls[0][0] as Array<{ status: string }>;
+      expect(digestInput[0].status).toBe('waiting_on_maintainer');
+      // Critical is never display-shelved, matching the daily check's partition.
+      expect(result.digest.shelvedPRs ?? []).toEqual([]);
+      expect(result.digest.summary.totalActivePRs).toBe(1);
+    });
   });
 
   it('re-throws rate limit error from fetchUserOpenPRs', async () => {

--- a/packages/core/src/commands/dashboard-data.ts
+++ b/packages/core/src/commands/dashboard-data.ts
@@ -4,7 +4,14 @@
  * Consumed by the dashboard HTTP server (dashboard-server.ts) for the SPA API.
  */
 
-import { getStateManager, PRMonitor, IssueConversationMonitor, getOctokit, CRITICAL_STATUSES } from '../core/index.js';
+import {
+  getStateManager,
+  PRMonitor,
+  IssueConversationMonitor,
+  getOctokit,
+  CRITICAL_STATUSES,
+  applyStatusOverrides,
+} from '../core/index.js';
 import { errorMessage, isRateLimitOrAuthError } from '../core/errors.js';
 import { warn } from '../core/logger.js';
 import { emptyPRCountsResult, fetchMergedPRsSince, fetchClosedPRsSince } from '../core/github-stats.js';
@@ -369,6 +376,13 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
   // try-catch: save errors should not crash the dashboard data fetch.
   try {
     stateManager.batch(() => {
+      // Apply status overrides BEFORE partitioning, mirroring the daily check
+      // (daily.ts partitions overriddenPRs). Partitioning on raw status let a
+      // dormant PR with a criticality-flipping override land in a different
+      // partition here than on the CLI surface (#1416). Inside the batch
+      // because getStatusOverride may auto-clear stale overrides with a save,
+      // which must defer to this guarded boundary rather than throw here.
+      const overriddenPRs = applyStatusOverrides(prs, stateManager.getState());
       // Store new merged PRs incrementally (dedupes by URL)
       try {
         const { dropped } = stateManager.addMergedPRs(newMergedPRs);
@@ -389,24 +403,34 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
         warn(MODULE, `Failed to store closed PRs: ${errorMessage(error)}`);
       }
 
-      // Store monthly chart data (opened/merged/closed) so charts have data
+      // Store monthly chart data (opened/merged/closed) so charts have data.
+      // Analytics intentionally consume RAW prs: overrides only change status,
+      // never the createdAt/mergedAt dates the monthly counts key off.
       const { monthlyCounts, monthlyOpenedCounts: openedFromMerged } = mergedResult;
       const { monthlyCounts: monthlyClosedCounts, monthlyOpenedCounts: openedFromClosed } = closedResult;
       updateMonthlyAnalytics(prs, monthlyCounts, monthlyClosedCounts, openedFromMerged, openedFromClosed);
 
+      // The digest keeps RAW statuses in openPRs: this digest becomes the
+      // server's cached/persisted rebuild source, and baking overridden
+      // statuses into it would make CLEARING an override (move target=auto) a
+      // silent no-op until the next full refresh — buildDashboardJson can
+      // only apply overrides that still exist, never un-apply baked ones. It
+      // re-applies live overrides per request before partitioning.
       const digest = prMonitor.generateDigest(prs, recentlyClosedPRs, recentlyMergedPRs);
 
       // Apply shelve partitioning for display (auto-unshelve only runs in daily check).
       // Dormant PRs are treated as shelved unless they need addressing, and a
       // critical PR is never display-shelved (#1352) — mirrors the daily
       // check's CRITICAL_STATUSES auto-unshelve so headline counts agree.
+      // Partitioned over overriddenPRs (#1416): the shelve decision must use
+      // the same post-override status the CLI partitions on.
       const shelvedUrls = new Set(stateManager.getState().config.shelvedPRUrls || []);
-      const freshShelved = prs.filter(
+      const freshShelved = overriddenPRs.filter(
         (pr) => !CRITICAL_STATUSES.has(pr.status) && (shelvedUrls.has(pr.url) || pr.stalenessTier === 'dormant'),
       );
       digest.shelvedPRs = freshShelved.map(toShelvedPRRef);
       digest.autoUnshelvedPRs = [];
-      digest.summary.totalActivePRs = prs.length - freshShelved.length;
+      digest.summary.totalActivePRs = overriddenPRs.length - freshShelved.length;
 
       stateManager.setLastDigest(digest);
     });

--- a/packages/core/src/commands/dashboard-override-partition.test.ts
+++ b/packages/core/src/commands/dashboard-override-partition.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Dashboard shelve partition vs status overrides (#1416).
+ *
+ * The CLI applies status overrides BEFORE partitioning (daily.ts), so a
+ * dormant PR with a criticality-flipping override is partitioned on its
+ * overridden status. The dashboard used to partition on RAW status and only
+ * apply overrides to the `activePRs` payload afterwards, so the two surfaces
+ * disagreed for exactly that PR class — violating the #1352 "headline counts
+ * cannot diverge" contract.
+ *
+ * dashboard-server.test.ts mocks `applyStatusOverrides` as identity (which is
+ * why no test caught the divergence), so this suite deliberately runs the
+ * REAL override pipeline: a real StateManager over a temp dir (paths.js
+ * redirected, same pattern as state-concurrency.test.ts) with overrides set
+ * via `setStatusOverride`, through the real `applyStatusOverrides`.
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+let mockTmpDir = '';
+
+vi.mock('../core/paths.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../core/paths.js')>();
+  return {
+    ...actual,
+    getDataDir: () => {
+      if (!mockTmpDir) throw new Error('mockTmpDir not set');
+      if (!fs.existsSync(mockTmpDir)) {
+        fs.mkdirSync(mockTmpDir, { recursive: true, mode: 0o700 });
+      }
+      return mockTmpDir;
+    },
+    getStatePath: () => {
+      if (!mockTmpDir) throw new Error('mockTmpDir not set');
+      if (!fs.existsSync(mockTmpDir)) {
+        fs.mkdirSync(mockTmpDir, { recursive: true, mode: 0o700 });
+      }
+      return path.join(mockTmpDir, 'state.json');
+    },
+    getBackupDir: () => {
+      if (!mockTmpDir) throw new Error('mockTmpDir not set');
+      const backupDir = path.join(mockTmpDir, 'backups');
+      if (!fs.existsSync(backupDir)) {
+        fs.mkdirSync(backupDir, { recursive: true, mode: 0o700 });
+      }
+      return backupDir;
+    },
+    getLegacyStatePath: () => {
+      if (!mockTmpDir) throw new Error('mockTmpDir not set');
+      return path.join(mockTmpDir, 'legacy-data', 'state.json');
+    },
+    getLegacyBackupDir: () => {
+      if (!mockTmpDir) throw new Error('mockTmpDir not set');
+      return path.join(mockTmpDir, 'legacy-data', 'backups');
+    },
+  };
+});
+
+import { getStateManager, resetStateManager, CRITICAL_STATUSES, toShelvedPRRef } from '../core/index.js';
+import { buildDashboardJson } from './dashboard-server.js';
+import { makeFetchedPR, makeDailyDigest } from '../core/test-utils.js';
+
+const PR_URL = 'https://github.com/owner/repo/pull/7';
+
+/** A dormant PR — the class where overrides survive (auto-clear needs new activity). */
+function makeDormantPR(status: 'needs_addressing' | 'waiting_on_maintainer') {
+  return makeFetchedPR({
+    repo: 'owner/repo',
+    number: 7,
+    status,
+    stalenessTier: 'dormant',
+    daysSinceActivity: 40,
+    updatedAt: '2026-05-01T00:00:00Z',
+  });
+}
+
+describe('buildDashboardJson partitions on post-override status (#1416)', () => {
+  beforeEach(() => {
+    mockTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dashboard-override-'));
+    resetStateManager();
+  });
+
+  afterEach(() => {
+    resetStateManager();
+    fs.rmSync(mockTmpDir, { recursive: true, force: true });
+    mockTmpDir = '';
+  });
+
+  it('shelves a dormant PR whose override flips needs_addressing -> waiting_on_maintainer (CLI parity)', () => {
+    const pr = makeDormantPR('needs_addressing');
+    const sm = getStateManager();
+    // lastActivityAt matches updatedAt so getStatusOverride does not auto-clear.
+    sm.setStatusOverride(PR_URL, 'waiting_on_maintainer', pr.updatedAt);
+
+    const digest = makeDailyDigest({
+      openPRs: [pr],
+      summary: { totalActivePRs: 1, totalNeedingAttention: 1, totalMergedAllTime: 0, mergeRate: 0 },
+    });
+    const data = buildDashboardJson(digest, sm.getState(), [], [], []);
+
+    // Same rule daily.ts applies post-override: dormant + non-critical => shelved.
+    expect(data.shelvedPRUrls).toContain(PR_URL);
+    expect(data.stats.activePRs).toBe(0);
+    // The payload PR carries the overridden status and a non-headline bucket.
+    expect(data.activePRs[0].status).toBe('waiting_on_maintainer');
+    expect(data.activePRs[0].attentionBucket).not.toBe('needs_attention');
+  });
+
+  it('keeps active a dormant PR whose override flips waiting_on_maintainer -> needs_addressing (CLI parity)', () => {
+    const pr = makeDormantPR('waiting_on_maintainer');
+    const sm = getStateManager();
+    sm.setStatusOverride(PR_URL, 'needs_addressing', pr.updatedAt);
+
+    const digest = makeDailyDigest({
+      openPRs: [pr],
+      summary: { totalActivePRs: 1, totalNeedingAttention: 0, totalMergedAllTime: 0, mergeRate: 0 },
+    });
+    const data = buildDashboardJson(digest, sm.getState(), [], [], []);
+
+    // Same rule daily.ts applies post-override: critical is never shelved.
+    expect(CRITICAL_STATUSES.has('needs_addressing')).toBe(true);
+    expect(data.shelvedPRUrls).not.toContain(PR_URL);
+    expect(data.stats.activePRs).toBe(1);
+    // Post-override status reaches the attention classifier, so the PR shows
+    // up in the headline bucket instead of vanishing into the shelf.
+    expect(data.activePRs[0].status).toBe('needs_addressing');
+    expect(data.activePRs[0].attentionBucket).toBe('needs_attention');
+  });
+
+  it('does not mutate the caller-owned cached digest', () => {
+    const pr = makeDormantPR('waiting_on_maintainer');
+    const sm = getStateManager();
+    sm.setStatusOverride(PR_URL, 'needs_addressing', pr.updatedAt);
+
+    const digest = makeDailyDigest({
+      openPRs: [pr],
+      summary: { totalActivePRs: 1, totalNeedingAttention: 0, totalMergedAllTime: 0, mergeRate: 0 },
+    });
+    buildDashboardJson(digest, sm.getState(), [], [], []);
+
+    // The cached digest the action path reuses must keep raw statuses and its
+    // original partition; every request re-derives from current state.
+    expect(digest.openPRs[0].status).toBe('waiting_on_maintainer');
+    expect(digest.shelvedPRs).toEqual([]);
+    expect(digest.summary.totalActivePRs).toBe(1);
+  });
+
+  it('drops a BAKED shelved ref when the override flips the PR critical (action-path flow)', () => {
+    // The POST /api/action flow: the cached digest already carries the PR in
+    // shelvedPRs, then runMove sets a criticality-flipping override. The
+    // reconcile FILTER branch must drop the baked ref on rebuild.
+    const pr = makeDormantPR('waiting_on_maintainer');
+    const sm = getStateManager();
+    sm.setStatusOverride(PR_URL, 'needs_addressing', pr.updatedAt);
+
+    const digest = makeDailyDigest({
+      openPRs: [pr],
+      shelvedPRs: [toShelvedPRRef(pr)],
+      summary: { totalActivePRs: 0, totalNeedingAttention: 0, totalMergedAllTime: 0, mergeRate: 0 },
+    });
+    const data = buildDashboardJson(digest, sm.getState(), [], [], []);
+
+    expect(data.shelvedPRUrls).not.toContain(PR_URL);
+    expect(data.stats.activePRs).toBe(1);
+  });
+
+  it('unshelves an EXPLICITLY shelved PR when the override flips it critical (#1352 parity)', () => {
+    // Not dormant — shelved purely via config.shelvedPRUrls. The critical
+    // check must run on the post-override status for the explicit-shelve
+    // branch too, matching the daily check's CRITICAL_STATUSES auto-unshelve.
+    const pr = makeFetchedPR({
+      repo: 'owner/repo',
+      number: 7,
+      status: 'waiting_on_maintainer',
+      stalenessTier: 'active',
+      updatedAt: '2026-05-01T00:00:00Z',
+    });
+    const sm = getStateManager();
+    sm.shelvePR(PR_URL);
+    sm.setStatusOverride(PR_URL, 'needs_addressing', pr.updatedAt);
+
+    const digest = makeDailyDigest({
+      openPRs: [pr],
+      summary: { totalActivePRs: 1, totalNeedingAttention: 0, totalMergedAllTime: 0, mergeRate: 0 },
+    });
+    const data = buildDashboardJson(digest, sm.getState(), [], [], []);
+
+    expect(data.shelvedPRUrls).not.toContain(PR_URL);
+    expect(data.stats.activePRs).toBe(1);
+    expect(data.activePRs[0].attentionBucket).toBe('needs_attention');
+  });
+
+  it('partitions on RAW status once new activity auto-clears a stale override', () => {
+    const pr = makeDormantPR('needs_addressing'); // updatedAt 2026-05-01
+    const sm = getStateManager();
+    // Override recorded against OLDER activity — getStatusOverride must
+    // auto-clear it when it sees the newer updatedAt.
+    sm.setStatusOverride(PR_URL, 'waiting_on_maintainer', '2026-04-01T00:00:00Z');
+
+    const digest = makeDailyDigest({
+      openPRs: [pr],
+      summary: { totalActivePRs: 1, totalNeedingAttention: 1, totalMergedAllTime: 0, mergeRate: 0 },
+    });
+    const data = buildDashboardJson(digest, sm.getState(), [], [], []);
+
+    // Raw critical status wins: never shelved, headline bucket.
+    expect(data.shelvedPRUrls).not.toContain(PR_URL);
+    expect(data.activePRs[0].status).toBe('needs_addressing');
+    // And the stale override is gone from state, same as the CLI path.
+    expect(sm.getState().config.statusOverrides?.[PR_URL]).toBeUndefined();
+  });
+
+  it('clearing an override takes effect on the next rebuild of the same cached digest', () => {
+    // Regression guard for the bake-in failure mode: digests cache RAW
+    // statuses, so move target=auto (clearStatusOverride) must be visible on
+    // the very next rebuild, not only after a full /api/refresh.
+    const pr = makeDormantPR('needs_addressing');
+    const sm = getStateManager();
+    sm.setStatusOverride(PR_URL, 'waiting_on_maintainer', pr.updatedAt);
+
+    const digest = makeDailyDigest({
+      openPRs: [pr],
+      summary: { totalActivePRs: 1, totalNeedingAttention: 1, totalMergedAllTime: 0, mergeRate: 0 },
+    });
+
+    const before = buildDashboardJson(digest, sm.getState(), [], [], []);
+    expect(before.shelvedPRUrls).toContain(PR_URL);
+    expect(before.activePRs[0].status).toBe('waiting_on_maintainer');
+
+    sm.clearStatusOverride(PR_URL);
+    const after = buildDashboardJson(digest, sm.getState(), [], [], []);
+    expect(after.shelvedPRUrls).not.toContain(PR_URL);
+    expect(after.activePRs[0].status).toBe('needs_addressing');
+    expect(after.activePRs[0].attentionBucket).toBe('needs_attention');
+  });
+});

--- a/packages/core/src/commands/dashboard-server.ts
+++ b/packages/core/src/commands/dashboard-server.ts
@@ -134,12 +134,23 @@ export function buildDashboardJson(
   allClosedPRs?: ClosedPR[],
   partialFailures?: string[],
 ): DashboardJsonData {
+  // Apply status overrides ONCE, before the shelve partition is derived, so
+  // the dashboard partitions on the same post-override status the CLI
+  // partitions on (#1416). This also covers overrides set AFTER the digest
+  // was cached (a dashboard move stores an override; the action path rebuilds
+  // from the cached digest). Work on a copy — the caller's cached digest must
+  // not accumulate per-request derivations.
+  const overriddenDigest: DailyDigest = {
+    ...digest,
+    openPRs: applyStatusOverrides(digest.openPRs || [], state),
+    summary: { ...digest.summary },
+  };
   // Re-derive the shelve partition from the CURRENT state before reading it.
   // The POST /api/action path rebuilds with a cached digest whose shelvedPRs
   // predates the shelve/unshelve, so without this the SPA action appears to do
   // nothing until the next full /api/refresh.
-  reconcileShelvePartition(digest, state);
-  const prsByRepo = computePRsByRepo(digest, state);
+  reconcileShelvePartition(overriddenDigest, state);
+  const prsByRepo = computePRsByRepo(overriddenDigest, state);
   const topRepos = computeTopRepos(prsByRepo);
   const { monthlyMerged, monthlyOpened, monthlyClosed } = getMonthlyData(state);
   // Derive from state if not provided (e.g. initial load from cached state)
@@ -152,7 +163,7 @@ export function buildDashboardJson(
     !isBelowMinStars(repoScores[pr.repo]?.stargazersCount, minStars);
   const filteredMergedPRs = mergedPRs.filter(isAboveMinStars);
   const filteredClosedPRs = closedPRs.filter(isAboveMinStars);
-  const stats = buildDashboardStats(digest, state, filteredMergedPRs.length, filteredClosedPRs.length);
+  const stats = buildDashboardStats(overriddenDigest, state, filteredMergedPRs.length, filteredClosedPRs.length);
   const dismissedIssues = state.config.dismissedIssues || {};
   const issueResponses = commentedIssues.filter(
     (i): i is CommentedIssueWithResponse => i.status === 'new_response' && !(i.url in dismissedIssues),
@@ -180,7 +191,10 @@ export function buildDashboardJson(
     monthlyClosed,
     // #1352: stamp the unified attention bucket so the SPA renders the same
     // taxonomy the CLI brief counts (single classifier, no second opinion).
-    activePRs: applyStatusOverrides(digest.openPRs || [], state).map((pr) => ({
+    // Overrides were already applied when overriddenDigest was built — a
+    // second application here would be a no-op but obscures the single
+    // apply-then-partition ordering (#1416).
+    activePRs: (overriddenDigest.openPRs || []).map((pr) => ({
       ...pr,
       attentionBucket: classifyAttentionBucket(pr),
     })),
@@ -188,10 +202,10 @@ export function buildDashboardJson(
     // and dormant-non-addressing PRs auto-shelved for display). Returning
     // only state.config.shelvedPRUrls would under-count and desync from
     // stats.shelvedPRs, which is already derived from digest.shelvedPRs. (#981)
-    shelvedPRUrls: (digest.shelvedPRs || []).map((ref) => ref.url),
-    recentlyMergedPRs: digest.recentlyMergedPRs || [],
-    recentlyClosedPRs: digest.recentlyClosedPRs || [],
-    autoUnshelvedPRs: digest.autoUnshelvedPRs || [],
+    shelvedPRUrls: (overriddenDigest.shelvedPRs || []).map((ref) => ref.url),
+    recentlyMergedPRs: overriddenDigest.recentlyMergedPRs || [],
+    recentlyClosedPRs: overriddenDigest.recentlyClosedPRs || [],
+    autoUnshelvedPRs: overriddenDigest.autoUnshelvedPRs || [],
     commentedIssues,
     issueResponses,
     allMergedPRs: filteredMergedPRs,

--- a/packages/core/src/core/strategy.test.ts
+++ b/packages/core/src/core/strategy.test.ts
@@ -26,7 +26,11 @@ function makeMergedPR(repo: string, n: number, opts: { title?: string; mergedAt?
   };
 }
 
-function makeState(overrides: Partial<AgentState> = {}): AgentState {
+function makeState(
+  // Same shape as test-utils' makeAgentState: config may be partial because
+  // AgentStateSchema.parse fills the remaining defaults.
+  overrides: Omit<Partial<AgentState>, 'config'> & { config?: Partial<AgentState['config']> } = {},
+): AgentState {
   return AgentStateSchema.parse({ version: 4, ...overrides });
 }
 
@@ -206,6 +210,75 @@ describe('computeStrategy — capacity', () => {
     });
     const cap = computeStrategy(state)?.capacity;
     expect(cap?.overExtended).toBe(false);
+  });
+
+  it('derives the waiting bucket from openPRs through the override map (#1416)', () => {
+    // Dashboard-written digests keep RAW statuses in openPRs; a live
+    // override flipping needs_addressing -> waiting must count as dormant.
+    const state = makeState({
+      mergedPRs: Array.from({ length: 10 }, (_, i) => makeMergedPR('a/r', i + 1)),
+      config: {
+        statusOverrides: {
+          'https://github.com/x/y/pull/1': {
+            status: 'waiting_on_maintainer',
+            setAt: '2026-05-02T00:00:00Z',
+            lastActivityAt: '2026-05-01T00:00:00Z',
+          },
+        },
+      },
+      lastDigest: {
+        generatedAt: new Date().toISOString(),
+        openPRs: [
+          { url: 'https://github.com/x/y/pull/1', status: 'needs_addressing', updatedAt: '2026-05-01T00:00:00Z' },
+          { url: 'https://github.com/m/n/pull/2', status: 'waiting_on_maintainer', updatedAt: '2026-05-01T00:00:00Z' },
+        ] as any,
+        needsAddressingPRs: [],
+        // Stored raw-basis array deliberately disagrees — it must be ignored
+        // when openPRs is available.
+        waitingOnMaintainerPRs: [{ url: 'https://github.com/m/n/pull/2' }] as any,
+        recentlyClosedPRs: [],
+        recentlyMergedPRs: [],
+        shelvedPRs: [],
+        autoUnshelvedPRs: [],
+        summary: { totalActivePRs: 2, totalNeedingAttention: 0, totalMergedAllTime: 10, mergeRate: 1 },
+      },
+    });
+    const cap = computeStrategy(state)?.capacity;
+    // Both PRs are waiting on the override-applied basis, across 2 repos.
+    expect(cap?.dormantPRCount).toBe(2);
+    expect(cap?.overExtended).toBe(true);
+  });
+
+  it('ignores a stale override (newer PR activity) when deriving the waiting bucket', () => {
+    const state = makeState({
+      mergedPRs: Array.from({ length: 10 }, (_, i) => makeMergedPR('a/r', i + 1)),
+      config: {
+        statusOverrides: {
+          'https://github.com/x/y/pull/1': {
+            status: 'waiting_on_maintainer',
+            setAt: '2026-04-02T00:00:00Z',
+            lastActivityAt: '2026-04-01T00:00:00Z',
+          },
+        },
+      },
+      lastDigest: {
+        generatedAt: new Date().toISOString(),
+        openPRs: [
+          // Activity is NEWER than the override's lastActivityAt: same rule
+          // as getStatusOverride, the override no longer applies.
+          { url: 'https://github.com/x/y/pull/1', status: 'needs_addressing', updatedAt: '2026-05-01T00:00:00Z' },
+        ] as any,
+        needsAddressingPRs: [],
+        waitingOnMaintainerPRs: [] as any,
+        recentlyClosedPRs: [],
+        recentlyMergedPRs: [],
+        shelvedPRs: [],
+        autoUnshelvedPRs: [],
+        summary: { totalActivePRs: 1, totalNeedingAttention: 1, totalMergedAllTime: 10, mergeRate: 1 },
+      },
+    });
+    const cap = computeStrategy(state)?.capacity;
+    expect(cap?.dormantPRCount).toBe(0);
   });
 
   it('suggests open_more when no PRs are open and no dormant follow-ups', () => {

--- a/packages/core/src/core/strategy.ts
+++ b/packages/core/src/core/strategy.ts
@@ -162,6 +162,22 @@ function recommendForOverExtension(openPRCount: number, dormantPRCount: number, 
 }
 
 /**
+ * Read-only mirror of the status-override lookup (#1416): same staleness
+ * rule as `StateManager.getStatusOverride` (an override recorded against
+ * older activity than the PR's `updatedAt` is ignored), but with NO
+ * auto-clear write — this module stays pure/no-I/O, and the daily and
+ * dashboard pipelines own clearing stale overrides.
+ */
+function effectiveStatus(pr: { url?: unknown; status?: unknown; updatedAt?: unknown }, state: AgentState): unknown {
+  if (typeof pr.url !== 'string') return pr.status;
+  const override = state.config.statusOverrides?.[pr.url];
+  if (!override) return pr.status;
+  if (typeof pr.updatedAt === 'string' && pr.updatedAt > override.lastActivityAt) return pr.status;
+  if (override.status !== 'needs_addressing' && override.status !== 'waiting_on_maintainer') return pr.status;
+  return override.status;
+}
+
+/**
  * Compute the deterministic strategy signal from agent state. Returns
  * null when state is thinner than {@link STRATEGY_MIN_PRS} merged PRs —
  * the auto-display surface uses this null sentinel as the
@@ -214,12 +230,21 @@ export function computeStrategy(state: AgentState): StrategyResult | null {
   // Capacity: read from the last digest. When no digest exists yet,
   // default to zero (the agent has nothing to recommend without a
   // digest). The DailyDigest schema does not store a `dormantCount`
-  // directly — derive it from the `waitingOnMaintainerPRs` array,
-  // which is the "PR flagged as awaiting maintainer review" bucket
-  // produced by `pr-monitor`.
+  // directly — derive it from the "awaiting maintainer review" bucket.
+  //
+  // Status-basis reconciliation (#1416): dashboard-written digests keep RAW
+  // statuses in `openPRs` (so override CLEARS stay visible on rebuild) while
+  // `summary.totalActivePRs` is override-basis. Re-derive the waiting bucket
+  // from `openPRs` through the override map so both capacity inputs share
+  // one basis; fall back to the stored array for digests without `openPRs`
+  // (which daily.ts builds post-override anyway).
   const summary = state.lastDigest?.summary;
   const openPRCount = summary?.totalActivePRs ?? 0;
-  const waiting = state.lastDigest?.waitingOnMaintainerPRs ?? [];
+  const openPRs = (state.lastDigest?.openPRs ?? []) as Array<{ url?: unknown; status?: unknown; updatedAt?: unknown }>;
+  const waiting =
+    openPRs.length > 0
+      ? openPRs.filter((pr) => effectiveStatus(pr, state) === 'waiting_on_maintainer')
+      : (state.lastDigest?.waitingOnMaintainerPRs ?? []);
   const dormantPRCount = waiting.length;
   // Overextended: dormant PRs spread across 2+ repos. Same definition
   // the issue body uses.


### PR DESCRIPTION
## Summary

Fixes #1416. The dashboard partitioned its shelve list on RAW PR status while the CLI partitions post-override, so a dormant PR with a live criticality-flipping override landed in different partitions on the two surfaces, violating the #1352 single-taxonomy contract.

## Changes

- **fetchDashboardData**: `applyStatusOverrides` now runs before the partition, inside the guarded batch (an override auto-clear save defers to the batch boundary instead of escaping as `ConcurrencyError`). `freshShelved` and `summary.totalActivePRs` derive from overridden statuses. The digest deliberately keeps RAW statuses in `openPRs`: it is the server's cached/persisted rebuild source, and baking overrides in would make *clearing* an override (move target `auto`) a silent no-op until the next full refresh.
- **buildDashboardJson**: overrides applied once, into a copied digest, before `reconcileShelvePartition`; partition, stats, attention buckets, and `activePRs` all derive from that single application. The cached digest is no longer mutated per request (this also closes a latent per-request accumulation into the cached digest).
- **computeStrategy**: re-derives the waiting bucket from `openPRs` through a pure override overlay (same staleness rule as `getStatusOverride`, no auto-clear write, preserving the module's no-I/O contract) so its capacity inputs share one status basis with `summary.totalActivePRs`. Falls back to the stored array for digests without `openPRs`.
- **Tests**: new `dashboard-override-partition.test.ts` runs the REAL override pipeline (real StateManager over a temp dir) — the identity mock of `applyStatusOverrides` in dashboard-server.test.ts is exactly why nothing caught this. Covers both flip directions, the baked-shelved-ref filter branch, the explicit-shelve branch, stale-override auto-clear, override-clear visibility on the next rebuild, and cached-digest immutability. The dashboard-data tests pin apply-then-partition ordering and the raw-digest persistence contract.

## Acceptance criteria

- [x] Dashboard partitions and buckets are computed from override-applied status
- [x] Dormant PR + criticality-flipping override lands in the same partition on both surfaces, both directions (real-fn tests; all fail on pre-fix code)
- [x] No double-application of overrides (single application in buildDashboardJson, before the partition)

## Test plan

- [x] Full core suite: 2738 passed / 15 skipped / 3 todo
- [x] `tsc --noEmit` + `tsc --noEmit -p tsconfig.tests.json` clean
- [x] eslint 0 errors, prettier clean
- [x] Red check: the three core partition tests fail with the source fix stashed