### PR TITLE
chore(deps): upgrade @oss-scout/core to ^1.1.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "@octokit/plugin-throttling": "^11.0.3",
     "@octokit/rest": "^22.0.1",
-    "@oss-scout/core": "^0.11.0",
+    "@oss-scout/core": "^1.1.0",
     "commander": "^15.0.0",
     "zod": "^4.4.3"
   },

--- a/packages/core/src/commands/features.ts
+++ b/packages/core/src/commands/features.ts
@@ -82,7 +82,11 @@ function toFeaturesCandidate(
   // this repo" rather than a fabricated score.
   const grade = gradeFromCandidate({
     repo: scoutCandidate.issue.repo,
-    projectHealth: { avgIssueResponseDays: null, daysSinceLastCommit: null, checkFailed: true },
+    projectHealth: {
+      repo: scoutCandidate.issue.repo,
+      checkFailed: true,
+      failureReason: 'health not fetched on the multi-issue feature surface',
+    },
     getRepoScore: (repo) => {
       const score = getState.getRepoScore(repo);
       return score

--- a/packages/core/src/commands/scout-bridge.ts
+++ b/packages/core/src/commands/scout-bridge.ts
@@ -94,8 +94,20 @@ export function buildScoutState(): ScoutState {
       // `--split-ratio` flags for overrides.
       featuresAnchorThreshold: 3,
       featuresSplitRatio: 0.6,
+      // Personalization-bias prefs, likewise required on the inferred type
+      // (scout #1244 / #168). Autopilot doesn't surface these as settings yet,
+      // so we pass scout's documented "no bias" defaults.
+      preferLanguages: [],
+      preferRepos: [],
+      diversityRatio: 0,
+      avoidRepos: [],
+      boostIssueTypes: [],
     },
     repoScores: state.repoScores,
+    // Scout #117 added tombstones (deletion records for gist merge). Autopilot
+    // synthesizes a fresh ScoutState per operation and tracks no deletions, so
+    // an empty list is correct here.
+    tombstones: [],
     starredRepos: config.starredRepos,
     starredReposLastFetched: config.starredReposLastFetched,
     mergedPRs: (state.mergedPRs ?? []).map((pr) => ({

--- a/packages/core/src/commands/search.test.ts
+++ b/packages/core/src/commands/search.test.ts
@@ -69,13 +69,13 @@ describe('runSearch', () => {
         {
           ...base,
           issue: { repo: 'a/b', number: 1, title: 'slot', url: 'https://github.com/a/b/issues/1', labels: [] },
-          diversitySlot: true,
+          // Scout 1.0 folded the flat boost/diversity fields into `personalization` (#158).
+          personalization: { kind: 'diversity' },
         },
         {
           ...base,
           issue: { repo: 'a/b', number: 2, title: 'boosted', url: 'https://github.com/a/b/issues/2', labels: [] },
-          boostScore: 3,
-          boostReasons: ['language match: TypeScript'],
+          personalization: { kind: 'boosted', score: 3, reasons: ['language match: TypeScript'] },
         },
       ],
       excludedRepos: [],

--- a/packages/core/src/commands/search.ts
+++ b/packages/core/src/commands/search.ts
@@ -119,7 +119,11 @@ export async function runSearch(options: SearchOptions): Promise<SearchOutput> {
       // before" rather than a fabricated score.
       const grade = gradeFromCandidate({
         repo: c.issue.repo,
-        projectHealth: { avgIssueResponseDays: null, daysSinceLastCommit: null, checkFailed: true },
+        projectHealth: {
+          repo: c.issue.repo,
+          checkFailed: true,
+          failureReason: 'health not fetched on the multi-issue search surface',
+        },
         getRepoScore: (repo) => {
           const score = stateManager.getRepoScore(repo);
           return score
@@ -157,9 +161,16 @@ export async function runSearch(options: SearchOptions): Promise<SearchOutput> {
             }
           : undefined,
         ...(linkedPR ? { linkedPR } : {}),
-        ...(typeof c.boostScore === 'number' ? { boostScore: c.boostScore } : {}),
-        ...(c.boostReasons && c.boostReasons.length > 0 ? { boostReasons: c.boostReasons } : {}),
-        ...(c.diversitySlot === true ? { diversitySlot: true } : {}),
+        // Scout 1.0 folded the boostScore/boostReasons/diversitySlot trio into a
+        // single `personalization` field (#158). Derive the flat output fields
+        // from it so this command's JSON shape is unchanged.
+        ...(c.personalization?.kind === 'boosted'
+          ? { boostScore: c.personalization.score }
+          : {}),
+        ...(c.personalization?.kind === 'boosted' && c.personalization.reasons.length > 0
+          ? { boostReasons: c.personalization.reasons }
+          : {}),
+        ...(c.personalization?.kind === 'diversity' ? { diversitySlot: true } : {}),
       };
     }),
     excludedRepos: result.excludedRepos,

--- a/packages/core/src/commands/search.ts
+++ b/packages/core/src/commands/search.ts
@@ -164,9 +164,7 @@ export async function runSearch(options: SearchOptions): Promise<SearchOutput> {
         // Scout 1.0 folded the boostScore/boostReasons/diversitySlot trio into a
         // single `personalization` field (#158). Derive the flat output fields
         // from it so this command's JSON shape is unchanged.
-        ...(c.personalization?.kind === 'boosted'
-          ? { boostScore: c.personalization.score }
-          : {}),
+        ...(c.personalization?.kind === 'boosted' ? { boostScore: c.personalization.score } : {}),
         ...(c.personalization?.kind === 'boosted' && c.personalization.reasons.length > 0
           ? { boostReasons: c.personalization.reasons }
           : {}),

--- a/packages/core/src/core/issue-grading.ts
+++ b/packages/core/src/core/issue-grading.ts
@@ -11,6 +11,8 @@
  * described as prose in agents/issue-scout.md.
  */
 
+import type { ProjectHealth } from '@oss-scout/core';
+
 export type GradeLetter = 'A' | 'B' | 'C' | 'F';
 
 export interface GradeSignals {
@@ -136,11 +138,10 @@ export function deriveGradeSignals(params: {
  */
 export function gradeFromCandidate(params: {
   repo: string;
-  projectHealth: {
-    avgIssueResponseDays: number | null;
-    daysSinceLastCommit: number | null;
-    checkFailed?: boolean;
-  };
+  // Scout 1.0 made ProjectHealth a discriminated union (success vs check-failed)
+  // (#158). Accept it whole; the failure arm carries no snapshot fields, so we
+  // normalize it to the minimal grade-input shape below.
+  projectHealth: ProjectHealth;
   getRepoScore: (repo: string) =>
     | {
         mergedPRCount: number;
@@ -150,9 +151,20 @@ export function gradeFromCandidate(params: {
     | undefined;
 }): GradeResult {
   const repoScore = params.getRepoScore(params.repo);
+  // Narrow the union into the minimal shape deriveGradeSignals expects. The
+  // check-failed arm has no avgIssueResponseDays/daysSinceLastCommit, and the
+  // grader already treats checkFailed as untrusted (no snapshot signals).
+  const ph = params.projectHealth;
+  const projectHealth = ph.checkFailed
+    ? { avgIssueResponseDays: null, daysSinceLastCommit: null, checkFailed: true }
+    : {
+        avgIssueResponseDays: ph.avgIssueResponseDays,
+        daysSinceLastCommit: ph.daysSinceLastCommit,
+        checkFailed: false,
+      };
   return computeSuccessGrade(
     deriveGradeSignals({
-      projectHealth: params.projectHealth,
+      projectHealth,
       repoScore: repoScore
         ? {
             mergedPRCount: repoScore.mergedPRCount,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,8 +70,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@oss-scout/core':
-        specifier: ^0.11.0
-        version: 0.11.0(@octokit/core@7.0.6)
+        specifier: ^1.1.0
+        version: 1.1.0(@octokit/core@7.0.6)
       commander:
         specifier: ^15.0.0
         version: 15.0.0
@@ -699,8 +699,8 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@oss-scout/core@0.11.0':
-    resolution: {integrity: sha512-OupQQ6EMgIVN3ZRTrF/mszXRqBUaRwRJZNDBfWoFHiuMy9yQabKIuCUjmMyA4cFFbmKUVEA+0RTAchGk72QJxA==}
+  '@oss-scout/core@1.1.0':
+    resolution: {integrity: sha512-QDaLX0GlrNzrIawJumv7IutoZKGkUZq99P4EOOQtt/SGCd5HgSJZsNkRikYK80MNSxQ7yhTnFF06l9J22I9ddA==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
@@ -3324,7 +3324,7 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@oss-scout/core@0.11.0(@octokit/core@7.0.6)':
+  '@oss-scout/core@1.1.0(@octokit/core@7.0.6)':
     dependencies:
       '@octokit/plugin-throttling': 11.0.3(@octokit/core@7.0.6)
       '@octokit/rest': 22.0.1


### PR DESCRIPTION
oss-scout shipped `1.0.0` (a breaking type-tightening major) and `1.1.0` (the `avoidRepos` / `boostIssueTypes` personalization biases). This bumps the dependency `^0.11.0` → `^1.1.0` and adapts autopilot to the 1.x API.

## Changes to match the 1.x API

- **`scout-bridge` `buildScoutState`** — the inferred `ScoutPreferences` type now requires the personalization-bias fields (`preferLanguages` / `preferRepos` / `diversityRatio` / `avoidRepos` / `boostIssueTypes`, from scout #1244 / #168) and `ScoutState` now requires `tombstones` (scout #117). Pass scout's documented no-bias defaults and an empty tombstones list (autopilot synthesizes a fresh state per operation and tracks no deletions).
- **`search` command** — scout #158 folded the `boostScore` / `boostReasons` / `diversitySlot` trio into a single `personalization` marker. Derive the flat output fields from it so this command's emitted JSON shape is unchanged.
- **`issue-grading` `gradeFromCandidate`** — `ProjectHealth` is now a discriminated union (scout #158); accept it whole and normalize the check-failed arm (which carries no snapshot fields) to the minimal grade-input shape internally. The two multi-issue surfaces (`features`, `search`) that synthesize an unknown-health sentinel now construct a valid `ProjectHealthFailure`.
- **`search.test.ts`** — mock candidates use the new `personalization` field.

## Verification

`@oss-autopilot/core` builds, typechecks (incl. test tsconfig), lints (0 errors), and all **2707 tests pass** against `@oss-scout/core@1.1.0`. No behavior change to autopilot — the adaptations are type-level plus deriving the same output fields from scout's new shapes.