### PR TITLE
fix(core): dashboard mutations surface and retry failed Gist checkpoints

### DIFF
--- a/packages/core/src/commands/dashboard-server.test.ts
+++ b/packages/core/src/commands/dashboard-server.test.ts
@@ -81,6 +81,7 @@ vi.mock('../core/index.js', async (importOriginal) => {
     getDataDir: vi.fn(() => pidTestDir),
     getCLIVersion: vi.fn(() => '0.44.6'),
     applyStatusOverrides: vi.fn((prs: unknown[]) => prs),
+    maybeCheckpoint: (...args: unknown[]) => mockMaybeCheckpoint(...args),
     // Real pure classifier + status set (#1352) so /api/data responses carry
     // genuine buckets and the shelve partition mirrors the daily check.
     classifyAttentionBucket: actual.classifyAttentionBucket,
@@ -121,6 +122,8 @@ vi.mock('./dashboard-data.js', async (importActual) => {
 
 // Mock move command so dashboard-server's dynamic import resolves without side effects
 const mockRunMove = vi.fn().mockResolvedValue({ url: '', target: 'shelved', description: 'done' });
+// Resolves null (no warning) by default; #1417 tests resolve a warning string.
+const mockMaybeCheckpoint = vi.fn().mockResolvedValue(null);
 vi.mock('./move.js', () => ({
   VALID_TARGETS: ['attention', 'waiting', 'shelved', 'auto'],
   runMove: (...args: unknown[]) => mockRunMove(...args),
@@ -997,6 +1000,231 @@ describe('dashboard-server', () => {
         'https://github.com/owner/repo/issues/42',
         expect.any(String),
       );
+    });
+
+    describe('gist sync warnings (#1417)', () => {
+      // The server instance is shared across the whole file, and pending
+      // gist-sync warnings clear only on a successful checkpoint PUSH — so
+      // every warning-producing test ends with a clean action to reset the
+      // banner for later tests (recordGistSyncOutcome(null) clears pending).
+      async function resetPendingWarnings(): Promise<void> {
+        const result = await sendRequest(
+          'POST',
+          '/api/action',
+          JSON.stringify({ action: 'move', url: 'https://github.com/owner/repo/pull/99', target: 'shelved' }),
+        );
+        expect(JSON.parse(result.body).partialFailures).toBeUndefined();
+      }
+
+      it('a successful checkpoint adds nothing to partialFailures', async () => {
+        const result = await sendRequest(
+          'POST',
+          '/api/action',
+          JSON.stringify({ action: 'move', url: 'https://github.com/owner/repo/pull/10', target: 'shelved' }),
+        );
+
+        expect(result.statusCode).toBe(200);
+        expect(JSON.parse(result.body).partialFailures).toBeUndefined();
+      });
+
+      it('dismiss checkpoints to Gist after the mutation', async () => {
+        mockMaybeCheckpoint.mockClear();
+
+        const result = await sendRequest(
+          'POST',
+          '/api/action',
+          JSON.stringify({
+            action: 'dismiss_issue_response',
+            url: 'https://github.com/owner/repo/issues/43',
+          }),
+        );
+
+        expect(result.statusCode).toBe(200);
+        // Checkpoint runs against the live state manager, after dismissIssue.
+        expect(mockMaybeCheckpoint).toHaveBeenCalledWith(mockStateManager, expect.any(String));
+        expect(mockMaybeCheckpoint.mock.invocationCallOrder[0]).toBeGreaterThan(
+          mockStateManager.dismissIssue.mock.invocationCallOrder[0],
+        );
+      });
+
+      it('surfaces a failed dismiss checkpoint in partialFailures', async () => {
+        const warning = 'Gist checkpoint push failed after retry; the local mutation is saved';
+        mockMaybeCheckpoint.mockResolvedValueOnce(warning);
+
+        const result = await sendRequest(
+          'POST',
+          '/api/action',
+          JSON.stringify({
+            action: 'dismiss_issue_response',
+            url: 'https://github.com/owner/repo/issues/44',
+          }),
+        );
+
+        expect(result.statusCode).toBe(200);
+        expect(JSON.parse(result.body).partialFailures).toContain(warning);
+
+        await resetPendingWarnings();
+      });
+
+      it('surfaces a move gistSyncWarning in partialFailures instead of discarding it', async () => {
+        const warning = 'Gist checkpoint failed (local mutation succeeded, will retry on next push): boom';
+        mockRunMove.mockResolvedValueOnce({
+          url: 'https://github.com/owner/repo/pull/9',
+          target: 'shelved',
+          description: 'done',
+          gistSyncWarning: warning,
+        });
+
+        const result = await sendRequest(
+          'POST',
+          '/api/action',
+          JSON.stringify({ action: 'move', url: 'https://github.com/owner/repo/pull/9', target: 'shelved' }),
+        );
+
+        expect(result.statusCode).toBe(200);
+        const body = JSON.parse(result.body);
+        expect(body.partialFailures).toContain(warning);
+
+        // The warning persists across the NEXT action rebuild and is not
+        // duplicated when the same warning fires again.
+        mockRunMove.mockResolvedValueOnce({
+          url: 'https://github.com/owner/repo/pull/9',
+          target: 'waiting',
+          description: 'done',
+          gistSyncWarning: warning,
+        });
+        const second = await sendRequest(
+          'POST',
+          '/api/action',
+          JSON.stringify({ action: 'move', url: 'https://github.com/owner/repo/pull/9', target: 'waiting' }),
+        );
+        const secondBody = JSON.parse(second.body);
+        expect(secondBody.partialFailures.filter((m: string) => m === warning)).toHaveLength(1);
+
+        await resetPendingWarnings();
+      });
+
+      it('surfaces the warning produced on the conflict-retry attempt', async () => {
+        const warning = 'Gist checkpoint push failed after retry; the local mutation is saved';
+        // First dismiss attempt conflicts; the server-side retry (#1397)
+        // succeeds but its checkpoint fails — the retry's warning must
+        // reach the response, not be lost with the failed first attempt.
+        mockStateManager.dismissIssue.mockImplementationOnce(() => {
+          throw new ConcurrencyError(1000, 2000);
+        });
+        mockMaybeCheckpoint.mockResolvedValueOnce(warning);
+
+        const result = await sendRequest(
+          'POST',
+          '/api/action',
+          JSON.stringify({
+            action: 'dismiss_issue_response',
+            url: 'https://github.com/owner/repo/issues/45',
+          }),
+        );
+
+        expect(result.statusCode).toBe(200);
+        expect(JSON.parse(result.body).partialFailures).toContain(warning);
+
+        await resetPendingWarnings();
+      });
+
+      it('a pending warning survives a GET /api/data rebuild', async () => {
+        const warning = 'Gist checkpoint failed (local mutation succeeded, will retry on next push): poll';
+        mockRunMove.mockResolvedValueOnce({
+          url: 'https://github.com/owner/repo/pull/11',
+          target: 'shelved',
+          description: 'done',
+          gistSyncWarning: warning,
+        });
+        await sendRequest(
+          'POST',
+          '/api/action',
+          JSON.stringify({ action: 'move', url: 'https://github.com/owner/repo/pull/11', target: 'shelved' }),
+        );
+
+        // Force the GET handler down its rebuild branch — the warning must be
+        // re-merged there, not only in the action response.
+        mockStateManager.reloadIfChanged.mockReturnValueOnce(true);
+        const result = await sendRequest('GET', '/api/data');
+
+        expect(result.statusCode).toBe(200);
+        expect(JSON.parse(result.body).partialFailures).toContain(warning);
+
+        await resetPendingWarnings();
+      });
+
+      it('a successful refresh does NOT clear a still-unpushed gist warning', async () => {
+        // Regression test for the lifecycle split: fetch partialFailures
+        // clear on a successful PULL, but a gist-sync warning means an
+        // un-pushed mutation — clearing it on pull is exactly when the
+        // mutation is at risk of silent revert.
+        const warning = 'Gist checkpoint push failed after retry; the local mutation is saved';
+        mockMaybeCheckpoint.mockResolvedValue(warning);
+        await sendRequest(
+          'POST',
+          '/api/action',
+          JSON.stringify({ action: 'dismiss_issue_response', url: 'https://github.com/owner/repo/issues/46' }),
+        );
+
+        vi.mocked(getGitHubToken).mockReturnValue('test-token');
+        vi.mocked(fetchDashboardData).mockResolvedValue({
+          digest: makeDigest(),
+          commentedIssues: [],
+          allMergedPRs: [],
+          allClosedPRs: [],
+          partialFailures: [],
+        });
+
+        const result = await sendRequest('POST', '/api/refresh');
+        expect(result.statusCode).toBe(200);
+        expect(JSON.parse(result.body).partialFailures).toContain(warning);
+
+        vi.mocked(getGitHubToken).mockReturnValue(null as never);
+        mockMaybeCheckpoint.mockResolvedValue(null);
+        await resetPendingWarnings();
+      });
+
+      it('gist mode: refresh re-pushes BEFORE pulling and clears the warning on success', async () => {
+        const warning = 'Gist checkpoint push failed after retry; the local mutation is saved';
+        mockStateManager.isGistMode.mockReturnValue(true);
+        try {
+          // Action fails its push -> warning pending. (reloadState's flush
+          // never calls maybeCheckpoint here: nothing pending pre-action.)
+          mockMaybeCheckpoint.mockResolvedValueOnce(warning);
+          await sendRequest(
+            'POST',
+            '/api/action',
+            JSON.stringify({ action: 'dismiss_issue_response', url: 'https://github.com/owner/repo/issues/47' }),
+          );
+
+          // Refresh: the network recovered, so the push-before-pull flush
+          // succeeds and the warning lifecycle ends with the push.
+          vi.mocked(getGitHubToken).mockReturnValue('test-token');
+          vi.mocked(fetchDashboardData).mockResolvedValue({
+            digest: makeDigest(),
+            commentedIssues: [],
+            allMergedPRs: [],
+            allClosedPRs: [],
+            partialFailures: [],
+          });
+          mockMaybeCheckpoint.mockClear();
+          mockStateManager.refreshFromGist.mockClear();
+          mockMaybeCheckpoint.mockResolvedValueOnce(null);
+
+          const result = await sendRequest('POST', '/api/refresh');
+          expect(result.statusCode).toBe(200);
+          expect(JSON.parse(result.body).partialFailures).toBeUndefined();
+          // Push-before-pull ordering: the flush ran before refreshFromGist.
+          expect(mockMaybeCheckpoint.mock.invocationCallOrder[0]).toBeLessThan(
+            mockStateManager.refreshFromGist.mock.invocationCallOrder[0],
+          );
+        } finally {
+          mockStateManager.isGistMode.mockReturnValue(false);
+          vi.mocked(getGitHubToken).mockReturnValue(null as never);
+          mockMaybeCheckpoint.mockResolvedValue(null);
+        }
+      });
     });
   });
 

--- a/packages/core/src/commands/dashboard-server.ts
+++ b/packages/core/src/commands/dashboard-server.ts
@@ -16,6 +16,7 @@ import {
   getCLIVersion,
   applyStatusOverrides,
   classifyAttentionBucket,
+  maybeCheckpoint,
 } from '../core/index.js';
 import { errorMessage, ValidationError, ConcurrencyError, GistConcurrencyError } from '../core/errors.js';
 import { warn } from '../core/logger.js';
@@ -386,11 +387,47 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
   // not disappear when /api/data rebuilds after a state change or after a
   // POST /api/action completes.
   let cachedPartialFailures: string[] | undefined = undefined;
+  // Gist checkpoint warnings from dashboard mutations (#1417). DELIBERATELY
+  // separate from cachedPartialFailures: fetch failures clear on a successful
+  // PULL, but a gist-sync warning means an un-pushed mutation, and a pull is
+  // exactly the event that can destroy it (refreshFromGist wholesale-replaces
+  // state). These clear only when a checkpoint PUSH succeeds.
+  let pendingGistSyncWarnings: string[] = [];
   // Tracks the last background-refresh failure so /api/data can surface
   // staleness to the SPA via the X-Dashboard-Stale header (#1205). Cleared
   // when a refresh succeeds. Without this, token expiry / GitHub outage
   // produces silent stale data hours old with no client-visible signal.
   let lastBackgroundRefreshError: string | null = null;
+
+  /** Record a mutation's checkpoint outcome. `null` means the push succeeded
+   * (or local mode) — and a successful push carries the FULL current state,
+   * so any previously pending warning is resolved with it. */
+  function recordGistSyncOutcome(warning: string | null): void {
+    if (warning === null) {
+      pendingGistSyncWarnings = [];
+      return;
+    }
+    if (!pendingGistSyncWarnings.includes(warning)) {
+      pendingGistSyncWarnings.push(warning);
+    }
+  }
+
+  /** Merge pending gist-sync warnings into a partialFailures payload for the
+   * SPA banner without coupling their lifecycles. */
+  function withPendingGistWarnings(failures: string[] | undefined): string[] | undefined {
+    if (pendingGistSyncWarnings.length === 0) return failures;
+    const base = failures ?? [];
+    return [...base, ...pendingGistSyncWarnings.filter((w) => !base.includes(w))];
+  }
+
+  /** Push-before-pull (#1417): an un-pushed mutation would be silently
+   * reverted by the next Gist pull. Retry the checkpoint first so a recovered
+   * network turns the pending warning into a real push before any pull runs.
+   * No-op when nothing is pending. */
+  async function flushPendingGistSync(): Promise<void> {
+    if (pendingGistSyncWarnings.length === 0) return;
+    recordGistSyncOutcome(await maybeCheckpoint(stateManager, MODULE));
+  }
 
   if (!cachedDigest) {
     throw new Error(
@@ -408,7 +445,7 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
       cachedCommentedIssues,
       undefined,
       undefined,
-      cachedPartialFailures,
+      withPendingGistWarnings(cachedPartialFailures),
     );
   } catch (error) {
     throw new Error(
@@ -450,6 +487,7 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
         // Re-read state if modified externally (file mtime for local, Gist API for Gist mode)
         let stateChanged = false;
         if (stateManager.isGistMode()) {
+          await flushPendingGistSync();
           stateChanged = await stateManager.refreshFromGist();
         } else {
           stateChanged = stateManager.reloadIfChanged();
@@ -465,7 +503,7 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
               cachedCommentedIssues,
               undefined,
               undefined,
-              cachedPartialFailures,
+              withPendingGistWarnings(cachedPartialFailures),
             );
             cachedIssueListMtimeMs = currentIssueListMtimeMs;
           } catch (error) {
@@ -550,6 +588,7 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
   /** Re-read state written by external processes (CLI) before mutating. */
   async function reloadState(): Promise<void> {
     if (stateManager.isGistMode()) {
+      await flushPendingGistSync();
       await stateManager.refreshFromGist();
     } else {
       stateManager.reloadIfChanged();
@@ -594,6 +633,11 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
 
     // Resolve the mutation up-front so target validation happens before the
     // state reload — keeps the reload-to-save freshness window minimal.
+    // Each mutation records the Gist checkpoint outcome (#1417): in gist mode
+    // `save()` only writes the local cache, and an un-pushed mutation can be
+    // wholesale-reverted by the next successful refreshFromGist — so a failed
+    // push must reach the SPA, not vanish into a discarded return value.
+    let gistSyncWarning: string | null = null;
     let applyMutation: () => Promise<void> | void;
     if (body.action === 'move') {
       const { VALID_TARGETS, runMove } = await import('./move.js');
@@ -603,12 +647,17 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
       }
       const target = body.target;
       applyMutation = async () => {
-        await runMove({ prUrl: body.url, target });
+        const output = await runMove({ prUrl: body.url, target });
+        gistSyncWarning = output.gistSyncWarning ?? null;
       };
     } else {
       // dismiss_issue_response
-      applyMutation = () => {
+      applyMutation = async () => {
         stateManager.dismissIssue(body.url, new Date().toISOString());
+        // Mirror runMove's contract: every mutating surface checkpoints to
+        // Gist and surfaces the warning. Never throws — failures come back
+        // as the warning string.
+        gistSyncWarning = await maybeCheckpoint(stateManager, MODULE);
       };
     }
 
@@ -649,6 +698,12 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
       }
     }
 
+    // Surface the checkpoint outcome through the partialFailures banner the
+    // SPA already renders (#1417). Tracked in pendingGistSyncWarnings — NOT
+    // cachedPartialFailures — because gist warnings clear on a successful
+    // PUSH, while fetch failures clear on a successful pull/refresh.
+    recordGistSyncOutcome(gistSyncWarning);
+
     // Rebuild dashboard data from cached digest + updated state. Persist
     // the last-known partialFailures across action rebuilds (#1035) so the
     // SPA banner survives user interactions until the next successful
@@ -659,7 +714,7 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
       cachedCommentedIssues,
       undefined,
       undefined,
-      cachedPartialFailures,
+      withPendingGistWarnings(cachedPartialFailures),
     );
     cachedIssueListMtimeMs = getIssueListMtimeMs();
 
@@ -689,7 +744,7 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
         cachedCommentedIssues,
         result.allMergedPRs,
         result.allClosedPRs,
-        cachedPartialFailures,
+        withPendingGistWarnings(cachedPartialFailures),
       );
       cachedIssueListMtimeMs = getIssueListMtimeMs();
       sendJson(res, 200, cachedJsonData);
@@ -816,6 +871,7 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
     fetchDashboardData(token)
       .then(async (result) => {
         if (stateManager.isGistMode()) {
+          await flushPendingGistSync();
           await stateManager.refreshFromGist();
         } else {
           stateManager.reloadIfChanged();
@@ -829,7 +885,7 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
           cachedCommentedIssues,
           result.allMergedPRs,
           result.allClosedPRs,
-          cachedPartialFailures,
+          withPendingGistWarnings(cachedPartialFailures),
         );
         cachedIssueListMtimeMs = getIssueListMtimeMs();
         // Successful refresh clears any prior failure signal (#1205).


### PR DESCRIPTION
## Summary

Fixes #1417. Dashboard move discarded `MoveOutput.gistSyncWarning` (failed Gist push invisible to the SPA, mutation revertible by the next `refreshFromGist`), and dismiss never checkpointed at all.

## Changes

- **Both mutations record their checkpoint outcome**: move captures `runMove`'s output; dismiss now calls `maybeCheckpoint` after `dismissIssue` (inside `applyMutation`, so the #1397 conflict-retry re-checkpoints against the fresh baseline).
- **Push-success lifecycle for gist warnings** (review-panel finding, the load-bearing part): warnings live in `pendingGistSyncWarnings`, separate from `cachedPartialFailures`. Fetch failures clear on a successful *pull*, but a gist warning means an un-pushed mutation, and a pull is exactly what destroys it. Pending warnings clear only when a checkpoint *push* succeeds, and are merged into all five `buildDashboardJson` payload sites.
- **Push-before-pull**: `flushPendingGistSync` retries the checkpoint before every Gist pull (action reload, `/api/data` poll, `/api/refresh`, startup background fetch), so a recovered network re-pushes the pending mutation before any pull can silently revert it.
- SPA needs no changes: the existing `partialFailures` banner renders the warning from both the POST `/api/action` response and `GET /api/data`.

## Acceptance criteria

- [x] A failed Gist push after a dashboard move/dismiss is visible to the SPA user (and survives refresh until actually pushed)
- [x] Dashboard dismiss checkpoints to Gist in gist mode
- [x] Tests cover both warning-surfaced paths

## Test plan

- [x] 10 new/updated tests: both warning sources, checkpoint-after-mutation ordering, dedupe + persistence across action and GET rebuilds, conflict-retry warning, refresh NOT clearing an un-pushed warning, gist-mode push-before-pull ordering and clear-on-success
- [x] Full core suite: 2746 passed / 15 skipped / 3 todo
- [x] `tsc --noEmit` + tests tsconfig clean; eslint 0 errors; prettier clean