### PR TITLE
chore: verification-audit hardening batch (#1421)

### DIFF
--- a/packages/core/src/cli-registry.test.ts
+++ b/packages/core/src/cli-registry.test.ts
@@ -50,6 +50,7 @@ vi.mock('./formatters/json.js', () => ({
   SetupOutputSchema: {},
   ConfigCommandOutputSchema: {},
   MoveOutputSchema: {},
+  VerifyIssueOutputSchema: {},
   PRTemplateOutputSchema: {},
   ParseIssueListOutputSchema: {},
   CheckIntegrationOutputSchema: {},
@@ -81,6 +82,9 @@ vi.mock('./commands/dashboard.js', () => ({ serveDashboard: mockServeDashboard }
 
 const mockRunSkipAdd = vi.fn();
 vi.mock('./commands/skip-add.js', () => ({ runSkipAdd: mockRunSkipAdd }));
+
+const mockRunVerifyIssue = vi.fn();
+vi.mock('./commands/verify-issue.js', () => ({ runVerifyIssue: mockRunVerifyIssue }));
 
 // ─── Import after mocks ────────────────────────────────────────────────────
 
@@ -217,6 +221,111 @@ describe('search count validation', () => {
     expect(consoleWarnSpy).toHaveBeenCalledWith('Capping search to 100 results (requested: 150)');
     expect(mockRunSearch).toHaveBeenCalledWith({ maxResults: 100 });
     expect(mockOutputJsonValidated).toHaveBeenCalledWith(expect.anything(), emptySearchResult);
+  });
+});
+
+// ─── Search text-mode display (#1421) ───────────────────────────────────────
+
+describe('search text-mode display', () => {
+  it('renders hiddenOwnPRCount, boost reasons, and the diversity-slot annotation', async () => {
+    mockRunSearch.mockResolvedValue({
+      candidates: [
+        {
+          issue: {
+            repo: 'octo/alpha',
+            number: 1,
+            title: 'Boosted pick',
+            url: 'https://github.com/octo/alpha/issues/1',
+            labels: [],
+          },
+          recommendation: 'approve',
+          reasonsToApprove: ['Active maintainers'],
+          reasonsToSkip: [],
+          viabilityScore: 88,
+          boostReasons: ['merged PR history', 'preferred org'],
+        },
+        {
+          issue: {
+            repo: 'octo/beta',
+            number: 2,
+            title: 'Diversity pick',
+            url: 'https://github.com/octo/beta/issues/2',
+            labels: [],
+          },
+          recommendation: 'needs_review',
+          reasonsToApprove: [],
+          reasonsToSkip: ['No prior relationship'],
+          viabilityScore: 60,
+          diversitySlot: true,
+        },
+      ],
+      excludedRepos: [],
+      aiPolicyBlocklist: [],
+      hiddenOwnPRCount: 2,
+    });
+    const program = buildProgram('search');
+
+    await program.parseAsync(['node', 'cli', 'search']);
+
+    const lines = consoleLogSpy.mock.calls.map((c: unknown[]) => c[0]);
+    expect(lines).toContain('Hidden: 2 candidate(s) were issues you already have open PRs for.');
+    expect(lines).toContain('  Why surfaced: merged PR history, preferred org');
+    expect(lines).toContain('  Diversity slot: outside your usual languages/repos');
+    expect(lines).toContain('Found 2 candidates:\n');
+  });
+});
+
+// ─── verify-issue text-mode display (#1421) ─────────────────────────────────
+
+describe('verify-issue text-mode display', () => {
+  it('renders state, verdict, assignees, and linked-PR annotations', async () => {
+    mockRunVerifyIssue.mockResolvedValue({
+      owner: 'octo',
+      repo: 'hello',
+      number: 7,
+      title: 'Fix the widget',
+      url: 'https://github.com/octo/hello/issues/7',
+      state: 'closed',
+      stateReason: 'completed',
+      closedAt: '2026-06-01T00:00:00Z',
+      verdict: 'closed',
+      verdictReason: 'Issue is closed (completed)',
+      assignees: ['alice'],
+      linkedPRs: [
+        {
+          number: 9,
+          state: 'merged',
+          isDraft: false,
+          linkType: 'closing',
+          author: 'bob',
+          isOwn: false,
+          url: 'https://github.com/octo/hello/pull/9',
+        },
+        {
+          number: 10,
+          state: 'open',
+          isDraft: true,
+          linkType: 'cross-referenced',
+          author: null,
+          isOwn: true,
+          url: 'https://github.com/octo/hello/pull/10',
+        },
+      ],
+    });
+    const program = buildProgram('verify-issue');
+
+    await program.parseAsync(['node', 'cli', 'verify-issue', 'https://github.com/octo/hello/issues/7']);
+
+    expect(mockRunVerifyIssue).toHaveBeenCalledWith({ issueUrl: 'https://github.com/octo/hello/issues/7' });
+    const lines = consoleLogSpy.mock.calls.map((c: unknown[]) => c[0]);
+    expect(lines).toContain('\nocto/hello#7: Fix the widget');
+    expect(lines).toContain('  State: closed (completed) — closed 2026-06-01T00:00:00Z');
+    expect(lines).toContain('  Verdict: closed — Issue is closed (completed)');
+    expect(lines).toContain('  Assignees: alice');
+    expect(lines).toContain('  PR #9 [merged] closing by bob: https://github.com/octo/hello/pull/9');
+    expect(lines).toContain(
+      '  PR #10 [open] [draft] cross-referenced by ghost (yours): https://github.com/octo/hello/pull/10',
+    );
   });
 });
 

--- a/packages/core/src/commands/dashboard-data.ts
+++ b/packages/core/src/commands/dashboard-data.ts
@@ -425,9 +425,10 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
       // Partitioned over overriddenPRs (#1416): the shelve decision must use
       // the same post-override status the CLI partitions on.
       const shelvedUrls = new Set(stateManager.getState().config.shelvedPRUrls || []);
-      const freshShelved = overriddenPRs.filter(
-        (pr) => !CRITICAL_STATUSES.has(pr.status) && (shelvedUrls.has(pr.url) || pr.stalenessTier === 'dormant'),
-      );
+      // Single copy of the shelve predicate (#1421): isShelvedForDisplay is
+      // the same rule reconcileShelvePartition applies on rebuilds, so its
+      // regression tests now guard this line too.
+      const freshShelved = overriddenPRs.filter((pr) => isShelvedForDisplay(pr, shelvedUrls));
       digest.shelvedPRs = freshShelved.map(toShelvedPRRef);
       digest.autoUnshelvedPRs = [];
       digest.summary.totalActivePRs = overriddenPRs.length - freshShelved.length;

--- a/packages/core/src/commands/dashboard-server.test.ts
+++ b/packages/core/src/commands/dashboard-server.test.ts
@@ -483,6 +483,41 @@ describe('dashboard-server', () => {
       expect(some.partialFailures).toEqual(['fetch recently merged PRs']);
     });
 
+    it('buildDashboardJson stamps attentionBucket on every served PR (#1421)', () => {
+      // The SPA falls back to 'waiting' when the stamp is absent, so dropping
+      // it would silently collapse stuck_ci / dormant_followup into waiting
+      // with every other test still green. classifyAttentionBucket is the
+      // REAL classifier here (see the core mock at the top of this file).
+      const stuckCI = {
+        url: 'https://github.com/owner/repo/pull/61',
+        repo: 'owner/repo',
+        number: 61,
+        status: 'waiting_on_maintainer',
+        ciStatus: 'pending',
+        reviewDecision: 'approved',
+        daysSinceActivity: 5,
+        stalenessTier: 'active',
+      };
+      const needsAttention = {
+        url: 'https://github.com/owner/repo/pull/62',
+        repo: 'owner/repo',
+        number: 62,
+        status: 'needs_addressing',
+        ciStatus: 'failing',
+        reviewDecision: 'approved',
+        daysSinceActivity: 1,
+        stalenessTier: 'active',
+      };
+      const digest = makeDigest({ openPRs: [stuckCI, needsAttention] as never[] });
+      const state = makeState({ lastDigest: digest });
+
+      const data = buildDashboardJson(digest, state, []);
+
+      const byUrl = new Map(data.activePRs.map((pr) => [pr.url, pr.attentionBucket]));
+      expect(byUrl.get(stuckCI.url)).toBe('stuck_ci');
+      expect(byUrl.get(needsAttention.url)).toBe('needs_attention');
+    });
+
     it('should derive shelvedPRUrls from digest.shelvedPRs, not config.shelvedPRUrls (#981)', () => {
       // Dashboard card shows `stats.shelvedPRs`, which counts digest.shelvedPRs.
       // The response's shelvedPRUrls must use the same source so the PR list

--- a/packages/core/src/commands/list-move-tier.ts
+++ b/packages/core/src/commands/list-move-tier.ts
@@ -256,9 +256,18 @@ export async function runListMoveTier(options: ListMoveTierOptions): Promise<Lis
   }
 
   if (result.moved) {
+    // tmp+rename so a crash mid-write can't truncate the curated list —
+    // same atomic pattern as list-mark-done (#1421).
+    const tmp = `${filePath}.tmp-${process.pid}-${Date.now()}`;
     try {
-      fs.writeFileSync(filePath, result.content, 'utf8');
+      fs.writeFileSync(tmp, result.content, 'utf8');
+      fs.renameSync(tmp, filePath);
     } catch (error) {
+      try {
+        fs.unlinkSync(tmp);
+      } catch {
+        // best-effort cleanup
+      }
       throw new Error(`Failed to write file: ${errorMessage(error)}`, { cause: error });
     }
   }

--- a/packages/mcp-server/src/gist-init.test.ts
+++ b/packages/mcp-server/src/gist-init.test.ts
@@ -45,6 +45,13 @@ vi.mock('@oss-autopilot/core/commands', () => ({
   runDismiss: vi.fn(),
   runUndismiss: vi.fn(),
   runMove: vi.fn(),
+  // #1421 top-up: registration touches these (guidelines list + the
+  // dynamically imported state commands) — without them a tool call in this
+  // suite would land on undefined instead of a mock.
+  runGuidelinesList: vi.fn(),
+  runStateShow: vi.fn(),
+  runStateSync: vi.fn(),
+  runStateUnlink: vi.fn(),
   runGuidelinesView: vi.fn(),
   runGuidelinesStore: vi.fn(),
   runGuidelinesReset: vi.fn(),

--- a/packages/mcp-server/src/tools-execution.test.ts
+++ b/packages/mcp-server/src/tools-execution.test.ts
@@ -7,6 +7,7 @@ const {
   mockRunDaily,
   mockRunSearch,
   mockRunMove,
+  mockRunVerifyIssue,
   mockRunGuidelinesList,
   mockRunGuidelinesView,
   mockRunGuidelinesStore,
@@ -16,6 +17,7 @@ const {
   mockRunDaily: vi.fn(),
   mockRunSearch: vi.fn(),
   mockRunMove: vi.fn(),
+  mockRunVerifyIssue: vi.fn(),
   mockRunGuidelinesList: vi.fn(),
   mockRunGuidelinesView: vi.fn(),
   mockRunGuidelinesStore: vi.fn(),
@@ -29,7 +31,7 @@ vi.mock('@oss-autopilot/core/commands', () => ({
   runStrategy: vi.fn(),
   runSearch: mockRunSearch,
   runVet: vi.fn(),
-  runVerifyIssue: vi.fn(),
+  runVerifyIssue: mockRunVerifyIssue,
   runVetList: vi.fn(),
   runTrack: vi.fn(),
   runComplianceScore: vi.fn(),
@@ -189,6 +191,37 @@ describe('tool execution', () => {
         prUrl: 'https://github.com/octocat/hello-world/pull/42',
         target: 'auto',
       });
+    });
+  });
+
+  // #1421: nothing executed the verify-issue handler — a miswired
+  // wrapTool(runVet) would have passed the whole suite.
+  describe('verify-issue delegation', () => {
+    it('verify-issue delegates to runVerifyIssue with the issueUrl', async () => {
+      mockRunVerifyIssue.mockResolvedValueOnce({ verdict: 'available' });
+
+      const result = await client.callTool({
+        name: 'verify-issue',
+        arguments: { issueUrl: 'https://github.com/octocat/hello-world/issues/7' },
+      });
+
+      expect(mockRunVerifyIssue).toHaveBeenCalledWith({
+        issueUrl: 'https://github.com/octocat/hello-world/issues/7',
+      });
+      expect(result.isError).toBeFalsy();
+      const content = result.content[0] as { type: string; text: string };
+      expect(JSON.parse(content.text)).toEqual({ verdict: 'available' });
+    });
+
+    it('rejects a non-issue URL at the schema layer', async () => {
+      mockRunVerifyIssue.mockClear();
+      const result = await client.callTool({
+        name: 'verify-issue',
+        arguments: { issueUrl: 'https://github.com/octocat/hello-world/pull/7' },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(mockRunVerifyIssue).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #1421 — all six hardening items from the 2026-06-11 verification audit.

## Items

1. **Atomic list write**: `list-move-tier` now writes via tmp+rename (mirrors `list-mark-done`, including best-effort tmp cleanup on failure) so a crash mid-write cannot truncate the curated list.
2. **MCP verify-issue execution test**: delegation test (callTool → `runVerifyIssue` with the issueUrl) plus a bonus schema-layer rejection test for a PR URL. Previously a miswired `wrapTool(runVet)` would have passed the whole suite.
3. **attentionBucket stamp test**: `buildDashboardJson` asserted to stamp the bucket on served PRs using the REAL classifier (`stuck_ci` and `needs_attention` cases) — dropping the stamp would have silently collapsed buckets into `waiting`.
4. **Single shelve predicate**: the inline `freshShelved` filter in `fetchDashboardData` replaced with the shared `isShelvedForDisplay` (the issue's preferred option). Coverage note: this is guarded by the existing `reconcileShelvePartition` regression tests through the shared predicate, not a new direct `freshShelved` assertion — behavior is identical by construction.
5. **CLI display coverage**: text-mode tests for search (`Hidden: N candidate(s)…`, `Why surfaced:`, `Diversity slot:`) and the full verify-issue renderer (state/verdict/assignees, `[draft]`/`ghost`/`(yours)` annotations), asserted against the exact template strings.
6. **gist-init mock top-up**: `runGuidelinesList` + `runStateShow`/`Sync`/`Unlink` added to the mock factory.

No items declined.

## Test plan

- [x] Core suite 2749 passed (re-verified after the scout ^1.1.0 bump landed on main); MCP suite 224 passed
- [x] `tsc --noEmit` + tests tsconfig clean on both packages
- [x] eslint 0 errors; prettier clean