### PR TITLE
docs: prompt-layer coherence batch (#1419)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -66,7 +66,7 @@ Seven specialized agents handle specific tasks autonomously:
 | `pr-compliance-checker` | Validate PRs against opensource.guide best practices |
 | `issue-scout` | Vet issues for claimability and fit |
 | `repo-evaluator` | Score repository health and responsiveness |
-| `contribution-strategist` | Plan implementation approach |
+| `contribution-strategist` | Analyze contribution patterns and advise on strategy |
 | `pre-commit-reviewer` | Fallback code review (when toolkit unavailable) |
 
 ### Skills (`skills/`)
@@ -140,7 +140,7 @@ Debug and warning output goes to stderr via the logger, so it never contaminates
 | `orphan-files` (alias: `check-integration`) | `check-integration.ts` | Audit new files on this branch for cross-references |
 | `doctor` | `doctor.ts` | System-health diagnostic — token, bundle, state, scout, rate limit |
 | `stats` | `stats.ts` | Show contribution statistics (merge rate, PR counts) |
-| `guidelines view/store/reset/fetch-corpus` | `guidelines.ts` | Per-repo guidelines persistence + raw PR comment corpus for the host's extract-learnings prompt (#867) |
+| `guidelines list/view/store/reset/fetch-corpus` | `guidelines.ts` | Per-repo guidelines persistence + raw PR comment corpus for the host's extract-learnings prompt (#867) |
 | `manifest` | `cli-registry.ts` | Print the registered command list + version (used by plugin contract tests) |
 | `detect-formatters` | `detect-formatters.ts` | Detect formatters and linters configured in a repository |
 | `pr-template` | `pr-template.ts` | Fetch a repository's PR description template |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,8 +14,6 @@ Have an idea? Open a [Discussion](https://github.com/costajohnt/oss-autopilot/di
 
 ## Later (no fixed timeline)
 
-- [ ] 1.0 launch content — blog post, social posts, competitive positioning ([#731](https://github.com/costajohnt/oss-autopilot/issues/731))
-- [ ] Marketing video with Remotion ([#698](https://github.com/costajohnt/oss-autopilot/issues/698))
 - [ ] Co-maintainer recruitment — the project is currently solo-maintained (bus factor of 1)
 
 Have an idea? Open a [Discussion](https://github.com/costajohnt/oss-autopilot/discussions) or file an issue.

--- a/agents/README.md
+++ b/agents/README.md
@@ -31,13 +31,13 @@ convenience. The frontmatter `tools:` line in each agent file is the source of
 truth; `packages/core/src/agents-contract.test.ts` enforces that every tool an
 agent's body instructs with is actually granted (#1377).
 
-- `contribution-strategist` — `Bash`, `Read`, `mcp__...__strategy` (read-only analyzer; emits a markdown report in chat).
-- `issue-scout` — `Bash`, `Read`, `mcp__...__search`, `mcp__...__vet`, `mcp__...__vet-list`, `mcp__...__status`.
-- `pr-compliance-checker` — `Bash`, `Read`, `Glob`, `Grep`, `mcp__...__track`, `mcp__...__comments`, `mcp__...__compliance-score`, `mcp__...__guidelines-get`.
-- `pr-health-checker` — `Bash`, `Read`, `Grep`, `mcp__...__track`, `mcp__...__comments`. (Reads config via the CLI `config --json`; the MCP config tool is a get-or-set mutator and is deliberately not granted.)
-- `pr-responder` — `Bash`, `Read`, `Edit`, `Write`, `Glob`, `Grep`, `mcp__...__track`, `mcp__...__comments`, `mcp__...__guidelines-get` (keeps `Write` for drafting response files under `/tmp` and `Edit` for formatting reverts; posting still routes through `draft-review-post`).
-- `pre-commit-reviewer` — `Bash`, `Read`, `Glob`, `Grep`, `mcp__...__guidelines-get` (local git/diff review).
-- `repo-evaluator` — `Bash`, `Read`, `Glob`, `mcp__...__vet`, `mcp__...__repo-vet`, `mcp__...__status`.
+- `contribution-strategist` — `Bash`, `Read`, `AskUserQuestion`, `mcp__...__strategy` (read-only analyzer; emits a markdown report in chat).
+- `issue-scout` — `Bash`, `Read`, `AskUserQuestion`, `mcp__...__search`, `mcp__...__verify-issue`, `mcp__...__vet`, `mcp__...__vet-list`, `mcp__...__status`.
+- `pr-compliance-checker` — `Bash`, `Read`, `Glob`, `Grep`, `AskUserQuestion`, `mcp__...__track`, `mcp__...__comments`, `mcp__...__compliance-score`, `mcp__...__guidelines-get`.
+- `pr-health-checker` — `Bash`, `Read`, `Grep`, `AskUserQuestion`, `mcp__...__track`, `mcp__...__comments`. (Reads config via the CLI `config --json`; the MCP config tool is a get-or-set mutator and is deliberately not granted.)
+- `pr-responder` — `Bash`, `Read`, `Edit`, `Write`, `Glob`, `Grep`, `AskUserQuestion`, `mcp__...__track`, `mcp__...__comments`, `mcp__...__guidelines-get` (keeps `Write` for drafting response files under `/tmp` and `Edit` for formatting reverts; posting still routes through `draft-review-post`).
+- `pre-commit-reviewer` — `Bash`, `Read`, `Glob`, `Grep`, `AskUserQuestion`, `mcp__...__guidelines-get` (local git/diff review).
+- `repo-evaluator` — `Bash`, `Read`, `Glob`, `AskUserQuestion`, `mcp__...__vet`, `mcp__...__repo-vet`, `mcp__...__status`.
 
 `track` here is the v2 read-only snapshot tool — it no longer mutates
 `~/.oss-autopilot/state.json`, which is why it can be granted despite the
@@ -70,7 +70,7 @@ Opus should not burn tokens on `pr-compliance-checker`'s deterministic rubric.
 | `pr-health-checker` | `sonnet` | Git rebase flow + CI log diagnosis; needs to reason about error messages and suggest fixes. |
 | `pr-responder` | `sonnet` | Claim verification + tone calibration + multi-step draft-accuracy procedure. Heavy reasoning. |
 | `pre-commit-reviewer` | `sonnet` | Five-phase diff review including security scan. Heavy reasoning. |
-| `repo-evaluator` | `haiku` | Aggregates cached repo scores into a verdict. Bounded scope. |
+| `repo-evaluator` | `sonnet` | Weighs repo-health and history signals into a recommendation; needs judgment beyond bounded aggregation. |
 
 Policy: **no agent uses `model: inherit`.** CI enforces this via the "Guard
 against `model: inherit` in agent frontmatter" step. If a future agent

--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -107,7 +107,9 @@ Remember to filter by `excludedRepos` manually.
 
 ### Step 0: deterministic verification — ALWAYS FIRST (#1353, #1354)
 
-Before ANY other analysis of a specific issue URL (curated-list re-vet, single-issue vet, or a search candidate you are about to recommend), call `verify-issue`. Its fields are ground truth fetched via GraphQL — trust them over anything you infer from comments, timelines, or issue prose. Never report `Open: yes/no` or "taken by PR #N" from your own reading; report what `verify-issue` returned.
+Before ANY other analysis of a specific issue URL (a single-issue vet, or a search candidate you are about to recommend), call `verify-issue`. Its fields are ground truth fetched via GraphQL — trust them over anything you infer from comments, timelines, or issue prose. Never report `Open: yes/no` or "taken by PR #N" from your own reading; report what `verify-issue` returned.
+
+Whole-list re-vets are the one exception by necessity: `vet-list` does NOT run `verify-issue` per entry, so its `listStatus` values are heuristic (REST-level availability checks without closing-vs-mention awareness). Treat a `vet-list` flag as a triage signal, and run `verify-issue` on the flagged entry's URL before acting on it (marking done, dropping, or recommending).
 
 Route on `verdict` with short-circuit semantics:
 
@@ -122,6 +124,8 @@ The `linkedPRs` array distinguishes `closing` (the PR's `closingIssuesReferences
 **Primary:** call `vet` (MCP tool or CLI). It runs the full checklist: availability (assignment, linked PRs, author classification via `linked-pr-classification.ts`), contribution guidelines (CONTRIBUTING.md, CLA, PR templates), existing PR analysis, issue quality, repo health — and returns `grade: {letter, reason}` alongside the score.
 
 ### Linked-PR classification
+
+**Precedence:** when this table and the Step 0 `verify-issue` verdict disagree on whether an issue is open or taken, the `verify-issue` verdict WINS. `vet`'s classifier has no closing-vs-cross-referenced awareness, so e.g. `other_open` here can be a mere mention that Step 0 already classified `at-risk` (still available). Use this table only for the supplementary signals Step 0 does not carry (friction history, maintainer-preference hints), never to overturn an availability verdict.
 
 The `vet` response includes a `linkedPRClassification` when scout exposes the raw linked-PR metadata. Route on the value (not substrings):
 
@@ -147,7 +151,7 @@ Never make a recommendation that contradicts the SLM call without saying so expl
 
 ### Per-repo learning guidelines (#867)
 
-At the implementation entry point (`draft-first-workflow.md` Step 1e), any stored per-repo guidelines are loaded via `oss-autopilot guidelines view --repo OWNER/REPO --json` and made available to the agent. These are extracted from past PR feedback in the user's Gist and encode durable maintainer preferences (code style, process, architecture, testing rules).
+At the implementation entry point (`draft-first-workflow.md` Step 1e), any stored per-repo guidelines are loaded via `node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" guidelines view --repo OWNER/REPO --json` and made available to the agent. These are extracted from past PR feedback in the user's Gist and encode durable maintainer preferences (code style, process, architecture, testing rules).
 
 When implementing, treat injected guidelines as **strong preferences**, not absolute rules:
 
@@ -158,11 +162,12 @@ When implementing, treat injected guidelines as **strong preferences**, not abso
 
 ### gh fallback vetting
 
-If MCP + CLI both fail, collect the vetting data with `gh` (inform the user first):
+If MCP + CLI both fail, collect the vetting data with `gh` (inform the user first). Step 0's verify-issue semantics are NOT satisfiable in this mode: `gh` cannot distinguish a closing PR from a cross-referencing mention, so fetch the real issue state directly and present any linked-PR signal as UNVERIFIED — say so explicitly instead of inferring a taken/available verdict.
 
 ```bash
-# Availability
-gh issue view OWNER/REPO#NUMBER --json assignees,body,comments
+# Availability (state/stateReason replace the verify-issue verdict; note the
+# `NUMBER -R OWNER/REPO` form — `gh issue view OWNER/REPO#NUMBER` is invalid)
+gh issue view NUMBER -R OWNER/REPO --json state,stateReason,closedAt,assignees,body,comments
 gh pr list --repo OWNER/REPO --search "issue:NUMBER" --state all --json number,title,state,author,createdAt
 
 # Guidelines

--- a/commands/oss-search.md
+++ b/commands/oss-search.md
@@ -70,18 +70,27 @@ Task(general-purpose, "Run the CLI search command and return the raw JSON output
 2. If `success: true`, each entry in `data.candidates` has this shape:
    ```
    {
-     issue: { repo, number, title, url, labels, createdAt },
+     issue: { repo, repoUrl, number, title, url, labels },
      recommendation: "approve" | "skip" | "needs_review",
      viabilityScore: number,
-     searchPriority: "merged_pr" | "starred" | "normal",
+     grade: { letter: "A" | "B" | "C" | "F", reason: string },
+     searchPriority: "merged_pr" | "preferred_org" | "starred" | "normal",
      reasonsToApprove: string[],
-     reasonsToSkip: string[]
+     reasonsToSkip: string[],
+     repoScore?: { score, mergedPRCount, closedWithoutMergeCount, isResponsive, lastMergedAt? },
+     linkedPR?: { number, state, url, updatedAt?, isStalled },
+     boostScore?: number,        // strategy-biased ranking (#1244)
+     boostReasons?: string[],    // human-readable "why surfaced" lines
+     diversitySlot?: boolean     // filled a diversity slot outside the usual stack
    }
    ```
 3. Normalize to `{ repo, number, title, url, labels, source, metadata }` where `source` is derived from `searchPriority`:
    - `merged_pr` → `"established-repo"` (user has merged or open PRs in this repo)
+   - `preferred_org` → `"preferred-org-repo"` (repo belongs to a configured preferred org)
    - `starred` → `"starred-repo"` (user starred this repo)
    - `normal` → `"trending-repo"` (discovered via broad/maintained phases)
+
+   Present `diversitySlot: true` candidates normally inside their group with a short "(diversity pick — outside your usual languages/repos)" annotation; the standard skip-file threshold applies during tiering. The counterweight operates at selection time, so no special scoring treatment is needed here.
 
 **If `data.candidates` is empty:**
 > "No matching issues found. Scout's search returned zero candidates — the skip list, exclude list, or filters may be too narrow."
@@ -97,6 +106,9 @@ Group candidates by `source` (omit empty groups):
 
 ### From Established Repos ({count})
 {results with source: 'established-repo'}
+
+### From Preferred Orgs ({count})
+{results with source: 'preferred-org-repo'}
 
 ### From Starred Repos ({count})
 {results with source: 'starred-repo'}

--- a/packages/core/src/agents-contract.test.ts
+++ b/packages/core/src/agents-contract.test.ts
@@ -565,3 +565,91 @@ describe('agent body tool references ↔ frontmatter tool grants (#1377)', () =>
     ).toEqual([]);
   });
 });
+
+// ── agents/README.md ↔ frontmatter parity (#1419) ─────────────────────────
+//
+// The README's allowlist bullets and model-tier table are hand-maintained
+// prose duplicating each agent's frontmatter. They drifted (issue-scout's
+// row omitted verify-issue; repo-evaluator's tier row said haiku while the
+// frontmatter says sonnet) because nothing gated README files. This gate
+// parses both surfaces and pins set equality.
+
+const MCP_TOOL_PREFIX = 'mcp__plugin_oss-autopilot_oss-autopilot__';
+
+function parseAgentFrontmatterField(file: string, field: string): string | null {
+  const lines = fs.readFileSync(file, 'utf8').split('\n');
+  const end = lines.indexOf('---', 1);
+  const line = lines.slice(1, end).find((l) => l.startsWith(`${field}:`));
+  return line ? line.slice(field.length + 1).trim() : null;
+}
+
+describe('agents/README.md ↔ agent frontmatter parity (#1419)', () => {
+  const readme = fs.readFileSync(path.join(REPO_ROOT, 'agents', 'README.md'), 'utf8');
+  const agents = listAgentFiles().map((file) => ({
+    name: path.basename(file, '.md'),
+    file,
+    doc: parseAgentDoc(file),
+  }));
+
+  it('every allowlist bullet matches the agent frontmatter tools exactly', () => {
+    const offenders: string[] = [];
+    for (const agent of agents) {
+      if (!agent.doc.tools) continue;
+      // The bullet form is: - `name` — `Tool`, `Tool`, `mcp__...__x`, ... (prose)
+      const bullet = readme.split('\n').find((line) => line.startsWith(`- \`${agent.name}\``));
+      if (!bullet) {
+        offenders.push(`${agent.name}: no allowlist bullet in agents/README.md`);
+        continue;
+      }
+      const listed = new Set(
+        [...bullet.matchAll(/`([^`]+)`/g)]
+          .map((m) => m[1])
+          .filter((token) => token !== agent.name && !token.includes(' '))
+          // README rows abbreviate the MCP prefix as `mcp__...__x`.
+          .map((token) => token.replace(/^mcp__\.\.\.__/u, MCP_TOOL_PREFIX))
+          // Drop tokens that are prose snippets, not tool names: a CLI
+          // example like `config --json` fails the space check above, and
+          // hyphenated prose like `draft-review-post` fails the
+          // letters-and-underscores regex below.
+          .filter((token) => /^[A-Za-z_]+$/u.test(token.replace(MCP_TOOL_PREFIX, '')) || token.startsWith('mcp__')),
+      );
+      const granted = agent.doc.tools;
+      const missing = [...granted].filter((t) => !listed.has(t));
+      const extra = [...listed].filter((t) => !granted.has(t) && (t.startsWith('mcp__') || /^[A-Z]/.test(t)));
+      if (missing.length > 0 || extra.length > 0) {
+        offenders.push(
+          `${agent.name}: README bullet drifted from frontmatter` +
+            (missing.length > 0 ? ` — missing ${missing.join(', ')}` : '') +
+            (extra.length > 0 ? ` — lists ungranted ${extra.join(', ')}` : ''),
+        );
+      }
+    }
+    expect(
+      offenders,
+      `agents/README.md allowlist bullets drifted from frontmatter \`tools:\` — update the README row:\n  ` +
+        offenders.join('\n  '),
+    ).toEqual([]);
+  });
+
+  it('every model-tier table row matches the agent frontmatter model', () => {
+    const offenders: string[] = [];
+    for (const agent of agents) {
+      const model = parseAgentFrontmatterField(agent.file, 'model');
+      if (!model) continue;
+      const row = readme.split('\n').find((line) => line.startsWith(`| \`${agent.name}\` |`));
+      if (!row) {
+        offenders.push(`${agent.name}: no model-tier table row in agents/README.md`);
+        continue;
+      }
+      const cell = row.split('|')[2]?.trim().replace(/`/g, '');
+      if (cell !== model) {
+        offenders.push(`${agent.name}: README tier table says "${cell}" but frontmatter model is "${model}"`);
+      }
+    }
+    expect(
+      offenders,
+      `agents/README.md model-tier table drifted from frontmatter \`model:\` — update the table row:\n  ` +
+        offenders.join('\n  '),
+    ).toEqual([]);
+  });
+});

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -170,7 +170,7 @@ export function registerTools(server: McpServer): void {
     'search',
     {
       description:
-        'Search GitHub for beginner-friendly open-source issues to contribute to. Returns issues matching configured languages and interests.',
+        'Search GitHub for beginner-friendly open-source issues to contribute to. Returns issues matching configured languages and interests. Candidates carry a grade and may carry boostScore/boostReasons (strategy-biased ranking) and diversitySlot annotations (#1244); issues you already have an open PR for are filtered out and counted in hiddenOwnPRCount (#1354).',
       inputSchema: {
         // Zod schema replaces the prior manual throw inside the handler
         // (#1058 M41). Invalid values now surface as proper schema

--- a/workflows/draft-first-workflow.md
+++ b/workflows/draft-first-workflow.md
@@ -593,7 +593,7 @@ branch=$(git branch --show-current)
 **Before generating the PR body**, fetch the target repo's PR template:
 
 ```bash
-oss-autopilot pr-template {upstream-owner}/{upstream-repo} --json
+node "${CLAUDE_PLUGIN_ROOT}/packages/core/dist/cli.bundle.cjs" pr-template {upstream-owner}/{upstream-repo} --json
 ```
 
 If a template is returned (`data.template` is non-null), the template body is the **baseline** for your PR description. You are merging your generated summary INTO it, not replacing it. Specifically:

--- a/workflows/reference.md
+++ b/workflows/reference.md
@@ -50,7 +50,7 @@ Local-only commands (no GitHub token needed): `checkSetup`, `clear-override`, `c
 # Deep-vet a specific issue
 <prefix> vet <issue-url> --json
 
-# Re-vet every available issue in the curated list (use --prune to drop unavailable items)
+# Re-vet every available issue in the curated list (--prune drops completed, terminal-status (Done/Skip/Dropped/Merged/Closed), and low-score (<6) items)
 <prefix> vet-list --json [--prune]
 
 # Claim an issue with optional message
@@ -198,7 +198,7 @@ rejected with a did-you-mean suggestion.
 | `--reset` | `setup` | Re-run the setup wizard even if already complete. |
 | `--set key=value` | `setup` | Apply settings non-interactively. Repeatable. Unknown keys are rejected with a did-you-mean suggestion. |
 | `--list-keys` | `config` | Dump every known config key with descriptions (alternative to `--json`). |
-| `--prune` | `vet-list` | Remove unavailable items from the curated list file after re-vetting. |
+| `--prune` | `vet-list` | Remove completed, terminal-status (Done/Skip/Dropped/Merged/Closed), and low-score (<6) items from the curated list file after re-vetting. |
 | `--path <file>` | `skip-add` | Override the configured `skippedIssuesPath` for a single invocation. |
 
 ---


### PR DESCRIPTION
## Summary

Fixes #1419 — all nine findings, with every doc claim verified against the code by the review pass.

## Changes

1. **issue-scout precedence rule** (the high-value item): the Step 0 `verify-issue` verdict explicitly wins over the vet `linkedPRClassification` table on open/taken questions; the table is scoped to supplementary signals (vet's classifier has no closing-vs-mention awareness).
2. **gh fallback fixed**: fetches `state,stateReason,closedAt` via the valid `gh issue view NUMBER -R OWNER/REPO` form (the documented `OWNER/REPO#NUMBER` syntax errors), and linked-PR signals are presented as unverified in fallback mode.
3. **Step 0 vs vet-list reconciled**: Step 0 scoped to single-issue flows; `vet-list`'s `listStatus` documented as heuristic with an instruction to run `verify-issue` per flagged entry before acting.
4. **oss-search candidate shape** rewritten field-for-field against `SearchCandidateSchema` (drops the nonexistent `createdAt`, adds `grade`/`repoScore`/`linkedPR`/`boostScore`/`boostReasons`/`diversitySlot`), `preferred_org` mapped to its own results group, plus a diversity-slot presentation line.
5. **agents/README**: all 7 allowlist bullets now mirror frontmatter exactly (every agent grants `AskUserQuestion`; issue-scout also `verify-issue`); repo-evaluator tier row corrected to `sonnet`. **New agents-contract gate** pins README bullets and the model-tier table to frontmatter — mutation-tested in both directions (acceptance criterion: gate added, not declined).
6. **ROADMAP**: the two Later rows closed as not-planned removed.
7. **ARCHITECTURE**: guidelines row gains `list`; strategist blurb matches frontmatter.
8. **MCP search description** now mentions the grade, boost/diversity annotations, and the own-PR filter with `hiddenOwnPRCount`.
9. **reference.md `--prune`** wording matches `pruneIssueList` (completed, Done/Skip/Dropped/Merged/Closed, score <6); the two bare `oss-autopilot` invocations got the bundle prefix.

## Test plan

- [x] Core suite 2750 passed (incl. the new README parity gate); MCP suite 222 passed
- [x] Gate mutation check: reverting either README fix fails the new tests
- [x] Both typechecks clean; eslint 0 errors; prettier clean