### PR TITLE
fix(core,mcp): transient gist-init failures retry instead of silently latching local-only

### DIFF
--- a/packages/core/src/core/auth.test.ts
+++ b/packages/core/src/core/auth.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Token-cache latch semantics (#1415).
+ *
+ * The front-door auth module previously latched `tokenFetchAttempted` BEFORE
+ * the `gh auth token` attempt, so a single transient failure (a 2s spawn
+ * timeout on a busy machine) returned null forever for the process — which
+ * permanently silenced Gist mode in the long-lived MCP server. The contract
+ * pinned here: timeouts do NOT latch (the next call retries), definitive
+ * outcomes (token, empty token, gh missing/not authenticated) DO latch.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  execFile: vi.fn(),
+  execFileSync: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({
+  execFile: mocks.execFile,
+  execFileSync: mocks.execFileSync,
+}));
+
+import { getGitHubToken, getGitHubTokenAsync, resetGitHubTokenCache } from './auth.js';
+
+type ExecFileCallback = (error: Error | null, stdout: string, stderr: string) => void;
+
+/** Queue one async `gh auth token` outcome. */
+function execFileOnce(outcome: { error?: Error; stdout?: string }): void {
+  mocks.execFile.mockImplementationOnce((_cmd: string, _args: string[], _opts: unknown, cb: ExecFileCallback) => {
+    if (outcome.error) cb(outcome.error, '', '');
+    else cb(null, outcome.stdout ?? '', '');
+    return {} as never;
+  });
+}
+
+/** An async execFile timeout kill, as Node reports it (killed, no code). */
+function asyncTimeoutError(): Error {
+  return Object.assign(new Error('spawn gh ETIMEDOUT'), { killed: true, signal: 'SIGTERM' });
+}
+
+/** A SYNC execFileSync timeout, as Node reports it: `code: 'ETIMEDOUT'`,
+ * NO `killed` property — the production shape the sync no-latch arm
+ * depends on (verified empirically; the two paths differ). */
+function syncTimeoutError(): Error {
+  return Object.assign(new Error('spawn gh ETIMEDOUT'), { code: 'ETIMEDOUT', signal: 'SIGTERM' });
+}
+
+/** gh not installed. */
+function enoentError(): Error {
+  return Object.assign(new Error('spawn gh ENOENT'), { code: 'ENOENT' });
+}
+
+let savedEnvToken: string | undefined;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetGitHubTokenCache();
+  savedEnvToken = process.env.GITHUB_TOKEN;
+  delete process.env.GITHUB_TOKEN;
+});
+
+afterEach(() => {
+  if (savedEnvToken !== undefined) process.env.GITHUB_TOKEN = savedEnvToken;
+  resetGitHubTokenCache();
+});
+
+describe('getGitHubTokenAsync latch semantics (#1415)', () => {
+  it('a timeout does NOT latch: the next call retries and can succeed', async () => {
+    execFileOnce({ error: asyncTimeoutError() });
+    expect(await getGitHubTokenAsync()).toBeNull();
+
+    execFileOnce({ stdout: 'ghp_recovered\n' });
+    expect(await getGitHubTokenAsync()).toBe('ghp_recovered');
+    expect(mocks.execFile).toHaveBeenCalledTimes(2);
+  });
+
+  it('gh missing (ENOENT) latches: the next call returns null without spawning', async () => {
+    execFileOnce({ error: enoentError() });
+    expect(await getGitHubTokenAsync()).toBeNull();
+
+    expect(await getGitHubTokenAsync()).toBeNull();
+    expect(mocks.execFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('an authoritative empty token latches', async () => {
+    execFileOnce({ stdout: '\n' });
+    expect(await getGitHubTokenAsync()).toBeNull();
+
+    expect(await getGitHubTokenAsync()).toBeNull();
+    expect(mocks.execFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('a successful fetch is cached: no second spawn', async () => {
+    execFileOnce({ stdout: 'ghp_cached\n' });
+    expect(await getGitHubTokenAsync()).toBe('ghp_cached');
+    expect(await getGitHubTokenAsync()).toBe('ghp_cached');
+    expect(mocks.execFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('a non-zero gh exit (not authenticated) latches', async () => {
+    // Async shape for `gh auth token` exiting 1: numeric code, killed false.
+    execFileOnce({ error: Object.assign(new Error('gh exited 1'), { code: 1, killed: false }) });
+    expect(await getGitHubTokenAsync()).toBeNull();
+
+    expect(await getGitHubTokenAsync()).toBeNull();
+    expect(mocks.execFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('GITHUB_TOKEN env wins without spawning', async () => {
+    process.env.GITHUB_TOKEN = 'ghp_env';
+    expect(await getGitHubTokenAsync()).toBe('ghp_env');
+    expect(mocks.execFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('getGitHubToken (sync) latch semantics (#1415)', () => {
+  it('a timeout does NOT latch the sync path either', () => {
+    mocks.execFileSync.mockImplementationOnce(() => {
+      throw syncTimeoutError();
+    });
+    expect(getGitHubToken()).toBeNull();
+
+    mocks.execFileSync.mockReturnValueOnce('ghp_sync\n');
+    expect(getGitHubToken()).toBe('ghp_sync');
+    expect(mocks.execFileSync).toHaveBeenCalledTimes(2);
+  });
+
+  it('a definitive failure latches the sync path', () => {
+    mocks.execFileSync.mockImplementationOnce(() => {
+      throw enoentError();
+    });
+    expect(getGitHubToken()).toBeNull();
+
+    expect(getGitHubToken()).toBeNull();
+    expect(mocks.execFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('the caches are shared: an async success makes sync instant', async () => {
+    execFileOnce({ stdout: 'ghp_shared\n' });
+    expect(await getGitHubTokenAsync()).toBe('ghp_shared');
+    expect(getGitHubToken()).toBe('ghp_shared');
+    expect(mocks.execFileSync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/core/auth.ts
+++ b/packages/core/src/core/auth.ts
@@ -18,6 +18,22 @@ let cachedGitHubToken: string | null = null;
 let tokenFetchAttempted = false;
 
 /**
+ * A `gh auth token` spawn that timed out is transient (#1415): the CLI is
+ * installed and may answer on the next call (slow disk, machine waking,
+ * momentary load). Everything else is definitive for the process lifetime —
+ * ENOENT (gh not installed) and a non-zero exit (not authenticated) will not
+ * change without user action, so those still latch `tokenFetchAttempted`.
+ * The async execFile timeout surfaces as `killed: true` (signal SIGTERM);
+ * the sync execFileSync timeout surfaces as `code: 'ETIMEDOUT'` (no
+ * `killed` property) — both arms are load-bearing, one per path.
+ */
+function isTransientTokenFetchError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const e = err as { killed?: unknown; code?: unknown };
+  return e.killed === true || e.code === 'ETIMEDOUT';
+}
+
+/**
  * Retrieves a GitHub authentication token, checking sources in priority order.
  *
  * Checks `GITHUB_TOKEN` environment variable first, then falls back to `gh auth token`
@@ -35,8 +51,6 @@ export function getGitHubToken(): string | null {
     return null;
   }
 
-  tokenFetchAttempted = true;
-
   if (process.env.GITHUB_TOKEN) {
     cachedGitHubToken = process.env.GITHUB_TOKEN;
     return cachedGitHubToken;
@@ -49,15 +63,22 @@ export function getGitHubToken(): string | null {
       timeout: 2000,
     }).trim();
 
+    // Definitive outcome (a token, or authoritatively none) — latch.
+    tokenFetchAttempted = true;
     if (token && token.length > 0) {
       cachedGitHubToken = token;
       debug(MODULE, 'Using GitHub token from gh CLI');
       return cachedGitHubToken;
     }
   } catch (err) {
-    // Promote to warn-once-per-session so a slow `gh` (2s timeout) or a
-    // misconfigured CLI is visible without DEBUG=1 (#1209 L6). The
-    // tokenFetchAttempted cache means subsequent calls don't re-warn.
+    // Latch only on definitive failures (#1415): a timeout must not
+    // permanently disable token fetch for a long-lived process (the MCP
+    // server), or gist-mode mutations silently degrade to local-only for
+    // the process lifetime. Promote to warn so a slow `gh` (2s timeout) or
+    // a misconfigured CLI is visible without DEBUG=1 (#1209 L6).
+    if (!isTransientTokenFetchError(err)) {
+      tokenFetchAttempted = true;
+    }
     warn(
       MODULE,
       `gh auth token failed (CLI unavailable or not authenticated): ${err instanceof Error ? err.message : String(err)}`,
@@ -118,8 +139,6 @@ export async function getGitHubTokenAsync(): Promise<string | null> {
     return null;
   }
 
-  tokenFetchAttempted = true;
-
   if (process.env.GITHUB_TOKEN) {
     cachedGitHubToken = process.env.GITHUB_TOKEN;
     return cachedGitHubToken;
@@ -136,13 +155,19 @@ export async function getGitHubTokenAsync(): Promise<string | null> {
       });
     });
 
+    // Definitive outcome (a token, or authoritatively none) — latch.
+    tokenFetchAttempted = true;
     if (token && token.length > 0) {
       cachedGitHubToken = token;
       debug(MODULE, 'Using GitHub token from gh CLI (async)');
       return cachedGitHubToken;
     }
   } catch (err) {
-    // Same warn-once promotion as the sync version (#1209 L6).
+    // Same transient/definitive split and warn promotion as the sync
+    // version (#1415, #1209 L6).
+    if (!isTransientTokenFetchError(err)) {
+      tokenFetchAttempted = true;
+    }
     warn(
       MODULE,
       `gh auth token failed (CLI unavailable or not authenticated): ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -8,6 +8,7 @@ export {
   getStateManager,
   getStateManagerAsync,
   ensureGistPersistence,
+  type GistPersistenceStatus,
   maybeCheckpoint,
   resetStateManager,
   type Stats,

--- a/packages/core/src/core/state-gist-init.test.ts
+++ b/packages/core/src/core/state-gist-init.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Gist init retry semantics on the state singleton (#1415).
+ *
+ * `getStateManagerAsync` falls back to the local manager on a transient
+ * network error during `createWithGist` (intentional CLI warn-and-proceed).
+ * The latch bug: the fallback assigned the local singleton, and the
+ * unconditional `if (stateManager) return stateManager` early-return made
+ * every later token-bearing call a no-op — so a long-lived gist-configured
+ * process (the MCP server) could never recover from one blip. Pinned here:
+ *
+ *  - the transient fallback reports `degraded` via ensureGistPersistence,
+ *  - a LATER call with a token retries createWithGist and upgrades the
+ *    singleton when it succeeds,
+ *  - non-transient/configuration errors still throw (no silent fallback),
+ *  - `no-token` and `local-mode` statuses are distinguished.
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+let mockTmpDir = '';
+
+vi.mock('./paths.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./paths.js')>();
+  return {
+    ...actual,
+    getDataDir: () => {
+      if (!mockTmpDir) throw new Error('mockTmpDir not set');
+      if (!fs.existsSync(mockTmpDir)) fs.mkdirSync(mockTmpDir, { recursive: true, mode: 0o700 });
+      return mockTmpDir;
+    },
+    getStatePath: () => {
+      if (!mockTmpDir) throw new Error('mockTmpDir not set');
+      if (!fs.existsSync(mockTmpDir)) fs.mkdirSync(mockTmpDir, { recursive: true, mode: 0o700 });
+      return path.join(mockTmpDir, 'state.json');
+    },
+    getBackupDir: () => {
+      if (!mockTmpDir) throw new Error('mockTmpDir not set');
+      const backupDir = path.join(mockTmpDir, 'backups');
+      if (!fs.existsSync(backupDir)) fs.mkdirSync(backupDir, { recursive: true, mode: 0o700 });
+      return backupDir;
+    },
+    getLegacyStatePath: () => path.join(mockTmpDir, 'legacy-data', 'state.json'),
+    getLegacyBackupDir: () => path.join(mockTmpDir, 'legacy-data', 'backups'),
+  };
+});
+
+import { StateManager, getStateManager, resetStateManager, ensureGistPersistence } from './state.js';
+import { GistPermissionError } from './errors.js';
+
+function writeGistConfiguredState(): void {
+  fs.writeFileSync(
+    path.join(mockTmpDir, 'state.json'),
+    JSON.stringify({ version: 4, config: { persistence: 'gist' } }),
+    'utf8',
+  );
+}
+
+function transientError(): Error {
+  return Object.assign(new Error('connect ECONNRESET api.github.com'), { code: 'ECONNRESET' });
+}
+
+describe('ensureGistPersistence retry/upgrade semantics (#1415)', () => {
+  let createWithGistSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gist-init-'));
+    resetStateManager();
+    createWithGistSpy = vi.spyOn(StateManager, 'createWithGist');
+  });
+
+  afterEach(() => {
+    createWithGistSpy.mockRestore();
+    resetStateManager();
+    fs.rmSync(mockTmpDir, { recursive: true, force: true });
+    mockTmpDir = '';
+  });
+
+  it('returns local-mode when the config does not request gist persistence', async () => {
+    expect(await ensureGistPersistence('token')).toBe('local-mode');
+    expect(createWithGistSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns no-token when gist is configured but no token is available', async () => {
+    writeGistConfiguredState();
+    expect(await ensureGistPersistence(null)).toBe('no-token');
+    expect(createWithGistSpy).not.toHaveBeenCalled();
+  });
+
+  it('a transient blip degrades to local — and a LATER call upgrades the singleton', async () => {
+    writeGistConfiguredState();
+
+    createWithGistSpy.mockRejectedValueOnce(transientError());
+    expect(await ensureGistPersistence('token')).toBe('degraded');
+    const localFallback = getStateManager();
+    expect(localFallback.isGistMode()).toBe(false);
+
+    // The blip clears: the retry must actually reach createWithGist again
+    // (pre-fix, the latched local singleton made this a dead no-op) and the
+    // singleton upgrades to the gist-backed manager.
+    const gistManager = { isGistMode: () => true } as unknown as StateManager;
+    createWithGistSpy.mockResolvedValueOnce(gistManager);
+    expect(await ensureGistPersistence('token')).toBe('gist');
+    expect(createWithGistSpy).toHaveBeenCalledTimes(2);
+    expect(getStateManager()).toBe(gistManager);
+  });
+
+  it('a lazily created local singleton does not block the gist upgrade', async () => {
+    writeGistConfiguredState();
+    // A tool body touched state before auth resolved — the local manager
+    // exists but gist mode is configured and a token is now available.
+    const lazyLocal = getStateManager();
+    expect(lazyLocal.isGistMode()).toBe(false);
+
+    const gistManager = { isGistMode: () => true } as unknown as StateManager;
+    createWithGistSpy.mockResolvedValueOnce(gistManager);
+    expect(await ensureGistPersistence('token')).toBe('gist');
+    expect(getStateManager()).toBe(gistManager);
+  });
+
+  it('a gist-backed singleton short-circuits: no second createWithGist', async () => {
+    writeGistConfiguredState();
+    const gistManager = { isGistMode: () => true } as unknown as StateManager;
+    createWithGistSpy.mockResolvedValueOnce(gistManager);
+
+    expect(await ensureGistPersistence('token')).toBe('gist');
+    expect(await ensureGistPersistence('token')).toBe('gist');
+    expect(createWithGistSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('an unreadable state file reports state-unreadable, not a local-mode choice', async () => {
+    fs.writeFileSync(path.join(mockTmpDir, 'state.json'), '{ not json', 'utf8');
+    expect(await ensureGistPersistence('token')).toBe('state-unreadable');
+    expect(createWithGistSpy).not.toHaveBeenCalled();
+  });
+
+  it('concurrent token-bearing calls share one in-flight createWithGist', async () => {
+    writeGistConfiguredState();
+    const gistManager = { isGistMode: () => true } as unknown as StateManager;
+    let release!: () => void;
+    createWithGistSpy.mockImplementationOnce(
+      () =>
+        new Promise<StateManager>((resolve) => {
+          release = () => resolve(gistManager);
+        }),
+    );
+
+    const a = ensureGistPersistence('token');
+    const b = ensureGistPersistence('token');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    release();
+
+    expect(await a).toBe('gist');
+    expect(await b).toBe('gist');
+    expect(createWithGistSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('configuration errors still surface instead of degrading (#1202)', async () => {
+    writeGistConfiguredState();
+    createWithGistSpy.mockRejectedValueOnce(new GistPermissionError('token lacks gist scope'));
+    await expect(ensureGistPersistence('token')).rejects.toThrow(/gist scope/);
+  });
+});

--- a/packages/core/src/core/state.ts
+++ b/packages/core/src/core/state.ts
@@ -1044,12 +1044,26 @@ export function getStateManager(): StateManager {
  * StateManager and Gist checkpoints will be no-ops.
  */
 export async function getStateManagerAsync(token?: string): Promise<StateManager> {
-  if (stateManager) return stateManager;
+  // #1415: a LOCAL-mode singleton does not short-circuit when a token is
+  // provided. The only token-bearing caller is ensureGistPersistence, which
+  // already verified the config says `persistence: gist` — so a local
+  // singleton here means a previous transient init failure fell back (or a
+  // tool body lazily created the local manager before auth resolved), and
+  // this call is the retry that must be allowed to upgrade it. The old
+  // unconditional early return made every retry a dead no-op, permanently
+  // latching gist-configured processes into silent local-only writes.
+  if (stateManager && (!token || stateManager.isGistMode())) return stateManager;
   if (asyncManagerPromise) return asyncManagerPromise;
 
   if (token) {
     asyncManagerPromise = StateManager.createWithGist(token)
       .then((mgr) => {
+        // Upgrade note: replacing a transient-fallback local singleton fixes
+        // FUTURE operations. Mutations made during the degraded window stay
+        // in the local state.json only — when a Gist already exists they are
+        // NOT merged into it by this upgrade (bootstrapWithMigration seeds a
+        // Gist from local state only on first creation). The per-call MCP
+        // warning is the signal that those writes were at risk.
         stateManager = mgr;
         asyncManagerPromise = null;
         return mgr;
@@ -1066,6 +1080,9 @@ export async function getStateManagerAsync(token?: string): Promise<StateManager
         // would write subsequent mutations to the local file while the Gist
         // marker stays in config, causing permanent cross-machine divergence.
         if (!isTransientNetworkError(err)) throw err;
+        // Intentional CLI semantics: a one-shot process warns and proceeds
+        // local-only. Long-lived callers (MCP) detect this via the
+        // ensureGistPersistence return status and retry on later calls.
         warn(MODULE, `Gist initialization failed (transient network error), falling back to local-only mode: ${err}`);
         return getStateManager();
       });
@@ -1093,21 +1110,44 @@ export async function getStateManagerAsync(token?: string): Promise<StateManager
  * // CLI bootstrap
  * await ensureGistPersistence(token);
  */
-export async function ensureGistPersistence(token: string | null): Promise<void> {
-  if (!token) return;
+export type GistPersistenceStatus =
+  /** No state file yet, or config does not request gist mode. */
+  | 'local-mode'
+  /** The state file exists but could not be read/parsed for this attempt
+   * (permissions, transient FS error, corrupt JSON). Callers must NOT
+   * memoize this as "local mode chosen" — a later attempt may succeed. */
+  | 'state-unreadable'
+  /** Gist mode is configured but no token was available for this attempt. */
+  | 'no-token'
+  /** Gist mode active: the singleton is gist-backed. */
+  | 'gist'
+  /** Gist mode is configured and a token was available, but init fell back
+   * to local-only (transient network failure). A later call may recover. */
+  | 'degraded';
 
+export async function ensureGistPersistence(token: string | null): Promise<GistPersistenceStatus> {
   let persistence: string | undefined;
   try {
     const raw = fs.readFileSync(getStatePath(), 'utf8');
     persistence = JSON.parse(raw)?.config?.persistence;
-  } catch {
-    // No state file or unreadable — stay in local mode
-    return;
+  } catch (err) {
+    // A missing file is the genuine "fresh local-mode user" case. Anything
+    // else (EACCES, EMFILE, corrupt JSON) must not be silently classified
+    // as a local-mode CHOICE — that would re-create the #1415 latch through
+    // a third door when the caller memoizes the answer.
+    if ((err as { code?: unknown }).code === 'ENOENT') return 'local-mode';
+    warn(MODULE, `State file unreadable during gist-persistence check (will retry): ${errorMessage(err)}`);
+    return 'state-unreadable';
   }
 
-  if (persistence === 'gist') {
-    await getStateManagerAsync(token);
-  }
+  if (persistence !== 'gist') return 'local-mode';
+  // #1415: report the distinction the MCP layer needs — "gist configured but
+  // token missing" and "init fell back to local" both mean the process is
+  // NOT writing to the Gist despite the config saying it should, and a
+  // long-lived caller must keep retrying instead of memoizing the outcome.
+  if (!token) return 'no-token';
+  const mgr = await getStateManagerAsync(token);
+  return mgr.isGistMode() ? 'gist' : 'degraded';
 }
 
 /**

--- a/packages/mcp-server/src/gist-init.test.ts
+++ b/packages/mcp-server/src/gist-init.test.ts
@@ -93,7 +93,7 @@ describe('ensureGistInit retry semantics (#1368)', () => {
   beforeEach(async () => {
     vi.resetModules();
     mockGetGitHubTokenAsync.mockReset().mockResolvedValue('test-token');
-    mockEnsureGistPersistence.mockReset().mockResolvedValue();
+    mockEnsureGistPersistence.mockReset().mockResolvedValue('gist');
     mockRunStatus.mockReset().mockResolvedValue({ ok: true });
     client = await freshClient();
   });
@@ -102,17 +102,94 @@ describe('ensureGistInit retry semantics (#1368)', () => {
     await client.close();
   });
 
-  it('a transient init failure surfaces as a tool error and the next call retries init', async () => {
-    mockGetGitHubTokenAsync.mockRejectedValueOnce(new Error('transient token failure'));
+  it('a hard init rejection surfaces as a tool error and the next call retries init', async () => {
+    // Reachable rejection mode: ensureGistPersistence CAN reject (e.g.
+    // GistPermissionError propagates). The previous version of this test
+    // pinned a getGitHubTokenAsync rejection, which the real function can
+    // never produce — it catches everything and resolves null (#1415).
+    mockEnsureGistPersistence.mockRejectedValueOnce(new Error('Gist scope missing'));
 
     const first = await client.callTool({ name: 'status', arguments: {} });
     expect(first.isError).toBe(true);
-    expect(mockEnsureGistPersistence).not.toHaveBeenCalled();
 
     const second = await client.callTool({ name: 'status', arguments: {} });
     expect(second.isError).toBeFalsy();
-    expect(mockEnsureGistPersistence).toHaveBeenCalledTimes(1);
+    expect(mockEnsureGistPersistence).toHaveBeenCalledTimes(2);
     expect(mockEnsureGistPersistence).toHaveBeenCalledWith('test-token');
+  });
+
+  it('a DEGRADED resolution succeeds with a warning and the next call retries init (#1415)', async () => {
+    // The real transient mode: getStateManagerAsync warn-and-falls-back, so
+    // ensureGistPersistence RESOLVES 'degraded' instead of rejecting. The
+    // tool must still work (warn-and-proceed), the degradation must be
+    // visible in the response, and init must NOT be memoized as success.
+    mockEnsureGistPersistence.mockResolvedValueOnce('degraded');
+
+    const first = await client.callTool({ name: 'status', arguments: {} });
+    expect(first.isError).toBeFalsy();
+    const firstPayload = JSON.parse((first.content as Array<{ text: string }>)[0].text);
+    expect(firstPayload.gistInitWarning).toMatch(/LOCAL-ONLY/);
+    expect(firstPayload.ok).toBe(true);
+
+    // Recovery: the next call re-runs init end to end and the warning clears.
+    const second = await client.callTool({ name: 'status', arguments: {} });
+    expect(second.isError).toBeFalsy();
+    const secondPayload = JSON.parse((second.content as Array<{ text: string }>)[0].text);
+    expect(secondPayload.gistInitWarning).toBeUndefined();
+    expect(mockEnsureGistPersistence).toHaveBeenCalledTimes(2);
+  });
+
+  it('a transient token-fetch failure (null token in gist mode) warns and retries (#1415)', async () => {
+    // getGitHubTokenAsync resolves null on a transient gh timeout (it no
+    // longer latches) — ensureGistPersistence reports 'no-token'.
+    mockGetGitHubTokenAsync.mockResolvedValueOnce(null);
+    mockEnsureGistPersistence.mockResolvedValueOnce('no-token');
+
+    const first = await client.callTool({ name: 'status', arguments: {} });
+    expect(first.isError).toBeFalsy();
+    const firstPayload = JSON.parse((first.content as Array<{ text: string }>)[0].text);
+    expect(firstPayload.gistInitWarning).toMatch(/no GitHub token/);
+
+    // Token fetch recovers on the next call; init re-runs with the token.
+    const second = await client.callTool({ name: 'status', arguments: {} });
+    expect(second.isError).toBeFalsy();
+    const secondPayload = JSON.parse((second.content as Array<{ text: string }>)[0].text);
+    expect(secondPayload.gistInitWarning).toBeUndefined();
+    expect(mockEnsureGistPersistence).toHaveBeenLastCalledWith('test-token');
+    expect(mockEnsureGistPersistence).toHaveBeenCalledTimes(2);
+  });
+
+  it('concurrent calls during a degraded init both carry the warning, then one retry', async () => {
+    let release!: (status: string) => void;
+    mockEnsureGistPersistence.mockImplementationOnce(
+      () =>
+        new Promise<string>((resolve) => {
+          release = resolve;
+        }),
+    );
+
+    const a = client.callTool({ name: 'status', arguments: {} });
+    const b = client.callTool({ name: 'status', arguments: {} });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    release('degraded');
+
+    const [resultA, resultB] = await Promise.all([a, b]);
+    for (const result of [resultA, resultB]) {
+      const payload = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+      expect(payload.gistInitWarning).toMatch(/LOCAL-ONLY/);
+    }
+    // Both shared one init; the NEXT call re-runs it (memo cleared once).
+    await client.callTool({ name: 'status', arguments: {} });
+    expect(mockEnsureGistPersistence).toHaveBeenCalledTimes(2);
+  });
+
+  it('local-mode resolution memoizes like success: no per-call re-init for local users', async () => {
+    mockEnsureGistPersistence.mockResolvedValue('local-mode');
+
+    const first = await client.callTool({ name: 'status', arguments: {} });
+    expect(JSON.parse((first.content as Array<{ text: string }>)[0].text).gistInitWarning).toBeUndefined();
+    await client.callTool({ name: 'status', arguments: {} });
+    expect(mockEnsureGistPersistence).toHaveBeenCalledTimes(1);
   });
 
   it('successful init is memoized: later calls do not re-run it', async () => {

--- a/packages/mcp-server/src/prompts.ts
+++ b/packages/mcp-server/src/prompts.ts
@@ -11,6 +11,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { runDaily, runComments, runSearch, MAX_SEARCH_RESULTS } from '@oss-autopilot/core/commands';
+import { ensureGistInit } from './tools.js';
 import { errorMessage, type PRCommentBundle } from '@oss-autopilot/core';
 
 /** Build a single-message prompt result with a user text message. */
@@ -38,6 +39,10 @@ export function registerPrompts(server: McpServer): void {
     },
     async () => {
       try {
+        // #1415: runDaily mutates state (digest, scores, checkpoint) — if a
+        // prompt is the FIRST interaction in a gist-configured process, the
+        // writes must not silently land in a lazily created local manager.
+        await ensureGistInit();
         const data = await runDaily();
         return userMessage(
           `Here is my current OSS contribution status. Help me triage and prioritize:\n\n${data.summary}\n\nActionable issues:\n${JSON.stringify(data.actionableIssues, null, 2)}\n\nFull data:\n${JSON.stringify(data.digest, null, 2)}`,
@@ -65,6 +70,7 @@ export function registerPrompts(server: McpServer): void {
     },
     async ({ prUrl }) => {
       try {
+        await ensureGistInit();
         const data = await runComments({ prUrl });
         return userMessage(
           `Help me respond to this pull request:\n\nPR: ${data.pr.title} (${data.pr.url})\nState: ${data.pr.state}\n\nReviews:\n${JSON.stringify(data.reviews, null, 2)}\n\nInline comments:\n${JSON.stringify(data.reviewComments, null, 2)}\n\nDiscussion:\n${JSON.stringify(data.issueComments, null, 2)}\n\nPlease help me draft a thoughtful response addressing the feedback.`,
@@ -91,6 +97,7 @@ export function registerPrompts(server: McpServer): void {
         let capped = maxResults ?? 5;
         if (!Number.isInteger(capped) || capped < 1) capped = 5;
         if (capped > MAX_SEARCH_RESULTS) capped = MAX_SEARCH_RESULTS;
+        await ensureGistInit();
         const data = await runSearch({ maxResults: capped });
         const candidateList = data.candidates
           .map(

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -76,27 +76,63 @@ const configKeySchema = KNOWN_CONFIG_KEYS.length > 0 ? z.enum(KNOWN_CONFIG_KEYS 
 
 /** One-shot Gist persistence activation (memoized per process, #1368). */
 let gistInitPromise: Promise<void> | null = null;
-async function ensureGistInit(): Promise<void> {
+/** Non-null while the process is in gist-configured-but-local-only mode
+ * (#1415). The CAUSE is stored; the warning prose is rendered at the edge. */
+type GistDegradedCause = 'no-token' | 'degraded' | 'state-unreadable';
+let gistDegradedCause: GistDegradedCause | null = null;
+
+function gistWarningText(cause: GistDegradedCause): string {
+  const reason =
+    cause === 'no-token'
+      ? 'no GitHub token was available'
+      : cause === 'state-unreadable'
+        ? 'the state file was unreadable'
+        : 'initialization hit a transient network failure';
+  return (
+    `Gist persistence is configured but ${reason}; writes are LOCAL-ONLY and may be ` +
+    'overwritten by the next successful Gist read. Will retry on the next tool call.'
+  );
+}
+
+export async function ensureGistInit(): Promise<GistDegradedCause | null> {
   // Memoize the in-flight promise instead of flipping a boolean up front:
   // the old flag was set before the awaits, so one transient failure (token
   // fetch, network) permanently skipped Gist init for the process and
   // gist-mode mutations silently landed in local state only (#1368).
-  // Failure clears the memo so the next tool call retries; success stays
-  // memoized; concurrent first calls share the same promise.
+  // Rejection clears the memo so the next tool call retries; so does a
+  // DEGRADED resolution (#1415) — both cited transient modes (token-fetch
+  // timeout, network blip during Gist bootstrap) RESOLVE rather than reject
+  // (auth returns null, getStateManagerAsync warn-and-falls-back), so
+  // rejection-only retry was dead code. Success stays memoized; concurrent
+  // first calls share the same promise.
   if (!gistInitPromise) {
     gistInitPromise = (async () => {
-      // Gist init errors (GistPermissionError, network) propagate to wrapTool's catch.
+      // Hard Gist init errors (GistPermissionError etc.) propagate to wrapTool's catch.
       // Shared helper in core unifies the "peek at state file, check persistence mode,
       // pre-set singleton" logic that was previously duplicated with cli.ts (#1000).
       const { ensureGistPersistence, getGitHubTokenAsync } = await import('@oss-autopilot/core');
       const token = await getGitHubTokenAsync();
-      await ensureGistPersistence(token);
+      const status = await ensureGistPersistence(token);
+      if (status === 'degraded' || status === 'no-token' || status === 'state-unreadable') {
+        gistDegradedCause = status;
+        console.error(`[MCP] ${gistWarningText(status)}`);
+        // Clear the memo so the NEXT tool call re-runs init end to end —
+        // a process that COULD reach the Gist after a blip must eventually
+        // do so (getStateManagerAsync allows the singleton upgrade).
+        gistInitPromise = null;
+      } else {
+        gistDegradedCause = null;
+      }
     })();
     gistInitPromise.catch(() => {
       gistInitPromise = null;
     });
   }
-  return gistInitPromise;
+  // Callers receive the cause OBSERVED BY THIS CALL'S init resolution —
+  // reading the module variable later would race a concurrent call's
+  // recovery and silently drop the warning from the one response whose
+  // mutation actually ran degraded (#1415).
+  return gistInitPromise.then(() => gistDegradedCause);
 }
 
 /** Standard MCP text content result. */
@@ -124,8 +160,19 @@ function err(e: unknown) {
 function wrapTool<A>(fn: (args: A) => Promise<unknown>): (args: A) => Promise<ReturnType<typeof ok | typeof err>> {
   return async (args: A) => {
     try {
-      await ensureGistInit();
-      return ok(await fn(args));
+      const degradedCause = await ensureGistInit();
+      const data = await fn(args);
+      // Degraded gist mode is surfaced IN the response (#1415), not just on
+      // stderr — the consuming agent must see that this mutation/read ran
+      // against local-only state. The cause snapshot from THIS call's init
+      // is used (not the module variable, which a concurrent recovery may
+      // have cleared by now). Object payloads get a warning field;
+      // non-object payloads pass through (every current tool returns an
+      // object or undefined).
+      if (degradedCause && data && typeof data === 'object' && !Array.isArray(data)) {
+        return ok({ ...(data as Record<string, unknown>), gistInitWarning: gistWarningText(degradedCause) });
+      }
+      return ok(data);
     } catch (e) {
       console.error('[MCP] Tool error:', e);
       return err(e);


### PR DESCRIPTION
## Summary

Fixes #1415 (HIGH). Both transient failure modes the #1368 fix cites RESOLVED rather than rejected (auth latched `tokenFetchAttempted` before the spawn and returned null; `getStateManagerAsync` caught transient errors and latched the local singleton), so the rejection-retry path was dead code and one blip silenced gist mode for the MCP process lifetime. The invariant restored: a process that COULD reach the Gist after a transient blip eventually does, or says loudly that it is not.

## Changes

- **auth.ts**: latch only on definitive outcomes; timeouts retry (async `killed: true`, sync `code: 'ETIMEDOUT'` — both production shapes verified empirically; the sync arm was the one the old test never exercised).
- **state.ts**: `getStateManagerAsync` lets a token-bearing retry upgrade a local-mode singleton (the only token-bearing caller is `ensureGistPersistence`, gist-config-gated). The CLI's intentional warn-and-proceed transient fallback is unchanged. `ensureGistPersistence` returns a status union; only ENOENT maps to `local-mode`, other read errors return `state-unreadable` so a transient FS error cannot be memoized as a local-mode choice.
- **mcp tools.ts**: `ensureGistInit` stores the degraded cause and returns the cause observed by each call's own init (snapshot — avoids the concurrent-recovery race that would drop the warning from exactly the call that ran degraded), clears the memo on degraded outcomes so the next tool call retries end to end, and `wrapTool` merges a `gistInitWarning` into every object payload.
- **mcp prompts.ts**: prompts now await gist init — `triage` runs `runDaily` (mutating) and previously had no init at all (panel CRITICAL).

## Acceptance criteria

- [x] A transient token-fetch failure at first MCP tool call does not permanently disable gist init
- [x] A transient network failure at first state-manager creation does not permanently latch the local-only singleton (singleton upgrade test: `createWithGist` reinvoked, identity flips)
- [x] The regression test exercises failure modes production can actually produce (old unreachable `getGitHubTokenAsync` rejection replaced; both real RESOLVE modes covered)
- [x] Silent local-only writes in gist mode are loudly surfaced (per-response `gistInitWarning` + stderr; prompts covered)

## Review

Full panel (code-reviewer, silent-failure-hunter, pr-test-analyzer, code-simplifier) + devil's advocate on the final diff (0 surviving attacks). Panel findings folded in: warning-snapshot race fix, `state-unreadable` status, prompts init, sync-timeout test fidelity, status-enum refactor. Known boundary documented in code: degraded-window mutations stay local-only on recovery when a Gist already exists — the per-call warning is the signal.

## Test plan

- [x] 24 new tests (auth 9, red-checked 6 fail pre-fix; state-gist-init 8; gist-init rewrite 7) — core suite 2765 passed, mcp 228 passed
- [x] Both typechecks + mcp typecheck clean; eslint 0 errors; prettier clean