### PR TITLE
fix(core,mcp): close gist-degradation gaps outside the MCP tool path

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -92,6 +92,19 @@ program.hook('preAction', async (thisCommand, actionCommand) => {
     // when Gist mode is the configured persistence (#1000).
     const { ensureGistPersistence } = await import('./core/index.js');
     await ensureGistPersistence(token);
+  } else {
+    // #1431: localOnly skips the AUTH GATE, not gist persistence. Mutating
+    // localOnly commands (shelve/move/dismiss/override/...) already call
+    // maybeCheckpoint, which silently no-ops when the singleton never
+    // bootstrapped — so a gist-configured user's CLI mutations were written
+    // local-only with no warning and never reached the Gist. Best-effort
+    // bootstrap; the warning semantics live (and are unit-tested) in
+    // bootstrapGistBestEffort.
+    const { bootstrapGistBestEffort } = await import('./core/index.js');
+    const localOnlyWarning = await bootstrapGistBestEffort(getGitHubTokenAsync);
+    if (localOnlyWarning) {
+      console.error(`Warning: ${localOnlyWarning}`);
+    }
   }
 });
 

--- a/packages/core/src/commands/config.e2e.test.ts
+++ b/packages/core/src/commands/config.e2e.test.ts
@@ -51,6 +51,67 @@ async function runConfig(
   return { stdout: result.stdout, stderr: result.stderr, json };
 }
 
+// ── #1431: localOnly commands bootstrap gist persistence best-effort ──────
+//
+// `config` is localOnly (no auth gate), but a gist-configured user's
+// mutating localOnly commands must not silently write local-only. The CLI
+// peeks the state file, warns on stderr when gist is configured but
+// unreachable, and still completes the command (warn-and-proceed — these
+// are the repair commands).
+describe.skipIf(!BUNDLE_EXISTS)('localOnly gist bootstrap warning E2E (#1431)', () => {
+  const GIST_HOME = '/tmp/oss-autopilot-e2e-gist-warn-test-' + process.pid;
+  // PATH with only node's own directory: `gh` is deliberately unresolvable,
+  // so the token probe fails deterministically with no network and no
+  // dependence on the runner's gh auth state.
+  const NODE_ONLY_PATH = path.dirname(process.execPath);
+
+  beforeAll(() => {
+    fs.mkdirSync(path.join(GIST_HOME, '.oss-autopilot'), { recursive: true });
+  });
+
+  afterAll(() => {
+    fs.rmSync(GIST_HOME, { recursive: true, force: true });
+  });
+
+  async function runConfigIn(home: string): Promise<{ stdout: string; stderr: string }> {
+    const result = await execFileAsync(process.execPath, [BUNDLE_PATH, 'config', '--json'], {
+      timeout: 10_000,
+      env: { ...process.env, GITHUB_TOKEN: '', PATH: NODE_ONLY_PATH, HOME: home },
+      cwd: home,
+    }).catch((err: any) => ({ stdout: (err.stdout as string) || '', stderr: (err.stderr as string) || '' }));
+    return { stdout: result.stdout, stderr: result.stderr };
+  }
+
+  it('warns LOCAL-ONLY on stderr and still succeeds when gist is configured but no token is available', async () => {
+    fs.writeFileSync(
+      path.join(GIST_HOME, '.oss-autopilot', 'state.json'),
+      JSON.stringify({ version: 4, config: { persistence: 'gist' } }),
+      'utf8',
+    );
+
+    const { stdout, stderr } = await runConfigIn(GIST_HOME);
+
+    expect(stderr).toContain('LOCAL-ONLY');
+    // The command itself still completes with a success envelope.
+    const json = JSON.parse(stdout);
+    expect(json).toHaveProperty('success', true);
+  });
+
+  it('emits no gist warning for a local-mode state file', async () => {
+    fs.writeFileSync(
+      path.join(GIST_HOME, '.oss-autopilot', 'state.json'),
+      JSON.stringify({ version: 4, config: { persistence: 'local' } }),
+      'utf8',
+    );
+
+    const { stdout, stderr } = await runConfigIn(GIST_HOME);
+
+    expect(stderr).not.toContain('LOCAL-ONLY');
+    const json = JSON.parse(stdout);
+    expect(json).toHaveProperty('success', true);
+  });
+});
+
 describe.skipIf(!BUNDLE_EXISTS)('config --json E2E', () => {
   beforeAll(() => {
     fs.mkdirSync(TEST_HOME, { recursive: true });

--- a/packages/core/src/commands/daily-orchestration.test.ts
+++ b/packages/core/src/commands/daily-orchestration.test.ts
@@ -29,6 +29,7 @@ const mockFetchCommentedIssues = vi.fn();
 
 // StateManager method mocks
 const mockGetState = vi.fn();
+const mockIsGistMode = vi.fn(() => false);
 const mockUpdateRepoScore = vi.fn();
 const mockAddTrustedProject = vi.fn();
 const mockSetMonthlyMergedCounts = vi.fn();
@@ -84,6 +85,7 @@ vi.mock('../core/index.js', async (importOriginal) => {
       getStatusOverride: mockGetStatusOverride,
       getStateStaleness: vi.fn(() => null),
       getLoadRecovery: vi.fn(() => null),
+      isGistMode: mockIsGistMode,
       batch: (fn: () => void) => fn(),
     })),
     requireGitHubToken: vi.fn(() => 'test-token'),
@@ -662,6 +664,31 @@ describe('executeDailyCheck() — repo score updates', () => {
 // ---------------------------------------------------------------------------
 
 describe('executeDailyCheck() — error resilience', () => {
+  it('surfaces gist-mode degradation in the warnings envelope (#1431)', async () => {
+    // Config says gist, but this process's manager is local-only (transient
+    // init fallback or a localOnly entry point). Previously the only signal
+    // was stderr — invisible to --json/cron consumers.
+    mockGetState.mockReturnValue(makeDefaultState({ config: { ...makeDefaultState().config, persistence: 'gist' } }));
+    mockIsGistMode.mockReturnValue(false);
+
+    const result = await executeDailyCheck('test-token');
+
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([expect.objectContaining({ phase: 'gist-init', operation: 'Gist persistence degraded' })]),
+    );
+  });
+
+  it('does not warn when gist mode is active or local mode is configured', async () => {
+    mockGetState.mockReturnValue(makeDefaultState({ config: { ...makeDefaultState().config, persistence: 'gist' } }));
+    mockIsGistMode.mockReturnValue(true);
+    const gistResult = await executeDailyCheck('test-token');
+    expect(gistResult.warnings.filter((w) => w.phase === 'gist-init')).toEqual([]);
+
+    mockGetState.mockReturnValue(makeDefaultState());
+    const localResult = await executeDailyCheck('test-token');
+    expect(localResult.warnings.filter((w) => w.phase === 'gist-init')).toEqual([]);
+  });
+
   it('continues if fetchRecentlyClosedPRs fails', async () => {
     mockFetchRecentlyClosedPRs.mockRejectedValue(new Error('Network error'));
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/packages/core/src/commands/daily.ts
+++ b/packages/core/src/commands/daily.ts
@@ -742,6 +742,23 @@ async function executeDailyCheckInternal(token: string): Promise<DailyCheckResul
   // callgraph documents which phases can produce non-fatal warnings. See #1042.
   const warnings: DailyWarning[] = [];
 
+  // Surface gist-mode degradation in the machine-readable envelope (#1431):
+  // a process whose config says `persistence: gist` but whose manager is
+  // local-only (transient init fallback, or a localOnly entry point that
+  // never bootstrapped) writes mutations that will not sync. Previously the
+  // only signal was a stderr warn, invisible to --json consumers.
+  const smForGistCheck = getStateManager();
+  if (smForGistCheck.getState().config.persistence === 'gist' && !smForGistCheck.isGistMode()) {
+    recordWarning(
+      warnings,
+      'gist-init',
+      'Gist persistence degraded',
+      new Error(
+        'configured for Gist but running local-only in this process; mutations will not sync until Gist init succeeds',
+      ),
+    );
+  }
+
   // Surface Gist staleness up-front so consumers see it even if Phase 1 fails (#1193).
   const staleness = getStateManager().getStateStaleness();
   if (staleness) {

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -8,6 +8,7 @@ export {
   getStateManager,
   getStateManagerAsync,
   ensureGistPersistence,
+  bootstrapGistBestEffort,
   type GistPersistenceStatus,
   maybeCheckpoint,
   resetStateManager,

--- a/packages/core/src/core/state-gist-init.test.ts
+++ b/packages/core/src/core/state-gist-init.test.ts
@@ -47,7 +47,13 @@ vi.mock('./paths.js', async (importOriginal) => {
   };
 });
 
-import { StateManager, getStateManager, resetStateManager, ensureGistPersistence } from './state.js';
+import {
+  StateManager,
+  getStateManager,
+  resetStateManager,
+  ensureGistPersistence,
+  bootstrapGistBestEffort,
+} from './state.js';
 import { GistPermissionError } from './errors.js';
 
 function writeGistConfiguredState(): void {
@@ -161,5 +167,72 @@ describe('ensureGistPersistence retry/upgrade semantics (#1415)', () => {
     writeGistConfiguredState();
     createWithGistSpy.mockRejectedValueOnce(new GistPermissionError('token lacks gist scope'));
     await expect(ensureGistPersistence('token')).rejects.toThrow(/gist scope/);
+  });
+});
+
+describe('bootstrapGistBestEffort — localOnly CLI entry points (#1431)', () => {
+  let createWithGistSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gist-besteffort-'));
+    resetStateManager();
+    createWithGistSpy = vi.spyOn(StateManager, 'createWithGist');
+  });
+
+  afterEach(() => {
+    createWithGistSpy.mockRestore();
+    resetStateManager();
+    fs.rmSync(mockTmpDir, { recursive: true, force: true });
+    mockTmpDir = '';
+  });
+
+  it('local mode: no warning and no token fetch at all', async () => {
+    const fetchToken = vi.fn().mockResolvedValue('token');
+    expect(await bootstrapGistBestEffort(fetchToken)).toBeNull();
+    expect(fetchToken).not.toHaveBeenCalled();
+    expect(createWithGistSpy).not.toHaveBeenCalled();
+  });
+
+  it('gist mode + token: bootstraps the singleton and returns no warning (mutations will checkpoint)', async () => {
+    writeGistConfiguredState();
+    const gistManager = { isGistMode: () => true } as unknown as StateManager;
+    createWithGistSpy.mockResolvedValueOnce(gistManager);
+
+    expect(await bootstrapGistBestEffort(vi.fn().mockResolvedValue('token'))).toBeNull();
+    // The load-bearing positive: the singleton is gist-backed, so the
+    // command's own maybeCheckpoint will actually push instead of no-op.
+    expect(getStateManager().isGistMode()).toBe(true);
+    expect(createWithGistSpy).toHaveBeenCalledWith('token');
+  });
+
+  it('gist mode + no token: LOCAL-ONLY warning, no bootstrap attempt', async () => {
+    writeGistConfiguredState();
+    const warning = await bootstrapGistBestEffort(vi.fn().mockResolvedValue(null));
+    expect(warning).toMatch(/LOCAL-ONLY/);
+    expect(warning).toMatch(/no GitHub token/);
+    expect(createWithGistSpy).not.toHaveBeenCalled();
+  });
+
+  it('transient init failure: degraded warning, command proceeds', async () => {
+    writeGistConfiguredState();
+    createWithGistSpy.mockRejectedValueOnce(transientError());
+    const warning = await bootstrapGistBestEffort(vi.fn().mockResolvedValue('token'));
+    expect(warning).toMatch(/LOCAL-ONLY/);
+    expect(warning).toMatch(/transient network failure/);
+  });
+
+  it('unreadable state file: warning, command proceeds', async () => {
+    fs.writeFileSync(path.join(mockTmpDir, 'state.json'), '{ not json', 'utf8');
+    const warning = await bootstrapGistBestEffort(vi.fn().mockResolvedValue('token'));
+    expect(warning).toMatch(/state file could not be read/);
+  });
+
+  it('hard ConfigurationError: warn-and-proceed with repair guidance, NEVER throws (repair commands must stay usable)', async () => {
+    writeGistConfiguredState();
+    createWithGistSpy.mockRejectedValueOnce(new GistPermissionError('token lacks gist scope'));
+    const warning = await bootstrapGistBestEffort(vi.fn().mockResolvedValue('token'));
+    expect(warning).toMatch(/LOCAL-ONLY/);
+    expect(warning).toMatch(/gist scope/);
+    expect(warning).toMatch(/fix the Gist setup/);
   });
 });

--- a/packages/core/src/core/state.ts
+++ b/packages/core/src/core/state.ts
@@ -1151,6 +1151,47 @@ export async function ensureGistPersistence(token: string | null): Promise<GistP
 }
 
 /**
+ * Best-effort gist bootstrap for entry points WITHOUT the auth gate (#1431):
+ * the CLI's localOnly commands (shelve/move/dismiss/override/config/setup/...)
+ * skip token enforcement, but a gist-configured user's mutations must still
+ * reach the Gist — their maybeCheckpoint calls silently no-op when the
+ * singleton never bootstrapped.
+ *
+ * Returns a human-readable LOCAL-ONLY warning when the process will write
+ * local-only despite a gist config, or null when no warning is needed
+ * (local mode, or gist mode successfully activated).
+ *
+ * Ordering: peek first with no token (zero spawn cost for genuinely-local
+ * users), fetch a token only when the config asks for gist. Hard
+ * ConfigurationErrors are converted to a warning instead of thrown — the
+ * localOnly set includes config/setup, the very commands needed to REPAIR a
+ * broken gist setup, so they must not be bricked by it. (The auth-gated
+ * path keeps throwing per #1202.)
+ */
+export async function bootstrapGistBestEffort(fetchToken: () => Promise<string | null>): Promise<string | null> {
+  let reason: string | null = null;
+  try {
+    let status = await ensureGistPersistence(null);
+    if (status === 'no-token') {
+      status = await ensureGistPersistence(await fetchToken());
+    }
+    if (status === 'no-token') reason = 'no GitHub token is available';
+    else if (status === 'state-unreadable') reason = 'the state file could not be read';
+    else if (status === 'degraded') reason = 'Gist initialization hit a transient network failure';
+  } catch (err) {
+    reason =
+      err instanceof ConfigurationError
+        ? `Gist initialization failed (${errorMessage(err)}) — fix the Gist setup (check the token's gist scope, or run state-show / setup) before relying on sync`
+        : `Gist initialization failed: ${errorMessage(err)}`;
+  }
+  if (reason === null) return null;
+  return (
+    `Gist persistence is configured but ${reason} — changes made by this command are ` +
+    'LOCAL-ONLY and may be overwritten by the next successful Gist sync.'
+  );
+}
+
+/**
  * Reset the singleton StateManager instance to null. Intended for test isolation.
  */
 export function resetStateManager(): void {

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -111,6 +111,7 @@ export type DailyWarningPhase =
   | 'scout-sync'
   | 'partition'
   | 'dismiss-filter'
+  | 'gist-init'
   | 'gist-checkpoint'
   | 'gist-staleness'
   | 'state-load';
@@ -294,6 +295,7 @@ const DailyWarningPhaseSchema = z.enum([
   'scout-sync',
   'partition',
   'dismiss-filter',
+  'gist-init',
   'gist-checkpoint',
   'gist-staleness',
   'state-load',

--- a/packages/mcp-server/src/gist-init.test.ts
+++ b/packages/mcp-server/src/gist-init.test.ts
@@ -131,12 +131,88 @@ describe('ensureGistInit retry semantics (#1368)', () => {
     expect(firstPayload.gistInitWarning).toMatch(/LOCAL-ONLY/);
     expect(firstPayload.ok).toBe(true);
 
-    // Recovery: the next call re-runs init end to end and the warning clears.
+    // Recovery: the next call re-runs init end to end, the warning clears,
+    // and a ONE-SHOT notice flags that degraded-window writes were not
+    // merged into the Gist (#1431) — instead of presenting a pristine run.
     const second = await client.callTool({ name: 'status', arguments: {} });
     expect(second.isError).toBeFalsy();
     const secondPayload = JSON.parse((second.content as Array<{ text: string }>)[0].text);
     expect(secondPayload.gistInitWarning).toBeUndefined();
+    expect(secondPayload.gistRecoveryNotice).toMatch(/recovered/i);
     expect(mockEnsureGistPersistence).toHaveBeenCalledTimes(2);
+
+    // One-shot: the call after recovery is clean.
+    const third = await client.callTool({ name: 'status', arguments: {} });
+    const thirdPayload = JSON.parse((third.content as Array<{ text: string }>)[0].text);
+    expect(thirdPayload.gistRecoveryNotice).toBeUndefined();
+  });
+
+  it.each([
+    ['config', {}],
+    ['setup', {}],
+    ['init', { username: 'testuser' }],
+    ['state-unlink', {}],
+  ] as const)(
+    'persistence-affecting tool %s resets the init memo so a mid-session flip takes effect (#1431)',
+    async (toolName, toolArgs) => {
+      // First call memoizes a local-mode resolution.
+      mockEnsureGistPersistence.mockResolvedValueOnce('local-mode');
+      await client.callTool({ name: 'status', arguments: {} });
+      expect(mockEnsureGistPersistence).toHaveBeenCalledTimes(1);
+
+      // The flip rides the memo itself, but resets it afterwards.
+      const flip = await client.callTool({ name: toolName, arguments: toolArgs as Record<string, unknown> });
+      expect(flip.isError).toBeFalsy();
+      expect(mockEnsureGistPersistence).toHaveBeenCalledTimes(1);
+
+      // Next tool call re-runs init end to end and honors the new mode.
+      await client.callTool({ name: 'status', arguments: {} });
+      expect(mockEnsureGistPersistence).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it('the memo resets even when the persistence-affecting tool FAILS (partial setup apply)', async () => {
+    // runSetup applies earlier --set pairs in memory before a later invalid
+    // value throws — the memo must reset either way.
+    mockEnsureGistPersistence.mockResolvedValueOnce('local-mode');
+    await client.callTool({ name: 'status', arguments: {} });
+
+    const { runSetup } = await import('@oss-autopilot/core/commands');
+    vi.mocked(runSetup).mockRejectedValueOnce(new Error('Invalid value for minStars'));
+    const failed = await client.callTool({ name: 'setup', arguments: {} });
+    expect(failed.isError).toBe(true);
+
+    await client.callTool({ name: 'status', arguments: {} });
+    expect(mockEnsureGistPersistence).toHaveBeenCalledTimes(2);
+  });
+
+  it('resource reads run gist init, and proceed on degraded AND hard init errors (#1431)', async () => {
+    // Degraded: read succeeds, init observed.
+    mockEnsureGistPersistence.mockResolvedValueOnce('degraded');
+    const degradedRead = await client.readResource({ uri: 'oss://status' });
+    expect(degradedRead.contents).toHaveLength(1);
+    expect(mockEnsureGistPersistence).toHaveBeenCalledTimes(1);
+
+    // Hard error: resources are diagnostic surfaces — the read still serves
+    // local state instead of bricking (unlike the tool path, which errors).
+    mockEnsureGistPersistence.mockRejectedValueOnce(new Error('Gist scope missing'));
+    const hardErrorRead = await client.readResource({ uri: 'oss://status' });
+    expect(hardErrorRead.contents).toHaveLength(1);
+  });
+
+  it('a recovery notice is dropped (not leaked) when the recovering response has no object payload', async () => {
+    mockEnsureGistPersistence.mockResolvedValueOnce('degraded');
+    await client.callTool({ name: 'status', arguments: {} });
+
+    // Recovery lands on a call whose tool returns undefined: notice dropped.
+    mockRunStatus.mockResolvedValueOnce(undefined);
+    const recovering = await client.callTool({ name: 'status', arguments: {} });
+    expect((recovering.content as Array<{ text: string }>)[0].text).toBe('{}');
+
+    // It must NOT resurface on the next unrelated response.
+    const after = await client.callTool({ name: 'status', arguments: {} });
+    const payload = JSON.parse((after.content as Array<{ text: string }>)[0].text);
+    expect(payload.gistRecoveryNotice).toBeUndefined();
   });
 
   it('a transient token-fetch failure (null token in gist mode) warns and retries (#1415)', async () => {

--- a/packages/mcp-server/src/resources.ts
+++ b/packages/mcp-server/src/resources.ts
@@ -8,6 +8,7 @@ import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { runStatus, runConfig } from '@oss-autopilot/core/commands';
 import { getStateManager, splitRepo, fenceFetchedPR } from '@oss-autopilot/core';
+import { ensureGistInit } from './tools.js';
 
 /** Build a standard MCP resource response with a single JSON content entry. */
 function resourceContent(uri: URL, data: unknown) {
@@ -28,12 +29,29 @@ function resourceContent(uri: URL, data: unknown) {
 function wrapResource(fn: () => Promise<unknown>): (uri: URL) => Promise<ReturnType<typeof resourceContent>> {
   return async (uri: URL) => {
     try {
+      await resourceGistInit();
       return resourceContent(uri, await fn());
     } catch (e) {
       console.error('[MCP] Resource error:', e);
       throw e;
     }
   };
+}
+
+/**
+ * Gist init for resource READS (#1431): before the first tool call in a
+ * gist-configured process the lazily created LOCAL manager would silently
+ * serve stale local state. Reads are non-destructive, so degraded init
+ * proceeds, and — unlike the tool path — HARD init errors also proceed on
+ * local state (stderr-logged): a broken Gist setup must not make the
+ * status/config resources unreadable, they are diagnostic surfaces.
+ */
+async function resourceGistInit(): Promise<void> {
+  try {
+    await ensureGistInit();
+  } catch (e) {
+    console.error('[MCP] Resource read proceeding on local state; gist init failed:', e);
+  }
 }
 
 /**
@@ -109,6 +127,7 @@ export function registerResources(server: McpServer): void {
     new ResourceTemplate('oss://pr/{owner}/{repo}/{number}', {
       list: async () => {
         try {
+          await resourceGistInit();
           const openPRs = getStateManager().getState().lastDigest?.openPRs ?? [];
           return {
             resources: openPRs.map((pr) => {
@@ -145,6 +164,7 @@ export function registerResources(server: McpServer): void {
         throw new Error(`Invalid PR number: ${String(number)}`);
       }
       try {
+        await resourceGistInit();
         const openPRs = getStateManager().getState().lastDigest?.openPRs ?? [];
         const fullRepo = `${String(owner)}/${String(repo)}`;
         const pr = openPRs.find((p) => p.repo === fullRepo && p.number === prNumber);
@@ -168,6 +188,7 @@ export function registerResources(server: McpServer): void {
     new ResourceTemplate('oss://repo/{owner}/{repo}/guidelines', {
       list: async () => {
         try {
+          await resourceGistInit();
           const repos = getStateManager().listGuidelinesRepos();
           return {
             resources: repos.map((fullRepo) => {
@@ -194,6 +215,7 @@ export function registerResources(server: McpServer): void {
     async (uri, { owner, repo }) => {
       try {
         const fullRepo = `${String(owner)}/${String(repo)}`;
+        await resourceGistInit();
         const content = getStateManager().getGuidelines(fullRepo);
         if (!content) {
           throw new Error(`No guidelines stored for ${fullRepo}`);

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -80,6 +80,19 @@ let gistInitPromise: Promise<void> | null = null;
  * (#1415). The CAUSE is stored; the warning prose is rendered at the edge. */
 type GistDegradedCause = 'no-token' | 'degraded' | 'state-unreadable';
 let gistDegradedCause: GistDegradedCause | null = null;
+/** One-shot recovery notice (#1431): after a degraded window ends, the next
+ * response says so instead of presenting a pristine run — mutations made
+ * during the outage were local-only and were not merged into the Gist. */
+let gistRecoveryNoticePending = false;
+
+/** Reset the init memo so the NEXT tool call re-runs gist init (#1431).
+ * Called after tools that can change the persistence config mid-session
+ * (setup/config/init/state-unlink) — without this, flipping
+ * `persistence=gist` after a memoized local-mode init silently stayed
+ * local-only until process restart. */
+function resetGistInitMemo(): void {
+  gistInitPromise = null;
+}
 
 function gistWarningText(cause: GistDegradedCause): string {
   const reason =
@@ -121,6 +134,12 @@ export async function ensureGistInit(): Promise<GistDegradedCause | null> {
         // do so (getStateManagerAsync allows the singleton upgrade).
         gistInitPromise = null;
       } else {
+        // Recovery edge (#1431): if the previous resolution was degraded,
+        // the next response carries a one-shot notice instead of silently
+        // presenting a pristine run.
+        if (gistDegradedCause !== null && status === 'gist') {
+          gistRecoveryNoticePending = true;
+        }
         gistDegradedCause = null;
       }
     })();
@@ -171,6 +190,22 @@ function wrapTool<A>(fn: (args: A) => Promise<unknown>): (args: A) => Promise<Re
       // object or undefined).
       if (degradedCause && data && typeof data === 'object' && !Array.isArray(data)) {
         return ok({ ...(data as Record<string, unknown>), gistInitWarning: gistWarningText(degradedCause) });
+      }
+      if (gistRecoveryNoticePending) {
+        // Consume the one-shot flag unconditionally — a non-object payload
+        // must DROP the notice (stderr already logged the recovery), not
+        // leak it onto an unrelated later response.
+        gistRecoveryNoticePending = false;
+        if (data && typeof data === 'object' && !Array.isArray(data)) {
+          return ok({
+            ...(data as Record<string, unknown>),
+            // "may not": reads during the window lost nothing, and a
+            // first-creation migration DOES carry local state into the new
+            // Gist — only an upgrade against an existing Gist strands them.
+            gistRecoveryNotice:
+              'Gist persistence recovered. Changes made while degraded were saved locally and may NOT have been merged into the Gist; review local state if anything looks missing.',
+          });
+        }
       }
       return ok(data);
     } catch (e) {
@@ -468,7 +503,17 @@ export function registerTools(server: McpServer): void {
       },
       annotations: { readOnlyHint: false, idempotentHint: true },
     },
-    wrapTool(runConfig),
+    wrapTool(async (args: Parameters<typeof runConfig>[0]) => {
+      // config can flip persistence-affecting keys — re-run gist init on the
+      // next call rather than trusting a memoized local-mode resolution.
+      // finally: the memo must reset even on failure — a partially applied
+      // call can still have flipped persistence-affecting config (#1431).
+      try {
+        return await runConfig(args);
+      } finally {
+        resetGistInitMemo();
+      }
+    }),
   );
 
   // 12. init — Initialize with GitHub username
@@ -482,7 +527,15 @@ export function registerTools(server: McpServer): void {
       },
       annotations: { readOnlyHint: false, destructiveHint: false },
     },
-    wrapTool(runInit),
+    wrapTool(async (args: Parameters<typeof runInit>[0]) => {
+      // finally: the memo must reset even on failure — a partially applied
+      // call can still have flipped persistence-affecting config (#1431).
+      try {
+        return await runInit(args);
+      } finally {
+        resetGistInitMemo();
+      }
+    }),
   );
 
   // 13. setup — Interactive setup
@@ -500,7 +553,18 @@ export function registerTools(server: McpServer): void {
       },
       annotations: { readOnlyHint: false, destructiveHint: false },
     },
-    wrapTool(runSetup),
+    wrapTool(async (args: Parameters<typeof runSetup>[0]) => {
+      // setup --set persistence=gist mid-session must take effect without a
+      // process restart (#1431).
+      // finally: runSetup applies earlier --set pairs in memory BEFORE a later
+      // invalid value throws, so even a FAILED call can have flipped
+      // persistence — the memo must reset either way (#1431).
+      try {
+        return await runSetup(args);
+      } finally {
+        resetGistInitMemo();
+      }
+    }),
   );
 
   // 14. check-setup — Check if setup is complete
@@ -632,7 +696,13 @@ export function registerTools(server: McpServer): void {
     },
     wrapTool(async () => {
       const { runStateUnlink } = await import('@oss-autopilot/core/commands');
-      return runStateUnlink();
+      // Unlink resets the core singleton; the init memo must follow (even on
+      // failure) so a later re-link is honored (#1431).
+      try {
+        return await runStateUnlink();
+      } finally {
+        resetGistInitMemo();
+      }
     }),
   );
 


### PR DESCRIPTION
## Summary

Fixes #1431 — the five follow-up items from the #1415 review panel.

## Changes

1. **CLI localOnly bootstrap** (`shelve`/`move`/`dismiss`/`override`/`config`/`setup`/...): new `bootstrapGistBestEffort` core helper — peek-first (zero spawn for local-mode users), token fetch only when the config asks for gist, LOCAL-ONLY stderr warning on every degraded outcome, and hard `ConfigurationError`s warn-and-proceed with repair guidance instead of throwing (localOnly includes the repair commands; the auth-gated path keeps throwing per #1202). Previously these wrote local-only in gist mode with no signal.
2. **`daily`/`startup` `--json`**: a `gist-init` `DailyWarning` (new phase) when the config says gist but the process manager is local — visible to cron/agent consumers, not just stderr.
3. **MCP mid-session persistence flips**: `config`/`init`/`setup`/`state-unlink` reset the gist-init memo in a `finally` (the failed-call path matters: `runSetup` applies earlier `--set` pairs in memory before a later invalid value throws).
4. **MCP resources**: all handlers (including the `pr-detail`/`repo-guidelines` list+read paths that bypass `wrapResource`) run gist init before reading the singleton, and proceed on local state for degraded AND hard errors — resources are diagnostic surfaces and must stay readable while the user repairs a broken setup (deliberate contrast with the tool path, which errors on hard failures).
5. **Recovery notice**: one-shot `gistRecoveryNotice` on the first clean response after a degraded window; consumed even when that response has no object payload (no leak onto later responses); prose says "may NOT have been merged" (reads lose nothing; first-creation migration carries local state into the new Gist).

Follow-up filed for the two panel findings beyond this issue's scope (#1433): dashboard `serve` degraded lifecycle (stdio-ignored warning, no retry) and machine-readable warnings in mutating localOnly `--json` envelopes.

## Test plan

- [x] 6 new `bootstrapGistBestEffort` unit tests (all outcomes incl. ConfigurationError warn-and-proceed and the gist-success singleton check)
- [x] daily-orchestration: warning present for config-gist + manager-local, absent for gist-active and local modes
- [x] gist-init: memo reset for all four flip tools (`it.each`) incl. the failed-call path; resource reads under degraded and hard init errors; recovery-notice one-shot + non-object drop
- [x] e2e: LOCAL-ONLY stderr warning + clean success envelope, deterministic via node-only PATH; clean local-mode case
- [x] Core 2780 passed (fresh bundle), MCP 235 passed; all typechecks clean; eslint 0 errors; prettier clean