### PR TITLE
fix(core): dashboard gist recovery lifecycle + gist warning in CLI JSON envelopes

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -89,9 +89,19 @@ program.hook('preAction', async (thisCommand, actionCommand) => {
 
     // Activate Gist persistence if configured, before any command runs.
     // Shared helper peeks at the state file and only pre-sets the singleton
-    // when Gist mode is the configured persistence (#1000).
+    // when Gist mode is the configured persistence (#1000). Hard errors
+    // still throw (#1202); the resolving degraded modes are surfaced in the
+    // JSON envelope so --json consumers see them too (#1433).
     const { ensureGistPersistence } = await import('./core/index.js');
-    await ensureGistPersistence(token);
+    const status = await ensureGistPersistence(token);
+    if (status === 'degraded' || status === 'state-unreadable') {
+      const { setEnvelopeGistWarning } = await import('./formatters/json.js');
+      setEnvelopeGistWarning(
+        'Gist persistence is configured but this run is LOCAL-ONLY (' +
+          (status === 'degraded' ? 'transient network failure during init' : 'state file could not be read') +
+          '); changes may be overwritten by the next successful Gist sync.',
+      );
+    }
   } else {
     // #1431: localOnly skips the AUTH GATE, not gist persistence. Mutating
     // localOnly commands (shelve/move/dismiss/override/...) already call
@@ -104,6 +114,11 @@ program.hook('preAction', async (thisCommand, actionCommand) => {
     const localOnlyWarning = await bootstrapGistBestEffort(getGitHubTokenAsync);
     if (localOnlyWarning) {
       console.error(`Warning: ${localOnlyWarning}`);
+      // Also thread it into the JSON envelope: shelve/move/dismiss --json
+      // consumers (the agent harness) must see the mutation will not sync —
+      // stderr alone is invisible to them (#1433).
+      const { setEnvelopeGistWarning } = await import('./formatters/json.js');
+      setEnvelopeGistWarning(localOnlyWarning);
     }
   }
 });

--- a/packages/core/src/commands/config.e2e.test.ts
+++ b/packages/core/src/commands/config.e2e.test.ts
@@ -92,9 +92,11 @@ describe.skipIf(!BUNDLE_EXISTS)('localOnly gist bootstrap warning E2E (#1431)', 
     const { stdout, stderr } = await runConfigIn(GIST_HOME);
 
     expect(stderr).toContain('LOCAL-ONLY');
-    // The command itself still completes with a success envelope.
+    // The command itself still completes with a success envelope, and the
+    // degradation also rides the envelope so --json consumers see it (#1433).
     const json = JSON.parse(stdout);
     expect(json).toHaveProperty('success', true);
+    expect(json.gistInitWarning).toContain('LOCAL-ONLY');
   });
 
   it('emits no gist warning for a local-mode state file', async () => {
@@ -109,6 +111,7 @@ describe.skipIf(!BUNDLE_EXISTS)('localOnly gist bootstrap warning E2E (#1431)', 
     expect(stderr).not.toContain('LOCAL-ONLY');
     const json = JSON.parse(stdout);
     expect(json).toHaveProperty('success', true);
+    expect(json).not.toHaveProperty('gistInitWarning');
   });
 });
 

--- a/packages/core/src/commands/dashboard-server.test.ts
+++ b/packages/core/src/commands/dashboard-server.test.ts
@@ -82,6 +82,7 @@ vi.mock('../core/index.js', async (importOriginal) => {
     getCLIVersion: vi.fn(() => '0.44.6'),
     applyStatusOverrides: vi.fn((prs: unknown[]) => prs),
     maybeCheckpoint: (...args: unknown[]) => mockMaybeCheckpoint(...args),
+    ensureGistPersistence: (...args: unknown[]) => mockEnsureGistPersistence(...args),
     // Real pure classifier + status set (#1352) so /api/data responses carry
     // genuine buckets and the shelve partition mirrors the daily check.
     classifyAttentionBucket: actual.classifyAttentionBucket,
@@ -124,6 +125,8 @@ vi.mock('./dashboard-data.js', async (importActual) => {
 const mockRunMove = vi.fn().mockResolvedValue({ url: '', target: 'shelved', description: 'done' });
 // Resolves null (no warning) by default; #1417 tests resolve a warning string.
 const mockMaybeCheckpoint = vi.fn().mockResolvedValue(null);
+// #1433 degraded-recovery tests resolve a status; default mirrors local mode.
+const mockEnsureGistPersistence = vi.fn().mockResolvedValue('local-mode');
 vi.mock('./move.js', () => ({
   VALID_TARGETS: ['attention', 'waiting', 'shelved', 'auto'],
   runMove: (...args: unknown[]) => mockRunMove(...args),
@@ -1218,6 +1221,103 @@ describe('dashboard-server', () => {
         vi.mocked(getGitHubToken).mockReturnValue(null as never);
         mockMaybeCheckpoint.mockResolvedValue(null);
         await resetPendingWarnings();
+      });
+
+      it('degraded gist mode: the LOCAL-ONLY banner rides partialFailures and recovery is attempted (#1433)', async () => {
+        // Config says gist, manager is local — the window where dashboard
+        // mutations are acknowledged then clobbered by the next pull.
+        const digest = makeDigest();
+        const degradedState = makeState({ config: { persistence: 'gist' }, lastDigest: digest });
+        mockStateManager.getState.mockReturnValue(degradedState);
+        try {
+          // No token: recovery cannot run, the banner must still show.
+          mockStateManager.reloadIfChanged.mockReturnValueOnce(true);
+          const result = await sendRequest('GET', '/api/data');
+          const body = JSON.parse(result.body);
+          expect(body.partialFailures?.some((m: string) => m.includes('LOCAL-ONLY'))).toBe(true);
+          expect(mockEnsureGistPersistence).not.toHaveBeenCalled();
+
+          // Token available: the request retries gist init; on success the
+          // banner clears in the same response.
+          vi.mocked(getGitHubToken).mockReturnValue('test-token');
+          mockEnsureGistPersistence.mockResolvedValueOnce('gist');
+          mockStateManager.isGistMode
+            .mockReturnValueOnce(false) // handler branch
+            .mockReturnValueOnce(false) // gistConfiguredButLocal pre-recovery
+            .mockReturnValue(true); // post-recovery
+          const recovered = await sendRequest('GET', '/api/data');
+          expect(mockEnsureGistPersistence).toHaveBeenCalledWith('test-token');
+          const recoveredBody = JSON.parse(recovered.body);
+          expect(recoveredBody.partialFailures?.some((m: string) => m.includes('LOCAL-ONLY'))).toBeFalsy();
+        } finally {
+          vi.mocked(getGitHubToken).mockReturnValue(null as never);
+          mockStateManager.isGistMode.mockReset();
+          mockStateManager.isGistMode.mockReturnValue(false);
+          mockEnsureGistPersistence.mockClear();
+          mockEnsureGistPersistence.mockResolvedValue('local-mode');
+          // Restore the default state and rebuild the cached payload so later
+          // tests don't see the degraded banner.
+          const cleanState = makeState({ lastDigest: makeDigest() });
+          mockStateManager.getState.mockReturnValue(cleanState);
+          mockStateManager.reloadIfChanged.mockReturnValueOnce(true);
+          await sendRequest('GET', '/api/data');
+        }
+      });
+
+      it('a refresh whose OWN recovery reverts degraded mutations still shows the loss notice (#1433 pass-2)', async () => {
+        const digest = makeDigest();
+        const degradedState = makeState({ config: { persistence: 'gist' }, lastDigest: digest });
+        mockStateManager.getState.mockReturnValue(degradedState);
+        // The recovery throttle is shared server state and an earlier test's
+        // attempt may have stamped it — jump past the 30s window.
+        const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(new Date('2030-01-01T00:00:00Z').getTime());
+        try {
+          // A mutation lands while degraded (no token, recovery impossible).
+          await sendRequest(
+            'POST',
+            '/api/action',
+            JSON.stringify({ action: 'move', url: 'https://github.com/owner/repo/pull/77', target: 'shelved' }),
+          );
+
+          // Token appears; the user clicks Refresh. Recovery happens INSIDE
+          // this handler and bootstraps from the existing Gist, reverting the
+          // mutation — the retrospective notice must reach this response.
+          vi.mocked(getGitHubToken).mockReturnValue('test-token');
+          vi.mocked(fetchDashboardData).mockResolvedValue({
+            digest: makeDigest(),
+            commentedIssues: [],
+            allMergedPRs: [],
+            allClosedPRs: [],
+            partialFailures: [],
+          });
+          mockEnsureGistPersistence.mockResolvedValueOnce('gist');
+          mockStateManager.isGistMode
+            .mockReturnValueOnce(false) // reloadState branch
+            .mockReturnValueOnce(false) // gistConfiguredButLocal pre-recovery
+            .mockReturnValue(true); // post-recovery
+
+          const result = await sendRequest('POST', '/api/refresh');
+          expect(result.statusCode).toBe(200);
+          const body = JSON.parse(result.body);
+          expect(body.partialFailures?.some((m: string) => m.includes('NOT merged'))).toBe(true);
+
+          // The next successful refresh retires the notice — it has now been
+          // visible across the window.
+          const second = await sendRequest('POST', '/api/refresh');
+          const secondBody = JSON.parse(second.body);
+          expect(secondBody.partialFailures?.some((m: string) => m.includes('NOT merged'))).toBeFalsy();
+        } finally {
+          nowSpy.mockRestore();
+          vi.mocked(getGitHubToken).mockReturnValue(null as never);
+          mockStateManager.isGistMode.mockReset();
+          mockStateManager.isGistMode.mockReturnValue(false);
+          mockEnsureGistPersistence.mockClear();
+          mockEnsureGistPersistence.mockResolvedValue('local-mode');
+          const cleanState = makeState({ lastDigest: makeDigest() });
+          mockStateManager.getState.mockReturnValue(cleanState);
+          mockStateManager.reloadIfChanged.mockReturnValueOnce(true);
+          await sendRequest('GET', '/api/data');
+        }
       });
 
       it('gist mode: refresh re-pushes BEFORE pulling and clears the warning on success', async () => {

--- a/packages/core/src/commands/dashboard-server.ts
+++ b/packages/core/src/commands/dashboard-server.ts
@@ -17,8 +17,15 @@ import {
   applyStatusOverrides,
   classifyAttentionBucket,
   maybeCheckpoint,
+  ensureGistPersistence,
 } from '../core/index.js';
-import { errorMessage, ValidationError, ConcurrencyError, GistConcurrencyError } from '../core/errors.js';
+import {
+  errorMessage,
+  ValidationError,
+  ConcurrencyError,
+  ConfigurationError,
+  GistConcurrencyError,
+} from '../core/errors.js';
 import { warn } from '../core/logger.js';
 import { validateUrl, validateGitHubUrl, PR_URL_PATTERN, ISSUE_URL_PATTERN } from './validation.js';
 import type { MoveTarget } from './move.js';
@@ -363,7 +370,10 @@ function sendConflict(res: http.ServerResponse): void {
 export async function startDashboardServer(options: DashboardServerOptions): Promise<void> {
   const { port: requestedPort, assetsDir, token, open } = options;
 
-  const stateManager = getStateManager();
+  // `let` (#1433): a degraded gist recovery replaces the core singleton, and
+  // this long-lived server must re-resolve its reference or every handler
+  // keeps using the orphaned local manager.
+  let stateManager = getStateManager();
   const resolvedAssetsDir = path.resolve(assetsDir);
 
   // ── CSRF token ──────────────────────────────────────────────────────────
@@ -415,9 +425,20 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
   /** Merge pending gist-sync warnings into a partialFailures payload for the
    * SPA banner without coupling their lifecycles. */
   function withPendingGistWarnings(failures: string[] | undefined): string[] | undefined {
-    if (pendingGistSyncWarnings.length === 0) return failures;
+    const extras = [...pendingGistSyncWarnings, ...recoveryLossNotices];
+    if (gistConfiguredButLocal()) {
+      extras.push(
+        recoveryHaltedReason === null
+          ? GIST_DEGRADED_WARNING
+          : `Gist persistence is configured but recovery FAILED permanently: ${recoveryHaltedReason} — ` +
+              'fix the Gist setup (check the token gist scope, or run state-show), then restart the dashboard.',
+      );
+    } else if (gistBootstrapDegraded()) {
+      extras.push(GIST_STALE_BOOTSTRAP_WARNING);
+    }
+    if (extras.length === 0) return failures;
     const base = failures ?? [];
-    return [...base, ...pendingGistSyncWarnings.filter((w) => !base.includes(w))];
+    return [...base, ...extras.filter((w) => !base.includes(w))];
   }
 
   /** Push-before-pull (#1417): an un-pushed mutation would be silently
@@ -427,6 +448,96 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
   async function flushPendingGistSync(): Promise<void> {
     if (pendingGistSyncWarnings.length === 0) return;
     recordGistSyncOutcome(await maybeCheckpoint(stateManager, MODULE));
+  }
+
+  /** True while the config asks for gist but this process's manager is
+   * local-only (#1433) — the degraded window in which every dashboard
+   * mutation is acknowledged and then clobbered by the next pull. */
+  function gistConfiguredButLocal(): boolean {
+    // Defensive: this is an advisory check that runs on EVERY request path
+    // (rebuilds, recovery probes). A getState failure has its own handling
+    // wherever state is actually consumed — the degraded probe must not
+    // become a new crash surface in front of it (#994's stale-serving path).
+    try {
+      return stateManager.getState().config.persistence === 'gist' && !stateManager.isGistMode();
+    } catch (err) {
+      warn(MODULE, `Degraded-gist probe failed (treating as not degraded): ${errorMessage(err)}`);
+      return false;
+    }
+  }
+
+  /** Gist-backed but the bootstrap itself fell back to the local cache —
+   * reads may be stale even though isGistMode() is true (#1433 review). */
+  function gistBootstrapDegraded(): boolean {
+    try {
+      return stateManager.isGistMode() && stateManager.isGistDegraded();
+    } catch {
+      return false;
+    }
+  }
+
+  const GIST_DEGRADED_WARNING =
+    'Gist persistence is configured but this dashboard process is running LOCAL-ONLY; ' +
+    'changes made here will NOT sync and may be overwritten by the next successful Gist read. ' +
+    'Recovery is retried automatically.';
+
+  const GIST_STALE_BOOTSTRAP_WARNING =
+    'Gist persistence is active but the last Gist read fell back to the local cache; ' +
+    'data shown may be stale until the next successful Gist read.';
+
+  // Recovery throttling + halt (#1433 review): a PERMANENT failure (token
+  // lacks gist scope, corrupt Gist) must not turn every dashboard poll into
+  // a doomed GitHub round trip for the life of the server, and its root
+  // cause must reach the banner — the detached spawn discards stderr.
+  const RECOVERY_RETRY_INTERVAL_MS = 30_000;
+  let lastRecoveryAttemptAt = 0;
+  let recoveryHaltedReason: string | null = null;
+
+  // Mutations acknowledged while degraded (#1433 review): a successful
+  // recovery bootstraps FROM the existing Gist, which reverts them — the
+  // user must get a retrospective notice, not just the prospective banner
+  // that clears at the exact moment of the loss. Cleared on a successful
+  // full refresh (by then the user has seen the notice across the window).
+  let degradedMutationCount = 0;
+  let recoveryLossNotices: string[] = [];
+
+  /** Re-attempt gist init while degraded (#1433). The serve process used to
+   * bootstrap exactly once at CLI preAction — with its stderr discarded by
+   * the detached spawn — and never retry, so one blip at startup meant
+   * local-only writes for the server's lifetime. Never throws. Transient
+   * failures retry no more often than RECOVERY_RETRY_INTERVAL_MS; permanent
+   * (ConfigurationError-class) failures halt retries and surface the reason
+   * in the banner. */
+  async function maybeRecoverGist(): Promise<void> {
+    if (!gistConfiguredButLocal()) return;
+    if (recoveryHaltedReason !== null) return;
+    const now = Date.now();
+    if (now - lastRecoveryAttemptAt < RECOVERY_RETRY_INTERVAL_MS) return;
+    const currentToken = token || getGitHubToken();
+    // A token-less probe is free (the auth cache answers instantly) and must
+    // not burn the retry window — stamp only when a real attempt starts.
+    if (!currentToken) return;
+    lastRecoveryAttemptAt = now;
+    try {
+      await ensureGistPersistence(currentToken);
+      // The upgrade replaced the core singleton — re-resolve our reference.
+      stateManager = getStateManager();
+      if (stateManager.isGistMode() && degradedMutationCount > 0) {
+        recoveryLossNotices.push(
+          `Gist persistence recovered, but ${degradedMutationCount} change(s) made while degraded were ` +
+            'saved locally only and were NOT merged into the Gist — they may have been reverted in this view. ' +
+            'Re-apply anything missing.',
+        );
+        degradedMutationCount = 0;
+      }
+    } catch (err) {
+      // ConfigurationError-class failures are permanent until the user acts
+      // (#1202 semantics) — stop hammering GitHub and say WHY in the banner.
+      if (err instanceof ConfigurationError) {
+        recoveryHaltedReason = errorMessage(err);
+      }
+      warn(MODULE, `Gist recovery attempt failed: ${errorMessage(err)}`);
+    }
   }
 
   if (!cachedDigest) {
@@ -491,6 +602,10 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
           stateChanged = await stateManager.refreshFromGist();
         } else {
           stateChanged = stateManager.reloadIfChanged();
+          await maybeRecoverGist();
+          // A successful recovery is a state-source change: rebuild so the
+          // degraded banner clears without waiting for another edit.
+          if (stateManager.isGistMode()) stateChanged = true;
         }
         // Also rebuild when the vetted issue list file was edited outside this server (#924)
         const currentIssueListMtimeMs = getIssueListMtimeMs();
@@ -591,7 +706,15 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
       await flushPendingGistSync();
       await stateManager.refreshFromGist();
     } else {
-      stateManager.reloadIfChanged();
+      if (stateManager.reloadIfChanged()) {
+        // An external config edit may BE the fix for a permanently-halted
+        // recovery (new token scope, repaired gist id) — give it one fresh
+        // attempt cycle (#1433 pass-2).
+        recoveryHaltedReason = null;
+      }
+      // reloadIfChanged may have just pulled a persistence=gist flip made
+      // from a terminal, and a degraded server heals here too (#1433).
+      await maybeRecoverGist();
     }
   }
 
@@ -704,6 +827,11 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
     // PUSH, while fetch failures clear on a successful pull/refresh.
     recordGistSyncOutcome(gistSyncWarning);
 
+    // Count mutations acknowledged while degraded (#1433): a later recovery
+    // bootstraps from the existing Gist and reverts them, and the loss
+    // notice needs to know whether there is anything to lose.
+    if (gistConfiguredButLocal()) degradedMutationCount++;
+
     // Rebuild dashboard data from cached digest + updated state. Persist
     // the last-known partialFailures across action rebuilds (#1035) so the
     // SPA banner survives user interactions until the next successful
@@ -730,6 +858,12 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
     }
 
     try {
+      // Clear PRE-EXISTING loss notices before the reload: by now they have
+      // been visible across the degraded window. Order matters — this
+      // refresh's own reloadState may RECOVER and produce a fresh notice,
+      // which must survive into the rebuild below, not be wiped 10 lines
+      // after its creation (#1433 pass-2).
+      recoveryLossNotices = [];
       await reloadState();
       warn(MODULE, 'Refreshing dashboard data from GitHub...');
       const result = await fetchDashboardData(currentToken);
@@ -870,11 +1004,14 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
   if (token) {
     fetchDashboardData(token)
       .then(async (result) => {
+        // Same clear-before-recover ordering as handleRefresh (#1433 pass-2).
+        recoveryLossNotices = [];
         if (stateManager.isGistMode()) {
           await flushPendingGistSync();
           await stateManager.refreshFromGist();
         } else {
           stateManager.reloadIfChanged();
+          await maybeRecoverGist();
         }
         cachedDigest = result.digest;
         cachedCommentedIssues = result.commentedIssues;

--- a/packages/core/src/formatters/json.test.ts
+++ b/packages/core/src/formatters/json.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { z } from 'zod';
 import {
   jsonSuccess,
+  setEnvelopeGistWarning,
   jsonError,
   outputJson,
   outputJsonError,
@@ -794,5 +795,24 @@ describe('Misc command schemas (#1155)', () => {
       fromCache: false,
     };
     expect(formatJson(LocalReposOutputSchema, data).success).toBe(true);
+  });
+});
+
+// ── Envelope-level gist degradation warning (#1433) ───────────────────────
+
+describe('setEnvelopeGistWarning', () => {
+  afterEach(() => {
+    setEnvelopeGistWarning(null);
+  });
+
+  it('threads the warning into success AND error envelopes once set', () => {
+    setEnvelopeGistWarning('Gist persistence is configured but this run is LOCAL-ONLY');
+    expect(jsonSuccess({ ok: true }).gistInitWarning).toMatch(/LOCAL-ONLY/);
+    expect(jsonError('boom').gistInitWarning).toMatch(/LOCAL-ONLY/);
+  });
+
+  it('is absent (not null) when unset, keeping the wire format minimal', () => {
+    expect('gistInitWarning' in jsonSuccess({ ok: true })).toBe(false);
+    expect('gistInitWarning' in jsonError('boom')).toBe(false);
   });
 });

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -55,6 +55,23 @@ export interface JsonOutput<T = unknown> {
   error?: string;
   errorCode?: ErrorCode;
   timestamp: string;
+  /** Present when the process is gist-configured but running local-only
+   * (#1433): machine consumers of mutating --json commands must see that
+   * the mutation will not sync. Set once per process from the CLI bootstrap
+   * via {@link setEnvelopeGistWarning}; envelope-level (not data-level) so
+   * per-command output schemas are untouched. */
+  gistInitWarning?: string;
+}
+
+// Process-level gist degradation warning threaded into every JSON envelope
+// (#1433). The CLI preAction bootstrap sets it; one-shot processes never
+// clear it (the whole invocation runs degraded or it doesn't).
+let envelopeGistWarning: string | null = null;
+
+/** Set (or clear) the gist degradation warning carried by every subsequent
+ * JSON envelope. Exported for the CLI bootstrap and for test isolation. */
+export function setEnvelopeGistWarning(warning: string | null): void {
+  envelopeGistWarning = warning;
 }
 
 // CapacityAssessment, ActionableIssue, ActionableIssueType,
@@ -1401,6 +1418,7 @@ export function jsonSuccess<T>(data: T): JsonOutput<T> {
     success: true,
     data,
     timestamp: new Date().toISOString(),
+    ...(envelopeGistWarning ? { gistInitWarning: envelopeGistWarning } : {}),
   };
 }
 
@@ -1413,6 +1431,7 @@ export function jsonError(message: string, errorCode?: ErrorCode): JsonOutput<ne
     error: message,
     errorCode,
     timestamp: new Date().toISOString(),
+    ...(envelopeGistWarning ? { gistInitWarning: envelopeGistWarning } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes #1433 — the two gaps the #1431 review panel found beyond that issue's scope.

## Dashboard serve degraded lifecycle

- **Per-request recovery**: `maybeRecoverGist` re-attempts gist init from every pull path. Transient failures retry at most every 30s (token-less probes don't burn the window); `ConfigurationError`-class failures **halt** retries and the banner names the root cause with repair guidance (previously the reason died on the detached spawn's discarded stderr while every poll hammered GitHub). An external config edit clears the halt for one fresh cycle.
- **Singleton re-resolution**: the captured `stateManager` became `let` — recovery replaces the core singleton and handlers must follow.
- **Banners**: LOCAL-ONLY while degraded; stale-cache notice when a gist-backed bootstrap fell back to the local cache (`isGistDegraded`); both ride the existing `partialFailures` channel.
- **Retrospective loss notice**: mutations acknowledged while degraded are counted; a successful recovery (which bootstraps from the existing Gist and reverts them) pushes a notice that **survives the refresh that produced it** — the pass-2 review caught the notice being wiped 10 lines after its own creation in `handleRefresh` — and retires on the next successful refresh.

## CLI --json envelope

`JsonOutput` gains an optional top-level `gistInitWarning`, set once from the preAction bootstrap (auth-gated degraded statuses + the localOnly best-effort warning). Envelope-level deliberately: per-command output schemas, goldens, and the CLI contract gates are untouched. `shelve`/`move`/`dismiss --json` consumers (the agent harness) now see that a mutation will not sync.

## Test plan

- [x] Dashboard: degraded banner + in-flight recovery clearing it; refresh-born loss notice surviving its own handler and retiring next refresh; mock-clock past the shared throttle window
- [x] json.test envelope pair; e2e envelope assertions both directions (deterministic node-only PATH)
- [x] Core suite 2784 passed (fresh bundle); both typechecks clean; eslint 0 errors; prettier clean
- [x] Two review passes (code-reviewer + silent-failure-hunter pass 1; code-reviewer pass 2 on revisions) — pass-2 CRITICAL fixed, halt-exit recommendation implemented