### PR TITLE
fix(state): keep the migrating machine in gist mode after state.json is renamed away (#1438)

### DIFF
--- a/packages/core/src/core/state-gist-migration.test.ts
+++ b/packages/core/src/core/state-gist-migration.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Post-migration persistence detection (#1438).
+ *
+ * The first-time Gist migration renames state.json to
+ * state.json.pre-gist-migration, and gist-mode saves only ever write
+ * state-cache.json. Before the fix, ensureGistPersistence treated a missing
+ * state.json as "fresh local-mode user", so the machine that CREATED the
+ * Gist permanently dropped out of gist mode on its very next process: fresh
+ * local state, orphaned Gist, and no warning anywhere (even the LOCAL-ONLY
+ * warning was suppressed because the status read local-mode). Pinned here:
+ *
+ *  - the real createWithGist migration path renames state.json and leaves
+ *    the cache + gist-id artifacts behind,
+ *  - a fresh process's ensureGistPersistence peek classifies that machine
+ *    as gist-configured (via the cache, or the gist-id file when the cache
+ *    is missing — e.g. installs migrated before the cache write existed),
+ *  - a genuinely fresh install (no artifacts at all) still reads local-mode,
+ *  - an explicit non-gist config in the cache wins over a stray gist-id file,
+ *  - an unreadable cache reports state-unreadable, not a local-mode choice.
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+let mockTmpDir = '';
+
+vi.mock('./paths.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./paths.js')>();
+  const dir = () => {
+    if (!mockTmpDir) throw new Error('mockTmpDir not set');
+    if (!fs.existsSync(mockTmpDir)) fs.mkdirSync(mockTmpDir, { recursive: true, mode: 0o700 });
+    return mockTmpDir;
+  };
+  return {
+    ...actual,
+    getDataDir: dir,
+    getStatePath: () => path.join(dir(), 'state.json'),
+    getStateCachePath: () => path.join(dir(), 'state-cache.json'),
+    getGistIdPath: () => path.join(dir(), 'gist-id'),
+    getBackupDir: () => {
+      const backupDir = path.join(dir(), 'backups');
+      if (!fs.existsSync(backupDir)) fs.mkdirSync(backupDir, { recursive: true, mode: 0o700 });
+      return backupDir;
+    },
+    getLegacyStatePath: () => path.join(mockTmpDir, 'legacy-data', 'state.json'),
+    getLegacyBackupDir: () => path.join(mockTmpDir, 'legacy-data', 'backups'),
+  };
+});
+
+const gistsCreate = vi.fn();
+const gistsList = vi.fn();
+const gistsGet = vi.fn();
+
+vi.mock('./github.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./github.js')>();
+  return {
+    ...actual,
+    getOctokit: () => ({
+      gists: {
+        create: gistsCreate,
+        list: gistsList,
+        get: gistsGet,
+      },
+    }),
+  };
+});
+
+import { resetStateManager, ensureGistPersistence } from './state.js';
+
+describe('post-migration persistence detection (#1438)', () => {
+  beforeEach(() => {
+    mockTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gist-migration-'));
+    resetStateManager();
+    vi.clearAllMocks();
+    // checkGistScope + searchForGist both call gists.list; an empty list
+    // passes the scope probe and forces the create-new-Gist migration path.
+    gistsList.mockResolvedValue({ data: [] });
+    gistsCreate.mockImplementation(({ files }: { files: Record<string, { content: string }> }) =>
+      Promise.resolve({ data: { id: 'gist-1438', files } }),
+    );
+  });
+
+  afterEach(() => {
+    resetStateManager();
+    fs.rmSync(mockTmpDir, { recursive: true, force: true });
+    mockTmpDir = '';
+  });
+
+  it('keeps the migrating machine in gist mode across processes', async () => {
+    fs.writeFileSync(
+      path.join(mockTmpDir, 'state.json'),
+      JSON.stringify({ version: 4, config: { persistence: 'gist' } }),
+      'utf8',
+    );
+
+    // Process 1: first gist-mode run migrates local state into a new Gist.
+    await expect(ensureGistPersistence('token-1')).resolves.toBe('gist');
+    expect(gistsCreate).toHaveBeenCalledTimes(1);
+    // The migration renames state.json away and leaves the gist artifacts.
+    expect(fs.existsSync(path.join(mockTmpDir, 'state.json'))).toBe(false);
+    expect(fs.existsSync(path.join(mockTmpDir, 'state.json.pre-gist-migration'))).toBe(true);
+    expect(fs.existsSync(path.join(mockTmpDir, 'state-cache.json'))).toBe(true);
+    expect(fs.readFileSync(path.join(mockTmpDir, 'gist-id'), 'utf8')).toBe('gist-1438');
+
+    // Process 2: a fresh peek must NOT classify this machine as local-mode —
+    // that was the #1438 regression (fresh local state, orphaned Gist).
+    resetStateManager();
+    await expect(ensureGistPersistence(null)).resolves.toBe('no-token');
+  });
+
+  it('falls back to the gist-id file when the cache is also missing', async () => {
+    fs.writeFileSync(path.join(mockTmpDir, 'gist-id'), 'gist-1438', 'utf8');
+    await expect(ensureGistPersistence(null)).resolves.toBe('no-token');
+  });
+
+  it('still reads local-mode on a genuinely fresh install', async () => {
+    await expect(ensureGistPersistence(null)).resolves.toBe('local-mode');
+  });
+
+  it('respects an explicit non-gist cache config over a stray gist-id file', async () => {
+    fs.writeFileSync(
+      path.join(mockTmpDir, 'state-cache.json'),
+      JSON.stringify({ version: 4, config: { persistence: 'local' } }),
+      'utf8',
+    );
+    fs.writeFileSync(path.join(mockTmpDir, 'gist-id'), 'gist-1438', 'utf8');
+    await expect(ensureGistPersistence(null)).resolves.toBe('local-mode');
+  });
+
+  it('reports state-unreadable, not local-mode, when the cache cannot be parsed', async () => {
+    fs.writeFileSync(path.join(mockTmpDir, 'state-cache.json'), '{not json', 'utf8');
+    await expect(ensureGistPersistence(null)).resolves.toBe('state-unreadable');
+  });
+});

--- a/packages/core/src/core/state.ts
+++ b/packages/core/src/core/state.ts
@@ -32,7 +32,7 @@ import { debug, warn } from './logger.js';
 import { errorMessage, ConfigurationError, ConcurrencyError, isTransientNetworkError } from './errors.js';
 import { GistStateStore, type OctokitLike } from './gist-state-store.js';
 import * as guidelinesStoreModule from './guidelines-store.js';
-import { getStatePath, getStateCachePath } from './paths.js';
+import { getStatePath, getStateCachePath, getGistIdPath } from './paths.js';
 import { parseGitHubUrl } from './urls.js';
 
 export { acquireLock, releaseLock, atomicWriteFileSync } from './state-persistence.js';
@@ -1131,13 +1131,24 @@ export async function ensureGistPersistence(token: string | null): Promise<GistP
     const raw = fs.readFileSync(getStatePath(), 'utf8');
     persistence = JSON.parse(raw)?.config?.persistence;
   } catch (err) {
-    // A missing file is the genuine "fresh local-mode user" case. Anything
-    // else (EACCES, EMFILE, corrupt JSON) must not be silently classified
-    // as a local-mode CHOICE — that would re-create the #1415 latch through
-    // a third door when the caller memoizes the answer.
-    if ((err as { code?: unknown }).code === 'ENOENT') return 'local-mode';
-    warn(MODULE, `State file unreadable during gist-persistence check (will retry): ${errorMessage(err)}`);
-    return 'state-unreadable';
+    // Anything other than a missing file (EACCES, EMFILE, corrupt JSON) must
+    // not be silently classified as a local-mode CHOICE — that would
+    // re-create the #1415 latch through a third door when the caller
+    // memoizes the answer.
+    if ((err as { code?: unknown }).code !== 'ENOENT') {
+      warn(MODULE, `State file unreadable during gist-persistence check (will retry): ${errorMessage(err)}`);
+      return 'state-unreadable';
+    }
+    // A missing state.json is NOT proof of local mode either (#1438): the
+    // first-time Gist migration renames state.json away, and gist-mode
+    // saves only ever write state-cache.json — so on the machine that
+    // created the Gist this peek is all that stands between the user and a
+    // silent fall back to fresh local state. Consult the gist-side
+    // artifacts before concluding "fresh local-mode user".
+    const fallback = peekGistArtifacts();
+    if (fallback === 'local') return 'local-mode';
+    if (fallback === 'unreadable') return 'state-unreadable';
+    persistence = 'gist';
   }
 
   if (persistence !== 'gist') return 'local-mode';
@@ -1148,6 +1159,35 @@ export async function ensureGistPersistence(token: string | null): Promise<GistP
   if (!token) return 'no-token';
   const mgr = await getStateManagerAsync(token);
   return mgr.isGistMode() ? 'gist' : 'degraded';
+}
+
+/**
+ * Decide persistence mode when `state.json` is absent (#1438).
+ *
+ * The local state cache is written by every successful Gist fetch and by
+ * first-time Gist creation, and carries the synced config; the gist-id file
+ * is written whenever a Gist is created or discovered. Either one identifies
+ * a gist-configured machine whose `state.json` was renamed away by the
+ * first-time migration — NOT a fresh local-mode install. A cache whose
+ * config explicitly says non-gist wins over the gist-id file: it reflects
+ * the most recent synced choice.
+ */
+function peekGistArtifacts(): 'gist' | 'local' | 'unreadable' {
+  try {
+    const raw = fs.readFileSync(getStateCachePath(), 'utf8');
+    return JSON.parse(raw)?.config?.persistence === 'gist' ? 'gist' : 'local';
+  } catch (err) {
+    if ((err as { code?: unknown }).code !== 'ENOENT') {
+      warn(MODULE, `State cache unreadable during gist-persistence check (will retry): ${errorMessage(err)}`);
+      return 'unreadable';
+    }
+  }
+  try {
+    return fs.existsSync(getGistIdPath()) ? 'gist' : 'local';
+  } catch (err) {
+    warn(MODULE, `Gist ID check failed during gist-persistence check (will retry): ${errorMessage(err)}`);
+    return 'unreadable';
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes #1438.

The first-time Gist migration renames `state.json` to `.pre-gist-migration`, and gist-mode saves only ever write `state-cache.json`. `ensureGistPersistence` treated a missing `state.json` as "fresh local-mode user", so the machine that created the Gist permanently dropped to local mode on its very next process: fresh local state, orphaned Gist, no warning anywhere (even the LOCAL-ONLY warning was suppressed because the status read local-mode).

## Fix

On ENOENT of `state.json`, peek the gist-side artifacts before concluding local mode:

1. `state-cache.json` config — written by every successful Gist fetch and by first-time creation; an explicit non-gist choice there wins (it reflects the most recent synced config).
2. The `gist-id` file — covers installs whose cache write failed or predates it.

Unreadable artifacts return `state-unreadable`, never a latched local-mode choice (consistent with the #1415 no-latch contract). Genuinely fresh installs (no artifacts) still read `local-mode`.

Already-bitten machines (those that wrote a fresh local `state.json` after the rename) are not auto-healed — `state.json` presence short-circuits the peek; recovery there is manual (restore from `.pre-gist-migration` or re-set persistence).

## Tests

New `state-gist-migration.test.ts`: cross-process lifecycle against the REAL `createWithGist` migration path (only octokit mocked) — asserts the rename + artifacts, then that a fresh process classifies the machine as gist-configured (`no-token`, not `local-mode`); plus the gist-id-only fallback, fresh-install, explicit-non-gist precedence, and corrupt-cache branches.

Gate: lint, format:check, typecheck (incl. tests tsconfig), 2789 core + 235 mcp tests green. code-reviewer pass: clean.