### PR TITLE
fix(cli): match curated-list URLs on a digit boundary shared by both list commands (#1442)

### DIFF
--- a/packages/core/src/commands/curated-list.ts
+++ b/packages/core/src/commands/curated-list.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared line-matching helpers for the curated issue-list commands
+ * (`list-move-tier`, `list-mark-done`). Both commands locate entries in the
+ * same markdown file, so they must agree on what counts as an entry line
+ * and on URL matching semantics — they had drifted on both (#1442).
+ */
+
+/** Top-level list entry — `- `, `* `, `+ `, or `1.` at the start (no leading whitespace). */
+export const ENTRY_LINE_RE = /^[*+-]\s|^\d+\.\s/;
+
+/** The entry's leading list marker, for stripping before inspecting the body. */
+export const ENTRY_MARKER_RE = /^(?:[*+-]\s+|\d+\.\s+)/;
+
+/**
+ * Match the URL only when followed by a non-digit character (or end of
+ * line). A bare `includes(issueUrl)` would match `issues/1` against a line
+ * containing `issues/10`, so acting on issue 1 would also hit issues
+ * 10/100/... (#1442).
+ */
+export function lineMentionsUrl(line: string, issueUrl: string): boolean {
+  const idx = line.indexOf(issueUrl);
+  if (idx === -1) return false;
+  const next = line.charCodeAt(idx + issueUrl.length);
+  // NaN (end of string) → boundary OK. Otherwise reject any digit
+  // immediately after the URL so 'issues/1' doesn't match 'issues/10'.
+  return Number.isNaN(next) || next < 48 /* '0' */ || next > 57; /* '9' */
+}

--- a/packages/core/src/commands/list-mark-done.test.ts
+++ b/packages/core/src/commands/list-mark-done.test.ts
@@ -266,3 +266,31 @@ describe('runMarkIssueListItemDone (filesystem)', () => {
     expect(siblings).toEqual(['list.md']);
   });
 });
+
+describe('entry-line parity with list-move-tier (#1442)', () => {
+  it('marks a numbered-list entry, striking the content not the marker', () => {
+    const content = ['### foo/bar', '', `1. [Issue one](${ISSUE_A}) — desc`, ''].join('\n');
+    const result = markIssueAsDone(content, { issueUrl: ISSUE_A, prUrl: PR_A, prStatus: 'merged' });
+    expect(result.marked).toBe(true);
+    expect(result.content).toContain(`1. ~~[Issue one](${ISSUE_A}) — desc~~`);
+  });
+
+  it('counts numbered entries when deciding whether the repo heading is done', () => {
+    const content = ['### foo/bar', '', `1. [One](${ISSUE_A})`, `2. [Two](${ISSUE_B})`, ''].join('\n');
+    const result = markIssueAsDone(content, { issueUrl: ISSUE_A, prUrl: PR_A, prStatus: 'merged' });
+    expect(result.marked).toBe(true);
+    // ISSUE_B is still open, so the repo heading must NOT be struck.
+    expect(result.repoHeadingStruck).toBe(false);
+    expect(result.remainingUnderRepo).toBe(1);
+  });
+});
+
+describe('numbered-entry idempotency (#1442 review)', () => {
+  it('returns already-marked on a re-run against a struck numbered entry', () => {
+    const content = ['### foo/bar', '', `1. ~~[Issue one](${ISSUE_A})~~`, ''].join('\n');
+    const result = markIssueAsDone(content, { issueUrl: ISSUE_A, prUrl: PR_A, prStatus: 'merged' });
+    expect(result.marked).toBe(false);
+    expect(result.reasonCode).toBe('already-marked');
+    expect(result.content).toBe(content);
+  });
+});

--- a/packages/core/src/commands/list-mark-done.ts
+++ b/packages/core/src/commands/list-mark-done.ts
@@ -18,6 +18,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { errorMessage, ValidationError } from '../core/errors.js';
+import { ENTRY_LINE_RE, ENTRY_MARKER_RE, lineMentionsUrl } from './curated-list.js';
 
 export interface MarkDoneOptions {
   issueUrl: string;
@@ -59,7 +60,6 @@ interface RepoSection {
 
 const STRIKE = '~~';
 const DONE_PREFIX = '  - **Done**';
-const ISSUE_LINE_RE = /^[*+-]\s/;
 const REPO_HEADING_RE = /^###\s/;
 const SECTION_BREAK_RE = /^#{1,3}\s/;
 const PR_NUMBER_RE = /\/(?:pull|issues)\/(\d+)(?:[/?#]|$)/;
@@ -73,7 +73,7 @@ function prNumberLabel(prUrl: string): string {
 /** Wrap a line in `~~...~~` if it isn't already. Returns the input unchanged when already wrapped. */
 function strikeLine(line: string): { line: string; alreadyStruck: boolean } {
   // Strip the leading list marker so we wrap the content, not the bullet.
-  const markerMatch = line.match(/^(?:[*+-]\s+|#{1,6}\s+)/);
+  const markerMatch = line.match(/^(?:[*+-]\s+|\d+\.\s+|#{1,6}\s+)/);
   const prefix = markerMatch ? markerMatch[0] : '';
   const body = line.slice(prefix.length);
   if (body.startsWith(STRIKE) && body.endsWith(STRIKE) && body.length >= 4) {
@@ -82,26 +82,11 @@ function strikeLine(line: string): { line: string; alreadyStruck: boolean } {
   return { line: `${prefix}${STRIKE}${body}${STRIKE}`, alreadyStruck: false };
 }
 
-/**
- * Match the URL only when followed by a non-digit, non-word character (or
- * end of line). A bare `includes(issueUrl)` would match `issues/1` against
- * a line containing `issues/10`, so finding/marking issue 1 would mark
- * whichever number-prefix line appears first.
- */
-function lineMentionsUrl(line: string, issueUrl: string): boolean {
-  const idx = line.indexOf(issueUrl);
-  if (idx === -1) return false;
-  const next = line.charCodeAt(idx + issueUrl.length);
-  // NaN (end of string) → digit boundary OK. Otherwise reject any digit
-  // immediately after the URL so 'issues/1' doesn't match 'issues/10'.
-  return Number.isNaN(next) || next < 48 /* '0' */ || next > 57; /* '9' */
-}
-
 /** Find the issue block (issue line plus any indented sub-bullets) that mentions the URL. */
 function findIssueBlock(lines: string[], issueUrl: string): IssueBlock | undefined {
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
-    if (!ISSUE_LINE_RE.test(line)) continue;
+    if (!ENTRY_LINE_RE.test(line)) continue;
     if (!lineMentionsUrl(line, issueUrl)) continue;
     let end = i + 1;
     while (end < lines.length && /^\s{2,}/.test(lines[end])) end++;
@@ -136,8 +121,8 @@ function countOpenIssues(lines: string[], section: RepoSection): number {
   let open = 0;
   for (let i = section.headingIndex + 1; i < section.end; i++) {
     const line = lines[i];
-    if (!ISSUE_LINE_RE.test(line)) continue;
-    const body = line.replace(/^[*+-]\s+/, '');
+    if (!ENTRY_LINE_RE.test(line)) continue;
+    const body = line.replace(ENTRY_MARKER_RE, '');
     if (!(body.startsWith(STRIKE) && body.endsWith(STRIKE))) open++;
   }
   return open;
@@ -175,7 +160,7 @@ export function markIssueAsDone(
   }
 
   const issueLine = lines[block.start];
-  const issueBody = issueLine.replace(/^[*+-]\s+/, '');
+  const issueBody = issueLine.replace(ENTRY_MARKER_RE, '');
   const alreadyMarked = issueBody.startsWith(STRIKE) && issueBody.endsWith(STRIKE);
 
   if (alreadyMarked) {

--- a/packages/core/src/commands/list-move-tier.test.ts
+++ b/packages/core/src/commands/list-move-tier.test.ts
@@ -186,3 +186,32 @@ describe('runListMoveTier (filesystem)', () => {
     expect(fs.readFileSync(listPath, 'utf8')).toBe(original);
   });
 });
+
+describe('URL matching precision (#1442)', () => {
+  it('does not drag issues/10 along when moving issues/1', () => {
+    const urlOne = 'https://github.com/foo/bar/issues/1';
+    const urlTen = 'https://github.com/foo/bar/issues/10';
+    const content = ['## Pursue', '', `- [Issue ten](${urlTen})`, `- [Issue one](${urlOne})`, '', '## Skip', ''].join(
+      '\n',
+    );
+
+    const result = moveIssueToTier(content, urlOne, 'skip');
+
+    expect(result.moved).toBe(true);
+    expect(result.count).toBe(1);
+    const pursueSection = result.content.slice(result.content.indexOf('## Pursue'), result.content.indexOf('## Skip'));
+    expect(pursueSection).toContain(urlTen);
+    expect(pursueSection).not.toContain(`[Issue one](${urlOne})`);
+    const skipSection = result.content.slice(result.content.indexOf('## Skip'));
+    expect(skipSection).toContain(`[Issue one](${urlOne})`);
+    expect(skipSection).not.toContain(urlTen);
+  });
+
+  it('matches a bare URL at end of line', () => {
+    const urlOne = 'https://github.com/foo/bar/issues/1';
+    const content = ['## Pursue', '', `- ${urlOne}`, '', '## Skip', ''].join('\n');
+    const result = moveIssueToTier(content, urlOne, 'skip');
+    expect(result.moved).toBe(true);
+    expect(result.count).toBe(1);
+  });
+});

--- a/packages/core/src/commands/list-move-tier.ts
+++ b/packages/core/src/commands/list-move-tier.ts
@@ -16,6 +16,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { errorMessage, ValidationError } from '../core/errors.js';
+import { ENTRY_LINE_RE, lineMentionsUrl } from './curated-list.js';
 
 export type Tier = 'pursue' | 'maybe' | 'skip';
 
@@ -82,13 +83,10 @@ function tierForLine(lines: string[], lineIndex: number): string | undefined {
 /** Locate every issue block (issue line + any sub-bullets) that mentions the URL. */
 function findIssueBlocks(lines: string[], issueUrl: string): IssueBlock[] {
   const blocks: IssueBlock[] = [];
-  // Use exact substring match on the URL — no regex escaping pitfalls and
-  // the URL itself contains no markdown delimiters that would split a line.
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
-    // Top-level list item — `- `, `* `, `+ `, or `1.` at the start (with no leading whitespace).
-    const isTopLevelListItem = /^[*+-]\s|^\d+\.\s/.test(line);
-    if (!isTopLevelListItem || !line.includes(issueUrl)) continue;
+    // lineMentionsUrl (not a bare includes) so issues/1 can't match issues/10 (#1442).
+    if (!ENTRY_LINE_RE.test(line) || !lineMentionsUrl(line, issueUrl)) continue;
 
     // Capture indented sub-bullets that follow this line.
     let end = i + 1;


### PR DESCRIPTION
Fixes #1442.

`list-move-tier` located entries with a raw substring match (`line.includes(issueUrl)`), so moving `issues/1` also dragged `issues/10` (and 100, ...) into the target tier — reproduced as `count: 2` before the fix. `list-mark-done` already had the digit-boundary guard (`lineMentionsUrl`), and the two commands additionally disagreed on what counts as an entry line (move-tier accepted ordered-list `1.` entries, mark-done only bullets — so an entry could be moved between tiers but not marked done).

## Fix

New shared `commands/curated-list.ts` (`ENTRY_LINE_RE`, `ENTRY_MARKER_RE`, `lineMentionsUrl`), consumed by both commands:

- move-tier: `findIssueBlocks` now routes through `lineMentionsUrl`.
- mark-done: accepts numbered entries everywhere — finding, striking (marker stripped before wrapping so `1. ~~content~~`, not `~~1. content~~`), open-issue counting for the repo-heading strike, and the already-marked idempotency check (a review pass caught that last site: without it, re-running against a struck numbered entry returned `marked: true` and appended a spurious Done bullet).

## Tests

`issues/1` vs `issues/10` isolation (count stays 1, issue 10 untouched), bare-URL-at-EOL match, numbered-entry marking + heading-count behavior, numbered-entry idempotency re-run.

Gate: root eslint, prettier, typecheck (incl. tests tsconfig), full core suite (2789) + mcp (235) green. code-reviewer pass converged (1 finding, fixed + pinned).