### PR TITLE
ci: run the pre-tool-use dispatcher hook test (#1449)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,12 @@ jobs:
       - name: Test guard-public-posts hook
         run: bash hooks/guard-public-posts.test.sh
 
+      - name: Test pre-tool-use dispatcher hook (#1449)
+        # The dispatcher is the fan-out point for every PreToolUse Bash guard
+        # (guard-public-posts, guard-git-operations, auto-format-before-push);
+        # a regression here silently disables all of them.
+        run: bash hooks/pre-tool-use-dispatcher.test.sh
+
       - name: Guard against phantom config field regressions
         # These keys were deleted from the v3 state schema (see
         # state-persistence.ts migrateV2ToV3). They must NOT reappear in


### PR DESCRIPTION
Fixes #1449.

CI runs four sibling hook/helper shell tests (safe-refresh-marketplace, build-cli-if-stale, build-dashboard-if-stale, guard-public-posts) but `hooks/pre-tool-use-dispatcher.test.sh` was never referenced by any workflow. The dispatcher is the fan-out point for every PreToolUse Bash guard; a regression there silently disables guard-public-posts, guard-git-operations, and auto-format-before-push for Bash calls, and guard-git-operations has no other coverage path.

One new step next to the existing hook tests. Verified the test passes locally before wiring it in.