### PR TITLE
fix(daily): persist the raw-status digest; overrides stay a view-layer concern (#1445)

### DIFF
--- a/packages/core/src/commands/daily-orchestration.test.ts
+++ b/packages/core/src/commands/daily-orchestration.test.ts
@@ -946,6 +946,48 @@ describe('executeDailyCheck() — status overrides (#644)', () => {
     expect(result.capacity.criticalIssueCount).toBe(1); // only normalPR
   });
 
+  it('persists the RAW status in lastDigest while the categorized output reflects the override (#1445)', async () => {
+    const overriddenPR = makePR({
+      repo: 'owner/repo',
+      number: 1,
+      status: 'needs_addressing',
+      actionReason: 'needs_response',
+    });
+    mockFetchUserOpenPRs.mockResolvedValue({ prs: [overriddenPR], failures: [] });
+    mockIsPRShelved.mockReturnValue(false);
+
+    const override = {
+      status: 'waiting_on_maintainer',
+      setAt: '2026-01-20T00:00:00Z',
+      lastActivityAt: overriddenPR.updatedAt,
+    };
+    mockGetState.mockReturnValue(stateWithOverrides({ [overriddenPR.url]: override }));
+    setupOverrideMock(overriddenPR.url, override);
+    mockGenerateDigest.mockImplementation((prs: FetchedPR[]) => makeDigest(prs));
+
+    const result = await executeDailyCheck('test-token');
+
+    // The persisted digest carries the RAW status: applyStatusOverrides can
+    // apply overrides but never un-apply baked ones, so persisting the
+    // override-applied digest would make clearing an override a silent no-op
+    // on dashboard rebuilds (#1445).
+    expect(mockSetLastDigest).toHaveBeenCalledOnce();
+    const persisted = mockSetLastDigest.mock.calls[0][0] as DailyDigest;
+    const persistedPR = persisted.openPRs.find((p) => p.url === overriddenPR.url);
+    expect(persistedPR?.status).toBe('needs_addressing');
+    expect(persisted.needsAddressingPRs.map((p) => p.url)).toContain(overriddenPR.url);
+    expect(persisted.waitingOnMaintainerPRs).toHaveLength(0);
+
+    // The returned (categorized) output still reflects the override — daily's
+    // own view stays override-applied (#644). Category arrays are compact
+    // URL references after toDailyOutput (#287).
+    const outputPR = result.digest.openPRs.find((p) => p.url === overriddenPR.url);
+    expect(outputPR?.status).toBe('waiting_on_maintainer');
+    expect(result.digest.waitingOnMaintainerPRs).toContain(overriddenPR.url);
+    expect(result.digest.needsAddressingPRs).toHaveLength(0);
+    expect(result.actionableIssues.map((i) => i.prUrl)).not.toContain(overriddenPR.url);
+  });
+
   it('PR overridden to needs_addressing appears in actionable issues', async () => {
     const overriddenPR = makePR({
       repo: 'owner/repo',

--- a/packages/core/src/commands/daily.ts
+++ b/packages/core/src/commands/daily.ts
@@ -500,6 +500,7 @@ function partitionPRs(
 
   // Wrap mutations in batch: unshelvePR calls + setLastDigest produce a single save.
   // Outer try-catch: save failure should not crash the daily check (in-memory mutations still apply).
+  let digest: DailyDigest | undefined;
   try {
     stateManager.batch(() => {
       for (const pr of overriddenPRs) {
@@ -520,27 +521,38 @@ function partitionPRs(
         }
       }
 
-      // Generate digest from override-applied PRs so status categories are correct.
+      // Generate the in-memory digest from override-applied PRs so daily's own
+      // status categories (needsAddressing/waiting partitions, counts, JSON
+      // output) reflect dashboard/CLI reclassifications.
       // Note: digest.openPRs contains ALL fetched PRs (including shelved).
       // We override summary fields below to reflect active-only counts.
-      const digest = prMonitor.generateDigest(overriddenPRs, recentlyClosedPRs, recentlyMergedPRs);
+      digest = prMonitor.generateDigest(overriddenPRs, recentlyClosedPRs, recentlyMergedPRs);
 
       // Attach shelve info to digest
       digest.shelvedPRs = shelvedPRs;
       digest.autoUnshelvedPRs = autoUnshelvedPRs;
       digest.summary.totalActivePRs = activePRs.length;
 
-      // Store digest in state so dashboard can render it
-      stateManager.setLastDigest(digest);
+      // The PERSISTED digest keeps RAW statuses (#1445): it seeds the
+      // dashboard server's cached rebuild source, and applyStatusOverrides
+      // can only apply overrides, never un-apply baked ones — persisting the
+      // override-applied digest would make CLEARING an override (move
+      // target=auto) a silent no-op whenever the dashboard's background
+      // refresh fails. Mirrors the raw-digest contract in dashboard-data.ts
+      // (which also attaches override-derived shelve info to a raw digest).
+      const rawDigest = prMonitor.generateDigest(prs, recentlyClosedPRs, recentlyMergedPRs);
+      rawDigest.shelvedPRs = shelvedPRs;
+      rawDigest.autoUnshelvedPRs = autoUnshelvedPRs;
+      rawDigest.summary.totalActivePRs = activePRs.length;
+      stateManager.setLastDigest(rawDigest);
     });
   } catch (error) {
     recordWarning(warnings, 'partition', 'persist partition state', error);
   }
 
-  // Digest was created inside batch — reconstruct from state
-  const digest = stateManager.getState().lastDigest!;
-
-  return { activePRs, shelvedPRs, autoUnshelvedPRs, digest };
+  // If digest generation threw inside the batch, fall back to the persisted
+  // digest (mirrors the previous read-back-from-state behavior).
+  return { activePRs, shelvedPRs, autoUnshelvedPRs, digest: digest ?? stateManager.getState().lastDigest! };
 }
 
 /**

--- a/packages/core/src/core/strategy.ts
+++ b/packages/core/src/core/strategy.ts
@@ -232,12 +232,13 @@ export function computeStrategy(state: AgentState): StrategyResult | null {
   // digest). The DailyDigest schema does not store a `dormantCount`
   // directly — derive it from the "awaiting maintainer review" bucket.
   //
-  // Status-basis reconciliation (#1416): dashboard-written digests keep RAW
+  // Status-basis reconciliation (#1416): persisted digests keep RAW
   // statuses in `openPRs` (so override CLEARS stay visible on rebuild) while
-  // `summary.totalActivePRs` is override-basis. Re-derive the waiting bucket
-  // from `openPRs` through the override map so both capacity inputs share
-  // one basis; fall back to the stored array for digests without `openPRs`
-  // (which daily.ts builds post-override anyway).
+  // `summary.totalActivePRs` is override-basis. Daily-written digests honor
+  // the same raw-status contract as dashboard-written ones (#1445).
+  // Re-derive the waiting bucket from `openPRs` through the override map so
+  // both capacity inputs share one basis; fall back to the stored array for
+  // digests without `openPRs` (legacy persisted states only).
   const summary = state.lastDigest?.summary;
   const openPRCount = summary?.totalActivePRs ?? 0;
   const openPRs = (state.lastDigest?.openPRs ?? []) as Array<{ url?: unknown; status?: unknown; updatedAt?: unknown }>;


### PR DESCRIPTION
Fixes #1445.

daily persisted an override-BAKED lastDigest (generateDigest over applyStatusOverrides output), while the dashboard rebuild contract requires RAW statuses in the persisted digest — dashboard-data.ts documents why: applyStatusOverrides can apply but never un-apply, so clearing an override via the dashboard against a daily-produced digest was a silent no-op until a full refresh.

## Fix

partitionPRs builds two digests, mirroring dashboard-data's exact split: the override-applied digest stays in-memory for daily's own categorization, summary, and JSON/text output (zero behavior change there — goldens unchanged), and a second generateDigest over raw PRs is what setLastDigest persists (with shelve refs attached the same way dashboard-data attaches them). strategy.ts's effectiveStatus assumption now holds for daily-written digests too.

Reviewer-traced consumer impact: stats.ts and strategy.ts read only fields identical across both digests; the persisted totalNeedingAttention (no longer stamped post-Phase-5) has zero readers — the dashboard recomputes attention buckets live. The failure-fallback (generation throws in-batch) keeps the pre-fix read-back semantics; the pre-existing first-run lastDigest! edge is tracked separately in #1456.

## Tests

New daily-orchestration test driving the real executeDailyCheck flow: with an active override, the setLastDigest argument carries the raw status while the returned digest categories and actionableIssues reflect the override.

Gate: root eslint, prettier, typecheck, 2795 core + 235 mcp green. code-reviewer pass: CLEAN.