### PR TITLE
fix(dashboard): surface persistence failures in partialFailures (#1447)

### DIFF
--- a/packages/core/src/commands/daily.ts
+++ b/packages/core/src/commands/daily.ts
@@ -814,7 +814,19 @@ async function executeDailyCheckInternal(token: string): Promise<DailyCheckResul
   // try-catch: analytics are supplementary — save failure should not crash the daily check.
   try {
     getStateManager().batch(() => {
-      updateMonthlyAnalytics(prs, monthlyCounts, monthlyClosedCounts, openedFromMerged, openedFromClosed);
+      const analyticsFailures = updateMonthlyAnalytics(
+        prs,
+        monthlyCounts,
+        monthlyClosedCounts,
+        openedFromMerged,
+        openedFromClosed,
+      );
+      // Per-metric setter failures are caught inside updateMonthlyAnalytics
+      // (one bad metric must not sink the others); surface each in the run's
+      // warnings[] instead of dropping the returned labels (#1447).
+      for (const failure of analyticsFailures) {
+        recordWarning(warnings, 'analytics', failure, null, 'persist failed');
+      }
 
       // Store recently merged/closed PRs in the persistent arrays.
       // This ensures the mergedPRs/closedPRs ledger is populated even when

--- a/packages/core/src/commands/dashboard-data.test.ts
+++ b/packages/core/src/commands/dashboard-data.test.ts
@@ -749,6 +749,12 @@ describe('buildDashboardStats with storedClosedCount', () => {
 describe('updateMonthlyAnalytics', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // mockReset (not just clear): throwing implementations installed by the
+    // failure tests below would otherwise leak into later tests and skew the
+    // returned failure labels (#1447).
+    mockSetMonthlyMergedCounts.mockReset();
+    mockSetMonthlyClosedCounts.mockReset();
+    mockSetMonthlyOpenedCounts.mockReset();
     mockGetState.mockReturnValue({
       monthlyMergedCounts: {},
       monthlyClosedCounts: {},
@@ -757,8 +763,9 @@ describe('updateMonthlyAnalytics', () => {
   });
 
   it('stores monthly merged counts when non-empty', () => {
-    updateMonthlyAnalytics([], { '2026-01': 5 }, {}, {}, {});
+    const failures = updateMonthlyAnalytics([], { '2026-01': 5 }, {}, {}, {});
     expect(mockSetMonthlyMergedCounts).toHaveBeenCalledWith({ '2026-01': 5 });
+    expect(failures).toEqual([]);
   });
 
   it('skips storing merged counts when empty', () => {
@@ -808,7 +815,7 @@ describe('updateMonthlyAnalytics', () => {
     });
 
     // Should not throw
-    updateMonthlyAnalytics([], { '2026-01': 5 }, { '2026-01': 2 }, {}, {});
+    const failures = updateMonthlyAnalytics([], { '2026-01': 5 }, { '2026-01': 2 }, {}, {});
 
     expect(mockWarn).toHaveBeenCalledWith(
       'dashboard-data',
@@ -816,6 +823,8 @@ describe('updateMonthlyAnalytics', () => {
     );
     // Closed counts should still be stored despite merged failure
     expect(mockSetMonthlyClosedCounts).toHaveBeenCalledWith({ '2026-01': 2 });
+    // The failure is reported back so fetchDashboardData can surface it (#1447)
+    expect(failures).toEqual(['store monthly merged counts']);
   });
 
   it('warns and continues when setMonthlyClosedCounts throws', () => {
@@ -823,7 +832,7 @@ describe('updateMonthlyAnalytics', () => {
       throw new Error('permission denied');
     });
 
-    updateMonthlyAnalytics([], { '2026-01': 5 }, { '2026-01': 2 }, { '2026-01': 1 }, {});
+    const failures = updateMonthlyAnalytics([], { '2026-01': 5 }, { '2026-01': 2 }, { '2026-01': 1 }, {});
 
     expect(mockWarn).toHaveBeenCalledWith(
       'dashboard-data',
@@ -832,6 +841,7 @@ describe('updateMonthlyAnalytics', () => {
     // Merged and opened should still be stored
     expect(mockSetMonthlyMergedCounts).toHaveBeenCalled();
     expect(mockSetMonthlyOpenedCounts).toHaveBeenCalled();
+    expect(failures).toEqual(['store monthly closed counts']);
   });
 
   it('warns and continues when setMonthlyOpenedCounts throws', () => {
@@ -839,12 +849,13 @@ describe('updateMonthlyAnalytics', () => {
       throw new Error('io error');
     });
 
-    updateMonthlyAnalytics([], {}, {}, { '2026-01': 1 }, {});
+    const failures = updateMonthlyAnalytics([], {}, {}, { '2026-01': 1 }, {});
 
     expect(mockWarn).toHaveBeenCalledWith(
       'dashboard-data',
       expect.stringContaining('Failed to store monthly opened counts'),
     );
+    expect(failures).toEqual(['store monthly opened counts']);
   });
 });
 
@@ -912,6 +923,17 @@ describe('fetchDashboardData', () => {
     mockGetClosedPRWatermark.mockReturnValue(undefined);
     mockGetMergedPRs.mockReturnValue([]);
     mockGetClosedPRs.mockReturnValue([]);
+    // The real addMergedPRs/addClosedPRs return { dropped }; an undefined
+    // return makes the destructure in fetchDashboardData throw, which now
+    // pollutes partialFailures with phantom persist failures (#1447). Also
+    // resets throwing implementations leaked from earlier tests.
+    mockAddMergedPRs.mockReset().mockReturnValue({ dropped: 0 });
+    mockAddClosedPRs.mockReset().mockReturnValue({ dropped: 0 });
+    // Reset monthly setters so throwing implementations from the
+    // updateMonthlyAnalytics failure tests above don't leak in here.
+    mockSetMonthlyMergedCounts.mockReset();
+    mockSetMonthlyClosedCounts.mockReset();
+    mockSetMonthlyOpenedCounts.mockReset();
 
     // PRMonitor defaults
     mockFetchUserOpenPRs.mockResolvedValue({ prs: [], failures: [] });
@@ -1114,6 +1136,8 @@ describe('fetchDashboardData', () => {
       expect.stringContaining('Failed to persist dashboard state'),
     );
     expect(result.digest).toBeDefined();
+    // The stale cached digest is served, but the banner says why (#1447)
+    expect(result.partialFailures).toContain('persist dashboard state');
   });
 
   it('throws when digest is null after batch', async () => {
@@ -1193,6 +1217,9 @@ describe('fetchDashboardData', () => {
     expect(mockAddClosedPRs).toHaveBeenCalled();
     expect(mockWarn).toHaveBeenCalledWith('dashboard-data', expect.stringContaining('Failed to store merged PRs'));
     expect(result.digest).toBeDefined();
+    // The persist failure is surfaced, not just logged (#1447)
+    expect(result.partialFailures).toContain('store merged PRs');
+    expect(result.partialFailures).not.toContain('store closed PRs');
   });
 
   it('isolates addClosedPRs failure from addMergedPRs', async () => {
@@ -1209,6 +1236,8 @@ describe('fetchDashboardData', () => {
     expect(mockAddClosedPRs).toHaveBeenCalled();
     expect(mockWarn).toHaveBeenCalledWith('dashboard-data', expect.stringContaining('Failed to store closed PRs'));
     expect(result.digest).toBeDefined();
+    expect(result.partialFailures).toContain('store closed PRs');
+    expect(result.partialFailures).not.toContain('store merged PRs');
   });
 
   // ── partialFailures surfacing (#1035) ────────────────────────────────
@@ -1240,5 +1269,36 @@ describe('fetchDashboardData', () => {
     mockFetchRecentlyMergedPRs.mockRejectedValue(rateLimitError);
     mockIsRateLimitOrAuthError.mockImplementation((err: unknown) => err === rateLimitError);
     await expect(fetchDashboardData('test-token')).rejects.toThrow('API rate limit exceeded');
+  });
+
+  // ── persist failures land in partialFailures too (#1447) ─────────────
+
+  it('records a monthly-counts persist failure in partialFailures while still serving data', async () => {
+    mockFetchUserMergedPRCounts.mockResolvedValue({
+      ...makePRCountsResult(),
+      monthlyCounts: { '2026-01': 5 },
+    });
+    mockSetMonthlyMergedCounts.mockImplementation(() => {
+      throw new Error('disk full');
+    });
+
+    const result = await fetchDashboardData('test-token');
+
+    expect(result.partialFailures).toContain('store monthly merged counts');
+    expect(result.digest).toBeDefined();
+  });
+
+  it('records a digest persist failure in partialFailures while serving the cached digest', async () => {
+    const cachedDigest = makeMockDigest();
+    const state = makeDefaultState({ lastDigest: cachedDigest });
+    mockGetState.mockReturnValue(state);
+    mockSetLastDigest.mockImplementation(() => {
+      throw new Error('disk write failed');
+    });
+
+    const result = await fetchDashboardData('test-token');
+
+    expect(result.partialFailures).toContain('persist dashboard state');
+    expect(result.digest).toBe(cachedDigest);
   });
 });

--- a/packages/core/src/commands/dashboard-data.ts
+++ b/packages/core/src/commands/dashboard-data.ts
@@ -72,10 +72,11 @@ export interface DashboardJsonData {
   lastUpdated?: string;
   /**
    * Labels of sub-fetches that degraded to empty fallbacks during this data
-   * build. Non-empty means one or more background calls failed and the
-   * corresponding sections of the response are approximations (stale or
-   * zero'd) rather than authoritative. The SPA surfaces this as a banner
-   * so users know the dashboard is showing partial data. See #1035.
+   * build, plus persistence steps that failed to save (#1447). Non-empty
+   * means one or more background calls failed and the corresponding sections
+   * of the response are approximations (stale or zero'd) rather than
+   * authoritative. The SPA surfaces this as a banner so users know the
+   * dashboard is showing partial data. See #1035.
    */
   partialFailures?: string[];
 }
@@ -218,6 +219,11 @@ export function mergeMonthlyCounts(
  * Each metric is isolated so partial failures don't produce inconsistent state.
  * Fresh API results are merged into existing data so historical months are preserved.
  * Skips updating when fresh data is empty to avoid wiping chart data on transient API failures.
+ *
+ * Returns the labels of any metrics that failed to persist (#1447) so callers
+ * with a partialFailures surface (fetchDashboardData) can push them into the
+ * SPA banner instead of the failure living only in stderr. Callers without
+ * that surface (daily.ts) may ignore the return value.
  */
 export function updateMonthlyAnalytics(
   prs: Array<{ createdAt?: string }>,
@@ -225,15 +231,17 @@ export function updateMonthlyAnalytics(
   monthlyClosedCounts: Record<string, number>,
   openedFromMerged: Record<string, number>,
   openedFromClosed: Record<string, number>,
-): void {
+): string[] {
   const stateManager = getStateManager();
   const state = stateManager.getState();
+  const failures: string[] = [];
 
   try {
     if (Object.keys(monthlyCounts).length > 0) {
       stateManager.setMonthlyMergedCounts(mergeMonthlyCounts(state.monthlyMergedCounts || {}, monthlyCounts));
     }
   } catch (error) {
+    failures.push('store monthly merged counts');
     warn(MODULE, `Failed to store monthly merged counts: ${errorMessage(error)}`);
   }
   try {
@@ -241,6 +249,7 @@ export function updateMonthlyAnalytics(
       stateManager.setMonthlyClosedCounts(mergeMonthlyCounts(state.monthlyClosedCounts || {}, monthlyClosedCounts));
     }
   } catch (error) {
+    failures.push('store monthly closed counts');
     warn(MODULE, `Failed to store monthly closed counts: ${errorMessage(error)}`);
   }
   try {
@@ -258,8 +267,10 @@ export function updateMonthlyAnalytics(
       stateManager.setMonthlyOpenedCounts(mergeMonthlyCounts(state.monthlyOpenedCounts || {}, combinedOpenedCounts));
     }
   } catch (error) {
+    failures.push('store monthly opened counts');
     warn(MODULE, `Failed to store monthly opened counts: ${errorMessage(error)}`);
   }
+  return failures;
 }
 
 export interface DashboardFetchResult {
@@ -269,11 +280,13 @@ export interface DashboardFetchResult {
   allClosedPRs: ClosedPR[];
   /**
    * Labels of non-critical sub-fetches that degraded to empty fallbacks
-   * during this run. Empty array means every fetch succeeded. Non-empty
-   * means one or more slices of the returned data are approximations —
-   * callers surface this to the user so "0 recently merged" does not look
-   * authoritative when it is actually "fetch failed, fell back to empty".
-   * See #1035.
+   * during this run, plus persistence steps that failed to save (#1447:
+   * monthly chart analytics, stored merged/closed PRs, the cached digest).
+   * Empty array means every fetch and persist succeeded. Non-empty means
+   * one or more slices of the returned data are approximations — callers
+   * surface this to the user so "0 recently merged" does not look
+   * authoritative when it is actually "fetch failed, fell back to empty",
+   * and so silently-stale charts/digest are flagged. See #1035.
    */
   partialFailures: string[];
 }
@@ -390,6 +403,7 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
           partialFailures.push(`Dropped ${dropped} merged PR(s) with invalid URLs before persistence`);
         }
       } catch (error) {
+        partialFailures.push('store merged PRs');
         warn(MODULE, `Failed to store merged PRs: ${errorMessage(error)}`);
       }
 
@@ -400,6 +414,7 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
           partialFailures.push(`Dropped ${dropped} closed PR(s) with invalid URLs before persistence`);
         }
       } catch (error) {
+        partialFailures.push('store closed PRs');
         warn(MODULE, `Failed to store closed PRs: ${errorMessage(error)}`);
       }
 
@@ -408,7 +423,9 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
       // never the createdAt/mergedAt dates the monthly counts key off.
       const { monthlyCounts, monthlyOpenedCounts: openedFromMerged } = mergedResult;
       const { monthlyCounts: monthlyClosedCounts, monthlyOpenedCounts: openedFromClosed } = closedResult;
-      updateMonthlyAnalytics(prs, monthlyCounts, monthlyClosedCounts, openedFromMerged, openedFromClosed);
+      partialFailures.push(
+        ...updateMonthlyAnalytics(prs, monthlyCounts, monthlyClosedCounts, openedFromMerged, openedFromClosed),
+      );
 
       // The digest keeps RAW statuses in openPRs: this digest becomes the
       // server's cached/persisted rebuild source, and baking overridden
@@ -436,6 +453,7 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
       stateManager.setLastDigest(digest);
     });
   } catch (error) {
+    partialFailures.push('persist dashboard state');
     warn(MODULE, `Failed to persist dashboard state: ${errorMessage(error)}`);
   }
   warn(MODULE, `Refreshed: ${prs.length} PRs fetched`);


### PR DESCRIPTION
Fixes #1447.

Six catch blocks in dashboard-data.ts logged persistence failures to stderr only while sibling catches push to partialFailures: the three monthly chart-count setters, the stored merged/closed PR ledgers (watermark stalls), and the batched digest save. The SPA showed a fully fresh, banner-free payload while charts went silently stale.

## Fix

Each persist catch now contributes a short label to partialFailures (style matches the existing trackingCatch labels). updateMonthlyAnalytics had no partialFailures in scope, so it returns the failure labels (void → string[]) and fetchDashboardData spreads them in. Fetch-degradation catches are untouched (reviewer census: all 7 verified left alone, all 6 persist sites covered).

Review escalation folded in: daily.ts shares updateMonthlyAnalytics and was discarding the returned labels — the same stderr-only gap on the CLI surface — so daily now records each label into its warnings[].

Also fixed a latent test-harness bug the change exposed: mockAddMergedPRs/mockAddClosedPRs returned undefined, so a destructure in fetchDashboardData was silently throwing (and being swallowed) in nearly every existing test; mocks now match the real `{ dropped }` shape with mockReset hygiene.

Known follow-up (out of scope, dashboard package): the SPA banner noun says "background fetches failed" and now also covers persist failures — generalizing the phrasing belongs with the #1446 visibility batch.

## Tests

New: monthly-counts persist failure and digest persist failure land in partialFailures while data is still served; per-metric return labels (3 failure + happy path); merged/closed ledger isolation assertions extended.

Gate: root eslint, prettier, typecheck, 2797 core + 235 mcp green. code-reviewer pass converged (daily-path gap fixed on-branch).