### PR TITLE
test(mcp): typecheck test files via tsconfig.tests.json (#1450)

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -22,7 +22,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.tests.json",
     "prepublishOnly": "pnpm run build && pnpm run bundle"
   },
   "dependencies": {

--- a/packages/mcp-server/src/index-main.test.ts
+++ b/packages/mcp-server/src/index-main.test.ts
@@ -194,16 +194,19 @@ describe('main() in-process', () => {
   });
 
   describe('HTTP mode - request handling', () => {
-    async function setupHttpHandler(): Promise<
-      (req: { url?: string; method?: string }, res: Record<string, unknown>) => Promise<void>
-    > {
+    // Structural stand-in for http.IncomingMessage; the handler only reads
+    // url, method, and headers.
+    type FakeRequest = { url?: string; method?: string; headers?: Record<string, string | undefined> };
+
+    async function setupHttpHandler(): Promise<(req: FakeRequest, res: Record<string, unknown>) => Promise<void>> {
       process.argv = ['node', 'test', '--http', '--port=3001'];
 
       const { createServer: mockCreateServer } = await import('node:http');
-      let requestHandler!: (req: { url?: string; method?: string }, res: Record<string, unknown>) => Promise<void>;
+      let requestHandler!: (req: FakeRequest, res: Record<string, unknown>) => Promise<void>;
       vi.mocked(mockCreateServer).mockImplementationOnce((handler: unknown) => {
         requestHandler = handler as typeof requestHandler;
-        return mockHttpServer as ReturnType<typeof mockCreateServer>;
+        // Partial mock: main() only calls listen/close on the server.
+        return mockHttpServer as unknown as ReturnType<typeof mockCreateServer>;
       });
 
       await main();

--- a/packages/mcp-server/src/resources.test.ts
+++ b/packages/mcp-server/src/resources.test.ts
@@ -115,6 +115,15 @@ import { createServer } from './server.js';
 import { runStatus } from '@oss-autopilot/core/commands';
 import { getStateManager } from '@oss-autopilot/core';
 
+type ResourceContent = Awaited<ReturnType<Client['readResource']>>['contents'][number];
+
+// readResource contents are a text | blob union; every resource in this suite
+// returns text content, so narrow before reading `.text`.
+function contentText(content: ResourceContent): string {
+  if (!('text' in content)) throw new Error('expected text resource content, got blob');
+  return content.text;
+}
+
 describe('MCP resource registrations', () => {
   let client: Client;
 
@@ -175,7 +184,7 @@ describe('MCP resource registrations', () => {
       expect(result.contents).toHaveLength(1);
       expect(result.contents[0].uri).toBe('oss://status');
       expect(result.contents[0].mimeType).toBe('application/json');
-      const data = JSON.parse(result.contents[0].text as string);
+      const data = JSON.parse(contentText(result.contents[0]));
       expect(data.success).toBe(true);
     });
 
@@ -184,7 +193,7 @@ describe('MCP resource registrations', () => {
       expect(result.contents).toHaveLength(1);
       expect(result.contents[0].uri).toBe('oss://config');
       expect(result.contents[0].mimeType).toBe('application/json');
-      const data = JSON.parse(result.contents[0].text as string);
+      const data = JSON.parse(contentText(result.contents[0]));
       expect(data.success).toBe(true);
     });
 
@@ -192,7 +201,7 @@ describe('MCP resource registrations', () => {
       const result = await client.readResource({ uri: 'oss://prs' });
       expect(result.contents).toHaveLength(1);
       expect(result.contents[0].uri).toBe('oss://prs');
-      const data = JSON.parse(result.contents[0].text as string);
+      const data = JSON.parse(contentText(result.contents[0]));
       expect(Array.isArray(data)).toBe(true);
       expect(data).toHaveLength(2);
       expect(data[0].repo).toBe('octocat/hello-world');
@@ -210,7 +219,7 @@ describe('MCP resource registrations', () => {
       const result = await client.readResource({ uri: 'oss://prs/shelved' });
       expect(result.contents).toHaveLength(1);
       expect(result.contents[0].uri).toBe('oss://prs/shelved');
-      const data = JSON.parse(result.contents[0].text as string);
+      const data = JSON.parse(contentText(result.contents[0]));
       expect(Array.isArray(data)).toBe(true);
       expect(data).toHaveLength(1);
       expect(data[0].number).toBe(99);
@@ -225,7 +234,7 @@ describe('MCP resource registrations', () => {
       });
       expect(result.contents).toHaveLength(1);
       expect(result.contents[0].uri).toBe('oss://pr/octocat/hello-world/42');
-      const data = JSON.parse(result.contents[0].text as string);
+      const data = JSON.parse(contentText(result.contents[0]));
       expect(data.repo).toBe('octocat/hello-world');
       expect(data.number).toBe(42);
       expect(data.title).toBe('Fix typo in README');
@@ -306,7 +315,7 @@ describe('MCP resource registrations', () => {
 
       expect(result.contents).toHaveLength(1);
       expect(result.contents[0].mimeType).toBe('text/markdown');
-      expect(result.contents[0].text).toBe('# Rules\n- be nice');
+      expect(contentText(result.contents[0])).toBe('# Rules\n- be nice');
     });
 
     it('throws when no guidelines are stored for the repo', async () => {

--- a/packages/mcp-server/src/tools-execution.test.ts
+++ b/packages/mcp-server/src/tools-execution.test.ts
@@ -74,6 +74,14 @@ vi.mock('@oss-autopilot/core', () => ({
 
 import { createServer } from './server.js';
 
+// callTool's return type is a union whose legacy CompatibilityCallToolResult
+// arm types `content` as `unknown`; every tool in this suite returns text content.
+type ToolCallResult = Awaited<ReturnType<Client['callTool']>>;
+
+function firstTextContent(result: ToolCallResult): { type: string; text: string } {
+  return (result.content as Array<{ type: string; text: string }>)[0];
+}
+
 describe('tool execution', () => {
   let client: Client;
 
@@ -98,7 +106,7 @@ describe('tool execution', () => {
 
       expect(result.isError).toBeFalsy();
       expect(result.content).toHaveLength(1);
-      const content = result.content[0] as { type: string; text: string };
+      const content = firstTextContent(result);
       expect(content.type).toBe('text');
       const parsed = JSON.parse(content.text);
       expect(parsed.summary).toBe('All clear');
@@ -111,7 +119,7 @@ describe('tool execution', () => {
 
       expect(result.isError).toBe(true);
       expect(result.content).toHaveLength(1);
-      const content = result.content[0] as { type: string; text: string };
+      const content = firstTextContent(result);
       expect(content.text).toContain('GitHub API rate limit');
     });
   });
@@ -136,7 +144,7 @@ describe('tool execution', () => {
       });
 
       expect(result.isError).toBe(true);
-      const content = result.content[0] as { type: string; text: string };
+      const content = firstTextContent(result);
       expect(content.text).toMatch(/maxresults/i);
     });
 
@@ -147,7 +155,7 @@ describe('tool execution', () => {
       });
 
       expect(result.isError).toBe(true);
-      const content = result.content[0] as { type: string; text: string };
+      const content = firstTextContent(result);
       // Zod's structured error payload surfaces the field name.
       expect(content.text).toMatch(/maxresults/i);
     });
@@ -159,7 +167,7 @@ describe('tool execution', () => {
       });
 
       expect(result.isError).toBe(true);
-      const content = result.content[0] as { type: string; text: string };
+      const content = firstTextContent(result);
       expect(content.text).toMatch(/maxresults/i);
     });
   });
@@ -209,7 +217,7 @@ describe('tool execution', () => {
         issueUrl: 'https://github.com/octocat/hello-world/issues/7',
       });
       expect(result.isError).toBeFalsy();
-      const content = result.content[0] as { type: string; text: string };
+      const content = firstTextContent(result);
       expect(JSON.parse(content.text)).toEqual({ verdict: 'available' });
     });
 
@@ -242,7 +250,7 @@ describe('tool execution', () => {
 
       expect(result.isError).toBeFalsy();
       expect(mockRunGuidelinesList).toHaveBeenCalledOnce();
-      const content = result.content[0] as { type: string; text: string };
+      const content = firstTextContent(result);
       const parsed = JSON.parse(content.text);
       expect(parsed.repos).toEqual(['owner/repo-a', 'owner/repo-b']);
       expect(parsed.count).toBe(2);
@@ -274,7 +282,7 @@ describe('tool execution', () => {
         arguments: { repo: 'not-a-repo' },
       });
       expect(result.isError).toBe(true);
-      const content = result.content[0] as { type: string; text: string };
+      const content = firstTextContent(result);
       expect(content.text).toMatch(/owner\/repo/i);
     });
   });
@@ -297,7 +305,7 @@ describe('tool execution', () => {
         arguments: { repo: 'owner/repo', content: '' },
       });
       expect(result.isError).toBe(true);
-      const content = result.content[0] as { type: string; text: string };
+      const content = firstTextContent(result);
       expect(content.text).toMatch(/content/i);
     });
 
@@ -308,7 +316,7 @@ describe('tool execution', () => {
         arguments: { repo: 'owner/repo', content: oversized },
       });
       expect(result.isError).toBe(true);
-      const content = result.content[0] as { type: string; text: string };
+      const content = firstTextContent(result);
       expect(content.text).toMatch(/8\s*KB|content/i);
     });
   });
@@ -363,7 +371,7 @@ describe('tool execution', () => {
         arguments: { repo: 'owner/repo', limit: 50 },
       });
       expect(result.isError).toBe(true);
-      const content = result.content[0] as { type: string; text: string };
+      const content = firstTextContent(result);
       expect(content.text).toMatch(/limit/i);
     });
 
@@ -376,7 +384,7 @@ describe('tool execution', () => {
       });
 
       expect(result.isError).toBe(true);
-      const content = result.content[0] as { type: string; text: string };
+      const content = firstTextContent(result);
       expect(content.text).toContain('GitHub rate limit exceeded');
     });
   });

--- a/packages/mcp-server/tsconfig.tests.json
+++ b/packages/mcp-server/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "lib": ["ES2023"],
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Fixes #1450.

mcp-server test files were invisible to every type-aware tool: tsconfig excluded `**/*.test.ts`, the typecheck script was plain `tsc --noEmit`, and eslint applies disableTypeChecked to tests — the exact failure class the core tests-tsconfig gate (#1418) closed, still open here.

## Fix

`packages/mcp-server/tsconfig.tests.json` mirroring core's, chained into the package typecheck script (`tsc --noEmit && tsc --noEmit -p tsconfig.tests.json`). CI needs no change: the root typecheck fans out via `pnpm -r run typecheck` (verified against ci.yml).

The new gate surfaced 22 latent test-type errors, fixed properly (no `as any` blankets): a typed `firstTextContent` helper replacing 12 unsafe `result.content[0]` accesses on the callTool union; a `contentText` helper narrowing the text|blob resource-contents union (6 sites); a FakeRequest type that actually declares the headers the auth tests send (3); one documented unknown-routed cast for a partial http.Server mock.

Gate: root lint, format:check, root typecheck (now includes the mcp tests gate), full core + mcp suites green.

Note: this branch was cut before #1471 (which adds state-reload.test.ts); if CI flags new type errors there after the branch update, they're the gate doing its job — will fix on this branch.