### PR TITLE
ci: build the dashboard in CI (#1451)

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "bundle": "pnpm run build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src --ext .ts,.tsx",


### PR DESCRIPTION
Fixes #1451.

The dashboard production build (tsc + vite) never ran in CI: the "Build bundle" step runs `pnpm -r run bundle` and the dashboard package had no bundle script, so pnpm skipped it; the build-dashboard-if-stale helper test exercises a fake tree. Vite-specific failures surfaced for the first time on user machines via the SessionStart hook ("Dashboard SPA build failed").

One line: `"bundle": "pnpm run build"` in packages/dashboard/package.json, symmetric with core/mcp. Both the ci matrix job and update-badge already invoke `pnpm -r run bundle` after building core types (verified ordering + topological -r), dist/ is gitignored at both levels, and devDependencies are installed in CI. Local verification: full `pnpm -r run bundle` builds the dashboard clean (123 modules, ~373ms).

Known minor cost: update-badge now also builds the dashboard (~30-60s). The "Verify bundles exist" step still checks only core/mcp paths; a failing dashboard build fails the job itself, which is what the issue asked for.