### PR TITLE
fix(core): surface remaining stderr-only failures in --json envelopes (#1448)

### DIFF
--- a/packages/core/src/commands/comments.test.ts
+++ b/packages/core/src/commands/comments.test.ts
@@ -387,6 +387,39 @@ describe('runClaim', () => {
     consoleSpy.mockRestore();
   });
 
+  it('threads stateSaveWarning into the envelope when addIssue throws after the comment posted (#1448)', async () => {
+    mockRequireGitHubToken.mockReturnValue('ghp_test123');
+    mockParseGitHubUrl.mockReturnValue({ owner: 'owner', repo: 'repo', number: 10, type: 'issues' });
+
+    const mockCreateComment = vi.fn().mockResolvedValue({
+      data: { html_url: 'https://github.com/owner/repo/issues/10#issuecomment-1' },
+    });
+    const mockIssuesGet = vi.fn().mockResolvedValue({
+      data: { title: 'x', labels: [], created_at: '2026-04-20T10:00:00Z' },
+    });
+    mockGetOctokit.mockReturnValue({
+      issues: { createComment: mockCreateComment, get: mockIssuesGet },
+    } as any);
+
+    mockGetStateManager.mockReturnValue({
+      addIssue: vi.fn().mockImplementation(() => {
+        throw new Error('CAS contention');
+      }),
+      save: vi.fn(),
+    } as any);
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await runClaim({ issueUrl: TEST_ISSUE_URL });
+
+    // The claim is live on GitHub but untracked locally — the envelope says so.
+    expect(result.stateSaveWarning).toContain('failed to save to local state');
+    expect(result.stateSaveWarning).toContain('CAS contention');
+    // The gist checkpoint never ran (addIssue threw first), so its warning is absent.
+    expect('gistSyncWarning' in result).toBe(false);
+    consoleSpy.mockRestore();
+  });
+
   it('should propagate API errors', async () => {
     mockRequireGitHubToken.mockReturnValue('ghp_test123');
     mockParseGitHubUrl.mockReturnValue({ owner: 'owner', repo: 'repo', number: 10, type: 'issues' });

--- a/packages/core/src/commands/comments.ts
+++ b/packages/core/src/commands/comments.ts
@@ -272,6 +272,7 @@ export async function runClaim(options: ClaimOptions): Promise<ClaimOutput> {
 
   // Add to tracked issues — non-fatal if state save fails (comment already posted)
   let gistSyncWarning: string | null = null;
+  let stateSaveWarning: string | undefined;
   try {
     const stateManager = getStateManager();
     stateManager.addIssue({
@@ -291,17 +292,19 @@ export async function runClaim(options: ClaimOptions): Promise<ClaimOutput> {
     // the degraded-sync signal, not just the stderr log (#1036 audit H1, #1370).
     gistSyncWarning = await maybeCheckpoint(stateManager, MODULE);
   } catch (error) {
-    // Structured warning instead of bare console.error so the breadcrumb shows
-    // up in the plugin's log pipeline (#1056 M24).
-    warn(
-      MODULE,
-      `Comment posted on ${options.issueUrl} but failed to save to local state: ${error instanceof Error ? error.message : error}`,
-    );
+    // The claim comment is live on GitHub but local state never tracked it —
+    // an otherwise-clean envelope would hide an invisible untracked claim, so
+    // thread the failure into the output (#1448). Structured warning instead
+    // of bare console.error so the breadcrumb shows up in the plugin's log
+    // pipeline (#1056 M24).
+    stateSaveWarning = `Comment posted on ${options.issueUrl} but failed to save to local state: ${error instanceof Error ? error.message : error}`;
+    warn(MODULE, stateSaveWarning);
   }
 
   return {
     commentUrl: comment.html_url,
     issueUrl: options.issueUrl,
     ...(gistSyncWarning ? { gistSyncWarning } : {}),
+    ...(stateSaveWarning ? { stateSaveWarning } : {}),
   };
 }

--- a/packages/core/src/commands/daily-orchestration.test.ts
+++ b/packages/core/src/commands/daily-orchestration.test.ts
@@ -600,6 +600,27 @@ describe('executeDailyCheck() — repo score updates', () => {
     });
   });
 
+  it('surfaces a repo-scores warning when only SOME merged count updates fail (#1448)', async () => {
+    const mergedRepos = new Map([
+      ['owner/repo-a', { count: 3, lastMergedAt: '2026-01-10T00:00:00Z' }],
+      ['owner/repo-b', { count: 1, lastMergedAt: '2026-01-05T00:00:00Z' }],
+    ]);
+    mockFetchUserMergedPRCounts.mockResolvedValue(makeMergedResult(mergedRepos));
+    // Only repo-a's merged-count update throws; repo-b succeeds. Previously the
+    // warning fired only when ALL updates failed, leaving 1-of-2 envelope-silent.
+    mockUpdateRepoScore.mockImplementation((repo: string, patch: Record<string, unknown>) => {
+      if (repo === 'owner/repo-a' && 'mergedPRCount' in patch && patch.mergedPRCount === 3) {
+        throw new Error('corrupted repo score');
+      }
+    });
+
+    const result = await executeDailyCheck('test-token');
+
+    const warning = result.warnings.find((w) => w.phase === 'repo-scores' && w.operation === 'update merged counts');
+    expect(warning).toBeDefined();
+    expect(warning?.message).toContain('1 of 2 merged count update(s) failed');
+  });
+
   it('syncs trusted projects for repos with merged PRs', async () => {
     const mergedRepos = new Map([['owner/repo-trusted', { count: 2, lastMergedAt: '2026-01-10T00:00:00Z' }]]);
     mockFetchUserMergedPRCounts.mockResolvedValue(makeMergedResult(mergedRepos));

--- a/packages/core/src/commands/daily.ts
+++ b/packages/core/src/commands/daily.ts
@@ -345,16 +345,20 @@ async function updateRepoScores(
           warn(MODULE, `Failed to update merged count for ${repo}: ${errorMessage(error)}`);
         }
       }
-      if (mergedCountFailures === mergedCounts.size && mergedCounts.size > 0) {
-        // Total failure: batch outer-catch sees nothing because the batch itself
-        // succeeded, but every individual mutation inside threw. State may be
-        // silently stale — surface it as a warning distinct from the outer catch.
+      if (mergedCountFailures > 0) {
+        // Partial or total failure (#1448): the batch outer-catch sees nothing
+        // because the batch itself succeeded, but individual mutations inside
+        // threw. The affected repos' scores are silently stale — surface it as
+        // a warning distinct from the outer catch.
         warnings.push({
           phase: 'repo-scores',
           operation: 'update merged counts',
-          message: `All ${mergedCounts.size} merged count update(s) failed. This may indicate corrupted state.`,
+          message: `${mergedCountFailures} of ${mergedCounts.size} merged count update(s) failed. This may indicate corrupted state.`,
         });
-        warn(MODULE, `[ALL_MERGED_COUNT_UPDATES_FAILED] All ${mergedCounts.size} merged count update(s) failed.`);
+        warn(
+          MODULE,
+          `[MERGED_COUNT_UPDATES_FAILED] ${mergedCountFailures} of ${mergedCounts.size} merged count update(s) failed.`,
+        );
       }
 
       // Populate closedWithoutMergeCount in repo scores.
@@ -376,13 +380,16 @@ async function updateRepoScores(
           warn(MODULE, `Failed to update closed count for ${repo}: ${errorMessage(error)}`);
         }
       }
-      if (closedCountFailures === closedCounts.size && closedCounts.size > 0) {
+      if (closedCountFailures > 0) {
         warnings.push({
           phase: 'repo-scores',
           operation: 'update closed counts',
-          message: `All ${closedCounts.size} closed count update(s) failed. This may indicate corrupted state.`,
+          message: `${closedCountFailures} of ${closedCounts.size} closed count update(s) failed. This may indicate corrupted state.`,
         });
-        warn(MODULE, `[ALL_CLOSED_COUNT_UPDATES_FAILED] All ${closedCounts.size} closed count update(s) failed.`);
+        warn(
+          MODULE,
+          `[CLOSED_COUNT_UPDATES_FAILED] ${closedCountFailures} of ${closedCounts.size} closed count update(s) failed.`,
+        );
       }
 
       // Update repo signals from observed open PR data
@@ -396,15 +403,15 @@ async function updateRepoScores(
           warn(MODULE, `Failed to update signals for ${repo}: ${errorMessage(error)}`);
         }
       }
-      if (signalUpdateFailures === repoSignals.size && repoSignals.size > 0) {
+      if (signalUpdateFailures > 0) {
         warnings.push({
           phase: 'repo-scores',
           operation: 'update repo signals',
-          message: `All ${repoSignals.size} signal update(s) failed. This may indicate corrupted state.`,
+          message: `${signalUpdateFailures} of ${repoSignals.size} signal update(s) failed. This may indicate corrupted state.`,
         });
         warn(
           MODULE,
-          `[ALL_SIGNAL_UPDATES_FAILED] All ${repoSignals.size} signal update(s) failed. This may indicate corrupted state.`,
+          `[SIGNAL_UPDATES_FAILED] ${signalUpdateFailures} of ${repoSignals.size} signal update(s) failed. This may indicate corrupted state.`,
         );
       }
     });
@@ -438,13 +445,16 @@ async function updateRepoScores(
           warn(MODULE, `Failed to update metadata for ${repo}: ${errorMessage(error)}`);
         }
       }
-      if (metadataUpdateFailures === repoMetadata.size && repoMetadata.size > 0) {
+      if (metadataUpdateFailures > 0) {
         warnings.push({
           phase: 'repo-scores',
           operation: 'update repo metadata',
-          message: `All ${repoMetadata.size} metadata update(s) failed. This may indicate corrupted state.`,
+          message: `${metadataUpdateFailures} of ${repoMetadata.size} metadata update(s) failed. This may indicate corrupted state.`,
         });
-        warn(MODULE, `[ALL_METADATA_UPDATES_FAILED] All ${repoMetadata.size} metadata update(s) failed.`);
+        warn(
+          MODULE,
+          `[METADATA_UPDATES_FAILED] ${metadataUpdateFailures} of ${repoMetadata.size} metadata update(s) failed.`,
+        );
       }
 
       // Auto-sync trustedProjects from repos with merged PRs
@@ -457,15 +467,15 @@ async function updateRepoScores(
           warn(MODULE, `Failed to sync trusted project ${repo}: ${errorMessage(error)}`);
         }
       }
-      if (trustSyncFailures === mergedCounts.size && mergedCounts.size > 0) {
+      if (trustSyncFailures > 0) {
         warnings.push({
           phase: 'repo-scores',
           operation: 'sync trusted projects',
-          message: `All ${mergedCounts.size} trusted project sync(s) failed. This may indicate corrupted state.`,
+          message: `${trustSyncFailures} of ${mergedCounts.size} trusted project sync(s) failed. This may indicate corrupted state.`,
         });
         warn(
           MODULE,
-          `[ALL_TRUST_SYNCS_FAILED] All ${mergedCounts.size} trusted project sync(s) failed. This may indicate corrupted state.`,
+          `[TRUST_SYNCS_FAILED] ${trustSyncFailures} of ${mergedCounts.size} trusted project sync(s) failed. This may indicate corrupted state.`,
         );
       }
     });
@@ -491,7 +501,13 @@ function partitionPRs(
   // Apply dashboard/CLI status overrides before partitioning.
   // This ensures PRs reclassified in the dashboard (e.g., "Need Attention" → "Waiting")
   // are respected by the CLI pipeline.
-  const overriddenPRs = applyStatusOverrides(prs, stateManager.getState());
+  // Override-application failures (#1448) mean a PR silently shows its
+  // un-overridden status — record each into the run's warnings[].
+  const overrideFailures: string[] = [];
+  const overriddenPRs = applyStatusOverrides(prs, stateManager.getState(), overrideFailures);
+  for (const failure of overrideFailures) {
+    recordWarning(warnings, 'partition', 'apply status override', null, failure);
+  }
 
   // Partition PRs into active vs shelved, auto-unshelving when maintainers engage
   const shelvedPRs: ShelvedPRRef[] = [];

--- a/packages/core/src/commands/dashboard-data.ts
+++ b/packages/core/src/commands/dashboard-data.ts
@@ -382,7 +382,9 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
       // partition here than on the CLI surface (#1416). Inside the batch
       // because getStatusOverride may auto-clear stale overrides with a save,
       // which must defer to this guarded boundary rather than throw here.
-      const overriddenPRs = applyStatusOverrides(prs, stateManager.getState());
+      // Per-PR override failures (#1448) land in partialFailures so the SPA
+      // banner flags PRs silently showing their un-overridden status.
+      const overriddenPRs = applyStatusOverrides(prs, stateManager.getState(), partialFailures);
       // Store new merged PRs incrementally (dedupes by URL)
       try {
         const { dropped } = stateManager.addMergedPRs(newMergedPRs);

--- a/packages/core/src/commands/dashboard-server.test.ts
+++ b/packages/core/src/commands/dashboard-server.test.ts
@@ -143,6 +143,18 @@ vi.mock('./rate-limiter.js', () => ({
   },
 }));
 
+// Wrap detectIssueList in a spy so readVettedIssues' list detection is
+// overridable per-test (#1448). Default passes through to the real
+// implementation — the #924 cache-invalidation tests depend on it reading
+// their tmp issue-list files.
+vi.mock('./startup.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./startup.js')>();
+  return {
+    ...actual,
+    detectIssueList: vi.fn(actual.detectIssueList),
+  };
+});
+
 import {
   buildDashboardJson,
   startDashboardServer,
@@ -155,6 +167,7 @@ import {
   type DashboardServerInfo,
 } from './dashboard-server.js';
 import { fetchDashboardData, storedToMergedPRs } from './dashboard-data.js';
+import { detectIssueList } from './startup.js';
 import { getGitHubToken } from '../core/index.js';
 import { ConcurrencyError } from '../core/errors.js';
 
@@ -484,6 +497,26 @@ describe('dashboard-server', () => {
 
       const some = buildDashboardJson(digest, state, [], undefined, undefined, ['fetch recently merged PRs']);
       expect(some.partialFailures).toEqual(['fetch recently merged PRs']);
+    });
+
+    it('pushes a partialFailures entry when the vetted-list read fails instead of a silently empty panel (#1448)', () => {
+      const digest = makeDigest();
+      const state = makeState({ lastDigest: digest });
+
+      // detectIssueList reports a list, but reading it throws (ENOENT here;
+      // EACCES/EIO behave the same) — previously the panel just went empty.
+      vi.mocked(detectIssueList).mockReturnValueOnce({
+        path: '/nonexistent-1448/issue-list.md',
+        source: 'configured',
+        availableCount: 0,
+        completedCount: 0,
+      });
+
+      const data = buildDashboardJson(digest, state, [], undefined, undefined, ['fetch recently merged PRs']);
+
+      expect(data.vettedIssues).toBeNull();
+      // Caller-provided failures are preserved; the build-local one is appended.
+      expect(data.partialFailures).toEqual(['fetch recently merged PRs', 'read vetted issue list']);
     });
 
     it('buildDashboardJson stamps attentionBucket on every served PR (#1421)', () => {

--- a/packages/core/src/commands/dashboard-server.ts
+++ b/packages/core/src/commands/dashboard-server.ts
@@ -100,8 +100,13 @@ const MIME_TYPES: Record<string, string> = {
 
 /**
  * Read and parse the vetted issue list file (non-fatal on failure).
+ *
+ * @param failures - Optional collector (#1448): a read/parse failure pushes a
+ *   label so the SPA's partialFailures banner shows the panel is degraded
+ *   rather than silently empty. "No list detected" is not a failure and
+ *   pushes nothing.
  */
-function readVettedIssues(): ParseIssueListOutput | null {
+function readVettedIssues(failures?: string[]): ParseIssueListOutput | null {
   try {
     const info = detectIssueList();
     if (!info) return null;
@@ -109,6 +114,7 @@ function readVettedIssues(): ParseIssueListOutput | null {
     return parseIssueList(content);
   } catch (error) {
     warn(MODULE, `Failed to read vetted issue list: ${errorMessage(error)}`);
+    failures?.push('read vetted issue list');
     return null;
   }
 }
@@ -142,6 +148,11 @@ export function buildDashboardJson(
   allClosedPRs?: ClosedPR[],
   partialFailures?: string[],
 ): DashboardJsonData {
+  // Collect build-local failures (#1448) alongside the caller-provided ones
+  // so degradations detected during THIS build (vetted-list read failure,
+  // status-override application failure) reach the SPA's partialFailures
+  // banner instead of living only in stderr.
+  const buildFailures: string[] = [...(partialFailures ?? [])];
   // Apply status overrides ONCE, before the shelve partition is derived, so
   // the dashboard partitions on the same post-override status the CLI
   // partitions on (#1416). This also covers overrides set AFTER the digest
@@ -150,7 +161,7 @@ export function buildDashboardJson(
   // not accumulate per-request derivations.
   const overriddenDigest: DailyDigest = {
     ...digest,
-    openPRs: applyStatusOverrides(digest.openPRs || [], state),
+    openPRs: applyStatusOverrides(digest.openPRs || [], state, buildFailures),
     summary: { ...digest.summary },
   };
   // Re-derive the shelve partition from the CURRENT state before reading it.
@@ -185,7 +196,9 @@ export function buildDashboardJson(
     }
   }
 
-  const vettedIssues = readVettedIssues();
+  // A vetted-list read failure reaches the SPA banner via buildFailures
+  // instead of leaving the panel silently empty (#1448).
+  const vettedIssues = readVettedIssues(buildFailures);
   if (vettedIssues) {
     stats.availableIssues = vettedIssues.availableCount;
   }
@@ -220,7 +233,7 @@ export function buildDashboardJson(
     allClosedPRs: filteredClosedPRs,
     repoMetadata,
     vettedIssues,
-    partialFailures: partialFailures && partialFailures.length > 0 ? partialFailures : undefined,
+    partialFailures: buildFailures.length > 0 ? buildFailures : undefined,
   };
 }
 

--- a/packages/core/src/commands/dashboard-server.ts
+++ b/packages/core/src/commands/dashboard-server.ts
@@ -233,7 +233,10 @@ export function buildDashboardJson(
     allClosedPRs: filteredClosedPRs,
     repoMetadata,
     vettedIssues,
-    partialFailures: buildFailures.length > 0 ? buildFailures : undefined,
+    // Dedup: the fetch path already applies status overrides into the cached
+    // partialFailures, and the rebuild applies them again above — the same
+    // failing override must not appear (and be counted) twice (#1448).
+    partialFailures: buildFailures.length > 0 ? [...new Set(buildFailures)] : undefined,
   };
 }
 

--- a/packages/core/src/commands/scout-bridge.test.ts
+++ b/packages/core/src/commands/scout-bridge.test.ts
@@ -18,16 +18,21 @@ vi.mock('@oss-scout/core', () => ({
 }));
 
 vi.mock('./skip-file-parser.js', () => ({
-  loadSkippedIssues: vi.fn(() => []),
+  loadSkippedIssuesDetailed: vi.fn(() => ({ issues: [] })),
 }));
 
 import { getStateManager } from '../core/index.js';
-import { adaptScoutLinkedPR, buildCandidateLinkedPR, buildScoutState } from './scout-bridge.js';
-import { loadSkippedIssues } from './skip-file-parser.js';
+import {
+  adaptScoutLinkedPR,
+  buildCandidateLinkedPR,
+  buildScoutState,
+  type ScoutBridgeDiagnostics,
+} from './scout-bridge.js';
+import { loadSkippedIssuesDetailed } from './skip-file-parser.js';
 import { makeAgentState, makeDailyDigest, makeFetchedPR, makeStateManagerMock } from '../core/test-utils.js';
 
 const mockGetStateManager = vi.mocked(getStateManager);
-const mockLoadSkippedIssues = vi.mocked(loadSkippedIssues);
+const mockLoadSkippedIssuesDetailed = vi.mocked(loadSkippedIssuesDetailed);
 
 describe('buildScoutState', () => {
   beforeEach(() => {
@@ -236,22 +241,49 @@ describe('buildScoutState', () => {
         skippedAt: '2026-04-15T00:00:00.000Z',
       },
     ];
-    mockLoadSkippedIssues.mockReturnValueOnce(skipped);
+    mockLoadSkippedIssuesDetailed.mockReturnValueOnce({ issues: skipped });
 
     const result = buildScoutState();
 
-    expect(mockLoadSkippedIssues).toHaveBeenCalledWith('/vault/open-source/skipped-issues.md');
+    expect(mockLoadSkippedIssuesDetailed).toHaveBeenCalledWith('/vault/open-source/skipped-issues.md');
     expect(result.skippedIssues).toEqual(skipped);
   });
 
   it('should default skippedIssues to [] when parser returns empty', () => {
     const state = makeAgentState({ config: { skippedIssuesPath: undefined } });
     mockGetStateManager.mockReturnValue(makeStateManagerMock({ state, config: state.config }));
-    mockLoadSkippedIssues.mockReturnValueOnce([]);
+    mockLoadSkippedIssuesDetailed.mockReturnValueOnce({ issues: [] });
 
     const result = buildScoutState();
 
     expect(result.skippedIssues).toEqual([]);
+  });
+
+  it('sets diagnostics.skipListUnavailable when the skip file read fails (#1448)', () => {
+    const state = makeAgentState({
+      config: { skippedIssuesPath: '/vault/open-source/skipped-issues.md' },
+    });
+    mockGetStateManager.mockReturnValue(makeStateManagerMock({ state, config: state.config }));
+    mockLoadSkippedIssuesDetailed.mockReturnValueOnce({ issues: [], readError: 'EACCES: permission denied' });
+
+    const diagnostics: ScoutBridgeDiagnostics = {};
+    const result = buildScoutState(diagnostics);
+
+    expect(diagnostics.skipListUnavailable).toBe(true);
+    expect(result.skippedIssues).toEqual([]);
+  });
+
+  it('leaves diagnostics.skipListUnavailable unset when the skip file loads cleanly (#1448)', () => {
+    const state = makeAgentState({
+      config: { skippedIssuesPath: '/vault/open-source/skipped-issues.md' },
+    });
+    mockGetStateManager.mockReturnValue(makeStateManagerMock({ state, config: state.config }));
+    mockLoadSkippedIssuesDetailed.mockReturnValueOnce({ issues: [] });
+
+    const diagnostics: ScoutBridgeDiagnostics = {};
+    buildScoutState(diagnostics);
+
+    expect(diagnostics.skipListUnavailable).toBeUndefined();
   });
 });
 

--- a/packages/core/src/commands/scout-bridge.ts
+++ b/packages/core/src/commands/scout-bridge.ts
@@ -7,7 +7,22 @@ import { createScout, type LinkedPR as ScoutLinkedPR, type OssScout, type ScoutS
 import { getStateManager, isLinkedPRStalled, requireGitHubToken } from '../core/index.js';
 import type { LinkedPR } from '../core/linked-pr-classification.js';
 import type { CandidateLinkedPR } from '../formatters/json.js';
-import { loadSkippedIssues } from './skip-file-parser.js';
+import { loadSkippedIssuesDetailed } from './skip-file-parser.js';
+
+/**
+ * Degradation signals collected while building a scout state (#1448).
+ * Callers pass an empty object and inspect it after the build — threading an
+ * out-param keeps `buildScoutState`/`createAutopilotScout` return types
+ * unchanged for the five command call sites.
+ */
+export interface ScoutBridgeDiagnostics {
+  /**
+   * Set when a configured skipped-issues file exists but could not be read.
+   * The scout state was built with an EMPTY skip list, so explicitly-skipped
+   * issues may resurface in results.
+   */
+  skipListUnavailable?: boolean;
+}
 
 /**
  * Convert scout 0.6.0's `LinkedPR` (separate `state` + `merged`) into the
@@ -59,10 +74,22 @@ export function buildCandidateLinkedPR(scoutLinkedPR: ScoutLinkedPR | null | und
 /**
  * Build a ScoutState from the current AgentState.
  * Maps oss-autopilot's config and state fields to oss-scout's state format.
+ *
+ * @param diagnostics - Optional collector for degradation signals (#1448);
+ *   `skipListUnavailable` is set when the skipped-issues file exists but
+ *   could not be read.
  */
-export function buildScoutState(): ScoutState {
+export function buildScoutState(diagnostics?: ScoutBridgeDiagnostics): ScoutState {
   const state = getStateManager().getState();
   const { config } = state;
+
+  // Read failure (not absence) of the skip file means scout will see an empty
+  // skip list and may resurface explicitly-skipped issues — flag it so the
+  // search envelope can carry the signal instead of only stderr (#1448).
+  const skippedIssuesLoad = loadSkippedIssuesDetailed(config.skippedIssuesPath);
+  if (skippedIssuesLoad.readError !== undefined && diagnostics) {
+    diagnostics.skipListUnavailable = true;
+  }
 
   return {
     version: 1,
@@ -128,7 +155,7 @@ export function buildScoutState(): ScoutState {
       openedAt: pr.createdAt,
     })),
     savedResults: [],
-    skippedIssues: loadSkippedIssues(config.skippedIssuesPath),
+    skippedIssues: skippedIssuesLoad.issues,
     lastRunAt: state.lastRunAt,
   };
 }
@@ -136,12 +163,15 @@ export function buildScoutState(): ScoutState {
 /**
  * Create an OssScout instance backed by the current AgentState.
  * Uses 'provided' persistence so scout reads from oss-autopilot's state.
+ *
+ * @param diagnostics - Optional collector for degradation signals (#1448),
+ *   forwarded to {@link buildScoutState}.
  */
-export async function createAutopilotScout(): Promise<OssScout> {
+export async function createAutopilotScout(diagnostics?: ScoutBridgeDiagnostics): Promise<OssScout> {
   const token = requireGitHubToken();
   return createScout({
     githubToken: token,
     persistence: 'provided',
-    initialState: buildScoutState(),
+    initialState: buildScoutState(diagnostics),
   });
 }

--- a/packages/core/src/commands/search.test.ts
+++ b/packages/core/src/commands/search.test.ts
@@ -25,6 +25,7 @@ vi.mock('../core/index.js', async () => {
 });
 
 import { getStateManager } from '../core/index.js';
+import { createAutopilotScout, type ScoutBridgeDiagnostics } from './scout-bridge.js';
 import { runSearch } from './search.js';
 
 const mockGetStateManager = vi.mocked(getStateManager);
@@ -208,6 +209,27 @@ describe('runSearch', () => {
     const result = await runSearch({ maxResults: 10 });
 
     expect(result.candidates).toEqual([]);
+  });
+
+  it('surfaces skipListUnavailable when the bridge reports an unreadable skip file, and omits it otherwise (#1448)', async () => {
+    mockSearch.mockResolvedValue({
+      candidates: [],
+      excludedRepos: [],
+      aiPolicyBlocklist: [],
+      strategiesUsed: [],
+    });
+
+    // Clean run: flag must be absent, not false (contract goldens stay byte-identical).
+    const cleanResult = await runSearch({ maxResults: 10 });
+    expect('skipListUnavailable' in cleanResult).toBe(false);
+
+    // Degraded run: bridge flags the unreadable skip file via the diagnostics out-param.
+    vi.mocked(createAutopilotScout).mockImplementationOnce(async (diagnostics?: ScoutBridgeDiagnostics) => {
+      if (diagnostics) diagnostics.skipListUnavailable = true;
+      return { search: mockSearch } as any;
+    });
+    const degradedResult = await runSearch({ maxResults: 10 });
+    expect(degradedResult.skipListUnavailable).toBe(true);
   });
 
   it('should include repoUrl derived from repo name (#789)', async () => {

--- a/packages/core/src/commands/search.ts
+++ b/packages/core/src/commands/search.ts
@@ -3,7 +3,12 @@
  * Searches for new issues to work on via @oss-scout/core
  */
 
-import { adaptScoutLinkedPR, buildCandidateLinkedPR, createAutopilotScout } from './scout-bridge.js';
+import {
+  adaptScoutLinkedPR,
+  buildCandidateLinkedPR,
+  createAutopilotScout,
+  type ScoutBridgeDiagnostics,
+} from './scout-bridge.js';
 import { classifyLinkedPR, getStateManager } from '../core/index.js';
 import { type SearchOutput } from '../formatters/json.js';
 import { gradeFromCandidate } from '../core/issue-grading.js';
@@ -67,7 +72,11 @@ function sanitizeViabilityScore(raw: unknown): number {
 }
 
 export async function runSearch(options: SearchOptions): Promise<SearchOutput> {
-  const scout = await createAutopilotScout();
+  // Collect bridge-level degradation signals (#1448): an unreadable skip file
+  // means scout searched with an empty skip list, so explicitly-skipped
+  // issues may resurface — the envelope must say so, not just stderr.
+  const bridgeDiagnostics: ScoutBridgeDiagnostics = {};
+  const scout = await createAutopilotScout(bridgeDiagnostics);
   const stateManager = getStateManager();
 
   // Derive personalization from local history (#1244). `computeStrategy`
@@ -177,6 +186,9 @@ export async function runSearch(options: SearchOptions): Promise<SearchOutput> {
   };
   if (result.rateLimitWarning) {
     searchOutput.rateLimitWarning = result.rateLimitWarning;
+  }
+  if (bridgeDiagnostics.skipListUnavailable) {
+    searchOutput.skipListUnavailable = true;
   }
   return searchOutput;
 }

--- a/packages/core/src/commands/skip-file-parser.test.ts
+++ b/packages/core/src/commands/skip-file-parser.test.ts
@@ -19,7 +19,7 @@ vi.mock('../core/logger.js', () => ({
 
 import * as fs from 'node:fs';
 import { warn } from '../core/logger.js';
-import { parseSkippedIssuesContent, loadSkippedIssues } from './skip-file-parser.js';
+import { parseSkippedIssuesContent, loadSkippedIssues, loadSkippedIssuesDetailed } from './skip-file-parser.js';
 
 const mockExistsSync = vi.mocked(fs.existsSync);
 const mockReadFileSync = vi.mocked(fs.readFileSync);
@@ -196,5 +196,42 @@ describe('loadSkippedIssues', () => {
     const result = loadSkippedIssues('/restricted/path.md');
     expect(result).toEqual([]);
     expect(mockWarn).toHaveBeenCalled();
+  });
+});
+
+describe('loadSkippedIssuesDetailed', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should set readError when the file exists but reading it throws (#1448)', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('EACCES');
+    });
+
+    const result = loadSkippedIssuesDetailed('/restricted/path.md');
+
+    expect(result.issues).toEqual([]);
+    expect(result.readError).toContain('EACCES');
+    expect(mockWarn).toHaveBeenCalled();
+  });
+
+  it('should NOT set readError when the path is unset or the file does not exist', () => {
+    expect(loadSkippedIssuesDetailed(undefined).readError).toBeUndefined();
+
+    mockExistsSync.mockReturnValue(false);
+    expect(loadSkippedIssuesDetailed('/missing/path.md').readError).toBeUndefined();
+  });
+
+  it('should return parsed issues without readError on a successful read', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('2026-04-15 https://github.com/owncast/owncast/issues/4883\n');
+
+    const result = loadSkippedIssuesDetailed('/real/path.md');
+
+    expect(result.readError).toBeUndefined();
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0].url).toBe('https://github.com/owncast/owncast/issues/4883');
   });
 });

--- a/packages/core/src/commands/skip-file-parser.ts
+++ b/packages/core/src/commands/skip-file-parser.ts
@@ -85,24 +85,51 @@ export function parseSkippedIssuesContent(content: string): SkippedIssue[] {
   return results;
 }
 
+/** Result of {@link loadSkippedIssuesDetailed}: parsed entries plus read-failure signal (#1448). */
+export interface SkippedIssuesLoadResult {
+  issues: SkippedIssue[];
+  /**
+   * Set when the file exists but could not be read (`issues` is `[]` in that
+   * case). Distinguishes "no skips configured" from "skip list unavailable" —
+   * without it, a read failure silently resurfaces explicitly-skipped issues
+   * in search results. Absent when the path is unset, the file does not
+   * exist, or the read succeeded.
+   */
+  readError?: string;
+}
+
 /**
- * Read the skipped-issues file from disk and parse it.
- * Returns `[]` when:
- *   - `path` is undefined or empty,
- *   - the file does not exist,
- *   - the file cannot be read (a warning is logged).
+ * Read the skipped-issues file from disk and parse it, surfacing read
+ * failures to the caller (#1448).
+ * Returns `{ issues: [] }` (no `readError`) when `path` is undefined/empty or
+ * the file does not exist; `{ issues: [], readError }` when the read throws
+ * (a warning is also logged).
  */
-export function loadSkippedIssues(path: string | undefined): SkippedIssue[] {
-  if (!path) return [];
-  if (!fs.existsSync(path)) return [];
+export function loadSkippedIssuesDetailed(path: string | undefined): SkippedIssuesLoadResult {
+  if (!path) return { issues: [] };
+  if (!fs.existsSync(path)) return { issues: [] };
 
   let content: string;
   try {
     content = fs.readFileSync(path, 'utf8');
   } catch (err) {
     warn('skip-file-parser', `Failed to read skipped-issues file at ${path}: ${errorMessage(err)}`);
-    return [];
+    return { issues: [], readError: errorMessage(err) };
   }
 
-  return parseSkippedIssuesContent(content);
+  return { issues: parseSkippedIssuesContent(content) };
+}
+
+/**
+ * Read the skipped-issues file from disk and parse it.
+ * Returns `[]` when:
+ *   - `path` is undefined or empty,
+ *   - the file does not exist,
+ *   - the file cannot be read (a warning is logged).
+ *
+ * Callers that need to distinguish "unreadable" from "no skips" should use
+ * {@link loadSkippedIssuesDetailed} instead.
+ */
+export function loadSkippedIssues(path: string | undefined): SkippedIssue[] {
+  return loadSkippedIssuesDetailed(path).issues;
 }

--- a/packages/core/src/commands/startup.test.ts
+++ b/packages/core/src/commands/startup.test.ts
@@ -287,6 +287,38 @@ describe('detectIssueList', () => {
     expect(result?.completedCount).toBe(1);
   });
 
+  it('should surface readError when the issue list file cannot be read (#1448)', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    existsSyncMock.mockImplementation((path: string) => {
+      return typeof path === 'string' && path === 'issues.md';
+    });
+    (fsImport as any).readFileSync = vi.fn().mockImplementation(() => {
+      throw new Error('EACCES: permission denied');
+    });
+
+    const result = detectIssueList();
+
+    // The 0/0 counts are a read failure, not an empty list — readError says so.
+    expect(result).toBeDefined();
+    expect(result?.path).toBe('issues.md');
+    expect(result?.availableCount).toBe(0);
+    expect(result?.completedCount).toBe(0);
+    expect(result?.readError).toContain('EACCES');
+    consoleSpy.mockRestore();
+  });
+
+  it('should not set readError on a successful read (#1448)', () => {
+    existsSyncMock.mockImplementation((path: string) => {
+      return typeof path === 'string' && path === 'issues.md';
+    });
+    (fsImport as any).readFileSync = vi.fn().mockReturnValue('- [#1](https://github.com/o/r/issues/1) — Issue\n');
+
+    const result = detectIssueList();
+
+    expect(result).toBeDefined();
+    expect('readError' in (result ?? {})).toBe(false);
+  });
+
   it('should detect issue list from state.json config (primary)', async () => {
     const { getStateManager } = await import('../core/index.js');
     vi.mocked(getStateManager).mockReturnValue({

--- a/packages/core/src/commands/startup.ts
+++ b/packages/core/src/commands/startup.ts
@@ -99,11 +99,16 @@ export function detectIssueList(): IssueListInfo | undefined {
   // 4. Count available/completed items
   let availableCount = 0;
   let completedCount = 0;
+  let readError: string | undefined;
   try {
     const content = fs.readFileSync(issueListPath, 'utf8');
     ({ availableCount, completedCount } = countIssueListItems(content));
   } catch (error) {
-    console.error(`[STARTUP] Failed to read issue list at ${issueListPath}:`, errorMessage(error));
+    // Surface the failure in the envelope (#1448): a 0/0 count from an
+    // unreadable list is indistinguishable from a genuinely empty list, and
+    // an agent seeing 0 available may trigger a redundant fresh search.
+    readError = errorMessage(error);
+    console.error(`[STARTUP] Failed to read issue list at ${issueListPath}:`, readError);
   }
 
   // 5. Detect skipped issues file
@@ -152,7 +157,14 @@ export function detectIssueList(): IssueListInfo | undefined {
     }
   }
 
-  return { path: issueListPath, source, availableCount, completedCount, skippedIssuesPath };
+  return {
+    path: issueListPath,
+    source,
+    availableCount,
+    completedCount,
+    skippedIssuesPath,
+    ...(readError !== undefined ? { readError } : {}),
+  };
 }
 
 /**

--- a/packages/core/src/commands/vet-list.test.ts
+++ b/packages/core/src/commands/vet-list.test.ts
@@ -34,14 +34,27 @@ vi.mock('./startup.js', () => ({
 
 vi.mock('./parse-list.js', () => ({
   runParseList: vi.fn(),
+  pruneIssueList: vi.fn(),
 }));
 
+// Mock fs so the prune path doesn't hit the real filesystem
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return {
+    ...actual,
+    readFileSync: vi.fn(),
+    writeFileSync: vi.fn(),
+  };
+});
+
+import * as fs from 'node:fs';
 import { detectIssueList } from './startup.js';
 import { runParseList } from './parse-list.js';
 import { runVetList, classifyListStatus } from './vet-list.js';
 
 const mockDetectIssueList = vi.mocked(detectIssueList);
 const mockRunParseList = vi.mocked(runParseList);
+const mockReadFileSync = vi.mocked(fs.readFileSync);
 
 function makeVetOutput(overrides: Partial<VetOutput> = {}): VetOutput {
   return {
@@ -536,5 +549,53 @@ describe('runVetList', () => {
     expect(result.results).toHaveLength(1);
     expect(result.results[0].listStatus).toBe('error');
     expect(result.results[0].errorMessage).toBe('string error');
+  });
+
+  it('returns pruneResult with removedCount 0 and the error when the prune fails (#1448)', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockDetectIssueList.mockReturnValue({
+      path: '/tmp/issues.md',
+      source: 'configured',
+      availableCount: 1,
+      completedCount: 0,
+    });
+    mockRunParseList.mockResolvedValue({
+      available: [
+        {
+          repo: 'owner/repo',
+          number: 1,
+          title: 'Fix bug',
+          tier: 'Pursue',
+          url: 'https://github.com/owner/repo/issues/1',
+        },
+      ],
+      completed: [],
+      availableCount: 1,
+      completedCount: 0,
+    });
+    mockVetIssue.mockResolvedValueOnce({
+      issue: {
+        repo: 'owner/repo',
+        number: 1,
+        title: 'Fix bug',
+        url: 'https://github.com/owner/repo/issues/1',
+        labels: [],
+      },
+      recommendation: 'approve' as const,
+      reasonsToApprove: ['OK'],
+      reasonsToSkip: [],
+      projectHealth: {},
+      vettingResult: {},
+    });
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('EACCES: permission denied');
+    });
+
+    const result = await runVetList({ prune: true });
+
+    // Previously a failed prune returned a plain success with pruneResult
+    // absent — the same shape as "prune not requested".
+    expect(result.pruneResult).toEqual({ removedCount: 0, error: 'EACCES: permission denied' });
+    consoleSpy.mockRestore();
   });
 });

--- a/packages/core/src/commands/vet-list.ts
+++ b/packages/core/src/commands/vet-list.ts
@@ -233,7 +233,7 @@ export async function runVetList(options: VetListOptions = {}): Promise<VetListO
   };
 
   // 4. Prune the file if requested — remove completed/skipped/low-score items
-  let pruneResult: { removedCount: number } | undefined;
+  let pruneResult: { removedCount: number; error?: string } | undefined;
   if (options.prune && issueListPath) {
     try {
       const content = fs.readFileSync(issueListPath, 'utf8');
@@ -245,6 +245,10 @@ export async function runVetList(options: VetListOptions = {}): Promise<VetListO
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       console.error(`Warning: Failed to prune ${issueListPath}: ${msg}`);
+      // Surface the failure in the envelope (#1448): without this, a failed
+      // prune returned a plain success with pruneResult simply absent — the
+      // same shape as "prune not requested".
+      pruneResult = { removedCount: 0, error: msg };
     }
   }
 

--- a/packages/core/src/core/daily-logic.test.ts
+++ b/packages/core/src/core/daily-logic.test.ts
@@ -833,4 +833,50 @@ describe('applyStatusOverrides', () => {
     // No direct save() call — persistence is handled by autoSave() inside mutations
     expect(mockSave).not.toHaveBeenCalled();
   });
+
+  it('collects a failure message when applying an override throws, keeping the PR un-overridden (#1448)', () => {
+    const prUrl = 'https://github.com/owner/repo/pull/1';
+    const prs = [makePR({ repo: 'owner/repo', number: 1, status: 'needs_addressing' })];
+    const state = makeState({
+      [prUrl]: {
+        status: 'waiting_on_maintainer',
+        setAt: '2026-01-01T00:00:00Z',
+        lastActivityAt: '2025-06-15T00:00:00Z',
+      },
+    });
+    mockGetStatusOverride.mockImplementation(() => {
+      throw new Error('corrupt override record');
+    });
+
+    const failures: string[] = [];
+    const result = applyStatusOverrides(prs, state, failures);
+
+    // The PR silently shows its un-overridden status — the collector says so.
+    expect(result[0].status).toBe('needs_addressing');
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toContain(prUrl);
+    expect(failures[0]).toContain('corrupt override record');
+  });
+
+  it('leaves the failures collector empty when overrides apply cleanly (#1448)', () => {
+    const prUrl = 'https://github.com/owner/repo/pull/1';
+    const prs = [makePR({ repo: 'owner/repo', number: 1, status: 'needs_addressing' })];
+    const state = makeState({
+      [prUrl]: {
+        status: 'waiting_on_maintainer',
+        setAt: '2026-01-01T00:00:00Z',
+        lastActivityAt: '2025-06-15T00:00:00Z',
+      },
+    });
+    mockGetStatusOverride.mockReturnValue({
+      status: 'waiting_on_maintainer',
+      setAt: '2026-01-01T00:00:00Z',
+      lastActivityAt: '2025-06-15T00:00:00Z',
+    });
+
+    const failures: string[] = [];
+    applyStatusOverrides(prs, state, failures);
+
+    expect(failures).toEqual([]);
+  });
 });

--- a/packages/core/src/core/daily-logic.ts
+++ b/packages/core/src/core/daily-logic.ts
@@ -78,9 +78,13 @@ const VALID_OVERRIDE_STATUSES: ReadonlySet<FetchedPRStatus> = new Set(['needs_ad
  *
  * @param prs - The fetched PR list to apply overrides to
  * @param state - Current agent state containing status overrides
+ * @param failures - Optional collector (#1448): a message is pushed for each
+ *   PR whose override lookup threw (that PR keeps its un-overridden status).
+ *   Call sites surface these in warnings[]/partialFailures so the silently
+ *   wrong status is visible in the envelope, not just stderr.
  * @returns New PR array with overrides applied (original array is not mutated)
  */
-export function applyStatusOverrides(prs: FetchedPR[], state: Readonly<AgentState>): FetchedPR[] {
+export function applyStatusOverrides(prs: FetchedPR[], state: Readonly<AgentState>, failures?: string[]): FetchedPR[] {
   const overrides = state.config.statusOverrides;
   if (!overrides || Object.keys(overrides).length === 0) return prs;
 
@@ -108,7 +112,9 @@ export function applyStatusOverrides(prs: FetchedPR[], state: Readonly<AgentStat
         }
         return { ...pr, status: override.status, waitReason: undefined, actionReason: 'needs_response' as const };
       } catch (err) {
-        warn('daily-logic', `Failed to apply status override for ${pr.url}: ${errorMessage(err)}`);
+        const message = `Failed to apply status override for ${pr.url}: ${errorMessage(err)}`;
+        warn('daily-logic', message);
+        failures?.push(message);
         return pr;
       }
     });

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -619,6 +619,9 @@ export const SearchOutputSchema = z.object({
   aiPolicyBlocklist: z.array(z.string()),
   hiddenOwnPRCount: z.number().int().nonnegative(),
   rateLimitWarning: z.string().optional(),
+  // Skip file unreadable — search ran with an empty skip list (#1448).
+  // Optional: absent on clean runs.
+  skipListUnavailable: z.boolean().optional(),
 });
 
 // ── Features output schema (scout 0.9.0 #97/#98/#99) ─────────────────
@@ -738,6 +741,9 @@ export const ClaimOutputSchema = z.object({
   issueUrl: z.string(),
   // Post-mutation Gist checkpoint failure (#1370). Optional: absent on clean runs.
   gistSyncWarning: z.string().optional(),
+  // Claim comment posted but local state save threw — claim is live but
+  // untracked (#1448). Optional: absent on clean runs.
+  stateSaveWarning: z.string().optional(),
 });
 
 export const InitOutputSchema = z.object({
@@ -1093,6 +1099,12 @@ export interface SearchOutput {
   hiddenOwnPRCount: number;
   /** Present when rate limits affected the search — either low pre-flight quota or mid-search rate limit hits (#100). */
   rateLimitWarning?: string;
+  /**
+   * Set when the configured skipped-issues file exists but could not be read
+   * (#1448). The search ran with an EMPTY skip list, so explicitly-skipped
+   * issues may appear in `candidates`. Absent on success.
+   */
+  skipListUnavailable?: boolean;
 }
 
 /** Horizon classification stamped on each features-mode candidate. */
@@ -1136,6 +1148,13 @@ export interface IssueListInfo {
   availableCount: number;
   completedCount: number;
   skippedIssuesPath?: string;
+  /**
+   * Set when the issue list file was detected but could not be read (#1448).
+   * In that case `availableCount`/`completedCount` are 0 because the content
+   * was unreadable, NOT because the list is empty — consumers should not
+   * treat the counts as authoritative. Absent on success.
+   */
+  readError?: string;
 }
 
 /**
@@ -1269,6 +1288,11 @@ export interface VetListOutput {
   };
   pruneResult?: {
     removedCount: number;
+    /**
+     * Set when the prune read/write failed (#1448); `removedCount` is 0 in
+     * that case and the list file is unchanged. Absent on a successful prune.
+     */
+    error?: string;
   };
 }
 
@@ -1382,6 +1406,12 @@ export interface ClaimOutput {
   issueUrl: string;
   /** Set when the post-mutation Gist checkpoint failed; the local mutation succeeded (#1370). */
   gistSyncWarning?: string;
+  /**
+   * Set when the claim comment posted to GitHub but saving the tracked issue
+   * to local state threw (#1448) — the claim is live but UNTRACKED, so daily
+   * runs will not monitor it. Absent on success.
+   */
+  stateSaveWarning?: string;
 }
 
 /** Info about a local git clone (#84) */


### PR DESCRIPTION
Fixes #1448.

Agents only see the envelope; stderr is invisible to them. Six confirmed stderr-only failure paths now surface structurally:

1. startup: unreadable issue list was indistinguishable from an empty one (0/0) — optional `issueList.readError`.
2. daily repo scores: the warnings[] gate fired only when ALL repos failed; all five `=== size` gates are now `> 0` with "N of M failed" messages (stderr tags renamed to drop the now-false ALL_ prefix).
3. skip file: a read failure silently degraded to "no skips" so explicitly-skipped issues resurfaced in search — new `loadSkippedIssuesDetailed` + diagnostics out-param through scout-bridge; search output carries optional `skipListUnavailable` (+ schema). Rethrow deliberately NOT chosen: the loader feeds five surfaces (search/vet/vet-list/features/daily) and EACCES on a non-essential file shouldn't crash them. Dashboard vetted-list read failure now lands in partialFailures instead of a silently empty panel.
4. vet-list --prune: write failure returned a plain success with pruneResult absent — now `pruneResult: { removedCount: 0, error }`.
5. status-override application failure: optional failures[] collector on applyStatusOverrides, wired at all three call sites (daily warnings[], dashboard-data and dashboard-server partialFailures). Review caught a double-report (fetch + rebuild both apply overrides) — fixed by dedup at payload finalization.
6. comments --claim: addIssue throwing after the GitHub comment posted returned a clean envelope — optional `stateSaveWarning` (+ schema).

All new fields optional and absent on success; contract goldens byte-identical (verified). Also fixed a latent harness bug the work exposed (dashboard-server detectIssueList passthrough spy; scout-bridge mock migration).

Gate: root eslint, prettier, typecheck, 2809 core + 235 mcp green. code-reviewer pass converged (1 finding, fixed on-branch).