### PR TITLE
test(cli): wire MoveOutputSchema into the registry; document the two validation tiers (#1453)

### DIFF
--- a/packages/core/src/cli-registry.test.ts
+++ b/packages/core/src/cli-registry.test.ts
@@ -89,7 +89,7 @@ vi.mock('./commands/verify-issue.js', () => ({ runVerifyIssue: mockRunVerifyIssu
 // ─── Import after mocks ────────────────────────────────────────────────────
 
 import { commands } from './cli-registry.js';
-import { outputJson, outputJsonError, outputJsonValidated } from './formatters/json.js';
+import { outputJson, outputJsonError, outputJsonValidated, MoveOutputSchema } from './formatters/json.js';
 
 const mockOutputJson = vi.mocked(outputJson);
 const mockOutputJsonError = vi.mocked(outputJsonError);
@@ -409,6 +409,47 @@ describe('override status validation', () => {
       'UNKNOWN',
     );
     expect(mockRunMove).not.toHaveBeenCalled();
+  });
+});
+
+// ─── move schema wiring (#1453) ─────────────────────────────────────────────
+
+describe('move schema wiring (#1453)', () => {
+  it('move --json routes through outputJsonValidated with MoveOutputSchema', async () => {
+    const payload = {
+      url: PR_URL,
+      target: 'shelved',
+      description: 'Shelved — excluded from capacity and actionable items',
+    };
+    mockRunMove.mockResolvedValue(payload);
+    const program = buildProgram('move');
+
+    await program.parseAsync(['node', 'cli', 'move', PR_URL, 'shelved', '--json']);
+
+    expect(mockRunMove).toHaveBeenCalledWith({ prUrl: PR_URL, target: 'shelved' });
+    expect(mockOutputJsonValidated).toHaveBeenCalledTimes(1);
+    const [schemaArg, dataArg] = mockOutputJsonValidated.mock.calls[0];
+    // Identity check: the registration must pass the exported MoveOutputSchema
+    // itself, not just any schema — otherwise the runtime --json validation
+    // path (#1105) can never fire for move.
+    expect(schemaArg).toBe(MoveOutputSchema);
+    expect(dataArg).toEqual(payload);
+    expect(mockOutputJson).not.toHaveBeenCalled();
+  });
+
+  it('move display mode prints the description without JSON output', async () => {
+    mockRunMove.mockResolvedValue({
+      url: PR_URL,
+      target: 'waiting',
+      description: 'Moved to Waiting on Maintainer',
+    });
+    const program = buildProgram('move');
+
+    await program.parseAsync(['node', 'cli', 'move', PR_URL, 'waiting']);
+
+    expect(consoleLogSpy).toHaveBeenCalledWith('Moved to Waiting on Maintainer');
+    expect(mockOutputJson).not.toHaveBeenCalled();
+    expect(mockOutputJsonValidated).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -47,6 +47,35 @@ export function handleCommandError(err: unknown, json?: boolean): never {
  * duplicated in every command action. Commands with non-standard output
  * modes (e.g. `--compact`, `--markdown`, `--badge`) inline their own
  * branching rather than squeezing through this helper.
+ *
+ * ── `--json` output validation tiers (#1453) ──────────────────────────────
+ *
+ * Two tiers gate the shape of `--json` output. When adding a command, pick
+ * a tier consciously:
+ *
+ * 1. **Runtime-validated**: the registration passes an exported Zod schema
+ *    (from `formatters/json.ts`) as `executeAction`'s 4th argument — or
+ *    calls `outputJsonValidated` directly — so a drifted shape throws at
+ *    the `--json` boundary instead of silently shipping (#1105).
+ *    Commands: manifest, daily, status, strategy, search, features,
+ *    verify-issue, skip-add, list-move-tier, list-mark-done,
+ *    compliance-score, post, claim, config, init, setup, checkSetup,
+ *    parse-issue-list, orphan-files, doctor, local-repos, move, override,
+ *    clear-override, pr-template, repo-vet, detect-formatters.
+ *
+ * 2. **Goldens-only**: no Zod schema exists; the command returns a TS
+ *    interface and its `*.contract.test.ts` golden snapshot is the only
+ *    shape gate. Nothing fires at runtime if the producer drifts after
+ *    the goldens were last updated.
+ *    Commands: state (show/sync/unlink), vet, vet-list, track, comments,
+ *    startup, shelve, unshelve, dismiss, undismiss, stats, and the five
+ *    guidelines subcommands (list/view/store/reset/fetch-corpus).
+ *
+ * (`dashboard serve` is exempt: it has no `--json` mode.)
+ *
+ * To promote a command to tier 1: export a Zod schema from
+ * `formatters/json.ts`, assert it in the command's contract test alongside
+ * the goldens, and pass it to `executeAction` here.
  */
 async function executeAction<T>(
   options: { json?: boolean },
@@ -1355,15 +1384,17 @@ export const commands: CLICommandDef[] = [
         .command('move <pr-url> <target>')
         .description('Move a PR between states: attention, waiting, shelved, or auto (reset to computed)')
         .option('--json', 'Output as JSON')
-        .action((prUrl, target, options) =>
-          executeAction(
+        .action(async (prUrl, target, options) => {
+          const { MoveOutputSchema } = await import('./formatters/json.js');
+          await executeAction(
             options,
             async () => (await import('./commands/move.js')).runMove({ prUrl, target }),
             (data) => {
               console.log(data.description);
             },
-          ),
-        );
+            MoveOutputSchema,
+          );
+        });
     },
   },
 

--- a/packages/core/src/commands/move.contract.test.ts
+++ b/packages/core/src/commands/move.contract.test.ts
@@ -66,4 +66,16 @@ describe('move --json contract', () => {
     expect(schemaIssues(MoveOutputSchema, result)).toEqual([]);
     await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/move.auto.json');
   });
+
+  // The registry now passes MoveOutputSchema to executeAction (#1453), which
+  // prints the Zod-parsed data rather than the raw runMove result. Pin that
+  // the parse round-trips byte-identically for every target, so wiring the
+  // schema cannot change happy-path --json output.
+  it.each(['attention', 'waiting', 'shelved', 'auto'] as const)(
+    'schema validation preserves the serialized bytes for target=%s (#1453)',
+    async (target) => {
+      const result = await runMove({ prUrl: TEST_PR_URL, target });
+      expect(JSON.stringify(MoveOutputSchema.parse(result), null, 2)).toBe(JSON.stringify(result, null, 2));
+    },
+  );
 });


### PR DESCRIPTION
Fixes #1453.

`move` exported MoveOutputSchema and its contract test validated goldens against it, but the registry's executeAction call passed no schema — the runtime --json validation path could never fire for move. Now wired (override/clear-override turned out to already be wired; the audit premise was stale on those two — verified rather than re-wired).

Survey of the remaining schema-less commands documented as a policy block above executeAction: 27 runtime-validated commands vs the goldens-only tier (state, vet, vet-list, track, comments, shelve/unshelve, dismiss/undismiss, stats, startup, guidelines×5 — every one has a golden contract test + TS interface), with promotion instructions so the next addition is a conscious choice.

Tests: registry-path assertion that move --json routes through outputJsonValidated with the schema (identity check), display-mode counterpart, and byte-identity pins (`JSON.stringify(schema.parse(result))` equals raw) across all four move targets — goldens unchanged, happy-path bytes unaffected.

Gate: root eslint, prettier, typecheck, 2801 core + 235 mcp green.