### PR TITLE
feat(state): persist openedAt and firstMaintainerResponseAt on the PR outcome ledger (#1461)

### DIFF
--- a/packages/core/src/commands/daily-orchestration.test.ts
+++ b/packages/core/src/commands/daily-orchestration.test.ts
@@ -43,6 +43,8 @@ const mockGetStats = vi.fn();
 const mockGetIssueDismissedAt = vi.fn();
 const mockUndismissIssue = vi.fn();
 const mockGetStatusOverride = vi.fn();
+const mockAddMergedPRs = vi.fn(() => ({ added: 0, dropped: 0 }));
+const mockAddClosedPRs = vi.fn(() => ({ added: 0, dropped: 0 }));
 
 // daily.ts imports everything from '../core/index.js', so we mock the whole barrel export.
 // PRMonitor and IssueConversationMonitor are used as classes (new PRMonitor(...)),
@@ -83,6 +85,8 @@ vi.mock('../core/index.js', async (importOriginal) => {
       getIssueDismissedAt: mockGetIssueDismissedAt,
       undismissIssue: mockUndismissIssue,
       getStatusOverride: mockGetStatusOverride,
+      addMergedPRs: mockAddMergedPRs,
+      addClosedPRs: mockAddClosedPRs,
       getStateStaleness: vi.fn(() => null),
       getLoadRecovery: vi.fn(() => null),
       isGistMode: mockIsGistMode,
@@ -841,6 +845,85 @@ describe('executeDailyCheck() — error resilience', () => {
     );
     expect(zeroCalls).toHaveLength(0);
     consoleSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// executeDailyCheck() — outcome ledger persistence (#1461)
+// ---------------------------------------------------------------------------
+
+describe('executeDailyCheck() — outcome ledger (#1461)', () => {
+  const mergedPR = {
+    url: 'https://github.com/org/repo/pull/7',
+    repo: 'org/repo',
+    number: 7,
+    title: 'Merged PR',
+    mergedAt: '2026-01-24T12:00:00Z',
+    openedAt: '2026-01-10T00:00:00Z',
+  };
+  const closedPR = {
+    url: 'https://github.com/org/repo/pull/8',
+    repo: 'org/repo',
+    number: 8,
+    title: 'Closed PR',
+    closedAt: '2026-01-24T13:00:00Z',
+    openedAt: '2026-01-11T00:00:00Z',
+  };
+
+  it('persists openedAt from the recently-merged/closed fetch results', async () => {
+    mockFetchRecentlyMergedPRs.mockResolvedValue([mergedPR]);
+    mockFetchRecentlyClosedPRs.mockResolvedValue([closedPR]);
+
+    await executeDailyCheck('test-token');
+
+    expect(mockAddMergedPRs).toHaveBeenCalledWith([
+      expect.objectContaining({
+        url: mergedPR.url,
+        title: mergedPR.title,
+        mergedAt: mergedPR.mergedAt,
+        openedAt: '2026-01-10T00:00:00Z',
+      }),
+    ]);
+    expect(mockAddClosedPRs).toHaveBeenCalledWith([
+      expect.objectContaining({
+        url: closedPR.url,
+        title: closedPR.title,
+        closedAt: closedPR.closedAt,
+        openedAt: '2026-01-11T00:00:00Z',
+      }),
+    ]);
+  });
+
+  it('recovers firstMaintainerResponseAt from the previous persisted digest', async () => {
+    // The just-merged PR was open during the previous enriched run, so the
+    // persisted digest's openPRs entry carries its first maintainer response.
+    const previouslyOpen = makePR({
+      repo: 'org/repo',
+      number: 7,
+      url: mergedPR.url,
+      status: 'waiting_on_maintainer',
+      firstMaintainerResponseAt: '2026-01-12T09:00:00Z',
+    });
+    mockGetState.mockReturnValue(makeDefaultState({ lastDigest: makeDigest([previouslyOpen]) }));
+    mockFetchRecentlyMergedPRs.mockResolvedValue([mergedPR]);
+
+    await executeDailyCheck('test-token');
+
+    expect(mockAddMergedPRs).toHaveBeenCalledWith([
+      expect.objectContaining({
+        url: mergedPR.url,
+        firstMaintainerResponseAt: '2026-01-12T09:00:00Z',
+      }),
+    ]);
+  });
+
+  it('leaves firstMaintainerResponseAt undefined when the PR never appeared in a digest', async () => {
+    mockFetchRecentlyMergedPRs.mockResolvedValue([mergedPR]);
+
+    await executeDailyCheck('test-token');
+
+    const [persisted] = mockAddMergedPRs.mock.calls[0] as unknown as [Array<Record<string, unknown>>];
+    expect(persisted[0].firstMaintainerResponseAt).toBeUndefined();
   });
 });
 

--- a/packages/core/src/commands/daily.ts
+++ b/packages/core/src/commands/daily.ts
@@ -111,7 +111,7 @@ export {
 // reuse it without crossing the commands → sibling-command boundary
 // (#1208 M7). Re-exported here for backward compatibility with anyone
 // importing from this module.
-import { buildStarFilter } from '../core/daily-logic.js';
+import { buildStarFilter, firstMaintainerResponseFromDigest } from '../core/daily-logic.js';
 export { buildStarFilter };
 
 /**
@@ -845,6 +845,10 @@ async function executeDailyCheckInternal(token: string): Promise<DailyCheckResul
   // Phase 3: Persist monthly analytics and store merged/closed PR history.
   // try-catch: analytics are supplementary — save failure should not crash the daily check.
   try {
+    // Previous run's digest — read BEFORE Phase 4 overwrites it. If a
+    // just-merged/closed PR was open during a prior enriched run, its
+    // openPRs entry carries firstMaintainerResponseAt for the ledger (#1461).
+    const previousDigest = getStateManager().getState().lastDigest;
     getStateManager().batch(() => {
       const analyticsFailures = updateMonthlyAnalytics(
         prs,
@@ -863,15 +867,30 @@ async function executeDailyCheckInternal(token: string): Promise<DailyCheckResul
       // Store recently merged/closed PRs in the persistent arrays.
       // This ensures the mergedPRs/closedPRs ledger is populated even when
       // the dashboard is never opened (which has its own fetch path).
-      // addMergedPRs/addClosedPRs deduplicate by URL, so overlaps are safe.
+      // addMergedPRs/addClosedPRs deduplicate by URL (re-seen entries upgrade
+      // missing ledger fields in place), so overlaps are safe. openedAt comes
+      // free from the search result; firstMaintainerResponseAt is best-effort
+      // from the previous run's enriched digest — zero new API calls (#1461).
       if (recentlyMergedPRs.length > 0) {
         getStateManager().addMergedPRs(
-          recentlyMergedPRs.map((pr) => ({ url: pr.url, title: pr.title, mergedAt: pr.mergedAt })),
+          recentlyMergedPRs.map((pr) => ({
+            url: pr.url,
+            title: pr.title,
+            mergedAt: pr.mergedAt,
+            openedAt: pr.openedAt,
+            firstMaintainerResponseAt: firstMaintainerResponseFromDigest(previousDigest, pr.url),
+          })),
         );
       }
       if (recentlyClosedPRs.length > 0) {
         getStateManager().addClosedPRs(
-          recentlyClosedPRs.map((pr) => ({ url: pr.url, title: pr.title, closedAt: pr.closedAt })),
+          recentlyClosedPRs.map((pr) => ({
+            url: pr.url,
+            title: pr.title,
+            closedAt: pr.closedAt,
+            openedAt: pr.openedAt,
+            firstMaintainerResponseAt: firstMaintainerResponseFromDigest(previousDigest, pr.url),
+          })),
         );
       }
     });

--- a/packages/core/src/commands/dashboard-data.test.ts
+++ b/packages/core/src/commands/dashboard-data.test.ts
@@ -1240,6 +1240,67 @@ describe('fetchDashboardData', () => {
     expect(result.partialFailures).not.toContain('store merged PRs');
   });
 
+  // ── outcome ledger threading (#1461) ─────────────────────────────────
+
+  it('passes openedAt through to addMergedPRs/addClosedPRs (#1461)', async () => {
+    mockFetchMergedPRsSince.mockResolvedValue([
+      {
+        url: 'https://github.com/a/b/pull/1',
+        title: 'New merged',
+        mergedAt: '2026-01-10T00:00:00Z',
+        openedAt: '2026-01-01T00:00:00Z',
+      },
+    ]);
+    mockFetchClosedPRsSince.mockResolvedValue([
+      {
+        url: 'https://github.com/a/b/pull/2',
+        title: 'New closed',
+        closedAt: '2026-01-11T00:00:00Z',
+        openedAt: '2026-01-02T00:00:00Z',
+      },
+    ]);
+
+    await fetchDashboardData('test-token');
+
+    expect(mockAddMergedPRs).toHaveBeenCalledWith([
+      expect.objectContaining({ url: 'https://github.com/a/b/pull/1', openedAt: '2026-01-01T00:00:00Z' }),
+    ]);
+    expect(mockAddClosedPRs).toHaveBeenCalledWith([
+      expect.objectContaining({ url: 'https://github.com/a/b/pull/2', openedAt: '2026-01-02T00:00:00Z' }),
+    ]);
+  });
+
+  it('recovers firstMaintainerResponseAt from the previous persisted digest (#1461)', async () => {
+    const prUrl = 'https://github.com/a/b/pull/1';
+    const previouslyOpen = makeFetchedPR({
+      repo: 'a/b',
+      number: 1,
+      url: prUrl,
+      firstMaintainerResponseAt: '2026-01-03T09:00:00Z',
+    });
+    mockGetState.mockReturnValue(makeDefaultState({ lastDigest: makeMockDigest([previouslyOpen]) }));
+    mockFetchMergedPRsSince.mockResolvedValue([
+      { url: prUrl, title: 'New merged', mergedAt: '2026-01-10T00:00:00Z', openedAt: '2026-01-01T00:00:00Z' },
+    ]);
+
+    await fetchDashboardData('test-token');
+
+    expect(mockAddMergedPRs).toHaveBeenCalledWith([
+      expect.objectContaining({ url: prUrl, firstMaintainerResponseAt: '2026-01-03T09:00:00Z' }),
+    ]);
+  });
+
+  it('leaves firstMaintainerResponseAt undefined when the PR never appeared in a digest (#1461)', async () => {
+    mockFetchMergedPRsSince.mockResolvedValue([
+      { url: 'https://github.com/a/b/pull/1', title: 'New merged', mergedAt: '2026-01-10T00:00:00Z' },
+    ]);
+
+    await fetchDashboardData('test-token');
+
+    const [persisted] = mockAddMergedPRs.mock.calls[0] as unknown as [Array<Record<string, unknown>>];
+    expect(persisted[0].firstMaintainerResponseAt).toBeUndefined();
+  });
+
   // ── partialFailures surfacing (#1035) ────────────────────────────────
 
   it('returns empty partialFailures when all sub-fetches succeed', async () => {

--- a/packages/core/src/commands/dashboard-data.ts
+++ b/packages/core/src/commands/dashboard-data.ts
@@ -31,7 +31,7 @@ import {
   type RepoMetadataEntry,
 } from '../core/types.js';
 import type { ParseIssueListOutput } from '../formatters/json.js';
-import { toShelvedPRRef, buildStarFilter } from '../core/index.js';
+import { toShelvedPRRef, buildStarFilter, firstMaintainerResponseFromDigest } from '../core/index.js';
 
 const MODULE = 'dashboard-data';
 
@@ -398,9 +398,23 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
       // Per-PR override failures (#1448) land in partialFailures so the SPA
       // banner flags PRs silently showing their un-overridden status.
       const overriddenPRs = applyStatusOverrides(prs, stateManager.getState(), partialFailures);
-      // Store new merged PRs incrementally (dedupes by URL)
+
+      // Previous run's digest — read BEFORE setLastDigest below replaces it.
+      // Supplies best-effort firstMaintainerResponseAt for PRs that were
+      // enriched while open, mirroring daily's Phase 3 (#1461). openedAt is
+      // already on the entries (created_at from the search result).
+      const previousDigest = stateManager.getState().lastDigest;
+
+      // Store new merged PRs incrementally (dedupes by URL; re-seen entries
+      // upgrade missing ledger fields in place)
       try {
-        const { dropped } = stateManager.addMergedPRs(newMergedPRs);
+        const { dropped } = stateManager.addMergedPRs(
+          newMergedPRs.map((pr) => ({
+            ...pr,
+            firstMaintainerResponseAt:
+              pr.firstMaintainerResponseAt ?? firstMaintainerResponseFromDigest(previousDigest, pr.url),
+          })),
+        );
         if (dropped > 0) {
           partialFailures.push(`Dropped ${dropped} merged PR(s) with invalid URLs before persistence`);
         }
@@ -409,9 +423,16 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
         warn(MODULE, `Failed to store merged PRs: ${errorMessage(error)}`);
       }
 
-      // Store new closed PRs incrementally (dedupes by URL)
+      // Store new closed PRs incrementally (dedupes by URL; re-seen entries
+      // upgrade missing ledger fields in place)
       try {
-        const { dropped } = stateManager.addClosedPRs(newClosedPRs);
+        const { dropped } = stateManager.addClosedPRs(
+          newClosedPRs.map((pr) => ({
+            ...pr,
+            firstMaintainerResponseAt:
+              pr.firstMaintainerResponseAt ?? firstMaintainerResponseFromDigest(previousDigest, pr.url),
+          })),
+        );
         if (dropped > 0) {
           partialFailures.push(`Dropped ${dropped} closed PR(s) with invalid URLs before persistence`);
         }

--- a/packages/core/src/core/daily-logic.test.ts
+++ b/packages/core/src/core/daily-logic.test.ts
@@ -18,6 +18,7 @@ import {
   groupPRsByRepo,
   computeActionMenu,
   applyStatusOverrides,
+  firstMaintainerResponseFromDigest,
   CRITICAL_STATUSES,
   STALE_STATUSES,
 } from './daily-logic.js';
@@ -962,5 +963,38 @@ describe('applyStatusOverrides', () => {
     applyStatusOverrides(prs, state, failures);
 
     expect(failures).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// firstMaintainerResponseFromDigest (#1461)
+// ---------------------------------------------------------------------------
+
+describe('firstMaintainerResponseFromDigest (#1461)', () => {
+  const url = 'https://github.com/owner/repo/pull/1';
+
+  it('returns undefined when there is no previous digest', () => {
+    expect(firstMaintainerResponseFromDigest(undefined, url)).toBeUndefined();
+  });
+
+  it('returns undefined when the PR is not in the digest openPRs', () => {
+    const digest = { openPRs: [makePR({ repo: 'owner/repo', number: 2 })] };
+    expect(firstMaintainerResponseFromDigest(digest, url)).toBeUndefined();
+  });
+
+  it('returns undefined when the digest entry predates the field', () => {
+    const pr = makePR({ repo: 'owner/repo', number: 1, url });
+    delete pr.firstMaintainerResponseAt;
+    expect(firstMaintainerResponseFromDigest({ openPRs: [pr] }, url)).toBeUndefined();
+  });
+
+  it('returns the timestamp recorded while the PR was open', () => {
+    const pr = makePR({
+      repo: 'owner/repo',
+      number: 1,
+      url,
+      firstMaintainerResponseAt: '2025-06-03T00:00:00Z',
+    });
+    expect(firstMaintainerResponseFromDigest({ openPRs: [pr] }, url)).toBe('2025-06-03T00:00:00Z');
   });
 });

--- a/packages/core/src/core/daily-logic.ts
+++ b/packages/core/src/core/daily-logic.ts
@@ -192,6 +192,26 @@ export function buildStarFilter(state: Readonly<AgentState>): StarFilter | undef
 }
 
 /**
+ * Look up a just-merged/closed PR's `firstMaintainerResponseAt` from the
+ * previous run's persisted digest (#1461). At detection time the PR is no
+ * longer open, so it cannot be enriched without new API calls — but if it
+ * was open during a prior enriched run, the persisted digest's openPRs carry
+ * the timestamp. Best-effort: returns undefined when the PR never appeared
+ * in a persisted digest (e.g. opened and merged between runs, or the digest
+ * predates the field).
+ *
+ * Lives in core/daily-logic.ts so both ledger writers (daily Phase 3 and
+ * dashboard-data) share one lookup. Callers must read `state.lastDigest`
+ * BEFORE the current run overwrites it via setLastDigest.
+ */
+export function firstMaintainerResponseFromDigest(
+  digest: { openPRs: FetchedPR[] } | undefined,
+  url: string,
+): string | undefined {
+  return digest?.openPRs.find((pr) => pr.url === url)?.firstMaintainerResponseAt;
+}
+
+/**
  * Group PRs by repository (#80).
  * Ensures one agent per repo during parallel dispatch, preventing branch checkout conflicts.
  *

--- a/packages/core/src/core/github-stats.test.ts
+++ b/packages/core/src/core/github-stats.test.ts
@@ -416,6 +416,39 @@ describe('fetchMergedPRsSince', () => {
     expect(result).toHaveLength(1);
     expect(result[0].mergedAt).toBe('2025-06-15T12:00:00Z');
   });
+
+  it('should persist openedAt from the search result created_at (#1461)', async () => {
+    const items = [
+      {
+        html_url: 'https://github.com/org/repo/pull/1',
+        title: 'Ledger PR',
+        created_at: '2025-06-01T08:00:00Z',
+        pull_request: { merged_at: '2025-06-15T12:00:00Z' },
+        closed_at: '2025-06-15T12:00:00Z',
+      },
+    ];
+    const octokit = makeOctokit(items);
+
+    const result = await fetchMergedPRsSince(octokit, { githubUsername: 'testuser' });
+
+    expect(result[0].openedAt).toBe('2025-06-01T08:00:00Z');
+  });
+
+  it('should leave openedAt undefined when created_at is absent (#1461)', async () => {
+    const items = [
+      {
+        html_url: 'https://github.com/org/repo/pull/1',
+        title: 'Legacy-shaped item',
+        pull_request: { merged_at: '2025-06-15T12:00:00Z' },
+        closed_at: '2025-06-15T12:00:00Z',
+      },
+    ];
+    const octokit = makeOctokit(items);
+
+    const result = await fetchMergedPRsSince(octokit, { githubUsername: 'testuser' });
+
+    expect(result[0].openedAt).toBeUndefined();
+  });
 });
 
 describe('fetchClosedPRsSince', () => {
@@ -480,6 +513,22 @@ describe('fetchClosedPRsSince', () => {
     const query = octokit.search.issuesAndPullRequests.mock.calls[0][0].q;
     expect(query).toContain('closed:>2025-07-01T00:00:00Z');
   });
+
+  it('should persist openedAt from the search result created_at (#1461)', async () => {
+    const items = [
+      {
+        html_url: 'https://github.com/org/repo/pull/9',
+        title: 'Ledger closed PR',
+        created_at: '2025-06-20T08:00:00Z',
+        closed_at: '2025-07-01T10:00:00Z',
+      },
+    ];
+    const octokit = makeOctokit(items);
+
+    const result = await fetchClosedPRsSince(octokit, { githubUsername: 'testuser' });
+
+    expect(result[0].openedAt).toBe('2025-06-20T08:00:00Z');
+  });
 });
 
 describe('fetchRecentlyMergedPRs', () => {
@@ -516,6 +565,23 @@ describe('fetchRecentlyMergedPRs', () => {
     const result = await fetchRecentlyMergedPRs(octokit, { githubUsername: '' });
     expect(result).toEqual([]);
   });
+
+  it('should carry openedAt from the search result created_at (#1461)', async () => {
+    const items = [
+      {
+        html_url: 'https://github.com/org/repo/pull/7',
+        title: 'Recent merge',
+        created_at: '2025-06-01T08:00:00Z',
+        pull_request: { merged_at: '2025-06-15T12:00:00Z' },
+        closed_at: '2025-06-15T12:00:00Z',
+      },
+    ];
+    const octokit = makeOctokit(items);
+
+    const result = await fetchRecentlyMergedPRs(octokit, { githubUsername: 'testuser' }, 7);
+
+    expect(result[0].openedAt).toBe('2025-06-01T08:00:00Z');
+  });
 });
 
 describe('fetchRecentlyClosedPRs', () => {
@@ -544,6 +610,22 @@ describe('fetchRecentlyClosedPRs', () => {
     expect(result[0].repo).toBe('org/repo');
     expect(result[0].number).toBe(3);
     expect(result[0].closedAt).toBe('2025-07-01T10:00:00Z');
+  });
+
+  it('should carry openedAt from the search result created_at (#1461)', async () => {
+    const items = [
+      {
+        html_url: 'https://github.com/org/repo/pull/3',
+        title: 'Closed without merge',
+        created_at: '2025-06-20T08:00:00Z',
+        closed_at: '2025-07-01T10:00:00Z',
+      },
+    ];
+    const octokit = makeOctokit(items);
+
+    const result = await fetchRecentlyClosedPRs(octokit, { githubUsername: 'testuser' }, 7);
+
+    expect(result[0].openedAt).toBe('2025-06-20T08:00:00Z');
   });
 });
 

--- a/packages/core/src/core/github-stats.ts
+++ b/packages/core/src/core/github-stats.ts
@@ -267,7 +267,13 @@ async function fetchRecentPRs<T>(
   label: string,
   days: number,
   mapItem: (
-    item: { html_url: string; title: string; closed_at: string | null; pull_request?: { merged_at?: string | null } },
+    item: {
+      html_url: string;
+      title: string;
+      created_at?: string | null;
+      closed_at: string | null;
+      pull_request?: { merged_at?: string | null };
+    },
     parsed: { owner: string; repo: string; number: number },
   ) => T,
 ): Promise<T[]> {
@@ -330,6 +336,8 @@ export async function fetchRecentlyClosedPRs(
       number,
       title: item.title,
       closedAt: item.closed_at || '',
+      // Free on the search result — feeds the outcome ledger (#1461).
+      openedAt: item.created_at || undefined,
     }),
   );
 }
@@ -363,6 +371,8 @@ export async function fetchRecentlyMergedPRs(
         number,
         title: item.title,
         mergedAt: mergedAt || item.closed_at || '',
+        // Free on the search result — feeds the outcome ledger (#1461).
+        openedAt: item.created_at || undefined,
       };
     },
   );
@@ -392,6 +402,7 @@ interface PRFetchAdapter<T> {
 type SearchItemForPRs = {
   html_url: string;
   title: string;
+  created_at?: string | null;
   closed_at?: string | null;
   pull_request?: { merged_at?: string | null } | null;
 };
@@ -465,7 +476,7 @@ async function fetchPRsSince<T>(
 /**
  * Fetch merged PRs since a watermark date for incremental storage.
  * If no watermark is provided (first-ever fetch), fetches all merged PRs (up to pagination cap).
- * Returns StoredMergedPR[] (minimal: url, title, mergedAt) for state persistence.
+ * Returns StoredMergedPR[] (url, title, mergedAt, openedAt) for state persistence.
  */
 export async function fetchMergedPRsSince(
   octokit: Octokit,
@@ -480,7 +491,13 @@ export async function fetchMergedPRsSince(
       dateNoun: 'merge',
       buildQuery: (u, s) => `is:pr is:merged author:${u} -user:${u}${s ? ` merged:>${s}` : ''}`,
       extractDate: (item) => item.pull_request?.merged_at || item.closed_at || '',
-      buildRecord: (item, date) => ({ url: item.html_url, title: item.title, mergedAt: date }),
+      buildRecord: (item, date) => ({
+        url: item.html_url,
+        title: item.title,
+        mergedAt: date,
+        // Free on the search result — feeds the outcome ledger (#1461).
+        openedAt: item.created_at || undefined,
+      }),
     },
     since,
   );
@@ -489,7 +506,7 @@ export async function fetchMergedPRsSince(
 /**
  * Fetch closed-without-merge PRs since a watermark date for incremental storage.
  * If no watermark is provided (first-ever fetch), fetches all closed PRs (up to pagination cap).
- * Returns StoredClosedPR[] (minimal: url, title, closedAt) for state persistence.
+ * Returns StoredClosedPR[] (url, title, closedAt, openedAt) for state persistence.
  * Uses `is:unmerged` to exclude merged PRs (which are also "closed" in GitHub's model).
  */
 export async function fetchClosedPRsSince(
@@ -505,7 +522,13 @@ export async function fetchClosedPRsSince(
       dateNoun: 'close',
       buildQuery: (u, s) => `is:pr is:closed is:unmerged author:${u} -user:${u}${s ? ` closed:>${s}` : ''}`,
       extractDate: (item) => item.closed_at || '',
-      buildRecord: (item, date) => ({ url: item.html_url, title: item.title, closedAt: date }),
+      buildRecord: (item, date) => ({
+        url: item.html_url,
+        title: item.title,
+        closedAt: date,
+        // Free on the search result — feeds the outcome ledger (#1461).
+        openedAt: item.created_at || undefined,
+      }),
     },
     since,
   );

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -79,6 +79,7 @@ export {
   computeActionMenu,
   toShelvedPRRef,
   buildStarFilter,
+  firstMaintainerResponseFromDigest,
   formatActionHint,
   formatBriefSummary,
   formatSummary,

--- a/packages/core/src/core/pr-monitor.test.ts
+++ b/packages/core/src/core/pr-monitor.test.ts
@@ -2904,6 +2904,96 @@ describe('review comment fetch error handling (#229)', () => {
   });
 });
 
+describe('fetchPRDetails firstMaintainerResponseAt (#1461)', () => {
+  const prUrl = 'https://github.com/owner/repo/pull/1';
+
+  const makeMocks = (comments: Array<{ user: { login: string }; body: string; created_at: string }>) => ({
+    search: {
+      issuesAndPullRequests: vi.fn().mockResolvedValue({
+        data: {
+          total_count: 1,
+          items: [
+            {
+              html_url: prUrl,
+              title: 'Test PR',
+              pull_request: { html_url: prUrl },
+              created_at: '2026-02-01T00:00:00Z',
+              updated_at: '2026-02-07T00:00:00Z',
+            },
+          ],
+        },
+      }),
+    },
+    pulls: {
+      get: vi.fn().mockResolvedValue({
+        data: {
+          id: 1,
+          title: 'Test PR',
+          created_at: '2026-02-01T00:00:00Z',
+          updated_at: '2026-02-07T00:00:00Z',
+          head: { sha: 'abc123' },
+          mergeable: true,
+          mergeable_state: 'clean',
+          body: '',
+          draft: false,
+          review_comments: 0,
+          commits: 1,
+        },
+      }),
+      listReviews: vi.fn().mockResolvedValue({ data: [] }),
+      listReviewComments: vi.fn().mockResolvedValue({ data: [] }),
+    },
+    issues: {
+      listComments: vi.fn().mockResolvedValue({ data: comments }),
+    },
+    repos: {
+      getCombinedStatusForRef: vi.fn().mockResolvedValue({
+        data: { state: 'success', statuses: [] },
+      }),
+      getCommit: vi.fn().mockResolvedValue({
+        data: { commit: { author: { date: '2026-02-01T00:00:00Z' } }, author: { login: 'testuser' } },
+      }),
+    },
+    checks: {
+      listForRef: vi.fn().mockResolvedValue({ data: { check_runs: [] } }),
+    },
+  });
+
+  beforeEach(() => {
+    vi.mocked(getStateManager).mockReturnValue(
+      makeStateManagerMock({
+        config: { githubUsername: 'testuser', excludeRepos: [], excludeOrgs: [] },
+      }),
+    );
+  });
+
+  it('sets firstMaintainerResponseAt from the earliest maintainer comment', async () => {
+    mockOctokitInstance = makeMocks([
+      { user: { login: 'testuser' }, body: 'My PR', created_at: '2026-02-01T10:00:00Z' },
+      { user: { login: 'maintainer' }, body: 'Thanks, looking', created_at: '2026-02-02T09:00:00Z' },
+      { user: { login: 'maintainer' }, body: 'One more thing', created_at: '2026-02-03T09:00:00Z' },
+    ]);
+
+    const monitor = new PRMonitor('fake-token');
+    const { prs } = await monitor.fetchUserOpenPRs();
+
+    expect(prs).toHaveLength(1);
+    expect(prs[0].firstMaintainerResponseAt).toBe('2026-02-02T09:00:00Z');
+  });
+
+  it('leaves firstMaintainerResponseAt undefined when no maintainer has responded', async () => {
+    mockOctokitInstance = makeMocks([
+      { user: { login: 'testuser' }, body: 'My PR', created_at: '2026-02-01T10:00:00Z' },
+    ]);
+
+    const monitor = new PRMonitor('fake-token');
+    const { prs } = await monitor.fetchUserOpenPRs();
+
+    expect(prs).toHaveLength(1);
+    expect(prs[0].firstMaintainerResponseAt).toBeUndefined();
+  });
+});
+
 describe('commitDatePromise error handling (#469)', () => {
   const prUrl = 'https://github.com/owner/repo/pull/1';
 

--- a/packages/core/src/core/pr-monitor.ts
+++ b/packages/core/src/core/pr-monitor.ts
@@ -39,6 +39,7 @@ import {
   determineReviewDecision,
   getLatestChangesRequestedDate,
   checkUnrespondedComments,
+  getFirstMaintainerResponseAt,
 } from './review-analysis.js';
 import { analyzeChecklist } from './checklist-analysis.js';
 import { extractMaintainerActionHints } from './maintainer-analysis.js';
@@ -410,6 +411,11 @@ export class PRMonitor {
       config.githubUsername,
     );
 
+    // Earliest maintainer response, computed from the comment/review timeline
+    // already in memory (#1461). Rides into the persisted digest so the
+    // outcome ledger can recover it after the PR merges or closes.
+    const firstMaintainerResponseAt = getFirstMaintainerResponseAt(comments, reviews, config.githubUsername);
+
     // Fetch CI status and (conditionally) latest commit date in parallel
     // We need the commit date when hasUnrespondedComment is true (to distinguish
     // "needs_response" from "waiting_on_maintainer") OR when reviewDecision is "changes_requested"
@@ -506,6 +512,7 @@ export class PRMonitor {
       actionReasons,
       createdAt: ghPR.created_at,
       updatedAt: ghPR.updated_at,
+      firstMaintainerResponseAt,
       daysSinceActivity,
       ciStatus,
       failingCheckNames,

--- a/packages/core/src/core/review-analysis.test.ts
+++ b/packages/core/src/core/review-analysis.test.ts
@@ -10,7 +10,53 @@ import {
   getInlineCommentBody,
   reviewHasInlineComments,
   checkUnrespondedComments,
+  getFirstMaintainerResponseAt,
 } from './review-analysis.js';
+
+describe('getFirstMaintainerResponseAt (#1461)', () => {
+  it('returns undefined when there are no comments or reviews', () => {
+    expect(getFirstMaintainerResponseAt([], [], 'contributor')).toBeUndefined();
+  });
+
+  it('returns undefined when the only activity is from the contributor', () => {
+    const comments = [{ user: { login: 'contributor' }, created_at: '2025-06-02T00:00:00Z' }];
+    expect(getFirstMaintainerResponseAt(comments, [], 'contributor')).toBeUndefined();
+  });
+
+  it('returns the earliest maintainer comment timestamp', () => {
+    const comments = [
+      { user: { login: 'contributor' }, created_at: '2025-06-01T00:00:00Z' },
+      { user: { login: 'maintainer' }, created_at: '2025-06-03T00:00:00Z' },
+      { user: { login: 'maintainer' }, created_at: '2025-06-02T00:00:00Z' },
+    ];
+    expect(getFirstMaintainerResponseAt(comments, [], 'contributor')).toBe('2025-06-02T00:00:00Z');
+  });
+
+  it('considers reviews and picks the earliest across comments and reviews', () => {
+    const comments = [{ user: { login: 'maintainer' }, created_at: '2025-06-05T00:00:00Z' }];
+    const reviews = [{ user: { login: 'reviewer' }, submitted_at: '2025-06-04T00:00:00Z' }];
+    expect(getFirstMaintainerResponseAt(comments, reviews, 'contributor')).toBe('2025-06-04T00:00:00Z');
+  });
+
+  it('skips bot authors', () => {
+    const comments = [
+      { user: { login: 'codecov[bot]' }, created_at: '2025-06-01T00:00:00Z' },
+      { user: { login: 'maintainer' }, created_at: '2025-06-03T00:00:00Z' },
+    ];
+    expect(getFirstMaintainerResponseAt(comments, [], 'contributor')).toBe('2025-06-03T00:00:00Z');
+  });
+
+  it('skips entries with missing authors or timestamps', () => {
+    const comments = [{ user: null, created_at: '2025-06-01T00:00:00Z' }];
+    const reviews = [{ user: { login: 'reviewer' }, submitted_at: null }];
+    expect(getFirstMaintainerResponseAt(comments, reviews, 'contributor')).toBeUndefined();
+  });
+
+  it('matches the contributor username case-insensitively', () => {
+    const comments = [{ user: { login: 'Contributor' }, created_at: '2025-06-01T00:00:00Z' }];
+    expect(getFirstMaintainerResponseAt(comments, [], 'contributor')).toBeUndefined();
+  });
+});
 
 describe('determineReviewDecision', () => {
   it('should return review_required when no reviews exist', () => {

--- a/packages/core/src/core/review-analysis.ts
+++ b/packages/core/src/core/review-analysis.ts
@@ -123,6 +123,34 @@ export function reviewHasInlineComments(reviewId: number, reviewComments: Review
 }
 
 /**
+ * Earliest maintainer response timestamp across issue comments and submitted
+ * reviews (#1461). A "response" is any comment or review by a non-bot
+ * account other than the contributor — acknowledgments and approvals count,
+ * since for latency purposes any human maintainer reply is a response.
+ * Computed from data fetchPRDetails already holds in memory (zero extra API
+ * calls). Returns undefined when no maintainer has responded yet.
+ */
+export function getFirstMaintainerResponseAt(
+  comments: Array<{ user?: { login?: string } | null; created_at: string }>,
+  reviews: Array<{ user?: { login?: string } | null; submitted_at?: string | null }>,
+  username: string,
+): string | undefined {
+  const usernameLower = username.toLowerCase();
+  let earliest: string | undefined;
+  const consider = (author: string | undefined | null, createdAt: string | undefined | null) => {
+    if (!author || !createdAt) return;
+    if (author.toLowerCase() === usernameLower) return;
+    if (isBotAuthor(author)) return;
+    if (!earliest || new Date(createdAt).getTime() < new Date(earliest).getTime()) {
+      earliest = createdAt;
+    }
+  };
+  for (const comment of comments) consider(comment.user?.login, comment.created_at);
+  for (const review of reviews) consider(review.user?.login, review.submitted_at);
+  return earliest;
+}
+
+/**
  * Check if there are unresponded comments from maintainers.
  * Combines issue comments and review comments into a timeline,
  * then finds maintainer comments after the user's last comment.

--- a/packages/core/src/core/state-schema.test.ts
+++ b/packages/core/src/core/state-schema.test.ts
@@ -7,6 +7,8 @@ import {
   AgentStateSchema,
   AgentConfigSchema,
   FetchedPRSchema,
+  MergedPRSchema,
+  ClosedPRSchema,
   ShelvedPRRefSchema,
   RepoScoreSchema,
   TrackedIssueSchema,
@@ -154,6 +156,69 @@ describe('AgentStateSchema', () => {
         ],
       });
       expect(result.closedPRs![0].learningsExtractedAt).toBe('2025-02-01T00:00:00Z');
+    });
+
+    it('should accept legacy StoredMergedPR/StoredClosedPR entries without ledger fields (#1461)', () => {
+      const result = AgentStateSchema.parse({
+        version: 4,
+        mergedPRs: [{ url: 'https://github.com/o/r/pull/1', title: 'Fix bug', mergedAt: '2025-01-01' }],
+        closedPRs: [{ url: 'https://github.com/o/r/pull/2', title: 'Try fix', closedAt: '2025-01-01' }],
+      });
+      expect(result.mergedPRs![0].openedAt).toBeUndefined();
+      expect(result.mergedPRs![0].firstMaintainerResponseAt).toBeUndefined();
+      expect(result.closedPRs![0].openedAt).toBeUndefined();
+      expect(result.closedPRs![0].firstMaintainerResponseAt).toBeUndefined();
+    });
+
+    it('should accept StoredMergedPR with openedAt and firstMaintainerResponseAt (#1461)', () => {
+      const result = AgentStateSchema.parse({
+        version: 4,
+        mergedPRs: [
+          {
+            url: 'https://github.com/o/r/pull/1',
+            title: 'Fix bug',
+            mergedAt: '2025-01-10T00:00:00Z',
+            openedAt: '2025-01-01T00:00:00Z',
+            firstMaintainerResponseAt: '2025-01-03T00:00:00Z',
+          },
+        ],
+      });
+      expect(result.mergedPRs![0].openedAt).toBe('2025-01-01T00:00:00Z');
+      expect(result.mergedPRs![0].firstMaintainerResponseAt).toBe('2025-01-03T00:00:00Z');
+    });
+
+    it('should accept StoredClosedPR with openedAt and firstMaintainerResponseAt (#1461)', () => {
+      const result = AgentStateSchema.parse({
+        version: 4,
+        closedPRs: [
+          {
+            url: 'https://github.com/o/r/pull/2',
+            title: 'Try fix',
+            closedAt: '2025-01-10T00:00:00Z',
+            openedAt: '2025-01-01T00:00:00Z',
+            firstMaintainerResponseAt: '2025-01-03T00:00:00Z',
+          },
+        ],
+      });
+      expect(result.closedPRs![0].openedAt).toBe('2025-01-01T00:00:00Z');
+      expect(result.closedPRs![0].firstMaintainerResponseAt).toBe('2025-01-03T00:00:00Z');
+    });
+
+    it('should accept digest MergedPR/ClosedPR entries with and without openedAt (#1461)', () => {
+      const base = {
+        url: 'https://github.com/o/r/pull/3',
+        repo: 'o/r',
+        number: 3,
+        title: 'Feat',
+      };
+      expect(MergedPRSchema.parse({ ...base, mergedAt: '2025-01-10' }).openedAt).toBeUndefined();
+      expect(MergedPRSchema.parse({ ...base, mergedAt: '2025-01-10', openedAt: '2025-01-01' }).openedAt).toBe(
+        '2025-01-01',
+      );
+      expect(ClosedPRSchema.parse({ ...base, closedAt: '2025-01-10' }).openedAt).toBeUndefined();
+      expect(ClosedPRSchema.parse({ ...base, closedAt: '2025-01-10', openedAt: '2025-01-01' }).openedAt).toBe(
+        '2025-01-01',
+      );
     });
 
     it('should accept analyzedIssueConversations', () => {

--- a/packages/core/src/core/state-schema.ts
+++ b/packages/core/src/core/state-schema.ts
@@ -62,7 +62,7 @@ export const StoredMergedPRSchema = z.object({
    */
   openedAt: z.string().optional(),
   /**
-   * Earliest maintainer (non-bot, non-contributor) comment or review on the
+   * Earliest maintainer (non-bot, non-author) comment or review on the
    * PR (#1461). Best-effort: only derivable when the PR was enriched while
    * open (looked up from the previous run's persisted digest at detection
    * time), so it is absent for PRs that merged before ever appearing in an

--- a/packages/core/src/core/state-schema.ts
+++ b/packages/core/src/core/state-schema.ts
@@ -55,6 +55,20 @@ export const StoredMergedPRSchema = z.object({
   url: z.string(),
   title: z.string(),
   mergedAt: z.string(),
+  /**
+   * When the PR was opened (#1461). Optional: entries persisted before the
+   * outcome ledger existed don't carry it. Sourced from the Search API's
+   * `created_at` at merge-detection time — zero extra API calls.
+   */
+  openedAt: z.string().optional(),
+  /**
+   * Earliest maintainer (non-bot, non-contributor) comment or review on the
+   * PR (#1461). Best-effort: only derivable when the PR was enriched while
+   * open (looked up from the previous run's persisted digest at detection
+   * time), so it is absent for PRs that merged before ever appearing in an
+   * enriched run.
+   */
+  firstMaintainerResponseAt: z.string().optional(),
   /** When the raw review-comment bundle for this PR was last fetched (#867). */
   // ISO-8601 datetime guards against `markPRCommentsFetched(url, "garbage")`
   // poisoning state through the stamping API (#1209 L4).
@@ -67,6 +81,13 @@ export const StoredClosedPRSchema = z.object({
   url: z.string(),
   title: z.string(),
   closedAt: z.string(),
+  /** When the PR was opened (#1461). See StoredMergedPRSchema.openedAt. */
+  openedAt: z.string().optional(),
+  /**
+   * Earliest maintainer response (#1461). See
+   * StoredMergedPRSchema.firstMaintainerResponseAt.
+   */
+  firstMaintainerResponseAt: z.string().optional(),
   /** When the raw review-comment bundle for this PR was last fetched (#867). */
   // ISO-8601 datetime guards against `markPRCommentsFetched(url, "garbage")`
   // poisoning state through the stamping API (#1209 L4).
@@ -316,6 +337,12 @@ export const ClosedPRSchema = z.object({
   title: z.string(),
   closedAt: z.string(),
   closedBy: z.string().optional(),
+  /**
+   * When the PR was opened (#1461). Carried from the Search API's
+   * `created_at` so close detection can persist it into the outcome ledger.
+   * Optional: digests persisted by older producers don't have it.
+   */
+  openedAt: z.string().optional(),
 });
 
 export const MergedPRSchema = z.object({
@@ -324,6 +351,12 @@ export const MergedPRSchema = z.object({
   number: z.number(),
   title: z.string(),
   mergedAt: z.string(),
+  /**
+   * When the PR was opened (#1461). Carried from the Search API's
+   * `created_at` so merge detection can persist it into the outcome ledger.
+   * Optional: digests persisted by older producers don't have it.
+   */
+  openedAt: z.string().optional(),
 });
 
 export const DailyDigestSummarySchema = z.object({

--- a/packages/core/src/core/state.test.ts
+++ b/packages/core/src/core/state.test.ts
@@ -758,6 +758,66 @@ describe('StateManager merged PRs', () => {
       stateManager.addMergedPRs([pr]);
       expect(stateManager.addMergedPRs([pr])).toEqual({ added: 0, dropped: 0 });
     });
+
+    it('upgrades a stored minimal entry with ledger fields when re-seen richer (#1461)', () => {
+      const minimal = { url: 'https://github.com/a/b/pull/1', title: 'PR 1', mergedAt: '2025-06-10T00:00:00Z' };
+      stateManager.addMergedPRs([minimal]);
+
+      const saveSpy = vi.spyOn(stateManager, 'save');
+      const result = stateManager.addMergedPRs([
+        {
+          ...minimal,
+          openedAt: '2025-06-01T00:00:00Z',
+          firstMaintainerResponseAt: '2025-06-03T00:00:00Z',
+        },
+      ]);
+
+      expect(result).toEqual({ added: 0, dropped: 0 });
+      // Upgrade mutates state, so it must persist even with zero new entries
+      expect(saveSpy).toHaveBeenCalled();
+      saveSpy.mockRestore();
+
+      const stored = stateManager.getMergedPRs();
+      expect(stored).toHaveLength(1);
+      expect(stored[0].openedAt).toBe('2025-06-01T00:00:00Z');
+      expect(stored[0].firstMaintainerResponseAt).toBe('2025-06-03T00:00:00Z');
+    });
+
+    it('never overwrites existing ledger fields on a re-seen entry (#1461)', () => {
+      const enriched = {
+        url: 'https://github.com/a/b/pull/1',
+        title: 'PR 1',
+        mergedAt: '2025-06-10T00:00:00Z',
+        openedAt: '2025-06-01T00:00:00Z',
+        firstMaintainerResponseAt: '2025-06-03T00:00:00Z',
+      };
+      stateManager.addMergedPRs([enriched]);
+
+      stateManager.addMergedPRs([
+        {
+          ...enriched,
+          openedAt: '2024-01-01T00:00:00Z',
+          firstMaintainerResponseAt: '2024-01-02T00:00:00Z',
+        },
+      ]);
+
+      const stored = stateManager.getMergedPRs();
+      expect(stored[0].openedAt).toBe('2025-06-01T00:00:00Z');
+      expect(stored[0].firstMaintainerResponseAt).toBe('2025-06-03T00:00:00Z');
+    });
+
+    it('deduplicates by URL within a single input batch (#1461)', () => {
+      const pr = { url: 'https://github.com/a/b/pull/1', title: 'PR 1', mergedAt: '2025-06-10T00:00:00Z' };
+      const richer = { ...pr, openedAt: '2025-06-01T00:00:00Z' };
+
+      const result = stateManager.addMergedPRs([pr, richer]);
+
+      expect(result).toEqual({ added: 1, dropped: 0 });
+      const stored = stateManager.getMergedPRs();
+      expect(stored).toHaveLength(1);
+      // The duplicate in the same batch upgraded the first occurrence
+      expect(stored[0].openedAt).toBe('2025-06-01T00:00:00Z');
+    });
   });
 
   describe('getMergedPRWatermark', () => {
@@ -855,6 +915,44 @@ describe('StateManager merged PRs', () => {
       stateManager.addClosedPRs([pr]);
 
       expect(stateManager.getClosedPRs()).toHaveLength(1);
+    });
+
+    it('upgrades a stored minimal entry with ledger fields when re-seen richer (#1461)', () => {
+      const minimal = { url: 'https://github.com/a/b/pull/1', title: 'PR 1', closedAt: '2025-06-10T00:00:00Z' };
+      stateManager.addClosedPRs([minimal]);
+
+      const result = stateManager.addClosedPRs([
+        {
+          ...minimal,
+          openedAt: '2025-06-01T00:00:00Z',
+          firstMaintainerResponseAt: '2025-06-03T00:00:00Z',
+        },
+      ]);
+
+      expect(result).toEqual({ added: 0, dropped: 0 });
+      const stored = stateManager.getClosedPRs();
+      expect(stored).toHaveLength(1);
+      expect(stored[0].openedAt).toBe('2025-06-01T00:00:00Z');
+      expect(stored[0].firstMaintainerResponseAt).toBe('2025-06-03T00:00:00Z');
+    });
+
+    it('never overwrites existing ledger fields on a re-seen entry (#1461)', () => {
+      const enriched = {
+        url: 'https://github.com/a/b/pull/1',
+        title: 'PR 1',
+        closedAt: '2025-06-10T00:00:00Z',
+        openedAt: '2025-06-01T00:00:00Z',
+        firstMaintainerResponseAt: '2025-06-03T00:00:00Z',
+      };
+      stateManager.addClosedPRs([enriched]);
+
+      stateManager.addClosedPRs([
+        { ...enriched, openedAt: '2024-01-01T00:00:00Z', firstMaintainerResponseAt: '2024-01-02T00:00:00Z' },
+      ]);
+
+      const stored = stateManager.getClosedPRs();
+      expect(stored[0].openedAt).toBe('2025-06-01T00:00:00Z');
+      expect(stored[0].firstMaintainerResponseAt).toBe('2025-06-03T00:00:00Z');
     });
 
     it('drops entries with invalid URLs and reports the count (#1120)', () => {

--- a/packages/core/src/core/state.ts
+++ b/packages/core/src/core/state.ts
@@ -64,6 +64,29 @@ function filterValidUrlEntries<T extends { url: string }>(
 }
 
 /**
+ * Fill outcome-ledger timestamps (#1461) missing on an existing stored PR
+ * from a richer re-seen entry. Only fills absent fields — never overwrites —
+ * so an earlier enriched write (and stamps like commentsFetchedAt that live
+ * solely on the stored entry) cannot be clobbered by a later minimal one.
+ * @returns true when at least one field was filled
+ */
+function upgradeLedgerFields(
+  existing: { openedAt?: string; firstMaintainerResponseAt?: string },
+  incoming: { openedAt?: string; firstMaintainerResponseAt?: string },
+): boolean {
+  let changed = false;
+  if (incoming.openedAt && !existing.openedAt) {
+    existing.openedAt = incoming.openedAt;
+    changed = true;
+  }
+  if (incoming.firstMaintainerResponseAt && !existing.firstMaintainerResponseAt) {
+    existing.firstMaintainerResponseAt = incoming.firstMaintainerResponseAt;
+    changed = true;
+  }
+  return changed;
+}
+
+/**
  * Push state to the backing Gist when Gist mode is active. Best-effort:
  * network/auth failures are logged via `warn()` but never propagated —
  * the caller's primary mutation has already succeeded locally and the
@@ -582,7 +605,15 @@ export class StateManager {
    * Entries with URLs that fail {@link parseGitHubUrl} are dropped before
    * persistence (read-side filters in dashboard-data already skip them, but
    * this prevents the bad data from reaching disk in the first place).
-   * @param prs - Merged PRs to add (duplicates by URL are ignored)
+   *
+   * Re-seen URLs are not re-added, but upgrade the stored entry in place
+   * (#1461): outcome-ledger fields (`openedAt`, `firstMaintainerResponseAt`)
+   * missing on the stored entry are filled from the richer incoming one.
+   * Existing values are never overwritten, so stamps that live only on the
+   * stored entry (commentsFetchedAt, learningsExtractedAt) and earlier
+   * enriched writes stay intact.
+   *
+   * @param prs - Merged PRs to add (duplicates by URL upgrade in place)
    * @returns count of entries added vs. dropped (invalid URL)
    */
   addMergedPRs(prs: StoredMergedPR[]): { added: number; dropped: number } {
@@ -590,9 +621,19 @@ export class StateManager {
     const { valid, dropped } = filterValidUrlEntries(prs, 'merged');
     if (valid.length === 0) return { added: 0, dropped };
     if (!this.state.mergedPRs) this.state.mergedPRs = [];
-    const existingUrls = new Set(this.state.mergedPRs.map((pr) => pr.url));
-    const newPRs = valid.filter((pr) => !existingUrls.has(pr.url));
-    if (newPRs.length === 0) return { added: 0, dropped };
+    const byUrl = new Map(this.state.mergedPRs.map((pr) => [pr.url, pr]));
+    const newPRs: StoredMergedPR[] = [];
+    let upgraded = false;
+    for (const pr of valid) {
+      const existing = byUrl.get(pr.url);
+      if (existing) {
+        upgraded = upgradeLedgerFields(existing, pr) || upgraded;
+      } else {
+        newPRs.push(pr);
+        byUrl.set(pr.url, pr);
+      }
+    }
+    if (newPRs.length === 0 && !upgraded) return { added: 0, dropped };
     this.state.mergedPRs.push(...newPRs);
     this.state.mergedPRs.sort((a, b) => b.mergedAt.localeCompare(a.mergedAt));
     debug(MODULE, `Added ${newPRs.length} merged PRs (total: ${this.state.mergedPRs.length})`);
@@ -617,7 +658,11 @@ export class StateManager {
    * Entries with URLs that fail {@link parseGitHubUrl} are dropped before
    * persistence (read-side filters in dashboard-data already skip them, but
    * this prevents the bad data from reaching disk in the first place).
-   * @param prs - Closed PRs to add (duplicates by URL are ignored)
+   *
+   * Re-seen URLs upgrade the stored entry's missing ledger fields in place
+   * (#1461) — see {@link addMergedPRs} for the full semantics.
+   *
+   * @param prs - Closed PRs to add (duplicates by URL upgrade in place)
    * @returns count of entries added vs. dropped (invalid URL)
    */
   addClosedPRs(prs: StoredClosedPR[]): { added: number; dropped: number } {
@@ -625,9 +670,19 @@ export class StateManager {
     const { valid, dropped } = filterValidUrlEntries(prs, 'closed');
     if (valid.length === 0) return { added: 0, dropped };
     if (!this.state.closedPRs) this.state.closedPRs = [];
-    const existingUrls = new Set(this.state.closedPRs.map((pr) => pr.url));
-    const newPRs = valid.filter((pr) => !existingUrls.has(pr.url));
-    if (newPRs.length === 0) return { added: 0, dropped };
+    const byUrl = new Map(this.state.closedPRs.map((pr) => [pr.url, pr]));
+    const newPRs: StoredClosedPR[] = [];
+    let upgraded = false;
+    for (const pr of valid) {
+      const existing = byUrl.get(pr.url);
+      if (existing) {
+        upgraded = upgradeLedgerFields(existing, pr) || upgraded;
+      } else {
+        newPRs.push(pr);
+        byUrl.set(pr.url, pr);
+      }
+    }
+    if (newPRs.length === 0 && !upgraded) return { added: 0, dropped };
     this.state.closedPRs.push(...newPRs);
     this.state.closedPRs.sort((a, b) => b.closedAt.localeCompare(a.closedAt));
     debug(MODULE, `Added ${newPRs.length} closed PRs (total: ${this.state.closedPRs.length})`);

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -237,6 +237,15 @@ export interface FetchedPR {
   createdAt: string;
   updatedAt: string;
 
+  /**
+   * Earliest maintainer (non-bot, non-contributor) comment or review on this
+   * PR (#1461). Computed by fetchPRDetails from the comment/review timeline
+   * it already fetches. Persisted with the digest's openPRs so merge/close
+   * detection can recover it for the outcome ledger after the PR leaves the
+   * open set. Undefined when no maintainer has responded yet.
+   */
+  firstMaintainerResponseAt?: string;
+
   /** Calendar days since the most recent activity (comment, commit, review). */
   daysSinceActivity: number;
 


### PR DESCRIPTION
Fixes #1461 — the audit's top build-next: the data foundation for maintainer-latency analytics, time-to-merge, funnel conversion, and latency-aware dormant cadence.

## What's persisted, honestly

| Write site | openedAt | firstMaintainerResponseAt |
|---|---|---|
| daily Phase 3 | free — the search items carry created_at; the old typed subset dropped it | recovered from the PREVIOUS lastDigest (read before Phase 4 overwrites): fetchPRDetails now computes it from the comments+reviews timeline already in memory and it rides the persisted raw digest |
| dashboard-data | same | same |

Zero new API calls. "First response" = earliest non-bot, non-author comment or submitted review. The field is genuinely unavailable for PRs that open and merge between runs, and has a one-run warm-up after deploy — both documented, fields optional.

## Semantics

addMergedPRs/addClosedPRs upgrade-on-richer-rewrite: re-seen URLs fill MISSING ledger fields in place, never overwrite (protects the commentsFetchedAt/learningsExtractedAt stamps); within-batch duplicate URLs now collapse instead of double-storing (strictly a fix). Old state loads unchanged.

Reviewer-verified: Phase 3 read precedes Phase 4 overwrite at both writers; the #1445 raw-digest contract carries the new field; fenceFetchedPR spreads (no loss); URL-in-both-lists cannot cross-mangle (separate arrays); typecheck across all three packages confirms no field-by-field consumer drops it.

21 new tests. Gate: root eslint, prettier, typecheck, 2878 core + 235 mcp green. code-reviewer pass: CLEAN.

Follow-ups this unlocks (not included): median first-response/time-to-merge per repo, funnel analytics, per-repo dormant thresholds (#1462's cadence), real responsiveness scoring.