### PR TITLE
feat(config): surface avoidRepos and boostIssueTypes; thread bias into features (#1464)

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ Configuration is stored in `~/.oss-autopilot/state.json` (inside the `config` fi
 | `squashByDefault` | `true` | Squash commits before merging (`true`, `false`, or `"ask"`) |
 | `excludeRepos` | `[]` | Repos to exclude from all tracking |
 | `excludeOrgs` | `[]` | Orgs to exclude from all tracking (e.g., private work orgs) |
+| `avoidRepos` | `[]` | Repos to softly downrank in discovery (milder than `excludeRepos`) |
+| `boostIssueTypes` | `[]` | Issue label types to softly boost in discovery ranking (e.g., `bug`) |
 | `includeDocIssues` | `true` | Include documentation issues in discovery |
 | `issueListPath` | (optional) | Path to curated issue list file |
 | `projectCategories` | `[]` | Project categories to prioritize (nonprofit, devtools, etc.) |

--- a/packages/core/src/commands/config.test.ts
+++ b/packages/core/src/commands/config.test.ts
@@ -170,6 +170,84 @@ describe('runConfig', () => {
     expect(mockUpdateConfig).not.toHaveBeenCalled();
   });
 
+  it('should add an avoid-repo with valid format (#1464)', async () => {
+    await runConfig({ key: 'add-avoid-repo', value: 'owner/repo' });
+
+    expect(mockUpdateConfig).toHaveBeenCalledWith({ avoidRepos: ['owner/repo'] });
+    // Soft penalty, not a hard exclusion — tracked data must stay intact.
+    expect(mockCleanupExcludedData).not.toHaveBeenCalled();
+  });
+
+  it('should throw error for invalid repo format in add-avoid-repo (#1464)', async () => {
+    await expect(runConfig({ key: 'add-avoid-repo', value: 'invalid' })).rejects.toThrow('Invalid repo format');
+  });
+
+  it('should not add duplicate avoid-repo (case-insensitive) (#1464)', async () => {
+    mockGetStateManager.mockReturnValue({
+      getState: vi.fn().mockReturnValue({ config: { ...DEFAULT_CONFIG, avoidRepos: ['Owner/Repo'] } }),
+      updateConfig: mockUpdateConfig,
+      cleanupExcludedData: mockCleanupExcludedData,
+      batch: (fn: () => void) => fn(),
+    } as any);
+
+    await runConfig({ key: 'add-avoid-repo', value: 'owner/repo' });
+
+    expect(mockUpdateConfig).not.toHaveBeenCalled();
+  });
+
+  it('should remove an avoid-repo case-insensitively (#1464)', async () => {
+    mockGetStateManager.mockReturnValue({
+      getState: vi.fn().mockReturnValue({ config: { ...DEFAULT_CONFIG, avoidRepos: ['Owner/Repo', 'other/repo'] } }),
+      updateConfig: mockUpdateConfig,
+      cleanupExcludedData: mockCleanupExcludedData,
+      batch: (fn: () => void) => fn(),
+    } as any);
+
+    await runConfig({ key: 'remove-avoid-repo', value: 'owner/repo' });
+
+    expect(mockUpdateConfig).toHaveBeenCalledWith({ avoidRepos: ['other/repo'] });
+  });
+
+  it('should throw when removing an avoid-repo that is not on the list (#1464)', async () => {
+    await expect(runConfig({ key: 'remove-avoid-repo', value: 'owner/repo' })).rejects.toThrow('not on the avoid list');
+  });
+
+  it('should add a boost issue type (#1464)', async () => {
+    await runConfig({ key: 'add-boost-issue-type', value: 'good first issue' });
+
+    expect(mockUpdateConfig).toHaveBeenCalledWith({ boostIssueTypes: ['good first issue'] });
+  });
+
+  it('should not add duplicate boost issue type (case-insensitive) (#1464)', async () => {
+    mockGetStateManager.mockReturnValue({
+      getState: vi.fn().mockReturnValue({ config: { ...DEFAULT_CONFIG, boostIssueTypes: ['Bug'] } }),
+      updateConfig: mockUpdateConfig,
+      cleanupExcludedData: mockCleanupExcludedData,
+      batch: (fn: () => void) => fn(),
+    } as any);
+
+    await runConfig({ key: 'add-boost-issue-type', value: 'bug' });
+
+    expect(mockUpdateConfig).not.toHaveBeenCalled();
+  });
+
+  it('should remove a boost issue type case-insensitively (#1464)', async () => {
+    mockGetStateManager.mockReturnValue({
+      getState: vi.fn().mockReturnValue({ config: { ...DEFAULT_CONFIG, boostIssueTypes: ['Bug', 'enhancement'] } }),
+      updateConfig: mockUpdateConfig,
+      cleanupExcludedData: mockCleanupExcludedData,
+      batch: (fn: () => void) => fn(),
+    } as any);
+
+    await runConfig({ key: 'remove-boost-issue-type', value: 'bug' });
+
+    expect(mockUpdateConfig).toHaveBeenCalledWith({ boostIssueTypes: ['enhancement'] });
+  });
+
+  it('should throw when removing a boost issue type that is not on the list (#1464)', async () => {
+    await expect(runConfig({ key: 'remove-boost-issue-type', value: 'bug' })).rejects.toThrow('not on the boost list');
+  });
+
   it('should remove a label', async () => {
     await runConfig({ key: 'remove-label', value: 'good first issue' });
 

--- a/packages/core/src/commands/config.ts
+++ b/packages/core/src/commands/config.ts
@@ -149,6 +149,53 @@ export async function runConfig(options: ConfigOptions): Promise<ConfigCommandOu
       }
       break;
     }
+    case 'add-avoid-repo': {
+      // Same owner/repo shape as exclude-repo, but no cleanupExcludedData
+      // call: avoidRepos is a soft ranking penalty, not a hard exclusion,
+      // so tracked data for the repo stays intact (#1464).
+      const parts = value.split('/');
+      if (parts.length !== 2 || !parts[0] || !parts[1]) {
+        throw new Error(`Invalid repo format "${value}". Use "owner/repo" format.`);
+      }
+      const currentAvoid = currentConfig.avoidRepos ?? [];
+      const valueLower = value.toLowerCase();
+      if (!currentAvoid.some((r) => r.toLowerCase() === valueLower)) {
+        stateManager.updateConfig({ avoidRepos: [...currentAvoid, value] });
+      }
+      break;
+    }
+    case 'remove-avoid-repo': {
+      const currentAvoid = currentConfig.avoidRepos ?? [];
+      const valueLower = value.toLowerCase();
+      if (!currentAvoid.some((r) => r.toLowerCase() === valueLower)) {
+        throw new Error(
+          `Repo "${value}" is not on the avoid list. Current avoid list: ${currentAvoid.join(', ') || '(empty)'}`,
+        );
+      }
+      stateManager.updateConfig({ avoidRepos: currentAvoid.filter((r) => r.toLowerCase() !== valueLower) });
+      break;
+    }
+    case 'add-boost-issue-type': {
+      // Scout matches boostIssueTypes against issue labels case-insensitively,
+      // so the duplicate check is case-insensitive too (#1464).
+      const currentTypes = currentConfig.boostIssueTypes ?? [];
+      const valueLower = value.toLowerCase();
+      if (!currentTypes.some((t) => t.toLowerCase() === valueLower)) {
+        stateManager.updateConfig({ boostIssueTypes: [...currentTypes, value] });
+      }
+      break;
+    }
+    case 'remove-boost-issue-type': {
+      const currentTypes = currentConfig.boostIssueTypes ?? [];
+      const valueLower = value.toLowerCase();
+      if (!currentTypes.some((t) => t.toLowerCase() === valueLower)) {
+        throw new Error(
+          `Issue type "${value}" is not on the boost list. Current boost list: ${currentTypes.join(', ') || '(empty)'}`,
+        );
+      }
+      stateManager.updateConfig({ boostIssueTypes: currentTypes.filter((t) => t.toLowerCase() !== valueLower) });
+      break;
+    }
     case 'issueListPath': {
       stateManager.updateConfig({ issueListPath: value || undefined });
       break;

--- a/packages/core/src/commands/features.test.ts
+++ b/packages/core/src/commands/features.test.ts
@@ -91,6 +91,26 @@ describe('runFeatures', () => {
     });
   });
 
+  it('never passes personalization bias knobs per-call — scout 1.1.0 features() does not accept them (#1464)', async () => {
+    // Strategy bias (preferLanguages/preferRepos/avoidRepos/boostIssueTypes/
+    // diversityRatio) reaches the features path through the bridge-built
+    // ScoutPreferences instead (see scout-bridge buildScoutState). Passing
+    // them here would be silently ignored by scout.
+    mockFeatures.mockResolvedValue({
+      quickWins: [],
+      biggerBets: [],
+      anchorRepos: [],
+      message: null,
+    });
+
+    await runFeatures({ maxResults: 5 });
+
+    const callArg = mockFeatures.mock.calls[0][0];
+    expect(Object.keys(callArg).toSorted()).toEqual(['anchorThreshold', 'count', 'splitRatio']);
+    expect(callArg).not.toHaveProperty('preferLanguages');
+    expect(callArg).not.toHaveProperty('diversityRatio');
+  });
+
   it('returns both buckets, anchorRepos, and a null message when scout reports a clean run', async () => {
     mockFeatures.mockResolvedValue({
       quickWins: [makeScoutFeatureCandidate({ horizon: 'quick-win' })],

--- a/packages/core/src/commands/features.ts
+++ b/packages/core/src/commands/features.ts
@@ -150,6 +150,12 @@ function toFeaturesCandidate(
  */
 export async function runFeatures(options: FeaturesOptions): Promise<FeaturesOutput> {
   const scout = await createAutopilotScout();
+  // Strategy bias (preferLanguages/preferRepos/avoidRepos/boostIssueTypes/
+  // diversityRatio) reaches this path through the bridge-built
+  // ScoutPreferences (#1464) — the same derivation `runSearch` uses per-call.
+  // scout.features() in scout 1.1.0 accepts only count/anchorThreshold/
+  // splitRatio/broad — do NOT pass bias knobs here; unsupported options
+  // would be silently ignored. Preferences are the supported channel.
   const result = await scout.features({
     count: options.maxResults,
     anchorThreshold: options.anchorThreshold,

--- a/packages/core/src/commands/scout-bridge.test.ts
+++ b/packages/core/src/commands/scout-bridge.test.ts
@@ -97,6 +97,76 @@ describe('buildScoutState', () => {
     expect(result.savedResults).toEqual([]);
   });
 
+  it('reads avoidRepos and boostIssueTypes from config into ScoutPreferences (#1464)', () => {
+    const state = makeAgentState({
+      config: {
+        avoidRepos: ['owner/meh', 'other/noisy'],
+        boostIssueTypes: ['bug', 'good first issue'],
+      },
+    });
+    mockGetStateManager.mockReturnValue(makeStateManagerMock({ state, config: state.config }));
+
+    const result = buildScoutState();
+
+    expect(result.preferences.avoidRepos).toEqual(['owner/meh', 'other/noisy']);
+    expect(result.preferences.boostIssueTypes).toEqual(['bug', 'good first issue']);
+  });
+
+  it.each(['avoidRepos', 'boostIssueTypes'] as const)('should default %s to [] when undefined in config', (field) => {
+    const state = makeAgentState({ config: { [field]: undefined } });
+    mockGetStateManager.mockReturnValue(makeStateManagerMock({ state, config: state.config }));
+
+    const result = buildScoutState();
+
+    expect(result.preferences[field]).toEqual([]);
+  });
+
+  it('threads strategy-derived bias into ScoutPreferences once the merged-PR floor is met (#1464)', () => {
+    // 10 merged PRs in one repo crosses STRATEGY_MIN_PRS, so computeStrategy
+    // recommends that repo and its language — the same derivation runSearch
+    // passes per-call (#1244) must land in the bridge-built preferences so
+    // surfaces without per-call knobs (features) share the bias.
+    const mergedPRs = Array.from({ length: 10 }, (_, i) => ({
+      url: `https://github.com/owner/fav/pull/${i + 1}`,
+      title: `fix: thing ${i + 1}`,
+      mergedAt: '2026-02-01T00:00:00Z',
+    }));
+    const state = makeAgentState({
+      mergedPRs,
+      repoScores: {
+        'owner/fav': {
+          repo: 'owner/fav',
+          score: 8,
+          mergedPRCount: 10,
+          closedWithoutMergeCount: 0,
+          avgResponseDays: null,
+          lastEvaluatedAt: '2026-02-01T00:00:00Z',
+          language: 'TypeScript',
+          signals: { hasActiveMaintainers: true, isResponsive: true, hasHostileComments: false },
+        },
+      },
+    });
+    mockGetStateManager.mockReturnValue(makeStateManagerMock({ state, config: state.config }));
+
+    const result = buildScoutState();
+
+    expect(result.preferences.preferRepos).toEqual(['owner/fav']);
+    expect(result.preferences.preferLanguages).toEqual(['TypeScript']);
+    expect(result.preferences.diversityRatio).toBe(0.2);
+  });
+
+  it('falls back to no-bias preferences below the strategy merged-PR floor (#1464)', () => {
+    const state = makeAgentState();
+    mockGetStateManager.mockReturnValue(makeStateManagerMock({ state, config: state.config }));
+
+    const result = buildScoutState();
+
+    expect(result.preferences.preferRepos).toEqual([]);
+    expect(result.preferences.preferLanguages).toEqual([]);
+    expect(result.preferences.avoidRepos).toEqual([]);
+    expect(result.preferences.boostIssueTypes).toEqual([]);
+  });
+
   it.each(['excludeOrgs', 'projectCategories'] as const)(
     'should default %s to [] when undefined in config',
     (field) => {

--- a/packages/core/src/commands/scout-bridge.ts
+++ b/packages/core/src/commands/scout-bridge.ts
@@ -6,8 +6,22 @@
 import { createScout, type LinkedPR as ScoutLinkedPR, type OssScout, type ScoutState } from '@oss-scout/core';
 import { getStateManager, isLinkedPRStalled, requireGitHubToken } from '../core/index.js';
 import type { LinkedPR } from '../core/linked-pr-classification.js';
+import { computeStrategy } from '../core/strategy.js';
 import type { CandidateLinkedPR } from '../formatters/json.js';
 import { loadSkippedIssuesDetailed } from './skip-file-parser.js';
+
+/**
+ * Fraction of search slots reserved for candidates that matched neither
+ * strategy-preferred languages nor repos (#1244). Counterweight against
+ * echo-chamber bias: without it, strategy-boosted searches return more of
+ * what already merged, which merges more of the same, and the profile
+ * narrows over time. Scout clamps to [0, 1]; 0.2 is the issue's proposal.
+ *
+ * Lives here (not `search.ts`, which re-exports it) since #1464: the same
+ * ratio is baked into the `ScoutPreferences` built by {@link buildScoutState}
+ * so every scout surface shares one policy.
+ */
+export const SEARCH_DIVERSITY_RATIO = 0.2;
 
 /**
  * Degradation signals collected while building a scout state (#1448).
@@ -91,6 +105,16 @@ export function buildScoutState(diagnostics?: ScoutBridgeDiagnostics): ScoutStat
     diagnostics.skipListUnavailable = true;
   }
 
+  // Strategy-derived personalization (#1464). `computeStrategy` returns null
+  // below the merged-PR floor — empty lists then read as "no bias" on scout's
+  // side. Baking the bias into the preferences (rather than only per-call
+  // search options, #1244) makes every scout surface share it: `search()`
+  // falls back to these when no per-call override is passed, and `features()`
+  // exposes no per-call bias knobs at all (scout 1.1.0 accepts only
+  // count/anchorThreshold/splitRatio/broad), so preferences are the only
+  // channel by which bias can reach the features path.
+  const strategy = computeStrategy(state);
+
   return {
     version: 1,
     preferences: {
@@ -121,14 +145,15 @@ export function buildScoutState(diagnostics?: ScoutBridgeDiagnostics): ScoutStat
       // `--split-ratio` flags for overrides.
       featuresAnchorThreshold: 3,
       featuresSplitRatio: 0.6,
-      // Personalization-bias prefs, likewise required on the inferred type
-      // (scout #1244 / #168). Autopilot doesn't surface these as settings yet,
-      // so we pass scout's documented "no bias" defaults.
-      preferLanguages: [],
-      preferRepos: [],
-      diversityRatio: 0,
-      avoidRepos: [],
-      boostIssueTypes: [],
+      // Personalization-bias prefs (scout #1244 / #168 / #1464).
+      // preferLanguages/preferRepos mirror the strategy derivation the search
+      // command uses per-call; avoidRepos/boostIssueTypes are user settings
+      // (config-registry keys); diversityRatio matches the search policy.
+      preferLanguages: strategy?.recommendations.languages ?? [],
+      preferRepos: strategy?.recommendations.repos ?? [],
+      diversityRatio: SEARCH_DIVERSITY_RATIO,
+      avoidRepos: config.avoidRepos ?? [],
+      boostIssueTypes: config.boostIssueTypes ?? [],
     },
     repoScores: state.repoScores,
     // Scout #117 added tombstones (deletion records for gist merge). Autopilot

--- a/packages/core/src/commands/search.ts
+++ b/packages/core/src/commands/search.ts
@@ -7,6 +7,7 @@ import {
   adaptScoutLinkedPR,
   buildCandidateLinkedPR,
   createAutopilotScout,
+  SEARCH_DIVERSITY_RATIO,
   type ScoutBridgeDiagnostics,
 } from './scout-bridge.js';
 import { classifyLinkedPR, getStateManager } from '../core/index.js';
@@ -27,13 +28,11 @@ const MODULE = 'search';
 export const MAX_SEARCH_RESULTS = 100;
 
 /**
- * Fraction of search slots reserved for candidates that matched neither
- * strategy-preferred languages nor repos (#1244). Counterweight against
- * echo-chamber bias: without it, strategy-boosted searches return more of
- * what already merged, which merges more of the same, and the profile
- * narrows over time. Scout clamps to [0, 1]; 0.2 is the issue's proposal.
+ * Diversity-counterweight ratio (#1244). Moved to `scout-bridge.ts` in #1464
+ * (it is now also baked into the bridge-built `ScoutPreferences`); re-exported
+ * here so existing importers keep working.
  */
-export const SEARCH_DIVERSITY_RATIO = 0.2;
+export { SEARCH_DIVERSITY_RATIO } from './scout-bridge.js';
 
 interface SearchOptions {
   maxResults: number;
@@ -81,9 +80,12 @@ export async function runSearch(options: SearchOptions): Promise<SearchOutput> {
 
   // Derive personalization from local history (#1244). `computeStrategy`
   // returns null below the merged-PR floor — in that case we pass nothing
-  // and scout's sort behaves exactly as before. Once strategy data is
-  // available, scout boosts language/repo matches into a separate sort
-  // tier (still no filtering).
+  // and scout falls back to the bridge-built preferences, which derive the
+  // same values from the same state (#1464), so the sort is identical either
+  // way. The explicit per-call pass is kept for self-documentation. Once
+  // strategy data is available, scout boosts language/repo matches into a
+  // separate sort tier (still no filtering). avoidRepos/boostIssueTypes are
+  // not passed per-call: scout reads them from the bridge-built preferences.
   const strategy = computeStrategy(stateManager.getState());
   const preferLanguages = strategy?.recommendations.languages ?? undefined;
   const preferRepos = strategy?.recommendations.repos ?? undefined;

--- a/packages/core/src/commands/setup.test.ts
+++ b/packages/core/src/commands/setup.test.ts
@@ -137,6 +137,40 @@ describe('runSetup', () => {
     consoleSpy.mockRestore();
   });
 
+  it('should set avoidRepos as a whole-list replace, filtering invalid entries (#1464)', async () => {
+    const result = (await runSetup({ set: ['avoidRepos=owner/repo,other/repo,not-a-repo'] })) as SetupSetOutput;
+
+    expect(mockUpdateConfig).toHaveBeenCalledWith({ avoidRepos: ['owner/repo', 'other/repo'] });
+    expect(result.warnings).toEqual(expect.arrayContaining([expect.stringContaining('not-a-repo')]));
+  });
+
+  it('should warn and not update avoidRepos when all entries are invalid (#1464)', async () => {
+    const result = (await runSetup({ set: ['avoidRepos=not-a-repo'] })) as SetupSetOutput;
+
+    expect(result.warnings).toEqual(expect.arrayContaining([expect.stringContaining('All entries were invalid')]));
+    expect(mockUpdateConfig).not.toHaveBeenCalledWith(expect.objectContaining({ avoidRepos: expect.anything() }));
+  });
+
+  it('should clear avoidRepos when set to an empty value (#1464)', async () => {
+    const result = (await runSetup({ set: ['avoidRepos='] })) as SetupSetOutput;
+
+    expect(mockUpdateConfig).toHaveBeenCalledWith({ avoidRepos: [] });
+    expect(result.settings.avoidRepos).toBe('(empty)');
+  });
+
+  it('should set boostIssueTypes as a deduped whole-list replace (#1464)', async () => {
+    await runSetup({ set: ['boostIssueTypes=bug,good first issue,bug'] });
+
+    expect(mockUpdateConfig).toHaveBeenCalledWith({ boostIssueTypes: ['bug', 'good first issue'] });
+  });
+
+  it('should clear boostIssueTypes when set to an empty value (#1464)', async () => {
+    const result = (await runSetup({ set: ['boostIssueTypes='] })) as SetupSetOutput;
+
+    expect(mockUpdateConfig).toHaveBeenCalledWith({ boostIssueTypes: [] });
+    expect(result.settings.boostIssueTypes).toBe('(empty)');
+  });
+
   it('should handle dormantDays setting', async () => {
     await runSetup({ set: ['dormantDays=14'] });
     expect(mockUpdateConfig).toHaveBeenCalledWith({ dormantThresholdDays: 14 });

--- a/packages/core/src/commands/setup.ts
+++ b/packages/core/src/commands/setup.ts
@@ -232,6 +232,51 @@ export async function runSetup(options: SetupOptions): Promise<SetupOutput> {
             results[key] = valid.length > 0 ? valid.join(', ') : '(empty)';
             break;
           }
+          case 'avoidRepos': {
+            // Same owner/repo validation as aiPolicyBlocklist: skip (and warn
+            // about) malformed entries instead of failing the whole set.
+            const entries = value
+              .split(',')
+              .map((r) => r.trim())
+              .filter(Boolean);
+            const valid: string[] = [];
+            const invalid: string[] = [];
+            for (const entry of entries) {
+              const normalized = entry.replace(/\s+/g, '');
+              if (/^[\w.-]+\/[\w.-]+$/.test(normalized)) {
+                valid.push(normalized);
+              } else {
+                invalid.push(entry);
+              }
+            }
+            if (invalid.length > 0) {
+              warnings.push(`Warning: Skipping invalid entries (expected "owner/repo" format): ${invalid.join(', ')}`);
+            }
+            if (valid.length === 0 && entries.length > 0) {
+              warnings.push('Warning: All entries were invalid. avoidRepos not updated.');
+              results[key] = '(all entries invalid)';
+              break;
+            }
+            const dedupedRepos = [...new Set(valid)];
+            stateManager.updateConfig({ avoidRepos: dedupedRepos });
+            results[key] = dedupedRepos.length > 0 ? dedupedRepos.join(', ') : '(empty)';
+            break;
+          }
+          case 'boostIssueTypes': {
+            // Free-form issue labels (scout matches them case-insensitively);
+            // an empty value clears the list.
+            const types = [
+              ...new Set(
+                value
+                  .split(',')
+                  .map((t) => t.trim())
+                  .filter(Boolean),
+              ),
+            ];
+            stateManager.updateConfig({ boostIssueTypes: types });
+            results[key] = types.length > 0 ? types.join(', ') : '(empty)';
+            break;
+          }
           case 'projectCategories': {
             const categories = value
               .split(',')

--- a/packages/core/src/core/config-registry.test.ts
+++ b/packages/core/src/core/config-registry.test.ts
@@ -38,9 +38,19 @@ describe('CONFIG_KEY_REGISTRY', () => {
       'starredRepos',
       'starredReposLastFetched',
       'skippedIssuesPath',
+      'avoidRepos',
+      'boostIssueTypes',
     ];
     for (const key of scoutBridgeReads) {
       expect(isKnownKey(key), `scout-bridge read "${key}" not in registry`).toBe(true);
+    }
+  });
+
+  it('registers the personalization bias keys on the expected surfaces (#1464)', () => {
+    expect(getKeyDef('avoidRepos')?.settableVia).toBe('setup');
+    expect(getKeyDef('boostIssueTypes')?.settableVia).toBe('setup');
+    for (const key of ['add-avoid-repo', 'remove-avoid-repo', 'add-boost-issue-type', 'remove-boost-issue-type']) {
+      expect(getKeyDef(key)?.settableVia, `${key} should be config-settable`).toBe('config');
     }
   });
 

--- a/packages/core/src/core/config-registry.ts
+++ b/packages/core/src/core/config-registry.ts
@@ -120,6 +120,19 @@ export const CONFIG_KEY_REGISTRY: readonly ConfigKeyDef[] = [
     settableVia: 'setup',
     valueHint: 'comma-separated list of owner/repo',
   },
+  {
+    key: 'avoidRepos',
+    description:
+      'Repos (owner/repo) to softly downrank in discovery results — milder than excludeRepos (whole-list replace).',
+    settableVia: 'setup',
+    valueHint: 'comma-separated list of owner/repo',
+  },
+  {
+    key: 'boostIssueTypes',
+    description: 'Issue label types to softly boost in discovery ranking (whole-list replace).',
+    settableVia: 'setup',
+    valueHint: 'comma-separated list (e.g. bug,good first issue)',
+  },
 
   // ── Exclusion list mutators (config-only) ────────────────────────────
   {
@@ -163,6 +176,30 @@ export const CONFIG_KEY_REGISTRY: readonly ConfigKeyDef[] = [
     description: 'Exclude an entire org from discovery.',
     settableVia: 'config',
     valueHint: 'org name (no slash)',
+  },
+  {
+    key: 'add-avoid-repo',
+    description: 'Append a repo (owner/repo) to the soft-downrank avoid list.',
+    settableVia: 'config',
+    valueHint: 'owner/repo',
+  },
+  {
+    key: 'remove-avoid-repo',
+    description: 'Remove a repo from the soft-downrank avoid list.',
+    settableVia: 'config',
+    valueHint: 'owner/repo (must already be present)',
+  },
+  {
+    key: 'add-boost-issue-type',
+    description: 'Append an issue label type to the discovery ranking boost list.',
+    settableVia: 'config',
+    valueHint: 'issue label (e.g. bug)',
+  },
+  {
+    key: 'remove-boost-issue-type',
+    description: 'Remove an issue label type from the discovery ranking boost list.',
+    settableVia: 'config',
+    valueHint: 'issue label (must already be present)',
   },
 
   // ── Tooling ──────────────────────────────────────────────────────────

--- a/packages/core/src/core/state-schema.ts
+++ b/packages/core/src/core/state-schema.ts
@@ -213,6 +213,23 @@ export const AgentConfigSchema = z.object({
   excludeRepos: z.array(z.string()).default([]),
   excludeOrgs: z.array(z.string()).optional(),
 
+  /**
+   * Repos (owner/repo) to softly downrank in discovery results (#1464).
+   * Milder than `excludeRepos`' hard filter: scout pushes matches below
+   * equally-recommended candidates but does not remove them, and a strong
+   * affinity boost can still outweigh the penalty (scout #168).
+   * Threaded to scout via `scout-bridge.ts`.
+   */
+  avoidRepos: z.array(z.string()).default([]),
+
+  /**
+   * Issue label types (e.g. "bug", "good first issue") to softly boost in
+   * discovery ranking, matched case-insensitively against issue labels
+   * (scout #168 / #1464). Does not filter results or change viability
+   * scores. Threaded to scout via `scout-bridge.ts`.
+   */
+  boostIssueTypes: z.array(z.string()).default([]),
+
   trustedProjects: z.array(z.string()).default([]),
 
   githubUsername: z.string().default(''),


### PR DESCRIPTION
Fixes #1464.

scout-bridge passed hardcoded no-bias defaults ("Autopilot doesn't surface these as settings yet") and the features path got no personalization at all while search threaded the full bias engine.

## Changes

- Config-registry keys end-to-end: `avoidRepos` (owner/repo validated; soft search-ranking penalty — deliberately no cleanupExcludedData, unlike excludeRepos' hard filter) and `boostIssueTypes` (free-form labels, scout matches case-insensitively). Setup whole-list arms mirror aiPolicyBlocklist (warn-and-filter); config add-/remove- mutators mirror exclude-repo (strict). MCP config tool picks the keys up automatically from the shared registry. README config table +2 rows.
- Strategy bias now lives in the bridge-built ScoutPreferences (computeStrategy → preferLanguages/preferRepos, diversityRatio 0.2 moved from search.ts with re-export): scout resolves per-call options ?? preferences, search's per-call pass derives from the same state in the same call so the channels cannot diverge (reviewer-traced precedence).
- Key finding: scout 1.1.0's features() accepts NO bias knobs (verified against the d.ts) and its discovery applies no personalization yet — preferences are the only channel and they're future-proof, not active for features ranking today (documented in-code; activating it is a scout-side feature).

Reviewer-verified: computeStrategy is pure/synchronous (no per-construction cost concern); vet verdicts cannot change from avoidRepos (bias is search-ranking-only in scout); fresh users below the strategy floor get byte-identical search behavior.

19 new tests. Gate: root eslint, prettier, typecheck, 2844 core + 235 mcp green incl. contract/docs gates. code-reviewer pass: CLEAN.

Note: config-path mutations of these keys will start checkpointing to the Gist when #1440 (PR #1472) lands — its single post-switch maybeCheckpoint covers all arms including these.