### PR TITLE
feat(daily): close the merge loop — auto mark-done list entries + extract-learnings nudge (#1463)

### DIFF
--- a/commands/oss.md
+++ b/commands/oss.md
@@ -236,6 +236,7 @@ When the user selects an action from the menu above, **read the relevant workflo
 | Specific PR selection (via "Other") | `${CLAUDE_PLUGIN_ROOT}/workflows/work-through-issues.md` | "Handle Specific PR Selection" |
 | "Review issue replies" | `${CLAUDE_PLUGIN_ROOT}/workflows/review-issue-replies.md` | "Handle Review Issue Replies" |
 | "Follow up on stuck-CI / dormant PRs" (`follow_up`) | `${CLAUDE_PLUGIN_ROOT}/workflows/dormant-pr-follow-up.md` | "Trigger" |
+| "Extract learnings from recently merged PRs" (`extract_learnings`) | `${CLAUDE_PLUGIN_ROOT}/workflows/extract-learnings.md` | "Steps" |
 | "Search for new issues" | Handled in core (below) | "Handle Find New Issues" |
 | "Done for now" | Handled in core (below) | "Session End" |
 

--- a/packages/core/src/commands/daily-orchestration.test.ts
+++ b/packages/core/src/commands/daily-orchestration.test.ts
@@ -7,6 +7,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
 import type { FetchedPR, DailyDigest, CommentedIssue } from '../core/types.js';
 import { makeFetchedPR } from '../core/test-utils.js';
 import type { FetchPRsResult } from '../core/pr-monitor.js';
@@ -1210,5 +1213,114 @@ describe('executeDailyCheck() — status overrides (#644)', () => {
     const actionableUrls = result.actionableIssues.map((i) => i.prUrl);
     expect(actionableUrls).toContain(overriddenPR.url);
     expect(result.capacity.criticalIssueCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// executeDailyCheck() — merge loop (#1463)
+// ---------------------------------------------------------------------------
+
+describe('executeDailyCheck() — merge loop (#1463)', () => {
+  const ISSUE_URL = 'https://github.com/foo/bar/issues/1';
+  const PR_URL = 'https://github.com/foo/bar/pull/123';
+  const mergedPR = {
+    url: PR_URL,
+    repo: 'foo/bar',
+    number: 123,
+    title: 'Fix the thing',
+    mergedAt: '2026-06-10T12:00:00Z',
+  };
+
+  let tmpDir: string;
+  let listPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'daily-merge-loop-'));
+    listPath = path.join(tmpDir, 'issue-list.md');
+    fs.writeFileSync(
+      listPath,
+      [
+        '### foo/bar',
+        `- [#1](${ISSUE_URL}) — first issue`,
+        `  - **In Progress** — PR [#123](${PR_URL}) open.`,
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /** State wired for the merge loop: configured list path + unextracted ledger entry. */
+  function stateWithListAndLedger() {
+    const state = makeDefaultState({
+      mergedPRs: [{ url: PR_URL, title: mergedPR.title, mergedAt: mergedPR.mergedAt }],
+    });
+    (state.config as Record<string, unknown>).issueListPath = listPath;
+    return state;
+  }
+
+  it('auto-marks the matching curated-list entry done and surfaces it in listUpdates', async () => {
+    mockGetState.mockReturnValue(stateWithListAndLedger());
+    mockFetchRecentlyMergedPRs.mockResolvedValue([mergedPR]);
+
+    const result = await executeDailyCheck('test-token');
+
+    expect(result.listUpdates).toEqual([
+      {
+        prUrl: PR_URL,
+        issueUrl: ISSUE_URL,
+        listPath: path.resolve(listPath),
+        repoHeadingStruck: true,
+      },
+    ]);
+    const written = fs.readFileSync(listPath, 'utf8');
+    expect(written).toContain(`- ~~[#1](${ISSUE_URL}) — first issue~~`);
+    expect(written).toContain(`  - **Done** — PR [#123](${PR_URL}) submitted, merged 2026-06-10.`);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('adds the extract_learnings menu item for recent merges without extracted learnings', async () => {
+    mockGetState.mockReturnValue(stateWithListAndLedger());
+    mockFetchRecentlyMergedPRs.mockResolvedValue([mergedPR]);
+
+    const result = await executeDailyCheck('test-token');
+
+    const item = result.actionMenu.items.find((i) => i.key === 'extract_learnings');
+    expect(item).toBeDefined();
+    expect(item!.label).toBe('Extract learnings from 1 recently merged PR');
+  });
+
+  it('omits extract_learnings when the merge already has learnings extracted', async () => {
+    const state = stateWithListAndLedger();
+    (state.mergedPRs as Array<Record<string, unknown>>)[0].learningsExtractedAt = '2026-06-11T00:00:00.000Z';
+    mockGetState.mockReturnValue(state);
+    mockFetchRecentlyMergedPRs.mockResolvedValue([mergedPR]);
+
+    const result = await executeDailyCheck('test-token');
+
+    expect(result.actionMenu.items.find((i) => i.key === 'extract_learnings')).toBeUndefined();
+  });
+
+  it('omits listUpdates entirely on a merge-free run', async () => {
+    mockFetchRecentlyMergedPRs.mockResolvedValue([]);
+
+    const result = await executeDailyCheck('test-token');
+
+    expect('listUpdates' in result).toBe(false);
+    expect(result.actionMenu.items.find((i) => i.key === 'extract_learnings')).toBeUndefined();
+  });
+
+  it('omits listUpdates when no list entry mentions the merged PR (silent no-op)', async () => {
+    fs.writeFileSync(listPath, '### foo/bar\n- [#9](https://github.com/foo/bar/issues/9) — unrelated\n', 'utf8');
+    mockGetState.mockReturnValue(stateWithListAndLedger());
+    mockFetchRecentlyMergedPRs.mockResolvedValue([mergedPR]);
+
+    const result = await executeDailyCheck('test-token');
+
+    expect(result.listUpdates).toBeUndefined();
+    expect(result.warnings).toEqual([]);
   });
 });

--- a/packages/core/src/commands/daily.contract.test.ts
+++ b/packages/core/src/commands/daily.contract.test.ts
@@ -142,4 +142,28 @@ describe('daily --json contract', () => {
     expectSchemaValid(result);
     await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/daily.degraded.json');
   });
+
+  it('merge-free output carries no listUpdates key (#1463 — pins golden stability)', () => {
+    const result = toDailyOutput(makeFixture());
+    expect('listUpdates' in result).toBe(false);
+    expect(JSON.stringify(result)).not.toContain('listUpdates');
+  });
+
+  it('auto-marked list entries pass through and validate against the schema (#1463)', () => {
+    const result = toDailyOutput(
+      makeFixture({
+        listUpdates: [
+          {
+            prUrl: 'https://github.com/octocat/spoon-knife/pull/44',
+            issueUrl: 'https://github.com/octocat/spoon-knife/issues/40',
+            listPath: '/home/user/open-source/potential-issue-list.md',
+            repoHeadingStruck: false,
+          },
+        ],
+      }),
+    );
+    expectSchemaValid(result);
+    expect(result.listUpdates).toHaveLength(1);
+    expect(result.listUpdates![0].issueUrl).toBe('https://github.com/octocat/spoon-knife/issues/40');
+  });
 });

--- a/packages/core/src/commands/daily.ts
+++ b/packages/core/src/commands/daily.ts
@@ -51,7 +51,9 @@ import {
   type CapacityAssessment,
   type ActionableIssue,
   type ActionMenu,
+  type MergedPRListUpdate,
 } from '../formatters/json.js';
+import { reconcileMergedPRsWithList } from './merge-loop.js';
 
 const MODULE = 'daily';
 
@@ -139,6 +141,12 @@ export interface DailyCheckResult {
    * where the gate stays silent.
    */
   strategySummary?: StrategyResult | null;
+  /**
+   * Curated-list entries auto-marked done because their PR merged (#1463).
+   * Set only when at least one entry was struck this run; merge-free runs
+   * omit it so serialized output (and contract goldens) stay unchanged.
+   */
+  listUpdates?: MergedPRListUpdate[];
 }
 
 // ---------------------------------------------------------------------------
@@ -599,6 +607,7 @@ function generateDigestOutput(
   failures: PRCheckFailure[],
   warnings: DailyWarning[],
   previousLastDigestAt?: string,
+  unextractedMergeCount?: number,
 ): DailyCheckResult {
   const stateManager = getStateManager();
 
@@ -656,7 +665,13 @@ function generateDigestOutput(
   // the same buckets per-PR, so the headline counts cannot diverge.
   const attention = summarizeAttentionBuckets(activePRs);
   const briefSummary = formatBriefSummary(digest, actionableIssues.length, issueResponses.length, attention);
-  const actionMenu = computeActionMenu(actionableIssues, capacity, filteredCommentedIssues, attention);
+  const actionMenu = computeActionMenu(
+    actionableIssues,
+    capacity,
+    filteredCommentedIssues,
+    attention,
+    unextractedMergeCount,
+  );
   const repoGroups = groupPRsByRepo(activePRs);
 
   // Periodic strategy snapshot (#1270 Step 2). Cadence-gated to fire every
@@ -749,6 +764,9 @@ export function toDailyOutput(result: DailyCheckResult): DailyOutput {
     failures: result.failures,
     warnings: result.warnings,
     strategySummary: result.strategySummary,
+    // Conditional spread (not a plain assignment) so merge-free runs carry
+    // no `listUpdates` key at all — serialized output and goldens unchanged.
+    ...(result.listUpdates ? { listUpdates: result.listUpdates } : {}),
   };
 }
 
@@ -897,6 +915,27 @@ async function executeDailyCheckInternal(token: string): Promise<DailyCheckResul
     recordWarning(warnings, 'analytics', 'persist monthly analytics', error);
   }
 
+  // Phase 3.5: Close the merge loop (#1463). Join detected merges against
+  // the curated issue list (the PR URL recorded in an entry's sub-bullets
+  // is the only deterministic PR→issue link that exists — see
+  // merge-loop.ts) and auto-mark matching entries done. Safe to auto-run:
+  // the PR is MERGED per GitHub, and already-marked entries are quiet
+  // no-ops. Failures land in warnings[] via the shared collector.
+  const listUpdates = reconcileMergedPRsWithList({ mergedPRs: recentlyMergedPRs, warnings });
+
+  // Count freshly-merged PRs whose ledger entry has no learnings extraction
+  // stamp yet (#867 plumbing). Drives the action menu's extract_learnings
+  // nudge: it stays up for the whole recently-merged window (7 days) until
+  // the user runs the extraction, then self-clears.
+  let unextractedMergeCount = 0;
+  try {
+    const ledger = getStateManager().getState().mergedPRs ?? [];
+    const recentUrls = new Set(recentlyMergedPRs.map((pr) => pr.url));
+    unextractedMergeCount = ledger.filter((pr) => recentUrls.has(pr.url) && !pr.learningsExtractedAt).length;
+  } catch (error) {
+    recordWarning(warnings, 'merge-loop', 'count unextracted merged PRs', error);
+  }
+
   // No scout pass here (#1458): the former Phase 3.5 fed recentlyMerged/ClosedPRs
   // to an oss-scout instance and called scout.checkpoint(). Both halves were dead:
   // scout's recordMergedPR/recordClosedPR deduplicate by URL against the ledger
@@ -928,7 +967,11 @@ async function executeDailyCheckInternal(token: string): Promise<DailyCheckResul
     failures,
     warnings,
     previousLastDigestAt,
+    unextractedMergeCount,
   );
+  if (listUpdates) {
+    result.listUpdates = listUpdates;
+  }
 
   // Checkpoint: push state to Gist if in Gist mode.
   // If getStateManagerAsync was not called before this command ran,

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -116,6 +116,8 @@ export {
   type MarkDoneOptions,
   type MarkDoneOutput,
 } from './list-mark-done.js';
+/** Daily merge-loop reconciliation — auto-mark curated-list entries whose PR merged (#1463). */
+export { reconcileMergedPRsWithList, findListEntryUrlByPrUrl } from './merge-loop.js';
 /** Check if new files are properly referenced/integrated. */
 export { runCheckIntegration } from './check-integration.js';
 /** System-health diagnostic — verifies tokens, bundle, state, scout, rate limit. */

--- a/packages/core/src/commands/locate-issue-list.ts
+++ b/packages/core/src/commands/locate-issue-list.ts
@@ -1,0 +1,75 @@
+/**
+ * Curated-list path detection (#1463).
+ *
+ * Extracted from `startup.ts` so the daily merge-loop reconciliation can
+ * locate the list without importing `startup.ts` — that would close an
+ * import cycle (startup → daily → merge-loop → startup). `startup.ts`
+ * re-exports `parseIssueListPathFromConfig` for back-compat and layers item
+ * counts / skipped-issues detection on top of `detectIssueListPath`.
+ */
+
+import * as fs from 'node:fs';
+import { getStateManager } from '../core/index.js';
+import { errorMessage } from '../core/errors.js';
+import { warn } from '../core/logger.js';
+
+/**
+ * Parse issueListPath from a config file's YAML frontmatter.
+ * @param configContent - Raw content of the config.md file
+ * @returns The path string or undefined if not found
+ */
+export function parseIssueListPathFromConfig(configContent: string): string | undefined {
+  const match = configContent.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return undefined;
+  const frontmatter = match[1];
+  const pathMatch = frontmatter.match(/issueListPath:\s*["']?([^"'\n]+)["']?/);
+  return pathMatch ? pathMatch[1].trim() : undefined;
+}
+
+export interface IssueListLocation {
+  path: string;
+  source: 'configured' | 'auto-detected';
+}
+
+/**
+ * Locate the curated issue-list file: state config first, then the legacy
+ * config.md frontmatter, then known default paths. Returns undefined when
+ * no list exists — callers treat that as "user has no curated list".
+ */
+export function detectIssueListPath(): IssueListLocation | undefined {
+  // 1. Check state.json config (primary)
+  try {
+    const stateManager = getStateManager();
+    const configuredPath = stateManager.getState().config.issueListPath;
+    if (configuredPath && fs.existsSync(configuredPath)) {
+      return { path: configuredPath, source: 'configured' };
+    }
+  } catch (error) {
+    // State manager may not be initialized yet — fall through to legacy config.md
+    warn('startup', `Could not read issueListPath from state: ${errorMessage(error)}`);
+  }
+
+  // 2. Fallback: config.md (legacy — will be removed in future)
+  const configPath = '.claude/oss-autopilot/config.md';
+  if (fs.existsSync(configPath)) {
+    try {
+      const configContent = fs.readFileSync(configPath, 'utf8');
+      const configuredPath = parseIssueListPathFromConfig(configContent);
+      if (configuredPath && fs.existsSync(configuredPath)) {
+        return { path: configuredPath, source: 'configured' };
+      }
+    } catch (error) {
+      console.error('[STARTUP] Failed to read config:', errorMessage(error));
+    }
+  }
+
+  // 3. Probe known paths
+  const probes = ['open-source/potential-issue-list.md', 'oss/issue-list.md', 'issues.md'];
+  for (const probe of probes) {
+    if (fs.existsSync(probe)) {
+      return { path: probe, source: 'auto-detected' };
+    }
+  }
+
+  return undefined;
+}

--- a/packages/core/src/commands/merge-loop.test.ts
+++ b/packages/core/src/commands/merge-loop.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tests for the daily merge-loop reconciliation (#1463).
+ *
+ * The join under test: a recently merged PR's URL found inside a curated-list
+ * entry's block (entry line or indented sub-bullet) auto-marks that entry
+ * done via the same transform `list-mark-done` uses.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import type { DailyWarning } from '../formatters/json.js';
+
+// detectIssueListPath reads the configured list path from state — mock the
+// barrel so each test can point it at a tmp file (or at nothing).
+const mockGetState = vi.fn();
+vi.mock('../core/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../core/index.js')>();
+  return {
+    ...actual,
+    getStateManager: vi.fn(() => ({ getState: mockGetState })),
+  };
+});
+
+import { findListEntryUrlByPrUrl, reconcileMergedPRsWithList } from './merge-loop.js';
+
+const ISSUE_A = 'https://github.com/foo/bar/issues/1';
+const ISSUE_B = 'https://github.com/foo/bar/issues/2';
+const PR_A = 'https://github.com/foo/bar/pull/123';
+const PR_B = 'https://github.com/foo/bar/pull/456';
+
+function makeList(): string {
+  return [
+    '# My List',
+    '',
+    '## Pursue',
+    '',
+    '### foo/bar',
+    `- [#1](${ISSUE_A}) — first issue`,
+    `  - **In Progress** — PR [#123](${PR_A}) open, awaiting review.`,
+    `- [#2](${ISSUE_B}) — second issue`,
+    '',
+  ].join('\n');
+}
+
+function setIssueListPath(p: string | undefined): void {
+  mockGetState.mockReturnValue({ config: { issueListPath: p } });
+}
+
+describe('findListEntryUrlByPrUrl', () => {
+  it('finds the entry whose sub-bullet mentions the PR URL and returns the entry-line URL', () => {
+    expect(findListEntryUrlByPrUrl(makeList(), PR_A)).toBe(ISSUE_A);
+  });
+
+  it('finds an entry whose entry line itself is the PR URL', () => {
+    const content = `- [#123](${PR_A}) — direct PR entry\n`;
+    expect(findListEntryUrlByPrUrl(content, PR_A)).toBe(PR_A);
+  });
+
+  it('returns undefined when no block mentions the PR URL', () => {
+    expect(findListEntryUrlByPrUrl(makeList(), PR_B)).toBeUndefined();
+  });
+
+  it('does not match a longer PR number sharing a prefix (#1442 boundary rule)', () => {
+    const content = [`- [#1](${ISSUE_A}) — entry`, `  - **In Progress** — PR ${PR_A}4 open.`, ''].join('\n');
+    expect(findListEntryUrlByPrUrl(content, PR_A)).toBeUndefined();
+  });
+
+  it('skips a mentioning block whose entry line has no GitHub URL', () => {
+    const content = ['- a loose note with no link', `  - mentions ${PR_A} in passing`, ''].join('\n');
+    expect(findListEntryUrlByPrUrl(content, PR_A)).toBeUndefined();
+  });
+});
+
+describe('reconcileMergedPRsWithList', () => {
+  let tmpDir: string;
+  let listPath: string;
+  let warnings: DailyWarning[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'merge-loop-test-'));
+    listPath = path.join(tmpDir, 'issue-list.md');
+    warnings = [];
+  });
+
+  afterEach(() => {
+    fs.chmodSync(tmpDir, 0o755);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('marks a list entry done when a merged PR URL appears in its sub-bullets (real file write)', () => {
+    fs.writeFileSync(listPath, makeList(), 'utf8');
+    setIssueListPath(listPath);
+
+    const updates = reconcileMergedPRsWithList({
+      mergedPRs: [{ url: PR_A, mergedAt: '2026-06-10T12:00:00Z' }],
+      warnings,
+    });
+
+    expect(updates).toEqual([
+      {
+        prUrl: PR_A,
+        issueUrl: ISSUE_A,
+        listPath: path.resolve(listPath),
+        repoHeadingStruck: false,
+      },
+    ]);
+    const written = fs.readFileSync(listPath, 'utf8');
+    expect(written).toContain(`- ~~[#1](${ISSUE_A}) — first issue~~`);
+    expect(written).toContain(`  - **Done** — PR [#123](${PR_A}) submitted, merged 2026-06-10.`);
+    // Unrelated entry untouched.
+    expect(written).toContain(`- [#2](${ISSUE_B}) — second issue`);
+    expect(warnings).toEqual([]);
+  });
+
+  it('is a silent no-op when there are no merged PRs', () => {
+    setIssueListPath(listPath);
+    expect(reconcileMergedPRsWithList({ mergedPRs: [], warnings })).toBeUndefined();
+    expect(warnings).toEqual([]);
+  });
+
+  it('is a silent no-op when no curated list exists', () => {
+    setIssueListPath(undefined);
+    expect(reconcileMergedPRsWithList({ mergedPRs: [{ url: PR_A }], warnings })).toBeUndefined();
+    expect(warnings).toEqual([]);
+  });
+
+  it('is a silent no-op when no list entry mentions the merged PR', () => {
+    const original = makeList();
+    fs.writeFileSync(listPath, original, 'utf8');
+    setIssueListPath(listPath);
+
+    expect(reconcileMergedPRsWithList({ mergedPRs: [{ url: PR_B }], warnings })).toBeUndefined();
+    expect(fs.readFileSync(listPath, 'utf8')).toBe(original);
+    expect(warnings).toEqual([]);
+  });
+
+  it('is idempotent — an already-marked entry is a quiet no-op on a re-run', () => {
+    fs.writeFileSync(listPath, makeList(), 'utf8');
+    setIssueListPath(listPath);
+
+    const first = reconcileMergedPRsWithList({ mergedPRs: [{ url: PR_A }], warnings });
+    expect(first).toHaveLength(1);
+    const afterFirst = fs.readFileSync(listPath, 'utf8');
+
+    const second = reconcileMergedPRsWithList({ mergedPRs: [{ url: PR_A }], warnings });
+    expect(second).toBeUndefined();
+    expect(fs.readFileSync(listPath, 'utf8')).toBe(afterFirst);
+    expect(warnings).toEqual([]);
+  });
+
+  it('strikes the repo heading when the merge completes the last open issue under it', () => {
+    const content = [
+      '### foo/bar',
+      `- [#1](${ISSUE_A}) — only issue`,
+      `  - **In Progress** — PR [#123](${PR_A}) open.`,
+      '',
+    ].join('\n');
+    fs.writeFileSync(listPath, content, 'utf8');
+    setIssueListPath(listPath);
+
+    const updates = reconcileMergedPRsWithList({ mergedPRs: [{ url: PR_A }], warnings });
+
+    expect(updates?.[0].repoHeadingStruck).toBe(true);
+    expect(fs.readFileSync(listPath, 'utf8')).toContain('### ~~foo/bar~~');
+  });
+
+  it('records a merge-loop warning instead of crashing when the list cannot be written', () => {
+    fs.writeFileSync(listPath, makeList(), 'utf8');
+    setIssueListPath(listPath);
+    // Read succeeds; the tmp-file write inside the read-only directory fails.
+    fs.chmodSync(tmpDir, 0o555);
+
+    const original = fs.readFileSync(listPath, 'utf8');
+    const updates = reconcileMergedPRsWithList({ mergedPRs: [{ url: PR_A }], warnings });
+
+    expect(updates).toBeUndefined();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].phase).toBe('merge-loop');
+    expect(warnings[0].operation).toBe('auto-mark merged list entries');
+    expect(warnings[0].message).toContain('write issue list');
+    fs.chmodSync(tmpDir, 0o755);
+    expect(fs.readFileSync(listPath, 'utf8')).toBe(original);
+  });
+
+  it('records a merge-loop warning when the list cannot be read', () => {
+    fs.writeFileSync(listPath, makeList(), 'utf8');
+    setIssueListPath(listPath);
+    fs.chmodSync(listPath, 0o000);
+
+    const updates = reconcileMergedPRsWithList({ mergedPRs: [{ url: PR_A }], warnings });
+
+    expect(updates).toBeUndefined();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].phase).toBe('merge-loop');
+    expect(warnings[0].message).toContain('read issue list');
+    fs.chmodSync(listPath, 0o644);
+  });
+
+  it('handles multiple merged PRs in one pass, marking each matching entry', () => {
+    const content = [
+      '### foo/bar',
+      `- [#1](${ISSUE_A}) — first`,
+      `  - **In Progress** — PR [#123](${PR_A}) open.`,
+      `- [#2](${ISSUE_B}) — second`,
+      `  - **In Progress** — PR [#456](${PR_B}) open.`,
+      '',
+    ].join('\n');
+    fs.writeFileSync(listPath, content, 'utf8');
+    setIssueListPath(listPath);
+
+    const updates = reconcileMergedPRsWithList({
+      mergedPRs: [{ url: PR_A }, { url: PR_B }],
+      warnings,
+    });
+
+    expect(updates).toHaveLength(2);
+    expect(updates?.[1].repoHeadingStruck).toBe(true); // second mark completes the repo
+    const written = fs.readFileSync(listPath, 'utf8');
+    expect(written).toContain(`- ~~[#1](${ISSUE_A}) — first~~`);
+    expect(written).toContain(`- ~~[#2](${ISSUE_B}) — second~~`);
+  });
+});

--- a/packages/core/src/commands/merge-loop.test.ts
+++ b/packages/core/src/commands/merge-loop.test.ts
@@ -223,3 +223,28 @@ describe('reconcileMergedPRsWithList', () => {
     expect(written).toContain(`- ~~[#2](${ISSUE_B}) — second~~`);
   });
 });
+
+describe('status-marker anchoring (#1463 review)', () => {
+  it('does not strike an entry whose sub-bullet merely references the PR without a status marker', () => {
+    const prUrl = 'https://github.com/foo/bar/pull/123';
+    const content = [
+      '### foo/bar',
+      '',
+      `- [Issue one](https://github.com/foo/bar/issues/1)`,
+      `  - **In Progress** — PR [#123](${prUrl})`,
+      `- [Issue two](https://github.com/foo/bar/issues/2)`,
+      `  - note: blocked by ${prUrl}`,
+      '',
+    ].join('\n');
+    // Issue two's bare mention must not win even though both blocks mention the PR.
+    expect(findListEntryUrlByPrUrl(content, prUrl)).toBe('https://github.com/foo/bar/issues/1');
+  });
+
+  it('returns undefined when the only mention is an unmarked sub-bullet note', () => {
+    const prUrl = 'https://github.com/foo/bar/pull/123';
+    const content = [`- [Issue two](https://github.com/foo/bar/issues/2)`, `  - note: blocked by ${prUrl}`, ''].join(
+      '\n',
+    );
+    expect(findListEntryUrlByPrUrl(content, prUrl)).toBeUndefined();
+  });
+});

--- a/packages/core/src/commands/merge-loop.ts
+++ b/packages/core/src/commands/merge-loop.ts
@@ -43,13 +43,23 @@ const MODULE = 'merge-loop';
 const GITHUB_URL_RE = /https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/(?:issues|pull)\/\d+/;
 
 /**
+ * A line counts as a STATUS sub-bullet only when it carries one of the
+ * markers the workflows write next to an entry's own PR (`**Done**`,
+ * `**In Progress**`, or a `PR [#N](...)` reference). A bare URL mention
+ * (e.g. a hand-written "blocked by <pr-url>" note under a DIFFERENT
+ * entry) must not auto-strike that entry (#1463 review).
+ */
+const STATUS_MARKER_RE = /\*\*(?:Done|In Progress)\*\*|PR \[#?\d/;
+
+/**
  * Find the curated-list entry whose block (entry line plus indented
- * sub-bullets) mentions `prUrl`, and return the entry line's own GitHub
- * URL — the URL `markIssueAsDone` needs to locate the block again.
+ * sub-bullets) mentions `prUrl` on a STATUS-marked line, and return the
+ * entry line's own GitHub URL — the URL `markIssueAsDone` needs to locate
+ * the block again.
  *
- * Returns undefined when no entry block mentions the PR URL, or when the
- * mentioning block's entry line carries no GitHub URL (nothing for the
- * mark-done transform to anchor on).
+ * Returns undefined when no entry block mentions the PR URL on a marked
+ * line, or when the mentioning block's entry line carries no GitHub URL
+ * (nothing for the mark-done transform to anchor on).
  */
 export function findListEntryUrlByPrUrl(content: string, prUrl: string): string | undefined {
   const lines = content.split('\n');
@@ -63,7 +73,13 @@ export function findListEntryUrlByPrUrl(content: string, prUrl: string): string 
     // list-mark-done's findIssueBlock).
     let end = i + 1;
     while (end < lines.length && /^\s{2,}/.test(lines[end])) end++;
-    if (lines.slice(i, end).some((line) => lineMentionsUrl(line, prUrl))) {
+    // The entry line mentioning the PR itself is self-anchored (no
+    // cross-entry ambiguity); sub-bullets must carry a status marker.
+    const entryMentions = lineMentionsUrl(lines[i], prUrl);
+    const markedSubBulletMentions = lines
+      .slice(i + 1, end)
+      .some((line) => lineMentionsUrl(line, prUrl) && STATUS_MARKER_RE.test(line));
+    if (entryMentions || markedSubBulletMentions) {
       const match = GITHUB_URL_RE.exec(lines[i]);
       if (match) return match[0];
       // Entry line has no URL to anchor a mark-done on — keep scanning in

--- a/packages/core/src/commands/merge-loop.ts
+++ b/packages/core/src/commands/merge-loop.ts
@@ -1,0 +1,152 @@
+/**
+ * Close the merge loop (#1463).
+ *
+ * When the daily check detects recently merged PRs, nothing previously
+ * connected the merge back to the curated issue list — `list-mark-done` is
+ * only offered interactively at PR-creation time (draft-first-workflow
+ * Step 10), so a skipped prompt left the entry open forever.
+ *
+ * The join: neither the merged-PR search result (url/repo/number/title/
+ * mergedAt) nor `state.activeIssues` (TrackedIssue — issue URL only, no PR
+ * URL) carries a deterministic PR→issue link. The only deterministic
+ * linkage lives in the curated list itself: workflows record the PR URL in
+ * an entry's sub-bullets (`**Done**` at Step 10, or in-progress markers
+ * like `**In Progress** — PR [#N](url)`). So the reconciliation traverses
+ * the list file's entry blocks for the merged PR URL, recovers the entry's
+ * own URL from its entry line, and marks it done via the exact transform
+ * `list-mark-done` uses. Repo-level guessing (matching a merged PR to "some
+ * claimed issue in the same repo") is deliberately avoided — it could
+ * strike the wrong entry when a repo has several listed issues.
+ *
+ * Auto vs offer: marking a list entry done for a PR that GitHub reports as
+ * MERGED is safe and idempotent (already-marked entries are quiet no-ops),
+ * so it runs automatically. The extract-learnings nudge stays an offer —
+ * it costs API calls and an LLM pass — surfaced via the action menu's
+ * `extract_learnings` item (see computeActionMenu in core/daily-logic.ts).
+ *
+ * Failures never crash the daily run: they land in `warnings[]` under the
+ * `merge-loop` phase.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { errorMessage } from '../core/errors.js';
+import { warn } from '../core/logger.js';
+import type { DailyWarning, MergedPRListUpdate } from '../formatters/json.js';
+import { ENTRY_LINE_RE, lineMentionsUrl } from './curated-list.js';
+import { markIssueAsDone } from './list-mark-done.js';
+import { detectIssueListPath } from './locate-issue-list.js';
+
+const MODULE = 'merge-loop';
+
+/** First GitHub issue-or-PR URL on a line, without trailing punctuation. */
+const GITHUB_URL_RE = /https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/(?:issues|pull)\/\d+/;
+
+/**
+ * Find the curated-list entry whose block (entry line plus indented
+ * sub-bullets) mentions `prUrl`, and return the entry line's own GitHub
+ * URL — the URL `markIssueAsDone` needs to locate the block again.
+ *
+ * Returns undefined when no entry block mentions the PR URL, or when the
+ * mentioning block's entry line carries no GitHub URL (nothing for the
+ * mark-done transform to anchor on).
+ */
+export function findListEntryUrlByPrUrl(content: string, prUrl: string): string | undefined {
+  const lines = content.split('\n');
+  let i = 0;
+  while (i < lines.length) {
+    if (!ENTRY_LINE_RE.test(lines[i])) {
+      i++;
+      continue;
+    }
+    // Block = entry line + following indented sub-bullets (same shape as
+    // list-mark-done's findIssueBlock).
+    let end = i + 1;
+    while (end < lines.length && /^\s{2,}/.test(lines[end])) end++;
+    if (lines.slice(i, end).some((line) => lineMentionsUrl(line, prUrl))) {
+      const match = GITHUB_URL_RE.exec(lines[i]);
+      if (match) return match[0];
+      // Entry line has no URL to anchor a mark-done on — keep scanning in
+      // case a later block also mentions the PR (e.g. duplicate sections).
+    }
+    i = end;
+  }
+  return undefined;
+}
+
+export interface ReconcileMergedPRsInput {
+  /** Recently merged PRs from the daily fetch (Phase 1). */
+  mergedPRs: Array<{ url: string; mergedAt?: string }>;
+  /** Shared daily warnings collector — failures land here, never throw. */
+  warnings: DailyWarning[];
+}
+
+/**
+ * Auto-mark curated-list entries done for recently merged PRs.
+ *
+ * Silent no-op cases (by design — these are normal, not failures):
+ *   - no merged PRs this run
+ *   - no curated list configured/detected
+ *   - no list entry mentions a merged PR's URL
+ *   - the matching entry is already marked done (idempotent re-run)
+ *
+ * Returns the entries actually struck this run, or undefined when nothing
+ * changed — callers omit the field from output rather than emitting `[]`.
+ */
+export function reconcileMergedPRsWithList(input: ReconcileMergedPRsInput): MergedPRListUpdate[] | undefined {
+  const { mergedPRs, warnings } = input;
+  if (mergedPRs.length === 0) return undefined;
+
+  const located = detectIssueListPath();
+  if (!located) return undefined;
+  const listPath = path.resolve(located.path);
+
+  let content: string;
+  try {
+    content = fs.readFileSync(listPath, 'utf8');
+  } catch (error) {
+    const message = `read issue list at ${listPath}: ${errorMessage(error)}`;
+    warnings.push({ phase: 'merge-loop', operation: 'auto-mark merged list entries', message });
+    warn(MODULE, message);
+    return undefined;
+  }
+
+  const updates: MergedPRListUpdate[] = [];
+  for (const pr of mergedPRs) {
+    const entryUrl = findListEntryUrlByPrUrl(content, pr.url);
+    if (!entryUrl) continue;
+
+    const prStatus = pr.mergedAt ? `merged ${pr.mergedAt.slice(0, 10)}` : 'merged';
+    const result = markIssueAsDone(content, { issueUrl: entryUrl, prUrl: pr.url, prStatus });
+    if (!result.marked) continue; // already-marked (or not-found race) — quiet no-op
+    content = result.content;
+    updates.push({
+      prUrl: pr.url,
+      issueUrl: entryUrl,
+      repoHeadingStruck: result.repoHeadingStruck,
+      listPath,
+    });
+  }
+
+  if (updates.length === 0) return undefined;
+
+  // Atomic write (tmp + rename), mirroring runMarkIssueListItemDone.
+  const tmp = `${listPath}.tmp-${process.pid}-${Date.now()}`;
+  try {
+    fs.writeFileSync(tmp, content, 'utf8');
+    fs.renameSync(tmp, listPath);
+  } catch (error) {
+    try {
+      fs.unlinkSync(tmp);
+    } catch {
+      // best-effort cleanup
+    }
+    const message = `write issue list at ${listPath}: ${errorMessage(error)}`;
+    warnings.push({ phase: 'merge-loop', operation: 'auto-mark merged list entries', message });
+    warn(MODULE, message);
+    // Nothing persisted — do not report updates that are not on disk.
+    return undefined;
+  }
+
+  return updates;
+}

--- a/packages/core/src/commands/startup.ts
+++ b/packages/core/src/commands/startup.ts
@@ -18,19 +18,12 @@ import { executeDailyCheck } from './daily.js';
 import { launchDashboardServer, type LaunchResult } from './dashboard-lifecycle.js';
 import { recordBrowserOpened } from './dashboard-process.js';
 import { parseIssueList } from './parse-list.js';
+import { detectIssueListPath } from './locate-issue-list.js';
 
-/**
- * Parse issueListPath from a config file's YAML frontmatter.
- * @param configContent - Raw content of the config.md file
- * @returns The path string or undefined if not found
- */
-export function parseIssueListPathFromConfig(configContent: string): string | undefined {
-  const match = configContent.match(/^---\n([\s\S]*?)\n---/);
-  if (!match) return undefined;
-  const frontmatter = match[1];
-  const pathMatch = frontmatter.match(/issueListPath:\s*["']?([^"'\n]+)["']?/);
-  return pathMatch ? pathMatch[1].trim() : undefined;
-}
+// Path detection moved to locate-issue-list.ts (#1463) so the daily
+// merge-loop can use it without an import cycle through this module.
+// Re-exported here for back-compat with existing consumers/tests.
+export { parseIssueListPathFromConfig } from './locate-issue-list.js';
 
 /**
  * Count available and completed items in an issue list file.
@@ -49,52 +42,12 @@ export function countIssueListItems(content: string): { availableCount: number; 
  * @returns Issue list info with path and item counts, or undefined if not found
  */
 export function detectIssueList(): IssueListInfo | undefined {
-  let issueListPath = '';
-  let source: IssueListInfo['source'] = 'auto-detected';
-
-  // 1. Check state.json config (primary)
-  try {
-    const stateManager = getStateManager();
-    const configuredPath = stateManager.getState().config.issueListPath;
-    if (configuredPath && fs.existsSync(configuredPath)) {
-      issueListPath = configuredPath;
-      source = 'configured';
-    }
-  } catch (error) {
-    // State manager may not be initialized yet — fall through to legacy config.md
-    warn('startup', `Could not read issueListPath from state: ${errorMessage(error)}`);
-  }
-
-  // 2. Fallback: config.md (legacy — will be removed in future)
-  if (!issueListPath) {
-    const configPath = '.claude/oss-autopilot/config.md';
-    if (fs.existsSync(configPath)) {
-      try {
-        const configContent = fs.readFileSync(configPath, 'utf8');
-        const configuredPath = parseIssueListPathFromConfig(configContent);
-        if (configuredPath && fs.existsSync(configuredPath)) {
-          issueListPath = configuredPath;
-          source = 'configured';
-        }
-      } catch (error) {
-        console.error('[STARTUP] Failed to read config:', errorMessage(error));
-      }
-    }
-  }
-
-  // 3. Probe known paths
-  if (!issueListPath) {
-    const probes = ['open-source/potential-issue-list.md', 'oss/issue-list.md', 'issues.md'];
-    for (const probe of probes) {
-      if (fs.existsSync(probe)) {
-        issueListPath = probe;
-        source = 'auto-detected';
-        break;
-      }
-    }
-  }
-
-  if (!issueListPath) return undefined;
+  // Steps 1-3 (state config → legacy config.md → known-path probes) live in
+  // locate-issue-list.ts (#1463), shared with the daily merge-loop.
+  const located = detectIssueListPath();
+  if (!located) return undefined;
+  const issueListPath = located.path;
+  const source: IssueListInfo['source'] = located.source;
 
   // 4. Count available/completed items
   let availableCount = 0;

--- a/packages/core/src/core/daily-logic.test.ts
+++ b/packages/core/src/core/daily-logic.test.ts
@@ -746,6 +746,38 @@ describe('computeActionMenu (core)', () => {
     expect(followUp).toBeDefined();
     expect(followUp!.label).toBe('Follow up on 1 stuck-CI and 1 dormant PRs');
   });
+
+  it('should include extract_learnings when recently merged PRs lack extracted learnings (#1463)', () => {
+    const menu = computeActionMenu([], makeCapacity(), [], undefined, 2);
+    const item = menu.items.find((i) => i.key === 'extract_learnings');
+
+    expect(item).toBeDefined();
+    expect(item!.label).toBe('Extract learnings from 2 recently merged PRs');
+  });
+
+  it('should use singular phrasing for one unextracted merge', () => {
+    const menu = computeActionMenu([], makeCapacity(), [], undefined, 1);
+    const item = menu.items.find((i) => i.key === 'extract_learnings');
+
+    expect(item).toBeDefined();
+    expect(item!.label).toBe('Extract learnings from 1 recently merged PR');
+  });
+
+  it('should omit extract_learnings when the unextracted count is zero', () => {
+    const menu = computeActionMenu([], makeCapacity(), [], undefined, 0);
+    expect(menu.items.find((i) => i.key === 'extract_learnings')).toBeUndefined();
+    expect(menu.items.map((i) => i.key)).toEqual(['search', 'done']);
+  });
+
+  it('should omit extract_learnings when the count is not provided', () => {
+    const menu = computeActionMenu([], makeCapacity());
+    expect(menu.items.find((i) => i.key === 'extract_learnings')).toBeUndefined();
+  });
+
+  it('should order extract_learnings after follow_up, before search', () => {
+    const menu = computeActionMenu([], makeCapacity(), [], { stuckCI: 1, dormantFollowup: 0 }, 1);
+    expect(menu.items.map((i) => i.key)).toEqual(['follow_up', 'extract_learnings', 'search', 'done']);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/core/daily-logic.ts
+++ b/packages/core/src/core/daily-logic.ts
@@ -406,6 +406,7 @@ export function collectActionableIssues(prs: FetchedPR[], lastDigestAt?: string)
  * @param capacity - Current capacity assessment
  * @param commentedIssues - Issues with comment activity
  * @param attention - Attention bucket counts; non-zero stuck-CI / dormant-followup buckets add a follow_up item
+ * @param unextractedMergeCount - Recently merged PRs whose learnings have not been extracted yet (#1463); non-zero adds an extract_learnings item
  * @returns Action menu with context flags for orchestration
  */
 export function computeActionMenu(
@@ -413,6 +414,7 @@ export function computeActionMenu(
   capacity: CapacityAssessment,
   commentedIssues: CommentedIssue[] = [],
   attention?: Pick<AttentionSummary, 'stuckCI' | 'dormantFollowup'>,
+  unextractedMergeCount?: number,
 ): ActionMenu {
   const issueResponses = commentedIssues.filter((i): i is CommentedIssueWithResponse => i.status === 'new_response');
   const items: ActionMenuItem[] = [];
@@ -456,6 +458,19 @@ export function computeActionMenu(
       key: 'follow_up',
       label: `Follow up on ${parts.join(' and ')} PR${total === 1 ? '' : 's'}`,
       description: 'Waiting PRs that may need a nudge (pending CI or no review activity)',
+    });
+  }
+
+  // Extract-learnings nudge (#1463) — recently merged PRs whose ledger
+  // entries carry no learningsExtractedAt stamp get a menu path to
+  // workflows/extract-learnings.md. The nudge persists across runs for the
+  // recently-merged window until the extraction runs, then self-clears.
+  const unextracted = unextractedMergeCount ?? 0;
+  if (unextracted > 0) {
+    items.push({
+      key: 'extract_learnings',
+      label: `Extract learnings from ${unextracted} recently merged PR${unextracted === 1 ? '' : 's'}`,
+      description: 'Distill maintainer review feedback into per-repo contribution guidelines',
     });
   }
 

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -125,6 +125,7 @@ export type DailyWarningPhase =
   | 'fetch'
   | 'repo-scores'
   | 'analytics'
+  | 'merge-loop'
   | 'partition'
   | 'dismiss-filter'
   | 'gist-init'
@@ -175,6 +176,24 @@ export function buildStalenessWarning(info: StalenessLike): DailyWarning {
   };
 }
 
+/**
+ * One curated-list entry auto-marked done because its PR merged (#1463).
+ * Produced by the daily merge-loop reconciliation (commands/merge-loop.ts):
+ * a recently merged PR's URL was found inside a list entry's block (the
+ * entry line or an indented sub-bullet), and the entry was struck through
+ * via the same transform `list-mark-done` uses.
+ */
+export interface MergedPRListUpdate {
+  /** The merged PR whose detection triggered the auto-mark. */
+  prUrl: string;
+  /** URL on the struck entry line (usually the issue URL the PR resolved). */
+  issueUrl: string;
+  /** Curated-list file that was updated. */
+  listPath: string;
+  /** True if the parent `### repo/name` heading was also struck through. */
+  repoHeadingStruck: boolean;
+}
+
 export interface DailyOutput {
   digest: DailyDigestCompact;
   capacity: CapacityAssessment;
@@ -200,6 +219,13 @@ export interface DailyOutput {
    * absent or null on runs where the gate stays silent.
    */
   strategySummary?: import('../core/strategy.js').StrategyResult | null;
+  /**
+   * Curated-list entries auto-marked done this run because their PR merged
+   * (#1463). Present only when at least one entry was actually struck —
+   * merge-free runs (and runs with no curated list / no matching entry)
+   * omit the field entirely so existing consumers and goldens see no change.
+   */
+  listUpdates?: MergedPRListUpdate[];
 }
 
 /**
@@ -230,6 +256,8 @@ export interface CompactDailyOutput {
   warnings: DailyWarning[];
   /** Periodic strategy snapshot, threaded through compact mode for parity. See {@link DailyOutput.strategySummary}. */
   strategySummary?: import('../core/strategy.js').StrategyResult | null;
+  /** Curated-list entries auto-marked done this run (#1463). See {@link DailyOutput.listUpdates}. */
+  listUpdates?: MergedPRListUpdate[];
 }
 
 /**
@@ -249,6 +277,7 @@ export function toCompactDailyOutput(output: DailyOutput): CompactDailyOutput {
     failureCount: output.failures.length,
     warnings: output.warnings,
     strategySummary: output.strategySummary,
+    listUpdates: output.listUpdates,
   };
 }
 
@@ -308,6 +337,7 @@ const DailyWarningPhaseSchema = z.enum([
   'fetch',
   'repo-scores',
   'analytics',
+  'merge-loop',
   'partition',
   'dismiss-filter',
   'gist-init',
@@ -526,6 +556,14 @@ export const AttentionSummarySchema = z.object({
   waiting: z.number().int().nonnegative(),
 });
 
+/** Mirrors {@link MergedPRListUpdate} (#1463). */
+const MergedPRListUpdateSchema = z.object({
+  prUrl: z.string(),
+  issueUrl: z.string(),
+  listPath: z.string(),
+  repoHeadingStruck: z.boolean(),
+});
+
 export const DailyOutputSchema = z.object({
   digest: DailyDigestCompactSchema,
   capacity: CapacityAssessmentSchema,
@@ -539,6 +577,7 @@ export const DailyOutputSchema = z.object({
   failures: z.array(PRCheckFailurePassthroughSchema),
   warnings: z.array(DailyWarningSchema),
   strategySummary: StrategyResultSchema.nullable().optional(),
+  listUpdates: z.array(MergedPRListUpdateSchema).optional(),
 });
 
 export const CompactDailyOutputSchema = z.object({
@@ -552,6 +591,7 @@ export const CompactDailyOutputSchema = z.object({
   failureCount: z.number().int().nonnegative(),
   warnings: z.array(DailyWarningSchema),
   strategySummary: StrategyResultSchema.nullable().optional(),
+  listUpdates: z.array(MergedPRListUpdateSchema).optional(),
 });
 
 // ── Search output schema (#1147) ─────────────────────────────────────

--- a/workflows/action-menu.md
+++ b/workflows/action-menu.md
@@ -82,6 +82,19 @@ Recently closed (informational):
 
 These do not require any action. They exist so the user knows what was closed. The Auto-Exclude prompt (in the work-through-issues workflow) may offer to exclude these repos from future searches.
 
+### Auto-Marked List Entries (Informational)
+
+If `data.daily.listUpdates` is present (#1463), the CLI detected merged PRs and automatically marked the matching curated-list entries done (same transform as `list-mark-done`). Display them after the recently-closed section so the user knows their list was updated without being asked:
+
+```
+Issue list updated automatically (PR merged):
+- {issueUrl} marked done — PR {prUrl}
+```
+
+If an entry's `repoHeadingStruck` is `true`, append "(all issues for this repo are now done)". No action needed; the field is absent on runs where nothing was marked. Failures to update the list appear in `data.daily.warnings` under the `merge-loop` phase — surface those like any other warning.
+
+The action menu may also contain an `extract_learnings` item (key: `extract_learnings`) when recently merged PRs have no learnings extracted yet — present it like any other pre-computed item; it routes to `workflows/extract-learnings.md` via the Phase Routing Table in `commands/oss.md`.
+
 ### Ask for Action (Using Pre-Computed Menu)
 
 Use `data.daily.actionMenu.items` directly as AskUserQuestion options. Each item has `key`, `label`, and `description` fields ready for display.


### PR DESCRIPTION
Fixes #1463.

When daily detects merged PRs, nothing connected the merge back to the curated list, the extract-learnings flow, or claimed issues — three manual steps the host LLM had to remember across sessions.

## Design (built on what's actually there)

No deterministic PR→issue link exists in state (TrackedIssue has no prUrl; merged search results carry no issue ref). The honest join is the list file itself: workflows record the PR url in an entry's status sub-bullets, so the loop scans entry blocks for the merged PR url — review-hardened to require a Done/In Progress/PR-reference MARKER on sub-bullet matches (a hand-written "blocked by PR-url" note under a different entry can no longer strike the wrong one; reproduced and pinned), with entry-line mentions self-anchored. Entries with no recorded PR url stay manual by design (closing that needs a prUrl field on TrackedIssue or PR-body fetches — separate issue material).

- **Auto:** mark-done for merged PRs (GitHub says MERGED; idempotent pure transform; same tmp+rename atomic write as list-mark-done), surfaced via optional DailyOutput.listUpdates (merge-free goldens byte-identical, pinned). Failures land in warnings[] under a merge-loop phase; failed writes report nothing.
- **Offer:** extract_learnings action-menu item (mirrors #1462's pattern), gated on 7-day-window merges lacking learningsExtractedAt — persists across runs until extracted. oss.md routing row → workflows/extract-learnings.md.
- locate-issue-list.ts extracted from startup.ts to break an import cycle (re-export kept; reviewer-verified behavior-preserving).

Reviewer-verified: Phase placement consumes Phase 1's in-memory fetch (ledger failures can't corrupt the join), legacy ledger entries can't crash the gate, atomic write + concurrent-read safety.

26 (+2 review) tests. Gate: root eslint, prettier, typecheck, 2957 core + 253 mcp green. code-reviewer pass converged (1 finding, fixed + pinned on-branch).