### PR TITLE
chore(dashboard): polish — honest caching, chart update-in-place, ticking timestamps (#1459)

### DIFF
--- a/packages/core/src/commands/dashboard-server.test.ts
+++ b/packages/core/src/commands/dashboard-server.test.ts
@@ -290,6 +290,10 @@ describe('dashboard-server', () => {
     fs.writeFileSync(path.join(tmpDir, 'test.css'), 'body { color: red; }');
     fs.writeFileSync(path.join(tmpDir, 'app.js'), 'console.log("app");');
     fs.writeFileSync(path.join(tmpDir, 'icon.svg'), '<svg></svg>');
+    // Hashed build outputs live under assets/ (Vite's content-addressed dir);
+    // these get the long cache while everything else revalidates (#1459).
+    fs.mkdirSync(path.join(tmpDir, 'assets'));
+    fs.writeFileSync(path.join(tmpDir, 'assets', 'index-abc123.js'), 'console.log("bundle");');
 
     // Set up state manager mock with a cached digest
     const digest = makeDigest();
@@ -415,6 +419,45 @@ describe('dashboard-server', () => {
       const result = await sendRequest('GET', '/icon.svg');
       expect(result.statusCode).toBe(200);
       expect(result.headers['Content-Type']).toBe('image/svg+xml');
+    });
+
+    // ── Honest caching + asset 404s (#1459) ─────────────────────────
+
+    it('serves index.html with Cache-Control no-cache so upgrades are picked up (direct, #1459)', async () => {
+      const result = await sendRequest('GET', '/');
+      expect(result.statusCode).toBe(200);
+      expect(result.headers['Content-Type']).toBe('text/html');
+      expect(result.headers['Cache-Control']).toBe('no-cache');
+    });
+
+    it('serves the SPA-fallback index.html with Cache-Control no-cache (#1459)', async () => {
+      const result = await sendRequest('GET', '/nonexistent/path');
+      expect(result.statusCode).toBe(200);
+      expect(result.headers['Content-Type']).toBe('text/html');
+      expect(result.headers['Cache-Control']).toBe('no-cache');
+    });
+
+    it('keeps the long cache for hashed files under /assets/ (#1459)', async () => {
+      const result = await sendRequest('GET', '/assets/index-abc123.js');
+      expect(result.statusCode).toBe(200);
+      expect(result.headers['Content-Type']).toBe('application/javascript');
+      expect(result.headers['Cache-Control']).toBe('public, max-age=3600');
+      expect(result.body).toContain('console.log("bundle")');
+    });
+
+    it('returns a real 404 for missing files under /assets/ instead of the SPA fallback (#1459)', async () => {
+      // Falling back to index.html (200 text/html) here made the module
+      // loader reject the response after an upgrade deleted old bundles.
+      const result = await sendRequest('GET', '/assets/index-deadbeef.js');
+      expect(result.statusCode).toBe(404);
+      expect(result.headers['Content-Type']).toBe('application/json');
+      expect(JSON.parse(result.body)).toEqual({ error: 'Not found' });
+    });
+
+    it('serves unhashed non-index files (favicon etc.) with no-cache (#1459)', async () => {
+      const result = await sendRequest('GET', '/icon.svg');
+      expect(result.statusCode).toBe(200);
+      expect(result.headers['Cache-Control']).toBe('no-cache');
     });
   });
 

--- a/packages/core/src/commands/dashboard-server.ts
+++ b/packages/core/src/commands/dashboard-server.ts
@@ -980,16 +980,28 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
       return;
     }
 
+    // Hashed build outputs live under /assets/ (Vite's content-addressed
+    // bundles). A missing file there must be a real 404, not the SPA
+    // fallback: serving index.html as 200 text/html makes the module loader
+    // reject the response, and after a plugin upgrade a cached index.html
+    // referencing deleted bundles would blank the dashboard (#1459).
+    const isAssetPath = urlPath.startsWith('/assets/');
+    const indexPath = path.join(resolvedAssetsDir, 'index.html');
+
     // If file doesn't exist or is a directory, serve index.html for SPA routing
     try {
       const stat = fs.statSync(filePath);
       if (stat.isDirectory()) {
-        filePath = path.join(resolvedAssetsDir, 'index.html');
+        filePath = indexPath;
       }
     } catch (err) {
       const nodeErr = err as NodeJS.ErrnoException;
       if (nodeErr.code === 'ENOENT') {
-        filePath = path.join(resolvedAssetsDir, 'index.html');
+        if (isAssetPath) {
+          sendError(res, 404, 'Not found');
+          return;
+        }
+        filePath = indexPath;
       } else {
         warn(MODULE, `Failed to stat file: ${filePath}`);
         sendError(res, 500, 'Internal server error');
@@ -1000,13 +1012,20 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
     const ext = path.extname(filePath).toLowerCase();
     const contentType = MIME_TYPES[ext] || 'application/octet-stream';
 
+    // Honest caching (#1459): only hashed /assets/* files are safe to cache —
+    // their names change with their content. index.html (direct or SPA
+    // fallback) and other unhashed files (favicon, etc.) must revalidate so a
+    // plugin upgrade is picked up on the next navigation instead of serving a
+    // stale page that references deleted bundles for up to an hour.
+    const cacheControl = isAssetPath && filePath !== indexPath ? 'public, max-age=3600' : 'no-cache';
+
     try {
       const content = fs.readFileSync(filePath);
       setSecurityHeaders(res);
       res.writeHead(200, {
         'Content-Type': contentType,
         'Content-Length': content.length,
-        'Cache-Control': 'public, max-age=3600',
+        'Cache-Control': cacheControl,
       });
       res.end(content);
     } catch (error) {

--- a/packages/dashboard/src/app.test.tsx
+++ b/packages/dashboard/src/app.test.tsx
@@ -368,6 +368,45 @@ describe('App', () => {
     vi.useRealTimers();
   });
 
+  // ── Relative timestamp ticking (#1459) ────────────────────────────
+
+  it('ticks the "Updated Xm ago" label over time without any network calls', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mockFetchOk(makeDashboardData());
+
+    const { container } = render(<App />);
+    await waitFor(() => expect(container.querySelector('.dashboard')).toBeTruthy());
+    expect(container.querySelector('.last-updated')?.textContent).toBe('Updated just now');
+
+    // Let the one-shot 5s auto-refresh land first — it bumps lastUpdated, so
+    // the window we measure below starts after it. act-wrapped per #1446's
+    // lesson: preact only flushes timer-scheduled effects deterministically
+    // inside act.
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+    });
+    await waitFor(() => {
+      const btn = container.querySelector('.refresh-btn') as HTMLButtonElement;
+      expect(btn.disabled).toBe(false);
+    });
+
+    const fetchMock = fetch as ReturnType<typeof vi.fn>;
+    const callsBefore = fetchMock.mock.calls.length;
+
+    // Two minutes pass with zero user interaction. The label used to stay
+    // frozen at "just now" because formatRelativeTime was computed at render
+    // only — the 30s tick interval must re-render the header.
+    await act(async () => {
+      vi.advanceTimersByTime(120_000);
+    });
+
+    expect(container.querySelector('.last-updated')?.textContent).toBe('Updated 2m ago');
+    // The tick is cosmetic: it must not trigger any fetches.
+    expect(fetchMock.mock.calls.length).toBe(callsBefore);
+
+    vi.useRealTimers();
+  });
+
   // ── Action round-trips (#966) ─────────────────────────────────────
   //
   // These tests exercise the wiring between the ActionBar buttons in the

--- a/packages/dashboard/src/app.tsx
+++ b/packages/dashboard/src/app.tsx
@@ -39,6 +39,10 @@ function RefreshIcon() {
   );
 }
 
+/** How often the header re-renders so the relative "Updated Xm ago" label
+ * ticks (#1459). Purely cosmetic — no network calls ride this interval. */
+const RELATIVE_TIME_TICK_MS = 30_000;
+
 function DashboardHeader({
   stats,
   loading,
@@ -49,6 +53,15 @@ function DashboardHeader({
   onToggleTheme,
   onCelebrate,
 }: DashboardHeaderProps) {
+  // formatRelativeTime is computed at render only, so without this tick an
+  // overnight tab would say "Updated just now" against 12-hour-old data
+  // (#1459). The state value is unused; bumping it schedules the re-render.
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), RELATIVE_TIME_TICK_MS);
+    return () => clearInterval(id);
+  }, []);
+
   return (
     <header class="dashboard-header">
       <div class="header-brand">

--- a/packages/dashboard/src/components/chart-panel.test.tsx
+++ b/packages/dashboard/src/components/chart-panel.test.tsx
@@ -1,8 +1,56 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/preact';
+
+// Mock Chart.js so the tests can observe instance lifecycle: chart-panel must
+// create each Chart exactly once and update it in place on data refreshes
+// instead of destroy-and-recreate, which replayed the 1.5s entrance animation
+// on every refresh and PR action (#1459).
+const chartMock = vi.hoisted(() => {
+  interface MockChartConfig {
+    type: string;
+    data: { labels: unknown[]; datasets: Array<{ label?: string; data: unknown[] }> };
+    options: Record<string, unknown>;
+  }
+  class MockChart {
+    static register = vi.fn();
+    type: string;
+    data: MockChartConfig['data'];
+    options: MockChartConfig['options'];
+    update = vi.fn();
+    destroy = vi.fn();
+    constructor(_canvas: unknown, config: MockChartConfig) {
+      this.type = config.type;
+      this.data = config.data;
+      this.options = config.options;
+      instances.push(this);
+    }
+  }
+  const instances: MockChart[] = [];
+  return { MockChart, instances };
+});
+
+vi.mock('chart.js', () => ({
+  Chart: chartMock.MockChart,
+  LineController: {},
+  BarController: {},
+  CategoryScale: {},
+  LinearScale: {},
+  PointElement: {},
+  LineElement: {},
+  BarElement: {},
+  Tooltip: {},
+  Legend: {},
+}));
+
 import { ChartPanel } from './chart-panel';
 
+const topRepos = [{ repo: 'a/b', active: 1, merged: 2, closed: 0 }];
+
 describe('ChartPanel', () => {
+  beforeEach(() => {
+    chartMock.instances.length = 0;
+  });
+
   it('renders canvas elements with aria-label and role="img"', () => {
     const { container } = render(<ChartPanel monthlyMerged={{}} topRepos={[]} theme="dark" />);
     const canvases = container.querySelectorAll('canvas');
@@ -11,5 +59,72 @@ describe('ChartPanel', () => {
       expect(canvas.getAttribute('role')).toBe('img');
       expect(canvas.getAttribute('aria-label')).toBeTruthy();
     });
+  });
+
+  it('creates one line chart and one bar chart on first render', () => {
+    render(<ChartPanel monthlyMerged={{ '2026-01': 3 }} topRepos={topRepos} theme="dark" />);
+    expect(chartMock.instances).toHaveLength(2);
+    expect(chartMock.instances.map((c) => c.type).sort()).toEqual(['bar', 'line']);
+  });
+
+  it('includes Opened and Closed datasets when monthly data is provided', () => {
+    render(
+      <ChartPanel
+        monthlyMerged={{ '2026-01': 3 }}
+        monthlyOpened={{ '2026-01': 4 }}
+        monthlyClosed={{ '2026-01': 1 }}
+        topRepos={topRepos}
+        theme="dark"
+      />,
+    );
+    const line = chartMock.instances.find((c) => c.type === 'line');
+    expect(line!.data.datasets.map((d) => d.label)).toEqual(['Opened', 'Merged', 'Closed']);
+  });
+
+  it('updates charts in place on a data refresh instead of destroy-and-recreate (#1459)', () => {
+    const { rerender } = render(<ChartPanel monthlyMerged={{ '2026-01': 3 }} topRepos={topRepos} theme="dark" />);
+    expect(chartMock.instances).toHaveLength(2);
+    const [line, bar] = chartMock.instances;
+
+    // Every /api response produces fresh object identities — simulate one.
+    rerender(
+      <ChartPanel
+        monthlyMerged={{ '2026-01': 5 }}
+        topRepos={[{ repo: 'a/b', active: 2, merged: 3, closed: 1 }]}
+        theme="dark"
+      />,
+    );
+
+    // Same two instances, updated in place — no re-creation, no destroy.
+    expect(chartMock.instances).toHaveLength(2);
+    expect(line!.destroy).not.toHaveBeenCalled();
+    expect(bar!.destroy).not.toHaveBeenCalled();
+    expect(line!.update).toHaveBeenCalledWith('none');
+    expect(bar!.update).toHaveBeenCalledWith('none');
+    expect(line!.data.datasets[0]!.data).toEqual([5]);
+    expect(bar!.data.datasets[0]!.data).toEqual([2]);
+  });
+
+  it('updates charts in place on a theme change (#1459)', () => {
+    const { rerender } = render(<ChartPanel monthlyMerged={{ '2026-01': 3 }} topRepos={topRepos} theme="dark" />);
+    const [line, bar] = chartMock.instances;
+
+    rerender(<ChartPanel monthlyMerged={{ '2026-01': 3 }} topRepos={topRepos} theme="light" />);
+
+    expect(chartMock.instances).toHaveLength(2);
+    expect(line!.destroy).not.toHaveBeenCalled();
+    expect(bar!.destroy).not.toHaveBeenCalled();
+    expect(line!.update).toHaveBeenCalledWith('none');
+    expect(bar!.update).toHaveBeenCalledWith('none');
+  });
+
+  it('destroys both chart instances on unmount', () => {
+    const { unmount } = render(<ChartPanel monthlyMerged={{ '2026-01': 3 }} topRepos={topRepos} theme="dark" />);
+    const [line, bar] = chartMock.instances;
+
+    unmount();
+
+    expect(line!.destroy).toHaveBeenCalledTimes(1);
+    expect(bar!.destroy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/dashboard/src/components/chart-panel.tsx
+++ b/packages/dashboard/src/components/chart-panel.tsx
@@ -73,7 +73,10 @@ export function ChartPanel({ monthlyMerged, monthlyOpened, monthlyClosed, topRep
   const lineChartRef = useRef<Chart | null>(null);
   const barChartRef = useRef<Chart | null>(null);
 
-  // Monthly activity line chart
+  // Monthly activity line chart. Created once, then updated in place: every
+  // /api/data|refresh|action response produces fresh array identities, so a
+  // destroy-and-recreate here replayed the 1.5s entrance animation on every
+  // refresh and PR action (#1459).
   useEffect(() => {
     const canvas = lineCanvasRef.current;
     if (!canvas) return;
@@ -116,29 +119,33 @@ export function ChartPanel({ monthlyMerged, monthlyOpened, monthlyClosed, topRep
       });
     }
 
-    lineChartRef.current = new Chart(canvas, {
-      type: 'line',
-      data: { labels: months, datasets },
-      options: {
-        responsive: true,
-        maintainAspectRatio: false,
-        // Entrance animation (#940) — visible for demos, tasteful for daily use.
-        animation: { duration: 1500, easing: 'easeOutQuart' },
-        plugins: { legend: legendOpts },
-        scales: {
-          x: scaleOpts,
-          y: { beginAtZero: true, ...scaleOpts },
-        },
+    const data = { labels: months, datasets };
+    const options = {
+      responsive: true,
+      maintainAspectRatio: false,
+      // Entrance animation (#940) — visible for demos, tasteful for daily use.
+      animation: { duration: 1500, easing: 'easeOutQuart' as const },
+      plugins: { legend: legendOpts },
+      scales: {
+        x: scaleOpts,
+        y: { beginAtZero: true, ...scaleOpts },
       },
-    });
-
-    return () => {
-      lineChartRef.current?.destroy();
-      lineChartRef.current = null;
     };
+
+    const existing = lineChartRef.current;
+    if (existing) {
+      existing.data = data;
+      existing.options = options;
+      // 'none' skips the transition — the entrance animation runs only when
+      // the chart is first created (#1459).
+      existing.update('none');
+      return;
+    }
+    lineChartRef.current = new Chart(canvas, { type: 'line', data, options });
   }, [monthlyMerged, monthlyOpened, monthlyClosed, theme]);
 
-  // Top repos bar chart
+  // Top repos bar chart — same create-once-then-update-in-place pattern as
+  // the line chart above (#1459).
   useEffect(() => {
     const canvas = barCanvasRef.current;
     if (!canvas) return;
@@ -149,48 +156,61 @@ export function ChartPanel({ monthlyMerged, monthlyOpened, monthlyClosed, topRep
     const repos = topRepos.slice(0, 10);
     const labels = repos.map((r) => r.repo);
 
-    barChartRef.current = new Chart(canvas, {
-      type: 'bar',
-      data: {
-        labels,
-        datasets: [
-          {
-            label: 'Active',
-            data: repos.map((r) => r.active),
-            backgroundColor: colors.green,
-          },
-          {
-            label: 'Merged',
-            data: repos.map((r) => r.merged),
-            backgroundColor: colors.purple,
-          },
-          {
-            label: 'Closed',
-            data: repos.map((r) => r.closed),
-            backgroundColor: colors.red,
-          },
-        ],
-      },
-      options: {
-        responsive: true,
-        maintainAspectRatio: false,
-        // Entrance animation (#940) matched with the line chart so both charts
-        // "come alive" together when the dashboard loads.
-        animation: { duration: 1500, easing: 'easeOutQuart' },
-        indexAxis: 'y',
-        plugins: { legend: legendOpts },
-        scales: {
-          x: { stacked: true, beginAtZero: true, ...scaleOpts },
-          y: { stacked: true, ...scaleOpts },
+    const data = {
+      labels,
+      datasets: [
+        {
+          label: 'Active',
+          data: repos.map((r) => r.active),
+          backgroundColor: colors.green,
         },
+        {
+          label: 'Merged',
+          data: repos.map((r) => r.merged),
+          backgroundColor: colors.purple,
+        },
+        {
+          label: 'Closed',
+          data: repos.map((r) => r.closed),
+          backgroundColor: colors.red,
+        },
+      ],
+    };
+    const options = {
+      responsive: true,
+      maintainAspectRatio: false,
+      // Entrance animation (#940) matched with the line chart so both charts
+      // "come alive" together when the dashboard loads.
+      animation: { duration: 1500, easing: 'easeOutQuart' as const },
+      indexAxis: 'y' as const,
+      plugins: { legend: legendOpts },
+      scales: {
+        x: { stacked: true, beginAtZero: true, ...scaleOpts },
+        y: { stacked: true, ...scaleOpts },
       },
-    });
+    };
 
-    return () => {
+    const existing = barChartRef.current;
+    if (existing) {
+      existing.data = data;
+      existing.options = options;
+      existing.update('none');
+      return;
+    }
+    barChartRef.current = new Chart(canvas, { type: 'bar', data, options });
+  }, [topRepos, theme]);
+
+  // Destroy chart instances only on unmount — not on every data/theme change
+  // (#1459); the effects above update existing instances in place.
+  useEffect(
+    () => () => {
+      lineChartRef.current?.destroy();
+      lineChartRef.current = null;
       barChartRef.current?.destroy();
       barChartRef.current = null;
-    };
-  }, [topRepos, theme]);
+    },
+    [],
+  );
 
   return (
     <div class="chart-panel">


### PR DESCRIPTION
Fixes #1459.

1. **Static caching:** long cache only for hashed /assets/ files; index.html (direct AND SPA fallback) and unhashed root files are no-cache; missing /assets/ files get a real JSON 404 instead of the index.html fallback that made post-upgrade dashboards blank for up to an hour (cached index referencing deleted hashed bundles → module loader rejects text/html). Deep-link SPA fallback and traversal guards untouched (reviewer-verified).
2. **Charts update in place:** chart.data/options assignment + update('none') when the instance exists; destroy is unmount-only. The 1.5s entrance animation runs on first render only — no more full re-animation on every refresh and PR action. Reviewer verified against Chart.js v4 source that options reassignment is picked up by update().
3. **"Updated Xm ago" ticks:** 30s mount-once interval bumps a tick state; cleanup on unmount, zero network.

10 new tests. Gate: root eslint, prettier, typecheck, 2912 core green; dashboard 278/278 + coverage 91.96/84.71/88.57/92.53 (gate 80/75/80/80) under node 22; dashboard build clean; 253 mcp. code-reviewer pass: CLEAN (also root-caused the local parallel-run failures: node 26's native localStorage shadowing jsdom — environmental, pre-existing).