### PR TITLE
refactor(dashboard): extract GistSyncCoordinator and DashboardCache from the server (#1457)

### DIFF
--- a/packages/core/src/commands/dashboard-cache.ts
+++ b/packages/core/src/commands/dashboard-cache.ts
@@ -1,0 +1,277 @@
+/**
+ * DashboardCache — the dashboard server's cached-response state.
+ *
+ * Extracted from dashboard-server.ts (#1457). Owns the cached digest,
+ * commented issues, partialFailures, built JSON payload, issue-list mtime
+ * and the last background-refresh error, plus buildDashboardJson (the
+ * payload builder the cache exists to memoize). The HTTP handlers consume
+ * it as a collaborator; nothing here touches req/res.
+ */
+
+import * as fs from 'node:fs';
+import { getStateManager, applyStatusOverrides, classifyAttentionBucket } from '../core/index.js';
+import { errorMessage } from '../core/errors.js';
+import { warn } from '../core/logger.js';
+import {
+  computePRsByRepo,
+  computeTopRepos,
+  getMonthlyData,
+  buildDashboardStats,
+  reconcileShelvePartition,
+  storedToMergedPRs,
+  storedToClosedPRs,
+  type DashboardJsonData,
+} from './dashboard-data.js';
+import { detectIssueList } from './startup.js';
+import { parseIssueList, type ParseIssueListOutput } from './parse-list.js';
+import {
+  isBelowMinStars,
+  type DailyDigest,
+  type AgentState,
+  type CommentedIssue,
+  type CommentedIssueWithResponse,
+  type MergedPR,
+  type ClosedPR,
+  type RepoMetadataEntry,
+} from '../core/types.js';
+
+const MODULE = 'dashboard-server';
+
+/**
+ * Read and parse the vetted issue list file (non-fatal on failure).
+ *
+ * @param failures - Optional collector (#1448): a read/parse failure pushes a
+ *   label so the SPA's partialFailures banner shows the panel is degraded
+ *   rather than silently empty. "No list detected" is not a failure and
+ *   pushes nothing.
+ */
+function readVettedIssues(failures?: string[]): ParseIssueListOutput | null {
+  try {
+    const info = detectIssueList();
+    if (!info) return null;
+    const content = fs.readFileSync(info.path, 'utf8');
+    return parseIssueList(content);
+  } catch (error) {
+    warn(MODULE, `Failed to read vetted issue list: ${errorMessage(error)}`);
+    failures?.push('read vetted issue list');
+    return null;
+  }
+}
+
+/**
+ * Get the mtime of the vetted issue list file in ms, or null if unknown.
+ * Used to detect external edits and invalidate the cached dashboard payload.
+ */
+export function getIssueListMtimeMs(): number | null {
+  try {
+    const info = detectIssueList();
+    if (!info) return null;
+    return fs.statSync(info.path).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build the JSON payload that the SPA expects from GET /api/data.
+ *
+ * Exported for unit testing of response-shape concerns that the full
+ * handler harness can't reach (it bakes a stale cachedDigest at server
+ * start-up, so tests that need a specific digest should call this directly).
+ */
+export function buildDashboardJson(
+  digest: DailyDigest,
+  state: Readonly<AgentState>,
+  commentedIssues: CommentedIssue[],
+  allMergedPRs?: MergedPR[],
+  allClosedPRs?: ClosedPR[],
+  partialFailures?: string[],
+): DashboardJsonData {
+  // Collect build-local failures (#1448) alongside the caller-provided ones
+  // so degradations detected during THIS build (vetted-list read failure,
+  // status-override application failure) reach the SPA's partialFailures
+  // banner instead of living only in stderr.
+  const buildFailures: string[] = [...(partialFailures ?? [])];
+  // Apply status overrides ONCE, before the shelve partition is derived, so
+  // the dashboard partitions on the same post-override status the CLI
+  // partitions on (#1416). This also covers overrides set AFTER the digest
+  // was cached (a dashboard move stores an override; the action path rebuilds
+  // from the cached digest). Work on a copy — the caller's cached digest must
+  // not accumulate per-request derivations.
+  const overriddenDigest: DailyDigest = {
+    ...digest,
+    openPRs: applyStatusOverrides(digest.openPRs || [], state, buildFailures),
+    summary: { ...digest.summary },
+  };
+  // Re-derive the shelve partition from the CURRENT state before reading it.
+  // The POST /api/action path rebuilds with a cached digest whose shelvedPRs
+  // predates the shelve/unshelve, so without this the SPA action appears to do
+  // nothing until the next full /api/refresh.
+  reconcileShelvePartition(overriddenDigest, state);
+  const prsByRepo = computePRsByRepo(overriddenDigest, state);
+  const topRepos = computeTopRepos(prsByRepo);
+  const { monthlyMerged, monthlyOpened, monthlyClosed } = getMonthlyData(state);
+  // Derive from state if not provided (e.g. initial load from cached state)
+  const mergedPRs = allMergedPRs ?? storedToMergedPRs(getStateManager().getMergedPRs());
+  const closedPRs = allClosedPRs ?? storedToClosedPRs(getStateManager().getClosedPRs());
+  // Filter out PRs from repos below the minStars threshold
+  const minStars = state.config.minStars ?? 50;
+  const repoScores = state.repoScores || {};
+  const isAboveMinStars = (pr: { repo: string }): boolean =>
+    !isBelowMinStars(repoScores[pr.repo]?.stargazersCount, minStars);
+  const filteredMergedPRs = mergedPRs.filter(isAboveMinStars);
+  const filteredClosedPRs = closedPRs.filter(isAboveMinStars);
+  const stats = buildDashboardStats(overriddenDigest, state, filteredMergedPRs.length, filteredClosedPRs.length);
+  const dismissedIssues = state.config.dismissedIssues || {};
+  const issueResponses = commentedIssues.filter(
+    (i): i is CommentedIssueWithResponse => i.status === 'new_response' && !(i.url in dismissedIssues),
+  );
+
+  // Build repo metadata map from repoScores — omit repos without stars or language to avoid empty entries
+  const repoMetadata: Record<string, RepoMetadataEntry> = {};
+  for (const [repo, score] of Object.entries(repoScores)) {
+    if (score.stargazersCount !== undefined || score.language !== undefined) {
+      repoMetadata[repo] = { stars: score.stargazersCount, language: score.language };
+    }
+  }
+
+  // A vetted-list read failure reaches the SPA banner via buildFailures
+  // instead of leaving the panel silently empty (#1448).
+  const vettedIssues = readVettedIssues(buildFailures);
+  if (vettedIssues) {
+    stats.availableIssues = vettedIssues.availableCount;
+  }
+
+  return {
+    stats,
+    prsByRepo,
+    topRepos: topRepos.map(([repo, data]) => ({ repo, ...data })),
+    monthlyMerged,
+    monthlyOpened,
+    monthlyClosed,
+    // #1352: stamp the unified attention bucket so the SPA renders the same
+    // taxonomy the CLI brief counts (single classifier, no second opinion).
+    // Overrides were already applied when overriddenDigest was built — a
+    // second application here would be a no-op but obscures the single
+    // apply-then-partition ordering (#1416).
+    activePRs: (overriddenDigest.openPRs || []).map((pr) => ({
+      ...pr,
+      attentionBucket: classifyAttentionBucket(pr),
+    })),
+    // Source of truth is digest.shelvedPRs (union of explicitly-shelved URLs
+    // and dormant-non-addressing PRs auto-shelved for display). Returning
+    // only state.config.shelvedPRUrls would under-count and desync from
+    // stats.shelvedPRs, which is already derived from digest.shelvedPRs. (#981)
+    shelvedPRUrls: (overriddenDigest.shelvedPRs || []).map((ref) => ref.url),
+    recentlyMergedPRs: overriddenDigest.recentlyMergedPRs || [],
+    recentlyClosedPRs: overriddenDigest.recentlyClosedPRs || [],
+    autoUnshelvedPRs: overriddenDigest.autoUnshelvedPRs || [],
+    commentedIssues,
+    issueResponses,
+    allMergedPRs: filteredMergedPRs,
+    allClosedPRs: filteredClosedPRs,
+    repoMetadata,
+    vettedIssues,
+    // Dedup: the fetch path already applies status overrides into the cached
+    // partialFailures, and the rebuild applies them again above — the same
+    // failing override must not appear (and be counted) twice (#1448).
+    partialFailures: buildFailures.length > 0 ? [...new Set(buildFailures)] : undefined,
+  };
+}
+
+/** The slice of DashboardFetchResult the cache adopts after a full refresh. */
+export interface DashboardFetchSnapshot {
+  digest: DailyDigest;
+  commentedIssues: CommentedIssue[];
+  partialFailures: string[];
+}
+
+export class DashboardCache {
+  // Start immediately with state.json data (written by the daily check that
+  // precedes this server launch). A background GitHub fetch refreshes the
+  // cache after the port is bound, so the startup poller sees us in time.
+  private cachedDigest: DailyDigest;
+  private cachedCommentedIssues: CommentedIssue[] = [];
+  // Persist the last-known partialFailures across rebuild requests (#1035).
+  // Cleared only when a fresh fetchDashboardData returns zero failures;
+  // re-threaded into every buildDashboardJson call so the SPA banner does
+  // not disappear when /api/data rebuilds after a state change or after a
+  // POST /api/action completes.
+  private cachedPartialFailures: string[] | undefined = undefined;
+  private cachedJsonData!: DashboardJsonData;
+  private cachedIssueListMtimeMs: number | null;
+  // Tracks the last background-refresh failure so /api/data can surface
+  // staleness to the SPA via the X-Dashboard-Stale header (#1205). Cleared
+  // when a refresh succeeds. Without this, token expiry / GitHub outage
+  // produces silent stale data hours old with no client-visible signal.
+  lastBackgroundRefreshError: string | null = null;
+
+  constructor(
+    initialDigest: DailyDigest,
+    /** Decorates a partialFailures payload with the gist-sync lifecycle's
+     * warnings/banners (GistSyncCoordinator.withPendingGistWarnings) on
+     * every rebuild — injected so the two lifecycles stay uncoupled. */
+    private readonly mergeWarnings: (failures: string[] | undefined) => string[] | undefined,
+  ) {
+    this.cachedDigest = initialDigest;
+    this.cachedIssueListMtimeMs = getIssueListMtimeMs();
+  }
+
+  get digest(): DailyDigest {
+    return this.cachedDigest;
+  }
+
+  get jsonData(): DashboardJsonData {
+    return this.cachedJsonData;
+  }
+
+  get issueListMtimeMs(): number | null {
+    return this.cachedIssueListMtimeMs;
+  }
+
+  /** Adopt a full fetchDashboardData result: replace the digest and
+   * commented issues unconditionally, and update the persistent banner
+   * signal — clear on a clean refresh, set when one or more sub-fetches
+   * degraded. See #1035. */
+  adoptFetchResult(result: DashboardFetchSnapshot): void {
+    this.cachedDigest = result.digest;
+    this.cachedCommentedIssues = result.commentedIssues;
+    this.cachedPartialFailures = result.partialFailures.length > 0 ? result.partialFailures : undefined;
+  }
+
+  /** A gist pull wholesale-replaces state, and the pulled state.lastDigest
+   * may be NEWER than this server's long-lived cachedDigest (another machine
+   * ran its daily check). Adopt it when its generatedAt is strictly newer so
+   * cross-machine results appear without a manual full refresh (#1446
+   * item 6). Unparsable timestamps compare as NaN and never adopt —
+   * conservative: keep what we have. */
+  adoptNewerPulledDigest(pulled: DailyDigest | undefined): void {
+    if (!pulled) return;
+    if (Date.parse(pulled.generatedAt) > Date.parse(this.cachedDigest.generatedAt)) {
+      this.cachedDigest = pulled;
+    }
+  }
+
+  /** Rebuild the cached JSON payload from the cached digest + the given
+   * state, then stamp the issue-list mtime the payload reflects. Throws
+   * when buildDashboardJson does — on failure neither the payload nor the
+   * mtime is updated, so the next request retries the rebuild. `issueListMtimeMs`
+   * lets GET /api/data stamp the value it compared against (#924); the other
+   * call sites re-stat after the build. */
+  rebuild(
+    state: Readonly<AgentState>,
+    allMergedPRs?: MergedPR[],
+    allClosedPRs?: ClosedPR[],
+    issueListMtimeMs?: number | null,
+  ): void {
+    this.cachedJsonData = buildDashboardJson(
+      this.cachedDigest,
+      state,
+      this.cachedCommentedIssues,
+      allMergedPRs,
+      allClosedPRs,
+      this.mergeWarnings(this.cachedPartialFailures),
+    );
+    this.cachedIssueListMtimeMs = issueListMtimeMs !== undefined ? issueListMtimeMs : getIssueListMtimeMs();
+  }
+}

--- a/packages/core/src/commands/dashboard-gist-sync.test.ts
+++ b/packages/core/src/commands/dashboard-gist-sync.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Direct unit tests for GistSyncCoordinator (dashboard-gist-sync.ts).
+ *
+ * The gist-sync lifecycle used to be reachable only through the dashboard
+ * server's full HTTP harness (#1457's stated motivation for the extraction).
+ * These tests pin the state machine directly: pending-warning lifecycle
+ * (#1417), loss-notice conversion (#1443), and the recovery throttle/halt
+ * (#1433). HTTP-level behavior (banners reaching responses, handler
+ * ordering) stays covered by dashboard-server.test.ts — not duplicated here.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import { ConfigurationError } from '../core/errors.js';
+
+// ── Mock the core barrel ──────────────────────────────────────────────
+// Same lazy-dispatch pattern as dashboard-server.test.ts so per-test fakes
+// can be swapped without re-mocking the module.
+const mockMaybeCheckpoint = vi.fn();
+const mockEnsureGistPersistence = vi.fn();
+let currentManager: FakeManager;
+let currentToken: string | null = null;
+
+vi.mock('../core/index.js', () => ({
+  getStateManager: vi.fn(() => currentManager),
+  getGitHubToken: vi.fn(() => currentToken),
+  maybeCheckpoint: (...args: unknown[]) => mockMaybeCheckpoint(...args),
+  ensureGistPersistence: (...args: unknown[]) => mockEnsureGistPersistence(...args),
+}));
+
+import { GistSyncCoordinator } from './dashboard-gist-sync.js';
+
+interface FakeManager {
+  getState: ReturnType<typeof vi.fn>;
+  isGistMode: ReturnType<typeof vi.fn>;
+  isGistDegraded: ReturnType<typeof vi.fn>;
+  refreshFromGist: ReturnType<typeof vi.fn>;
+}
+
+function makeManager(overrides: Partial<Record<keyof FakeManager, unknown>> = {}): FakeManager {
+  return {
+    getState: vi.fn(() => ({ config: { persistence: 'local' } })),
+    isGistMode: vi.fn(() => false),
+    isGistDegraded: vi.fn(() => false),
+    refreshFromGist: vi.fn(async () => false),
+    ...(overrides as Partial<FakeManager>),
+  };
+}
+
+/** Config asks for gist but the manager is local-only — the #1433 degraded window. */
+function makeDegradedLocalManager(): FakeManager {
+  return makeManager({
+    getState: vi.fn(() => ({ config: { persistence: 'gist' } })),
+    isGistMode: vi.fn(() => false),
+  });
+}
+
+function makeCoordinator(token: string | null = null): GistSyncCoordinator {
+  currentToken = token;
+  return new GistSyncCoordinator(token, 'dashboard-server');
+}
+
+describe('GistSyncCoordinator', () => {
+  beforeAll(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    currentManager = makeManager();
+    currentToken = null;
+    mockMaybeCheckpoint.mockReset();
+    mockMaybeCheckpoint.mockResolvedValue(null);
+    mockEnsureGistPersistence.mockReset();
+    mockEnsureGistPersistence.mockResolvedValue('gist');
+  });
+
+  describe('pending-warning lifecycle (#1417)', () => {
+    it('accumulates warnings without duplicates and clears them all on a successful push', () => {
+      const sync = makeCoordinator();
+
+      sync.recordGistSyncOutcome('push failed: a');
+      sync.recordGistSyncOutcome('push failed: a');
+      sync.recordGistSyncOutcome('push failed: b');
+      expect(sync.withPendingGistWarnings(undefined)).toEqual(['push failed: a', 'push failed: b']);
+
+      // null = a successful push carried the FULL current state — all
+      // previously pending warnings are resolved with it.
+      sync.recordGistSyncOutcome(null);
+      expect(sync.withPendingGistWarnings(undefined)).toBeUndefined();
+    });
+
+    it('merges into an existing failures payload without duplicating entries already present', () => {
+      const sync = makeCoordinator();
+      sync.recordGistSyncOutcome('push failed: a');
+
+      const merged = sync.withPendingGistWarnings(['fetch failed', 'push failed: a']);
+      expect(merged).toEqual(['fetch failed', 'push failed: a']);
+      // And the caller's array is not mutated.
+      const base = ['fetch failed'];
+      expect(sync.withPendingGistWarnings(base)).toEqual(['fetch failed', 'push failed: a']);
+      expect(base).toEqual(['fetch failed']);
+    });
+
+    it('flushPendingGistSync is a no-op when nothing is pending and re-pushes when something is', async () => {
+      const sync = makeCoordinator();
+
+      await sync.flushPendingGistSync();
+      expect(mockMaybeCheckpoint).not.toHaveBeenCalled();
+
+      sync.recordGistSyncOutcome('push failed: a');
+      // The retry succeeds (null) — the warning lifecycle ends with the push.
+      await sync.flushPendingGistSync();
+      expect(mockMaybeCheckpoint).toHaveBeenCalledWith(currentManager, 'dashboard-server');
+      expect(sync.withPendingGistWarnings(undefined)).toBeUndefined();
+    });
+  });
+
+  describe('loss-notice conversion (#1443)', () => {
+    it('a pull that replaces state converts still-pending warnings into a loss notice', async () => {
+      currentManager = makeManager({ refreshFromGist: vi.fn(async () => true) });
+      const sync = makeCoordinator();
+      sync.recordGistSyncOutcome('push failed: a');
+
+      await expect(sync.pullFromGist()).resolves.toBe(true);
+
+      const failures = sync.withPendingGistWarnings(undefined)!;
+      expect(failures.some((m) => m.includes('NOT synced'))).toBe(true);
+      expect(failures).not.toContain('push failed: a');
+      // A later unrelated successful push must NOT clear the notice — that
+      // push never contained the destroyed mutation.
+      sync.recordGistSyncOutcome(null);
+      expect(sync.withPendingGistWarnings(undefined)!.some((m) => m.includes('NOT synced'))).toBe(true);
+      // The notice retires at the start of the next refresh cycle.
+      sync.clearRecoveryLossNotices();
+      expect(sync.withPendingGistWarnings(undefined)).toBeUndefined();
+    });
+
+    it('a no-change pull leaves pending warnings pending', async () => {
+      const sync = makeCoordinator();
+      sync.recordGistSyncOutcome('push failed: a');
+
+      await expect(sync.pullFromGist()).resolves.toBe(false);
+
+      expect(sync.withPendingGistWarnings(undefined)).toEqual(['push failed: a']);
+    });
+  });
+
+  describe('recovery throttle and halt (#1433)', () => {
+    it('does not attempt recovery when not degraded', async () => {
+      const sync = makeCoordinator('tok');
+      await sync.maybeRecoverGist();
+      expect(mockEnsureGistPersistence).not.toHaveBeenCalled();
+    });
+
+    it('a token-less probe attempts nothing and does not burn the retry window', async () => {
+      currentManager = makeDegradedLocalManager();
+      const sync = makeCoordinator(null);
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+      try {
+        await sync.maybeRecoverGist();
+        expect(mockEnsureGistPersistence).not.toHaveBeenCalled();
+
+        // Token appears one tick later — still inside what WOULD have been
+        // the 30s window had the probe stamped it. The attempt must run.
+        currentToken = 'tok';
+        nowSpy.mockReturnValue(1_000_001);
+        await sync.maybeRecoverGist();
+        expect(mockEnsureGistPersistence).toHaveBeenCalledTimes(1);
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
+
+    it('throttles transient failures to one attempt per interval', async () => {
+      currentManager = makeDegradedLocalManager();
+      mockEnsureGistPersistence.mockRejectedValue(new Error('network blip'));
+      const sync = makeCoordinator('tok');
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+      try {
+        await sync.maybeRecoverGist();
+        expect(mockEnsureGistPersistence).toHaveBeenCalledTimes(1);
+
+        // Within the 30s window: no second round trip.
+        nowSpy.mockReturnValue(1_000_000 + 29_999);
+        await sync.maybeRecoverGist();
+        expect(mockEnsureGistPersistence).toHaveBeenCalledTimes(1);
+
+        // Past the window: one more attempt.
+        nowSpy.mockReturnValue(1_000_000 + 30_000);
+        await sync.maybeRecoverGist();
+        expect(mockEnsureGistPersistence).toHaveBeenCalledTimes(2);
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
+
+    it('a ConfigurationError halts retries, surfaces the reason in the banner, and unhaltRecovery re-arms', async () => {
+      currentManager = makeDegradedLocalManager();
+      mockEnsureGistPersistence.mockRejectedValueOnce(new ConfigurationError('token lacks gist scope'));
+      const sync = makeCoordinator('tok');
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+      try {
+        await sync.maybeRecoverGist();
+        expect(mockEnsureGistPersistence).toHaveBeenCalledTimes(1);
+
+        // Halted: even far past the throttle window, no further round trips.
+        nowSpy.mockReturnValue(1_000_000 + 600_000);
+        await sync.maybeRecoverGist();
+        expect(mockEnsureGistPersistence).toHaveBeenCalledTimes(1);
+
+        // The root cause reaches the banner instead of the generic warning.
+        const failures = sync.withPendingGistWarnings(undefined)!;
+        expect(failures.some((m) => m.includes('FAILED permanently') && m.includes('token lacks gist scope'))).toBe(
+          true,
+        );
+
+        // An external state edit un-halts (#1433 pass-2): one fresh cycle.
+        sync.unhaltRecovery();
+        nowSpy.mockReturnValue(1_000_000 + 700_000);
+        await sync.maybeRecoverGist();
+        expect(mockEnsureGistPersistence).toHaveBeenCalledTimes(2);
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
+
+    it('a successful recovery re-resolves the manager and reports degraded mutations as a loss notice', async () => {
+      currentManager = makeDegradedLocalManager();
+      const sync = makeCoordinator('tok');
+
+      // Two mutations acknowledged while degraded; a third while healthy
+      // (after recovery) must not count.
+      sync.recordMutationWhileDegraded();
+      sync.recordMutationWhileDegraded();
+
+      // Recovery succeeds: the core singleton is replaced with an armed
+      // gist-backed manager.
+      const armedManager = makeManager({ isGistMode: vi.fn(() => true) });
+      mockEnsureGistPersistence.mockImplementationOnce(async () => {
+        currentManager = armedManager;
+        return 'gist';
+      });
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(2_000_000);
+      try {
+        await sync.maybeRecoverGist();
+      } finally {
+        nowSpy.mockRestore();
+      }
+
+      expect(sync.stateManager).toBe(armedManager);
+      const failures = sync.withPendingGistWarnings(undefined)!;
+      expect(failures.some((m) => m.includes('2 change(s)') && m.includes('NOT merged'))).toBe(true);
+
+      // Healthy now: further mutations are not counted as degraded, and the
+      // count was reset — a hypothetical second recovery has nothing to report.
+      sync.recordMutationWhileDegraded();
+      sync.clearRecoveryLossNotices();
+      expect(sync.withPendingGistWarnings(undefined)).toBeUndefined();
+    });
+  });
+
+  describe('degraded banners', () => {
+    it('adds the LOCAL-ONLY banner while config asks for gist but the manager is local', () => {
+      currentManager = makeDegradedLocalManager();
+      const sync = makeCoordinator();
+      expect(sync.withPendingGistWarnings(undefined)!.some((m) => m.includes('LOCAL-ONLY'))).toBe(true);
+      expect(sync.gistConfiguredButLocal()).toBe(true);
+    });
+
+    it('adds the stale-bootstrap banner when gist-backed but the bootstrap fell back to the local cache', () => {
+      currentManager = makeManager({
+        getState: vi.fn(() => ({ config: { persistence: 'gist' } })),
+        isGistMode: vi.fn(() => true),
+        isGistDegraded: vi.fn(() => true),
+      });
+      const sync = makeCoordinator();
+      expect(sync.withPendingGistWarnings(undefined)!.some((m) => m.includes('fell back to the local cache'))).toBe(
+        true,
+      );
+      expect(sync.gistBootstrapDegraded()).toBe(true);
+    });
+
+    it('treats a getState failure in the degraded probe as not degraded (#994 stale-serving path)', () => {
+      currentManager = makeManager({
+        getState: vi.fn(() => {
+          throw new Error('boom');
+        }),
+      });
+      const sync = makeCoordinator();
+      expect(sync.gistConfiguredButLocal()).toBe(false);
+      expect(sync.withPendingGistWarnings(undefined)).toBeUndefined();
+    });
+  });
+});

--- a/packages/core/src/commands/dashboard-gist-sync.ts
+++ b/packages/core/src/commands/dashboard-gist-sync.ts
@@ -1,0 +1,254 @@
+/**
+ * GistSyncCoordinator — the dashboard server's gist-sync lifecycle state machine.
+ *
+ * Extracted from dashboard-server.ts (#1457). Owns the five pieces of gist
+ * lifecycle state (pending push warnings, loss notices, degraded mutation
+ * count, recovery halt reason, recovery throttle stamp) plus the live
+ * StateManager reference, which a degraded recovery replaces (#1433). The
+ * HTTP handlers consume it as a collaborator; nothing here touches req/res.
+ */
+
+import {
+  getStateManager,
+  getGitHubToken,
+  maybeCheckpoint,
+  ensureGistPersistence,
+  type StateManager,
+} from '../core/index.js';
+import { errorMessage, ConfigurationError } from '../core/errors.js';
+import { warn } from '../core/logger.js';
+
+const GIST_DEGRADED_WARNING =
+  'Gist persistence is configured but this dashboard process is running LOCAL-ONLY; ' +
+  'changes made here will NOT sync and may be overwritten by the next successful Gist read. ' +
+  'Recovery is retried automatically.';
+
+// #1443: a degraded bootstrap disarms the store, so "the next successful
+// Gist read" can never arrive on its own — maybeRecoverGist re-bootstraps
+// (the gate below treats this state as recoverable), which is the retry
+// this banner now promises.
+const GIST_STALE_BOOTSTRAP_WARNING =
+  'Gist persistence is active but the last Gist read fell back to the local cache; ' +
+  'data shown may be stale. Recovery is retried automatically.';
+
+// Recovery throttling + halt (#1433 review): a PERMANENT failure (token
+// lacks gist scope, corrupt Gist) must not turn every dashboard poll into
+// a doomed GitHub round trip for the life of the server, and its root
+// cause must reach the banner — the detached spawn discards stderr.
+const RECOVERY_RETRY_INTERVAL_MS = 30_000;
+
+export class GistSyncCoordinator {
+  // Mutable (#1433): a degraded gist recovery replaces the core singleton, and
+  // this long-lived server must re-resolve its reference or every handler
+  // keeps using the orphaned local manager.
+  private manager: StateManager;
+
+  // Gist checkpoint warnings from dashboard mutations (#1417). DELIBERATELY
+  // separate from cachedPartialFailures: fetch failures clear on a successful
+  // PULL, but a gist-sync warning means an un-pushed mutation, and a pull is
+  // exactly the event that can destroy it (refreshFromGist wholesale-replaces
+  // state). These clear only when a checkpoint PUSH succeeds.
+  private pendingGistSyncWarnings: string[] = [];
+
+  private lastRecoveryAttemptAt = 0;
+  private recoveryHaltedReason: string | null = null;
+
+  // Mutations acknowledged while degraded (#1433 review): a successful
+  // recovery bootstraps FROM the existing Gist, which reverts them — the
+  // user must get a retrospective notice, not just the prospective banner
+  // that clears at the exact moment of the loss. Cleared on a successful
+  // full refresh (by then the user has seen the notice across the window).
+  private degradedMutationCount = 0;
+  private recoveryLossNotices: string[] = [];
+
+  constructor(
+    /** Token from server options; falls back to getGitHubToken() per recovery attempt. */
+    private readonly token: string | null,
+    /** Logger module tag (kept identical to the server's so log output is unchanged). */
+    private readonly module: string,
+  ) {
+    this.manager = getStateManager();
+  }
+
+  /** The live state manager. Always read through this accessor — a degraded
+   * gist recovery replaces the core singleton mid-flight (#1433). */
+  get stateManager(): StateManager {
+    return this.manager;
+  }
+
+  /** Record a mutation's checkpoint outcome. `null` means the push succeeded
+   * (or local mode) — and a successful push carries the FULL current state,
+   * so any previously pending warning is resolved with it. */
+  recordGistSyncOutcome(warning: string | null): void {
+    if (warning === null) {
+      this.pendingGistSyncWarnings = [];
+      return;
+    }
+    if (!this.pendingGistSyncWarnings.includes(warning)) {
+      this.pendingGistSyncWarnings.push(warning);
+    }
+  }
+
+  /** Merge pending gist-sync warnings into a partialFailures payload for the
+   * SPA banner without coupling their lifecycles. */
+  withPendingGistWarnings(failures: string[] | undefined): string[] | undefined {
+    const extras = [...this.pendingGistSyncWarnings, ...this.recoveryLossNotices];
+    if (this.gistConfiguredButLocal()) {
+      extras.push(
+        this.recoveryHaltedReason === null
+          ? GIST_DEGRADED_WARNING
+          : `Gist persistence is configured but recovery FAILED permanently: ${this.recoveryHaltedReason} — ` +
+              'fix the Gist setup (check the token gist scope, or run state-show), then restart the dashboard.',
+      );
+    } else if (this.gistBootstrapDegraded()) {
+      // Same halt surfacing as the local-only branch (#1443): a permanent
+      // recovery failure must reach the banner here too, or the stale-data
+      // retry promise in GIST_STALE_BOOTSTRAP_WARNING would dangle forever
+      // with no visible reason.
+      extras.push(
+        this.recoveryHaltedReason === null
+          ? GIST_STALE_BOOTSTRAP_WARNING
+          : `Gist persistence is degraded and recovery FAILED permanently: ${this.recoveryHaltedReason} — ` +
+              'fix the Gist setup (check the token gist scope, or run state-show), then restart the dashboard.',
+      );
+    }
+    if (extras.length === 0) return failures;
+    const base = failures ?? [];
+    return [...base, ...extras.filter((w) => !base.includes(w))];
+  }
+
+  /** Push-before-pull (#1417): an un-pushed mutation would be silently
+   * reverted by the next Gist pull. Retry the checkpoint first so a recovered
+   * network turns the pending warning into a real push before any pull runs.
+   * No-op when nothing is pending. */
+  async flushPendingGistSync(): Promise<void> {
+    if (this.pendingGistSyncWarnings.length === 0) return;
+    this.recordGistSyncOutcome(await maybeCheckpoint(this.manager, this.module));
+  }
+
+  /** True while the config asks for gist but this process's manager is
+   * local-only (#1433) — the degraded window in which every dashboard
+   * mutation is acknowledged and then clobbered by the next pull. */
+  gistConfiguredButLocal(): boolean {
+    // Defensive: this is an advisory check that runs on EVERY request path
+    // (rebuilds, recovery probes). A getState failure has its own handling
+    // wherever state is actually consumed — the degraded probe must not
+    // become a new crash surface in front of it (#994's stale-serving path).
+    try {
+      return this.manager.getState().config.persistence === 'gist' && !this.manager.isGistMode();
+    } catch (err) {
+      warn(this.module, `Degraded-gist probe failed (treating as not degraded): ${errorMessage(err)}`);
+      return false;
+    }
+  }
+
+  /** Gist-backed but the bootstrap itself fell back to the local cache —
+   * reads may be stale even though isGistMode() is true (#1433 review). */
+  gistBootstrapDegraded(): boolean {
+    try {
+      return this.manager.isGistMode() && this.manager.isGistDegraded();
+    } catch {
+      return false;
+    }
+  }
+
+  /** A successful PULL (refresh, or a recovery re-bootstrap) wholesale-
+   * replaces in-memory state. If push warnings are still pending at that
+   * moment, the mutations they describe are gone from the working state and
+   * a LATER push can never carry them — so an unrelated future push must not
+   * be allowed to "resolve" them (#1443). Convert the prospective warnings
+   * into a retrospective loss notice. Lifecycle invariants from #1417/#1433
+   * are unchanged: pending warnings still clear only via recordGistSyncOutcome
+   * on a successful push, and loss notices still clear at the start of the
+   * next refresh cycle. */
+  convertPendingWarningsToLossNotices(): void {
+    if (this.pendingGistSyncWarnings.length === 0) return;
+    this.recoveryLossNotices.push(
+      `A Gist read replaced local state while ${this.pendingGistSyncWarnings.length} change(s) were still un-pushed — ` +
+        'they were NOT synced to the Gist and may have been reverted in this view. Re-apply anything missing.',
+    );
+    this.pendingGistSyncWarnings = [];
+  }
+
+  /** Pull from the Gist, converting still-pending push warnings into a loss
+   * notice when the pull actually replaced state (#1443). All dashboard pull
+   * sites go through here; callers flush pending pushes first (#1417), so a
+   * warning that is still pending at pull time means the flush failed. */
+  async pullFromGist(): Promise<boolean> {
+    const refreshed = await this.manager.refreshFromGist();
+    if (refreshed) this.convertPendingWarningsToLossNotices();
+    return refreshed;
+  }
+
+  /** Re-attempt gist init while degraded (#1433). The serve process used to
+   * bootstrap exactly once at CLI preAction — with its stderr discarded by
+   * the detached spawn — and never retry, so one blip at startup meant
+   * local-only writes for the server's lifetime. Never throws. Transient
+   * failures retry no more often than RECOVERY_RETRY_INTERVAL_MS; permanent
+   * (ConfigurationError-class) failures halt retries and surface the reason
+   * in the banner.
+   *
+   * Covers BOTH degraded shapes (#1443): a local-only manager under a gist
+   * config, and a gist-backed manager whose bootstrap fell back to the local
+   * cache (disarmed store — refreshFromGist can never heal it on its own). */
+  async maybeRecoverGist(): Promise<void> {
+    if (!this.gistConfiguredButLocal() && !this.gistBootstrapDegraded()) return;
+    if (this.recoveryHaltedReason !== null) return;
+    const now = Date.now();
+    if (now - this.lastRecoveryAttemptAt < RECOVERY_RETRY_INTERVAL_MS) return;
+    const currentToken = this.token || getGitHubToken();
+    // A token-less probe is free (the auth cache answers instantly) and must
+    // not burn the retry window — stamp only when a real attempt starts.
+    if (!currentToken) return;
+    this.lastRecoveryAttemptAt = now;
+    try {
+      await ensureGistPersistence(currentToken);
+      // The upgrade replaced the core singleton — re-resolve our reference.
+      this.manager = getStateManager();
+      // Genuinely armed only: a retry can resolve via ANOTHER degraded
+      // bootstrap (isGistMode() true, store disarmed) — that is not a
+      // recovery and must not produce a recovery notice (#1443).
+      const recovered = this.manager.isGistMode() && !this.manager.isGistDegraded();
+      if (recovered) {
+        // The re-bootstrap pulled the existing Gist: un-pushed mutations
+        // from the degraded window are not in the replacement state.
+        this.convertPendingWarningsToLossNotices();
+      }
+      if (recovered && this.degradedMutationCount > 0) {
+        this.recoveryLossNotices.push(
+          `Gist persistence recovered, but ${this.degradedMutationCount} change(s) made while degraded were ` +
+            'saved locally only and were NOT merged into the Gist — they may have been reverted in this view. ' +
+            'Re-apply anything missing.',
+        );
+        this.degradedMutationCount = 0;
+      }
+    } catch (err) {
+      // ConfigurationError-class failures are permanent until the user acts
+      // (#1202 semantics) — stop hammering GitHub and say WHY in the banner.
+      if (err instanceof ConfigurationError) {
+        this.recoveryHaltedReason = errorMessage(err);
+      }
+      warn(this.module, `Gist recovery attempt failed: ${errorMessage(err)}`);
+    }
+  }
+
+  /** An external config edit may BE the fix for a permanently-halted
+   * recovery (new token scope, repaired gist id) — give it one fresh
+   * attempt cycle (#1433 pass-2). */
+  unhaltRecovery(): void {
+    this.recoveryHaltedReason = null;
+  }
+
+  /** Count mutations acknowledged while degraded (#1433): a later recovery
+   * bootstraps from the existing Gist and reverts them, and the loss
+   * notice needs to know whether there is anything to lose. */
+  recordMutationWhileDegraded(): void {
+    if (this.gistConfiguredButLocal()) this.degradedMutationCount++;
+  }
+
+  /** Retire pre-existing loss notices — by the time a refresh cycle starts
+   * they have been visible across the degraded window (#1433 pass-2). */
+  clearRecoveryLossNotices(): void {
+    this.recoveryLossNotices = [];
+  }
+}

--- a/packages/core/src/commands/dashboard-server.ts
+++ b/packages/core/src/commands/dashboard-server.ts
@@ -4,57 +4,33 @@
  * for live data fetching and state mutations (PR state transitions, issue dismiss).
  *
  * Uses Node's built-in http module — no Express/Fastify.
+ *
+ * Collaborators (#1457): the gist-sync lifecycle lives in
+ * GistSyncCoordinator (dashboard-gist-sync.ts) and the cached-response
+ * state in DashboardCache (dashboard-cache.ts); this file is wiring,
+ * routing and the HTTP handlers.
  */
 
 import * as http from 'node:http';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as crypto from 'node:crypto';
-import {
-  getStateManager,
-  getGitHubToken,
-  getCLIVersion,
-  applyStatusOverrides,
-  classifyAttentionBucket,
-  maybeCheckpoint,
-  ensureGistPersistence,
-} from '../core/index.js';
-import {
-  errorMessage,
-  ValidationError,
-  ConcurrencyError,
-  ConfigurationError,
-  GistConcurrencyError,
-} from '../core/errors.js';
+import { getGitHubToken, getCLIVersion, maybeCheckpoint } from '../core/index.js';
+import { errorMessage, ValidationError, ConcurrencyError, GistConcurrencyError } from '../core/errors.js';
 import { warn } from '../core/logger.js';
 import { validateUrl, validateGitHubUrl, PR_URL_PATTERN, ISSUE_URL_PATTERN } from './validation.js';
 import type { MoveTarget } from './move.js';
-import {
-  fetchDashboardData,
-  computePRsByRepo,
-  computeTopRepos,
-  getMonthlyData,
-  buildDashboardStats,
-  reconcileShelvePartition,
-  storedToMergedPRs,
-  storedToClosedPRs,
-  type DashboardJsonData,
-  type ActionRequest,
-} from './dashboard-data.js';
-import { openInBrowser, detectIssueList } from './startup.js';
-import { parseIssueList, type ParseIssueListOutput } from './parse-list.js';
+import { fetchDashboardData, type ActionRequest } from './dashboard-data.js';
+import { openInBrowser } from './startup.js';
 import { writeDashboardServerInfo, removeDashboardServerInfo } from './dashboard-process.js';
 import { RateLimiter } from './rate-limiter.js';
-import {
-  isBelowMinStars,
-  type DailyDigest,
-  type AgentState,
-  type CommentedIssue,
-  type CommentedIssueWithResponse,
-  type MergedPR,
-  type ClosedPR,
-  type RepoMetadataEntry,
-} from '../core/types.js';
+import { GistSyncCoordinator } from './dashboard-gist-sync.js';
+import { DashboardCache, getIssueListMtimeMs } from './dashboard-cache.js';
+
+// Re-export the payload builder for backward compatibility — it moved to
+// dashboard-cache.ts with the cache extraction (#1457) but is unit-tested
+// (and consumed) under this module's name.
+export { buildDashboardJson } from './dashboard-cache.js';
 
 // Re-export process management functions for backward compatibility
 export {
@@ -97,148 +73,6 @@ const MIME_TYPES: Record<string, string> = {
 };
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
-
-/**
- * Read and parse the vetted issue list file (non-fatal on failure).
- *
- * @param failures - Optional collector (#1448): a read/parse failure pushes a
- *   label so the SPA's partialFailures banner shows the panel is degraded
- *   rather than silently empty. "No list detected" is not a failure and
- *   pushes nothing.
- */
-function readVettedIssues(failures?: string[]): ParseIssueListOutput | null {
-  try {
-    const info = detectIssueList();
-    if (!info) return null;
-    const content = fs.readFileSync(info.path, 'utf8');
-    return parseIssueList(content);
-  } catch (error) {
-    warn(MODULE, `Failed to read vetted issue list: ${errorMessage(error)}`);
-    failures?.push('read vetted issue list');
-    return null;
-  }
-}
-
-/**
- * Get the mtime of the vetted issue list file in ms, or null if unknown.
- * Used to detect external edits and invalidate the cached dashboard payload.
- */
-function getIssueListMtimeMs(): number | null {
-  try {
-    const info = detectIssueList();
-    if (!info) return null;
-    return fs.statSync(info.path).mtimeMs;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Build the JSON payload that the SPA expects from GET /api/data.
- *
- * Exported for unit testing of response-shape concerns that the full
- * handler harness can't reach (it bakes a stale cachedDigest at server
- * start-up, so tests that need a specific digest should call this directly).
- */
-export function buildDashboardJson(
-  digest: DailyDigest,
-  state: Readonly<AgentState>,
-  commentedIssues: CommentedIssue[],
-  allMergedPRs?: MergedPR[],
-  allClosedPRs?: ClosedPR[],
-  partialFailures?: string[],
-): DashboardJsonData {
-  // Collect build-local failures (#1448) alongside the caller-provided ones
-  // so degradations detected during THIS build (vetted-list read failure,
-  // status-override application failure) reach the SPA's partialFailures
-  // banner instead of living only in stderr.
-  const buildFailures: string[] = [...(partialFailures ?? [])];
-  // Apply status overrides ONCE, before the shelve partition is derived, so
-  // the dashboard partitions on the same post-override status the CLI
-  // partitions on (#1416). This also covers overrides set AFTER the digest
-  // was cached (a dashboard move stores an override; the action path rebuilds
-  // from the cached digest). Work on a copy — the caller's cached digest must
-  // not accumulate per-request derivations.
-  const overriddenDigest: DailyDigest = {
-    ...digest,
-    openPRs: applyStatusOverrides(digest.openPRs || [], state, buildFailures),
-    summary: { ...digest.summary },
-  };
-  // Re-derive the shelve partition from the CURRENT state before reading it.
-  // The POST /api/action path rebuilds with a cached digest whose shelvedPRs
-  // predates the shelve/unshelve, so without this the SPA action appears to do
-  // nothing until the next full /api/refresh.
-  reconcileShelvePartition(overriddenDigest, state);
-  const prsByRepo = computePRsByRepo(overriddenDigest, state);
-  const topRepos = computeTopRepos(prsByRepo);
-  const { monthlyMerged, monthlyOpened, monthlyClosed } = getMonthlyData(state);
-  // Derive from state if not provided (e.g. initial load from cached state)
-  const mergedPRs = allMergedPRs ?? storedToMergedPRs(getStateManager().getMergedPRs());
-  const closedPRs = allClosedPRs ?? storedToClosedPRs(getStateManager().getClosedPRs());
-  // Filter out PRs from repos below the minStars threshold
-  const minStars = state.config.minStars ?? 50;
-  const repoScores = state.repoScores || {};
-  const isAboveMinStars = (pr: { repo: string }): boolean =>
-    !isBelowMinStars(repoScores[pr.repo]?.stargazersCount, minStars);
-  const filteredMergedPRs = mergedPRs.filter(isAboveMinStars);
-  const filteredClosedPRs = closedPRs.filter(isAboveMinStars);
-  const stats = buildDashboardStats(overriddenDigest, state, filteredMergedPRs.length, filteredClosedPRs.length);
-  const dismissedIssues = state.config.dismissedIssues || {};
-  const issueResponses = commentedIssues.filter(
-    (i): i is CommentedIssueWithResponse => i.status === 'new_response' && !(i.url in dismissedIssues),
-  );
-
-  // Build repo metadata map from repoScores — omit repos without stars or language to avoid empty entries
-  const repoMetadata: Record<string, RepoMetadataEntry> = {};
-  for (const [repo, score] of Object.entries(repoScores)) {
-    if (score.stargazersCount !== undefined || score.language !== undefined) {
-      repoMetadata[repo] = { stars: score.stargazersCount, language: score.language };
-    }
-  }
-
-  // A vetted-list read failure reaches the SPA banner via buildFailures
-  // instead of leaving the panel silently empty (#1448).
-  const vettedIssues = readVettedIssues(buildFailures);
-  if (vettedIssues) {
-    stats.availableIssues = vettedIssues.availableCount;
-  }
-
-  return {
-    stats,
-    prsByRepo,
-    topRepos: topRepos.map(([repo, data]) => ({ repo, ...data })),
-    monthlyMerged,
-    monthlyOpened,
-    monthlyClosed,
-    // #1352: stamp the unified attention bucket so the SPA renders the same
-    // taxonomy the CLI brief counts (single classifier, no second opinion).
-    // Overrides were already applied when overriddenDigest was built — a
-    // second application here would be a no-op but obscures the single
-    // apply-then-partition ordering (#1416).
-    activePRs: (overriddenDigest.openPRs || []).map((pr) => ({
-      ...pr,
-      attentionBucket: classifyAttentionBucket(pr),
-    })),
-    // Source of truth is digest.shelvedPRs (union of explicitly-shelved URLs
-    // and dormant-non-addressing PRs auto-shelved for display). Returning
-    // only state.config.shelvedPRUrls would under-count and desync from
-    // stats.shelvedPRs, which is already derived from digest.shelvedPRs. (#981)
-    shelvedPRUrls: (overriddenDigest.shelvedPRs || []).map((ref) => ref.url),
-    recentlyMergedPRs: overriddenDigest.recentlyMergedPRs || [],
-    recentlyClosedPRs: overriddenDigest.recentlyClosedPRs || [],
-    autoUnshelvedPRs: overriddenDigest.autoUnshelvedPRs || [],
-    commentedIssues,
-    issueResponses,
-    allMergedPRs: filteredMergedPRs,
-    allClosedPRs: filteredClosedPRs,
-    repoMetadata,
-    vettedIssues,
-    // Dedup: the fetch path already applies status overrides into the cached
-    // partialFailures, and the rebuild applies them again above — the same
-    // failing override must not appear (and be counted) twice (#1448).
-    partialFailures: buildFailures.length > 0 ? [...new Set(buildFailures)] : undefined,
-  };
-}
 
 /**
  * Read the full request body as a UTF-8 string, with a size limit.
@@ -395,10 +229,12 @@ function sendConflict(res: http.ServerResponse): void {
 export async function startDashboardServer(options: DashboardServerOptions): Promise<void> {
   const { port: requestedPort, assetsDir, token, open } = options;
 
-  // `let` (#1433): a degraded gist recovery replaces the core singleton, and
-  // this long-lived server must re-resolve its reference or every handler
-  // keeps using the orphaned local manager.
-  let stateManager = getStateManager();
+  // Gist-sync lifecycle state machine (#1457): pending push warnings (#1417),
+  // degraded recovery with throttle/halt (#1433), loss notices (#1443). It
+  // also owns the live StateManager reference — a degraded gist recovery
+  // replaces the core singleton, and this long-lived server must re-resolve
+  // its reference (#1433), so always read it via gistSync.stateManager.
+  const gistSync = new GistSyncCoordinator(token, MODULE);
   const resolvedAssetsDir = path.resolve(assetsDir);
 
   // ── CSRF token ──────────────────────────────────────────────────────────
@@ -414,228 +250,19 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
   // Start immediately with state.json data (written by the daily check that
   // precedes this server launch). A background GitHub fetch refreshes the
   // cache after the port is bound, so the startup poller sees us in time.
-  let cachedDigest: DailyDigest = stateManager.getState().lastDigest!;
-  let cachedCommentedIssues: CommentedIssue[] = [];
-  // Persist the last-known partialFailures across rebuild requests (#1035).
-  // Cleared only when a fresh fetchDashboardData returns zero failures;
-  // re-threaded into every buildDashboardJson call so the SPA banner does
-  // not disappear when /api/data rebuilds after a state change or after a
-  // POST /api/action completes.
-  let cachedPartialFailures: string[] | undefined = undefined;
-  // Gist checkpoint warnings from dashboard mutations (#1417). DELIBERATELY
-  // separate from cachedPartialFailures: fetch failures clear on a successful
-  // PULL, but a gist-sync warning means an un-pushed mutation, and a pull is
-  // exactly the event that can destroy it (refreshFromGist wholesale-replaces
-  // state). These clear only when a checkpoint PUSH succeeds.
-  let pendingGistSyncWarnings: string[] = [];
-  // Tracks the last background-refresh failure so /api/data can surface
-  // staleness to the SPA via the X-Dashboard-Stale header (#1205). Cleared
-  // when a refresh succeeds. Without this, token expiry / GitHub outage
-  // produces silent stale data hours old with no client-visible signal.
-  let lastBackgroundRefreshError: string | null = null;
+  const initialDigest = gistSync.stateManager.getState().lastDigest!;
 
-  /** Record a mutation's checkpoint outcome. `null` means the push succeeded
-   * (or local mode) — and a successful push carries the FULL current state,
-   * so any previously pending warning is resolved with it. */
-  function recordGistSyncOutcome(warning: string | null): void {
-    if (warning === null) {
-      pendingGistSyncWarnings = [];
-      return;
-    }
-    if (!pendingGistSyncWarnings.includes(warning)) {
-      pendingGistSyncWarnings.push(warning);
-    }
-  }
-
-  /** Merge pending gist-sync warnings into a partialFailures payload for the
-   * SPA banner without coupling their lifecycles. */
-  function withPendingGistWarnings(failures: string[] | undefined): string[] | undefined {
-    const extras = [...pendingGistSyncWarnings, ...recoveryLossNotices];
-    if (gistConfiguredButLocal()) {
-      extras.push(
-        recoveryHaltedReason === null
-          ? GIST_DEGRADED_WARNING
-          : `Gist persistence is configured but recovery FAILED permanently: ${recoveryHaltedReason} — ` +
-              'fix the Gist setup (check the token gist scope, or run state-show), then restart the dashboard.',
-      );
-    } else if (gistBootstrapDegraded()) {
-      // Same halt surfacing as the local-only branch (#1443): a permanent
-      // recovery failure must reach the banner here too, or the stale data
-      // promise below would dangle forever with no visible reason.
-      extras.push(
-        recoveryHaltedReason === null
-          ? GIST_STALE_BOOTSTRAP_WARNING
-          : `Gist persistence is degraded and recovery FAILED permanently: ${recoveryHaltedReason} — ` +
-              'fix the Gist setup (check the token gist scope, or run state-show), then restart the dashboard.',
-      );
-    }
-    if (extras.length === 0) return failures;
-    const base = failures ?? [];
-    return [...base, ...extras.filter((w) => !base.includes(w))];
-  }
-
-  /** Push-before-pull (#1417): an un-pushed mutation would be silently
-   * reverted by the next Gist pull. Retry the checkpoint first so a recovered
-   * network turns the pending warning into a real push before any pull runs.
-   * No-op when nothing is pending. */
-  async function flushPendingGistSync(): Promise<void> {
-    if (pendingGistSyncWarnings.length === 0) return;
-    recordGistSyncOutcome(await maybeCheckpoint(stateManager, MODULE));
-  }
-
-  /** True while the config asks for gist but this process's manager is
-   * local-only (#1433) — the degraded window in which every dashboard
-   * mutation is acknowledged and then clobbered by the next pull. */
-  function gistConfiguredButLocal(): boolean {
-    // Defensive: this is an advisory check that runs on EVERY request path
-    // (rebuilds, recovery probes). A getState failure has its own handling
-    // wherever state is actually consumed — the degraded probe must not
-    // become a new crash surface in front of it (#994's stale-serving path).
-    try {
-      return stateManager.getState().config.persistence === 'gist' && !stateManager.isGistMode();
-    } catch (err) {
-      warn(MODULE, `Degraded-gist probe failed (treating as not degraded): ${errorMessage(err)}`);
-      return false;
-    }
-  }
-
-  /** Gist-backed but the bootstrap itself fell back to the local cache —
-   * reads may be stale even though isGistMode() is true (#1433 review). */
-  function gistBootstrapDegraded(): boolean {
-    try {
-      return stateManager.isGistMode() && stateManager.isGistDegraded();
-    } catch {
-      return false;
-    }
-  }
-
-  const GIST_DEGRADED_WARNING =
-    'Gist persistence is configured but this dashboard process is running LOCAL-ONLY; ' +
-    'changes made here will NOT sync and may be overwritten by the next successful Gist read. ' +
-    'Recovery is retried automatically.';
-
-  // #1443: a degraded bootstrap disarms the store, so "the next successful
-  // Gist read" can never arrive on its own — maybeRecoverGist re-bootstraps
-  // (the gate below treats this state as recoverable), which is the retry
-  // this banner now promises.
-  const GIST_STALE_BOOTSTRAP_WARNING =
-    'Gist persistence is active but the last Gist read fell back to the local cache; ' +
-    'data shown may be stale. Recovery is retried automatically.';
-
-  // Recovery throttling + halt (#1433 review): a PERMANENT failure (token
-  // lacks gist scope, corrupt Gist) must not turn every dashboard poll into
-  // a doomed GitHub round trip for the life of the server, and its root
-  // cause must reach the banner — the detached spawn discards stderr.
-  const RECOVERY_RETRY_INTERVAL_MS = 30_000;
-  let lastRecoveryAttemptAt = 0;
-  let recoveryHaltedReason: string | null = null;
-
-  // Mutations acknowledged while degraded (#1433 review): a successful
-  // recovery bootstraps FROM the existing Gist, which reverts them — the
-  // user must get a retrospective notice, not just the prospective banner
-  // that clears at the exact moment of the loss. Cleared on a successful
-  // full refresh (by then the user has seen the notice across the window).
-  let degradedMutationCount = 0;
-  let recoveryLossNotices: string[] = [];
-
-  /** A successful PULL (refresh, or a recovery re-bootstrap) wholesale-
-   * replaces in-memory state. If push warnings are still pending at that
-   * moment, the mutations they describe are gone from the working state and
-   * a LATER push can never carry them — so an unrelated future push must not
-   * be allowed to "resolve" them (#1443). Convert the prospective warnings
-   * into a retrospective loss notice. Lifecycle invariants from #1417/#1433
-   * are unchanged: pending warnings still clear only via recordGistSyncOutcome
-   * on a successful push, and loss notices still clear at the start of the
-   * next refresh cycle. */
-  function convertPendingWarningsToLossNotices(): void {
-    if (pendingGistSyncWarnings.length === 0) return;
-    recoveryLossNotices.push(
-      `A Gist read replaced local state while ${pendingGistSyncWarnings.length} change(s) were still un-pushed — ` +
-        'they were NOT synced to the Gist and may have been reverted in this view. Re-apply anything missing.',
-    );
-    pendingGistSyncWarnings = [];
-  }
-
-  /** Pull from the Gist, converting still-pending push warnings into a loss
-   * notice when the pull actually replaced state (#1443). All dashboard pull
-   * sites go through here; callers flush pending pushes first (#1417), so a
-   * warning that is still pending at pull time means the flush failed. */
-  async function pullFromGist(): Promise<boolean> {
-    const refreshed = await stateManager.refreshFromGist();
-    if (refreshed) convertPendingWarningsToLossNotices();
-    return refreshed;
-  }
-
-  /** Re-attempt gist init while degraded (#1433). The serve process used to
-   * bootstrap exactly once at CLI preAction — with its stderr discarded by
-   * the detached spawn — and never retry, so one blip at startup meant
-   * local-only writes for the server's lifetime. Never throws. Transient
-   * failures retry no more often than RECOVERY_RETRY_INTERVAL_MS; permanent
-   * (ConfigurationError-class) failures halt retries and surface the reason
-   * in the banner.
-   *
-   * Covers BOTH degraded shapes (#1443): a local-only manager under a gist
-   * config, and a gist-backed manager whose bootstrap fell back to the local
-   * cache (disarmed store — refreshFromGist can never heal it on its own). */
-  async function maybeRecoverGist(): Promise<void> {
-    if (!gistConfiguredButLocal() && !gistBootstrapDegraded()) return;
-    if (recoveryHaltedReason !== null) return;
-    const now = Date.now();
-    if (now - lastRecoveryAttemptAt < RECOVERY_RETRY_INTERVAL_MS) return;
-    const currentToken = token || getGitHubToken();
-    // A token-less probe is free (the auth cache answers instantly) and must
-    // not burn the retry window — stamp only when a real attempt starts.
-    if (!currentToken) return;
-    lastRecoveryAttemptAt = now;
-    try {
-      await ensureGistPersistence(currentToken);
-      // The upgrade replaced the core singleton — re-resolve our reference.
-      stateManager = getStateManager();
-      // Genuinely armed only: a retry can resolve via ANOTHER degraded
-      // bootstrap (isGistMode() true, store disarmed) — that is not a
-      // recovery and must not produce a recovery notice (#1443).
-      const recovered = stateManager.isGistMode() && !stateManager.isGistDegraded();
-      if (recovered) {
-        // The re-bootstrap pulled the existing Gist: un-pushed mutations
-        // from the degraded window are not in the replacement state.
-        convertPendingWarningsToLossNotices();
-      }
-      if (recovered && degradedMutationCount > 0) {
-        recoveryLossNotices.push(
-          `Gist persistence recovered, but ${degradedMutationCount} change(s) made while degraded were ` +
-            'saved locally only and were NOT merged into the Gist — they may have been reverted in this view. ' +
-            'Re-apply anything missing.',
-        );
-        degradedMutationCount = 0;
-      }
-    } catch (err) {
-      // ConfigurationError-class failures are permanent until the user acts
-      // (#1202 semantics) — stop hammering GitHub and say WHY in the banner.
-      if (err instanceof ConfigurationError) {
-        recoveryHaltedReason = errorMessage(err);
-      }
-      warn(MODULE, `Gist recovery attempt failed: ${errorMessage(err)}`);
-    }
-  }
-
-  if (!cachedDigest) {
+  if (!initialDigest) {
     throw new Error(
       'No dashboard data available. Run the daily check first: GITHUB_TOKEN=$(gh auth token) npm start -- daily',
     );
   }
 
+  const cache = new DashboardCache(initialDigest, (failures) => gistSync.withPendingGistWarnings(failures));
+
   // ── Build cached JSON response ───────────────────────────────────────────
-  let cachedJsonData: DashboardJsonData;
-  let cachedIssueListMtimeMs = getIssueListMtimeMs();
   try {
-    cachedJsonData = buildDashboardJson(
-      cachedDigest,
-      stateManager.getState(),
-      cachedCommentedIssues,
-      undefined,
-      undefined,
-      withPendingGistWarnings(cachedPartialFailures),
-    );
+    cache.rebuild(gistSync.stateManager.getState());
   } catch (error) {
     throw new Error(
       `Failed to build dashboard data: ${errorMessage(error)}. State data may be corrupted — try running: daily --json`,
@@ -688,28 +315,20 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
         // this — StateManager sets the marker when in-memory state diverged
         // from the canonical Gist (refresh failure, invalid payload,
         // degraded bootstrap) and clears it on a successful pull.
-        const staleness = stateManager.getStateStaleness();
+        const staleness = gistSync.stateManager.getStateStaleness();
         if (staleness !== null) {
           res.setHeader('X-Dashboard-Stale', '1');
           res.setHeader('X-Dashboard-Stale-Reason', sanitizeHeaderValue(`state-stale: ${staleness.reason}`));
         }
         // Also rebuild when the vetted issue list file was edited outside this server (#924)
         const currentIssueListMtimeMs = getIssueListMtimeMs();
-        const issueListChanged = currentIssueListMtimeMs !== cachedIssueListMtimeMs;
+        const issueListChanged = currentIssueListMtimeMs !== cache.issueListMtimeMs;
         if (stateChanged || issueListChanged) {
           try {
-            cachedJsonData = buildDashboardJson(
-              cachedDigest,
-              stateManager.getState(),
-              cachedCommentedIssues,
-              undefined,
-              undefined,
-              withPendingGistWarnings(cachedPartialFailures),
-            );
-            cachedIssueListMtimeMs = currentIssueListMtimeMs;
+            cache.rebuild(gistSync.stateManager.getState(), undefined, undefined, currentIssueListMtimeMs);
           } catch (error) {
             warn(MODULE, `Failed to rebuild dashboard data after state reload: ${errorMessage(error)}`);
-            // Serve previous cachedJsonData rather than returning 500.
+            // Serve previous cached payload rather than returning 500.
             // Signal staleness via response header so clients can detect the degraded mode (#994).
             res.setHeader('X-Dashboard-Stale', '1');
           }
@@ -718,14 +337,14 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
         // token expiry / GitHub outage produces a client-visible signal
         // rather than silent stale data. Only set the header when a failure
         // is recorded — successful refreshes clear it.
-        if (lastBackgroundRefreshError !== null) {
+        if (cache.lastBackgroundRefreshError !== null) {
           res.setHeader('X-Dashboard-Stale', '1');
           res.setHeader(
             'X-Dashboard-Stale-Reason',
-            sanitizeHeaderValue(`background-refresh-failed: ${lastBackgroundRefreshError}`),
+            sanitizeHeaderValue(`background-refresh-failed: ${cache.lastBackgroundRefreshError}`),
           );
         }
-        sendJson(res, 200, cachedJsonData);
+        sendJson(res, 200, cache.jsonData);
         return;
       }
 
@@ -789,27 +408,13 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
 
   // ── POST /api/action handler ─────────────────────────────────────────────
 
-  /** A gist pull wholesale-replaces state, and the pulled state.lastDigest
-   * may be NEWER than this server's long-lived cachedDigest (another machine
-   * ran its daily check). Adopt it when its generatedAt is strictly newer so
-   * cross-machine results appear without a manual full refresh (#1446
-   * item 6). Unparsable timestamps compare as NaN and never adopt —
-   * conservative: keep what we have. */
-  function adoptNewerPulledDigest(): void {
-    const pulled = stateManager.getState().lastDigest;
-    if (!pulled) return;
-    if (Date.parse(pulled.generatedAt) > Date.parse(cachedDigest.generatedAt)) {
-      cachedDigest = pulled;
-    }
-  }
-
   /** Re-read state written by external processes (CLI) before mutating.
    * Returns true when the state source changed (gist pull refreshed, local
    * file reloaded, or a gist recovery completed) — GET /api/data uses this
    * to decide whether to rebuild the cached payload (#1446 item 5). */
   async function reloadState(): Promise<boolean> {
-    if (stateManager.isGistMode()) {
-      await flushPendingGistSync();
+    if (gistSync.stateManager.isGistMode()) {
+      await gistSync.flushPendingGistSync();
       // Both post-pull steps consume the same refreshFromGist outcome, in
       // this order: pullFromGist (#1443) settles the LOSS side first —
       // still-pending push warnings become a loss notice at the instant the
@@ -819,34 +424,34 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
       // because the background-refresh path also pulls but replaces
       // cachedDigest unconditionally right after — adoption is a
       // reloadState-path concern only.
-      const refreshed = await pullFromGist();
-      if (refreshed) adoptNewerPulledDigest();
-      if (gistBootstrapDegraded()) {
+      const refreshed = await gistSync.pullFromGist();
+      if (refreshed) cache.adoptNewerPulledDigest(gistSync.stateManager.getState().lastDigest);
+      if (gistSync.gistBootstrapDegraded()) {
         // #1443: a degraded bootstrap keeps isGistMode() true while the
         // store is disarmed, so refreshFromGist() short-circuits forever
         // and the local-branch recovery below never sees it. Same
         // throttle/halt machinery applies inside maybeRecoverGist.
-        await maybeRecoverGist();
+        await gistSync.maybeRecoverGist();
         // A successful recovery replaced the singleton with state pulled
         // from the Gist — report a change so callers rebuild and the
         // stale-bootstrap banner clears now.
-        if (!gistBootstrapDegraded()) return true;
+        if (!gistSync.gistBootstrapDegraded()) return true;
       }
       return refreshed;
     }
-    let changed = stateManager.reloadIfChanged();
+    let changed = gistSync.stateManager.reloadIfChanged();
     if (changed) {
       // An external config edit may BE the fix for a permanently-halted
       // recovery (new token scope, repaired gist id) — give it one fresh
       // attempt cycle (#1433 pass-2).
-      recoveryHaltedReason = null;
+      gistSync.unhaltRecovery();
     }
     // reloadIfChanged may have just pulled a persistence=gist flip made
     // from a terminal, and a degraded server heals here too (#1433).
-    await maybeRecoverGist();
+    await gistSync.maybeRecoverGist();
     // A successful recovery is a state-source change: rebuild so the
     // degraded banner clears without waiting for another edit.
-    if (stateManager.isGistMode()) changed = true;
+    if (gistSync.stateManager.isGistMode()) changed = true;
     return changed;
   }
 
@@ -908,11 +513,11 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
     } else {
       // dismiss_issue_response
       applyMutation = async () => {
-        stateManager.dismissIssue(body.url, new Date().toISOString());
+        gistSync.stateManager.dismissIssue(body.url, new Date().toISOString());
         // Mirror runMove's contract: every mutating surface checkpoints to
         // Gist and surfaces the warning. Never throws — failures come back
         // as the warning string.
-        gistSyncWarning = await maybeCheckpoint(stateManager, MODULE);
+        gistSyncWarning = await maybeCheckpoint(gistSync.stateManager, MODULE);
       };
     }
 
@@ -957,28 +562,20 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
     // SPA already renders (#1417). Tracked in pendingGistSyncWarnings — NOT
     // cachedPartialFailures — because gist warnings clear on a successful
     // PUSH, while fetch failures clear on a successful pull/refresh.
-    recordGistSyncOutcome(gistSyncWarning);
+    gistSync.recordGistSyncOutcome(gistSyncWarning);
 
     // Count mutations acknowledged while degraded (#1433): a later recovery
     // bootstraps from the existing Gist and reverts them, and the loss
     // notice needs to know whether there is anything to lose.
-    if (gistConfiguredButLocal()) degradedMutationCount++;
+    gistSync.recordMutationWhileDegraded();
 
     // Rebuild dashboard data from cached digest + updated state. Persist
     // the last-known partialFailures across action rebuilds (#1035) so the
     // SPA banner survives user interactions until the next successful
     // refresh clears it.
-    cachedJsonData = buildDashboardJson(
-      cachedDigest,
-      stateManager.getState(),
-      cachedCommentedIssues,
-      undefined,
-      undefined,
-      withPendingGistWarnings(cachedPartialFailures),
-    );
-    cachedIssueListMtimeMs = getIssueListMtimeMs();
+    cache.rebuild(gistSync.stateManager.getState());
 
-    sendJson(res, 200, cachedJsonData);
+    sendJson(res, 200, cache.jsonData);
   }
 
   // ── POST /api/refresh handler ────────────────────────────────────────────
@@ -995,25 +592,13 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
       // refresh's own reloadState may RECOVER and produce a fresh notice,
       // which must survive into the rebuild below, not be wiped 10 lines
       // after its creation (#1433 pass-2).
-      recoveryLossNotices = [];
+      gistSync.clearRecoveryLossNotices();
       await reloadState();
       warn(MODULE, 'Refreshing dashboard data from GitHub...');
       const result = await fetchDashboardData(currentToken);
-      cachedDigest = result.digest;
-      cachedCommentedIssues = result.commentedIssues;
-      // Update the persistent banner signal — clear on a clean refresh,
-      // set when one or more sub-fetches degraded. See #1035.
-      cachedPartialFailures = result.partialFailures.length > 0 ? result.partialFailures : undefined;
-      cachedJsonData = buildDashboardJson(
-        cachedDigest,
-        stateManager.getState(),
-        cachedCommentedIssues,
-        result.allMergedPRs,
-        result.allClosedPRs,
-        withPendingGistWarnings(cachedPartialFailures),
-      );
-      cachedIssueListMtimeMs = getIssueListMtimeMs();
-      sendJson(res, 200, cachedJsonData);
+      cache.adoptFetchResult(result);
+      cache.rebuild(gistSync.stateManager.getState(), result.allMergedPRs, result.allClosedPRs);
+      sendJson(res, 200, cache.jsonData);
     } catch (error) {
       // No server-side retry here (unlike handleAction): a refresh re-run is a
       // full GitHub fetch — expensive and rate-limited. The 409 is retryable
@@ -1156,38 +741,28 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
     fetchDashboardData(token)
       .then(async (result) => {
         // Same clear-before-recover ordering as handleRefresh (#1433 pass-2).
-        recoveryLossNotices = [];
-        if (stateManager.isGistMode()) {
-          await flushPendingGistSync();
-          await pullFromGist();
+        gistSync.clearRecoveryLossNotices();
+        if (gistSync.stateManager.isGistMode()) {
+          await gistSync.flushPendingGistSync();
+          await gistSync.pullFromGist();
           // Heal a degraded bootstrap from the background refresh too (#1443).
-          if (gistBootstrapDegraded()) await maybeRecoverGist();
+          if (gistSync.gistBootstrapDegraded()) await gistSync.maybeRecoverGist();
         } else {
-          stateManager.reloadIfChanged();
-          await maybeRecoverGist();
+          gistSync.stateManager.reloadIfChanged();
+          await gistSync.maybeRecoverGist();
         }
-        cachedDigest = result.digest;
-        cachedCommentedIssues = result.commentedIssues;
-        cachedPartialFailures = result.partialFailures.length > 0 ? result.partialFailures : undefined;
-        cachedJsonData = buildDashboardJson(
-          cachedDigest,
-          stateManager.getState(),
-          cachedCommentedIssues,
-          result.allMergedPRs,
-          result.allClosedPRs,
-          withPendingGistWarnings(cachedPartialFailures),
-        );
-        cachedIssueListMtimeMs = getIssueListMtimeMs();
+        cache.adoptFetchResult(result);
+        cache.rebuild(gistSync.stateManager.getState(), result.allMergedPRs, result.allClosedPRs);
         // Successful refresh clears any prior failure signal (#1205).
-        lastBackgroundRefreshError = null;
+        cache.lastBackgroundRefreshError = null;
         warn(MODULE, 'Background data refresh complete');
         return;
       })
       .catch((error) => {
         // Capture so /api/data can surface staleness via X-Dashboard-Stale
         // header — previously the catch only logged to stderr (#1205).
-        lastBackgroundRefreshError = errorMessage(error);
-        warn(MODULE, `Background data refresh failed (serving cached data): ${lastBackgroundRefreshError}`);
+        cache.lastBackgroundRefreshError = errorMessage(error);
+        warn(MODULE, `Background data refresh failed (serving cached data): ${cache.lastBackgroundRefreshError}`);
       });
   }
 


### PR DESCRIPTION
Fixes #1457.

dashboard-server.ts was the repo's growth hotspot (1,212 lines after absorbing the #1443/#1446/#1448/#1459/#1444 waves; ~13 mutable closure variables; the gist lifecycle untestable except through the full HTTP harness).

## Split

- **GistSyncCoordinator** (commands/dashboard-gist-sync.ts, 254 lines): the gist-sync state machine — pending push warnings, loss notices, degraded-mutation count, recovery throttle/halt/un-halt, flush/pull/recover, the live StateManager reference (re-resolved on recovery), and the #1444 probeGistHealth port (this branch reconciled the #1444 merge — the probe semantics were re-verified exactly equivalent).
- **DashboardCache** (commands/dashboard-cache.ts, 277 lines): cached digest/json/mtime/partialFailures, adoptFetchResult, adoptNewerPulledDigest, and a single rebuild() replacing the 4× build-then-stamp sequence; buildDashboardJson lives here, re-exported from the server for import compat. Gist coupling injected as a mergeWarnings function (live-object capture, reviewer-verified no stale closure).
- Server keeps HTTP/security/routes/reloadState wiring: 787 lines.

Zero behavior change, reviewer-verified at the riskiest seams: reloadState's flush→pull→adopt→recover ordering line-for-line identical to main modulo mechanical substitution; every call site reads the manager through the coordinator fresh (no stale-reference window); the one disclosed delta is one extra fs.stat of the issue list at boot (semantics unchanged). All #1417/#1433/#1443/#1446 invariant comments moved with their code. The pre-existing dashboard-server.test.ts passes unmodified by the split commit; 13 new coordinator unit tests cover the lifecycle without the HTTP harness (mock getGistHealth derived to consume underlying mocks once per probe, documented).

Gate: root eslint, prettier, typecheck, 2951 core + 247 mcp green; coverage gate passes (new files 100/98 and 93/72 with the aggregate-glob thresholds clear). code-reviewer pass: CLEAN.