### PR TITLE
ci: run the token-gated e2e suites in a nightly workflow; fix their seeding and timeouts (#1452)

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -1,0 +1,74 @@
+name: Nightly E2E (live GitHub API)
+
+# Runs the two token-gated CLI e2e suites against the live GitHub API. The
+# per-PR CI (ci.yml) deliberately SKIPS these: they need a real GITHUB_TOKEN
+# (Actions does not auto-export one to the test step there) and they hit
+# GitHub's rate-limited /search/issues, which made them slow and flaky across
+# the 3-way PR matrix. See #1452 for the full rationale and the decision to
+# move them to a single-leg, serialized nightly run instead.
+#
+# These suites are READ-ONLY against GitHub: `search` calls /search/issues +
+# repos.get, `daily` calls issues.listForRepo / PR reads via the bundled CLI.
+# Nothing posts, comments, or mutates, so the job-level `contents: read`
+# permission (which is what scopes the ambient GITHUB_TOKEN) is sufficient.
+on:
+  schedule:
+    # 07:00 UTC daily — off-peak for the Americas (late night) so a transient
+    # rate-limit backoff doesn't compete with daytime interactive usage.
+    - cron: '0 7 * * *'
+  workflow_dispatch: {}
+
+# Read-only token is all these tests need (see header). This also scopes the
+# ambient GITHUB_TOKEN the test step receives.
+permissions:
+  contents: read
+
+# Never let two nightly runs (e.g. a scheduled run overlapping a manual
+# dispatch) race against the same rate-limited search API.
+concurrency:
+  group: nightly-e2e
+  cancel-in-progress: false
+
+jobs:
+  e2e:
+    name: Live-API e2e (Node 22 / ubuntu-latest)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build core types
+        run: pnpm --filter @oss-autopilot/core run build
+
+      # The e2e suites execute dist/cli.bundle.cjs and skip if it is absent
+      # (same gate as #1366), so the bundle MUST exist before tests run.
+      - name: Build CLI bundle (required by e2e suites, #1366)
+        run: pnpm --filter @oss-autopilot/core run bundle
+
+      - name: Run token-gated e2e suites (serialized, live GitHub API)
+        env:
+          # Read-only ambient token (scoped by `permissions: contents: read`).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Marker that flips the suites' loud-skip guard on: if the token is
+          # somehow absent here, the guard FAILS the run instead of silently
+          # skipping the tests this workflow exists to run (#1452).
+          OSS_AUTOPILOT_NIGHTLY: '1'
+        # --no-file-parallelism runs the two suites sequentially so they don't
+        # compound each other's /search/issues rate-limit pressure.
+        run: >-
+          pnpm --filter @oss-autopilot/core exec vitest run
+          src/commands/search.e2e.test.ts
+          src/commands/daily.e2e.test.ts
+          --no-file-parallelism

--- a/packages/core/src/commands/daily.e2e.test.ts
+++ b/packages/core/src/commands/daily.e2e.test.ts
@@ -25,6 +25,41 @@ const TEST_HOME = '/tmp/oss-autopilot-e2e-daily-test-' + process.pid;
  */
 const HAS_GITHUB_TOKEN = !!process.env.GITHUB_TOKEN;
 
+/**
+ * Set by the nightly live-API workflow (.github/workflows/nightly-e2e.yml, #1452).
+ * Its whole purpose is to run these token-gated tests, so a missing token in
+ * that context must fail loudly rather than silently skip. Unset in per-PR CI
+ * and local runs, where skipping is the correct behavior.
+ */
+const IS_NIGHTLY = process.env.OSS_AUTOPILOT_NIGHTLY === '1';
+
+/**
+ * GitHub user the seeded `daily` run queries open PRs for. Hardcoded to the
+ * repo owner (a stable, public account) rather than the token's own user so
+ * the test is deterministic regardless of which token the nightly runner holds
+ * — `daily` only needs SOME resolvable username to drive its PR fetch, and the
+ * assertions validate the envelope shape, not which PRs come back.
+ */
+const SEED_USERNAME = 'costajohnt';
+
+// The token-gated `daily` run does live GitHub I/O (multi-phase fetch); 30s is
+// too tight once a transient backoff is in play. 120s gives a single retry
+// room without failing the test (#1452).
+const EXEC_TIMEOUT_MS = 120_000;
+
+/**
+ * Seed a githubUsername into the test HOME so `daily --json` reaches its
+ * success path instead of returning the CONFIGURATION error envelope. Runs the
+ * bundle's `init <username>` against the same HOME the daily run uses.
+ */
+async function seedUsername(): Promise<void> {
+  await execFileAsync('node', [BUNDLE_PATH, 'init', SEED_USERNAME, '--json'], {
+    timeout: EXEC_TIMEOUT_MS,
+    env: { ...process.env, HOME: TEST_HOME },
+    cwd: TEST_HOME,
+  });
+}
+
 async function runDaily(
   env?: Record<string, string>,
 ): Promise<{ stdout: string; stderr: string; json: any; exitCode: number | null }> {
@@ -32,7 +67,7 @@ async function runDaily(
   let signal: string | null = null;
 
   const result = await execFileAsync('node', [BUNDLE_PATH, 'daily', '--json'], {
-    timeout: 30_000,
+    timeout: EXEC_TIMEOUT_MS,
     env: { ...process.env, ...env, HOME: TEST_HOME },
     cwd: TEST_HOME,
   }).catch((err: any) => {
@@ -79,25 +114,50 @@ describe.skipIf(!BUNDLE_EXISTS)('daily --json E2E', () => {
     expect(json).toMatchObject({ success: false, errorCode: 'AUTH_REQUIRED' });
   });
 
+  // Loud-skip guard (#1452): the nightly live-API workflow exists specifically
+  // to run the token-gated tests below. If it runs without a token they would
+  // silently skip, defeating the workflow's purpose — fail instead. Runs only
+  // when the nightly marker is set, so per-PR CI and local runs (no marker)
+  // are unaffected even when they lack a token.
+  it.runIf(IS_NIGHTLY)('nightly workflow must provide a GitHub token (#1452)', () => {
+    expect(
+      HAS_GITHUB_TOKEN,
+      'OSS_AUTOPILOT_NIGHTLY=1 but GITHUB_TOKEN is absent; the nightly e2e job cannot run the live-API tests it exists for.',
+    ).toBe(true);
+  });
+
   describe.skipIf(!HAS_GITHUB_TOKEN)('with GitHub token', () => {
-    it('should output valid JSON', async () => {
+    // One live `daily` run shared across the structural assertions below
+    // (#1452): daily does heavy multi-phase GitHub I/O, so calling it per-test
+    // (eight times) was both slow and pointlessly chatty. The username seed
+    // makes the run reach its success path instead of the CONFIGURATION error
+    // envelope a fresh HOME would otherwise produce.
+    let sharedJson: any;
+    let sharedDurationMs = 0;
+
+    beforeAll(async () => {
+      await seedUsername();
+      const start = Date.now();
       const { json } = await runDaily();
-      expect(json, 'CLI should return parseable JSON output').not.toBeNull();
-      expect(typeof json).toBe('object');
+      sharedDurationMs = Date.now() - start;
+      sharedJson = json;
+    }, EXEC_TIMEOUT_MS);
+
+    it('should output valid JSON', () => {
+      expect(sharedJson, 'CLI should return parseable JSON output').not.toBeNull();
+      expect(typeof sharedJson).toBe('object');
     });
 
-    it('should include success and data fields in the envelope', async () => {
-      const { json } = await runDaily();
-      expect(json, 'CLI should return parseable JSON output').not.toBeNull();
-      expect(json).toHaveProperty('success', true);
-      expect(json).toHaveProperty('data');
-      expect(json).toHaveProperty('timestamp');
+    it('should include success and data fields in the envelope', () => {
+      expect(sharedJson, 'CLI should return parseable JSON output').not.toBeNull();
+      expect(sharedJson).toHaveProperty('success', true);
+      expect(sharedJson).toHaveProperty('data');
+      expect(sharedJson).toHaveProperty('timestamp');
     });
 
-    it('should include digest, capacity, and summary in data', async () => {
-      const { json } = await runDaily();
-      expect(json, 'CLI should return parseable JSON output').not.toBeNull();
-      const data = json.data;
+    it('should include digest, capacity, and summary in data', () => {
+      expect(sharedJson, 'CLI should return parseable JSON output').not.toBeNull();
+      const data = sharedJson.data;
       expect(data).toHaveProperty('digest');
       expect(data).toHaveProperty('capacity');
       expect(data).toHaveProperty('summary');
@@ -108,10 +168,9 @@ describe.skipIf(!BUNDLE_EXISTS)('daily --json E2E', () => {
       expect(data).toHaveProperty('failures');
     });
 
-    it('should return capacity with expected fields', async () => {
-      const { json } = await runDaily();
-      expect(json, 'CLI should return parseable JSON output').not.toBeNull();
-      const { capacity } = json.data;
+    it('should return capacity with expected fields', () => {
+      expect(sharedJson, 'CLI should return parseable JSON output').not.toBeNull();
+      const { capacity } = sharedJson.data;
       expect(typeof capacity.hasCapacity).toBe('boolean');
       expect(typeof capacity.activePRCount).toBe('number');
       expect(typeof capacity.maxActivePRs).toBe('number');
@@ -120,10 +179,9 @@ describe.skipIf(!BUNDLE_EXISTS)('daily --json E2E', () => {
       expect(typeof capacity.reason).toBe('string');
     });
 
-    it('should return digest with summary fields', async () => {
-      const { json } = await runDaily();
-      expect(json, 'CLI should return parseable JSON output').not.toBeNull();
-      const { digest } = json.data;
+    it('should return digest with summary fields', () => {
+      expect(sharedJson, 'CLI should return parseable JSON output').not.toBeNull();
+      const { digest } = sharedJson.data;
       expect(digest).toHaveProperty('summary');
       expect(typeof digest.summary.totalActivePRs).toBe('number');
       expect(typeof digest.summary.totalNeedingAttention).toBe('number');
@@ -131,10 +189,9 @@ describe.skipIf(!BUNDLE_EXISTS)('daily --json E2E', () => {
       expect(typeof digest.summary.mergeRate).toBe('number');
     });
 
-    it('should return actionMenu with items and context', async () => {
-      const { json } = await runDaily();
-      expect(json, 'CLI should return parseable JSON output').not.toBeNull();
-      const { actionMenu } = json.data;
+    it('should return actionMenu with items and context', () => {
+      expect(sharedJson, 'CLI should return parseable JSON output').not.toBeNull();
+      const { actionMenu } = sharedJson.data;
       expect(Array.isArray(actionMenu.items)).toBe(true);
       expect(actionMenu).toHaveProperty('context');
       expect(typeof actionMenu.context.hasActionableIssues).toBe('boolean');
@@ -142,19 +199,18 @@ describe.skipIf(!BUNDLE_EXISTS)('daily --json E2E', () => {
       expect(typeof actionMenu.context.hasCapacity).toBe('boolean');
     });
 
-    it('should return arrays for actionableIssues, repoGroups, and failures', async () => {
-      const { json } = await runDaily();
-      expect(json, 'CLI should return parseable JSON output').not.toBeNull();
-      expect(Array.isArray(json.data.actionableIssues)).toBe(true);
-      expect(Array.isArray(json.data.repoGroups)).toBe(true);
-      expect(Array.isArray(json.data.failures)).toBe(true);
+    it('should return arrays for actionableIssues, repoGroups, and failures', () => {
+      expect(sharedJson, 'CLI should return parseable JSON output').not.toBeNull();
+      expect(Array.isArray(sharedJson.data.actionableIssues)).toBe(true);
+      expect(Array.isArray(sharedJson.data.repoGroups)).toBe(true);
+      expect(Array.isArray(sharedJson.data.failures)).toBe(true);
     });
 
-    it('should complete within 30 seconds', async () => {
-      const start = Date.now();
-      await runDaily();
-      const duration = Date.now() - start;
-      expect(duration).toBeLessThan(30_000);
+    it('should complete within the live-API time budget', () => {
+      // Ceiling raised from the old 30s to the live-API budget (#1452): a real
+      // multi-phase daily fetch with a transient backoff legitimately exceeds
+      // 30s. This guards against pathological hangs, not normal latency.
+      expect(sharedDurationMs).toBeLessThan(EXEC_TIMEOUT_MS);
     });
   });
 });

--- a/packages/core/src/commands/search.e2e.test.ts
+++ b/packages/core/src/commands/search.e2e.test.ts
@@ -25,6 +25,26 @@ const TEST_HOME = '/tmp/oss-autopilot-e2e-search-test-' + process.pid;
  */
 const HAS_GITHUB_TOKEN = !!process.env.GITHUB_TOKEN;
 
+/**
+ * Set by the nightly live-API workflow (.github/workflows/nightly-e2e.yml, #1452).
+ * Its whole purpose is to run these token-gated tests, so a missing token in
+ * that context must fail loudly rather than silently skip. Unset in per-PR CI
+ * and local runs, where skipping is the correct behavior.
+ */
+const IS_NIGHTLY = process.env.OSS_AUTOPILOT_NIGHTLY === '1';
+
+// A single live `search` invocation walks several `/search/issues` phases that
+// scout normally spaces 30s/90s apart to dodge GitHub's secondary rate limit
+// (see scout-bridge buildScoutState). That makes one run take ~100s. For the
+// e2e/nightly run we collapse the delays via these env vars (read by
+// commands/search.ts, #1452) AND raise the per-exec timeout to 120s so a single
+// secondary-limit backoff still has room to retry instead of failing the test.
+const EXEC_TIMEOUT_MS = 120_000;
+const SCOUT_DELAY_ENV = {
+  OSS_AUTOPILOT_SCOUT_INTER_PHASE_DELAY_MS: '0',
+  OSS_AUTOPILOT_SCOUT_BROAD_PHASE_DELAY_MS: '0',
+};
+
 async function runSearch(
   args: string[] = [],
   env?: Record<string, string>,
@@ -33,8 +53,8 @@ async function runSearch(
   let signal: string | null = null;
 
   const result = await execFileAsync('node', [BUNDLE_PATH, 'search', '--json', ...args], {
-    timeout: 30_000,
-    env: { ...process.env, ...env, HOME: TEST_HOME },
+    timeout: EXEC_TIMEOUT_MS,
+    env: { ...process.env, ...SCOUT_DELAY_ENV, ...env, HOME: TEST_HOME },
     cwd: TEST_HOME,
   }).catch((err: any) => {
     exitCode = err.code ?? null;
@@ -80,34 +100,59 @@ describe.skipIf(!BUNDLE_EXISTS)('search --json E2E', () => {
     expect(json).toMatchObject({ success: false, errorCode: 'AUTH_REQUIRED' });
   });
 
+  // Loud-skip guard (#1452): the nightly live-API workflow exists specifically
+  // to run the token-gated tests below. If it runs without a token they would
+  // silently skip, defeating the workflow's purpose — fail instead. Runs only
+  // when the nightly marker is set, so per-PR CI and local runs (no marker)
+  // are unaffected even when they lack a token.
+  it.runIf(IS_NIGHTLY)('nightly workflow must provide a GitHub token (#1452)', () => {
+    expect(
+      HAS_GITHUB_TOKEN,
+      'OSS_AUTOPILOT_NIGHTLY=1 but GITHUB_TOKEN is absent; the nightly e2e job cannot run the live-API tests it exists for.',
+    ).toBe(true);
+  });
+
   describe.skipIf(!HAS_GITHUB_TOKEN)('with GitHub token', () => {
-    it('should output valid JSON', async () => {
+    // Live search hits GitHub's rate-limited /search/issues across several
+    // phases, so the biggest reliability lever is making FEWER live calls
+    // (#1452). One `search --json 1` is run in beforeAll and shared across the
+    // envelope/structure assertions instead of one call per test; only the
+    // count-argument test needs a second, distinct invocation. Each test then
+    // does no network I/O, so a rate-limit hiccup can only affect the two
+    // shared runs, not all seven assertions.
+    let sharedJson: any;
+    let sharedDurationMs = 0;
+
+    beforeAll(async () => {
+      const start = Date.now();
       const { json } = await runSearch(['1']);
-      expect(json, 'CLI should return parseable JSON output').not.toBeNull();
-      expect(typeof json).toBe('object');
+      sharedDurationMs = Date.now() - start;
+      sharedJson = json;
+    }, EXEC_TIMEOUT_MS);
+
+    it('should output valid JSON', () => {
+      expect(sharedJson, 'CLI should return parseable JSON output').not.toBeNull();
+      expect(typeof sharedJson).toBe('object');
     });
 
-    it('should include success and data fields in the envelope', async () => {
-      const { json } = await runSearch(['1']);
-      expect(json, 'CLI should return parseable JSON output').not.toBeNull();
-      expect(json).toHaveProperty('success', true);
-      expect(json).toHaveProperty('data');
-      expect(json).toHaveProperty('timestamp');
+    it('should include success and data fields in the envelope', () => {
+      expect(sharedJson, 'CLI should return parseable JSON output').not.toBeNull();
+      expect(sharedJson).toHaveProperty('success', true);
+      expect(sharedJson).toHaveProperty('data');
+      expect(sharedJson).toHaveProperty('timestamp');
     });
 
-    it('should include candidates and excludedRepos in data', async () => {
-      const { json } = await runSearch(['1']);
-      expect(json, 'CLI should return parseable JSON output').not.toBeNull();
-      const data = json.data;
+    it('should include candidates and excludedRepos in data', () => {
+      expect(sharedJson, 'CLI should return parseable JSON output').not.toBeNull();
+      const data = sharedJson.data;
       expect(Array.isArray(data.candidates)).toBe(true);
       expect(Array.isArray(data.excludedRepos)).toBe(true);
       expect(Array.isArray(data.aiPolicyBlocklist)).toBe(true);
     });
 
-    it('should return candidates with expected structure when results exist', async () => {
-      const { json } = await runSearch(['1']);
-      expect(json, 'CLI should return parseable JSON output').not.toBeNull();
-      const { candidates } = json.data;
+    it('should return candidates with expected structure when results exist', () => {
+      expect(sharedJson, 'CLI should return parseable JSON output').not.toBeNull();
+      const { candidates } = sharedJson.data;
       // May be empty if no issues match the configured languages/labels, so only validate structure if non-empty
       if (candidates.length > 0) {
         const candidate = candidates[0];
@@ -125,17 +170,22 @@ describe.skipIf(!BUNDLE_EXISTS)('search --json E2E', () => {
       }
     });
 
-    it('should respect the count argument', async () => {
-      const { json } = await runSearch(['2']);
-      expect(json, 'CLI should return parseable JSON output').not.toBeNull();
-      expect(json.data.candidates.length).toBeLessThanOrEqual(2);
-    });
+    it(
+      'should respect the count argument',
+      async () => {
+        const { json } = await runSearch(['2']);
+        expect(json, 'CLI should return parseable JSON output').not.toBeNull();
+        expect(json.data.candidates.length).toBeLessThanOrEqual(2);
+      },
+      EXEC_TIMEOUT_MS,
+    );
 
-    it('should complete within 30 seconds', async () => {
-      const start = Date.now();
-      await runSearch(['1']);
-      const duration = Date.now() - start;
-      expect(duration).toBeLessThan(30_000);
+    it('should complete within the live-API time budget', () => {
+      // Ceiling raised from the old 30s to the live-API budget (#1452): even
+      // with the inter-phase delays collapsed to 0, a live multi-phase search
+      // plus a possible secondary-rate-limit backoff legitimately exceeds 30s.
+      // This guards against pathological hangs, not normal latency.
+      expect(sharedDurationMs).toBeLessThan(EXEC_TIMEOUT_MS);
     });
   });
 });

--- a/packages/core/src/commands/search.ts
+++ b/packages/core/src/commands/search.ts
@@ -70,6 +70,34 @@ function sanitizeViabilityScore(raw: unknown): number {
   return raw;
 }
 
+/**
+ * Read a non-negative integer scout-delay override from an env var.
+ *
+ * Scout spaces its multi-phase `/search/issues` calls with an inter-phase
+ * delay (default 30s) and a broad-phase delay (default 90s) to stay under
+ * GitHub's secondary rate limit (see `buildScoutState`). Those delays make a
+ * single `search` invocation take ~100s, which is fine in normal use but makes
+ * the live-API e2e suite (`search.e2e.test.ts`, run only in the nightly
+ * workflow — see #1452) impractically slow. These env vars let that suite
+ * collapse the delays so the test completes in a realistic CI window.
+ *
+ * Returns `undefined` when the var is unset/empty or not a parseable
+ * non-negative integer, so scout falls back to its preference value and
+ * production behavior is unchanged. Only the live test/nightly run sets them.
+ */
+function readScoutDelayOverride(envVar: string): number | undefined {
+  const raw = process.env[envVar];
+  if (raw === undefined || raw === '') {
+    return undefined;
+  }
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    warn(MODULE, `Ignoring invalid ${envVar}="${raw}" (expected a non-negative integer); using scout's default delay`);
+    return undefined;
+  }
+  return parsed;
+}
+
 export async function runSearch(options: SearchOptions): Promise<SearchOutput> {
   // Collect bridge-level degradation signals (#1448): an unreadable skip file
   // means scout searched with an empty skip list, so explicitly-skipped
@@ -96,11 +124,19 @@ export async function runSearch(options: SearchOptions): Promise<SearchOutput> {
     );
   }
 
+  // Live-API test/nightly affordance (#1452): collapse scout's inter-phase
+  // delays so the e2e suite finishes in a realistic window. Unset in normal
+  // use → undefined → scout falls back to the 30s/90s preference defaults.
+  const interPhaseDelayMs = readScoutDelayOverride('OSS_AUTOPILOT_SCOUT_INTER_PHASE_DELAY_MS');
+  const broadPhaseDelayMs = readScoutDelayOverride('OSS_AUTOPILOT_SCOUT_BROAD_PHASE_DELAY_MS');
+
   const result = await scout.search({
     maxResults: options.maxResults,
     preferLanguages,
     preferRepos,
     diversityRatio: SEARCH_DIVERSITY_RATIO,
+    ...(interPhaseDelayMs !== undefined ? { interPhaseDelayMs } : {}),
+    ...(broadPhaseDelayMs !== undefined ? { broadPhaseDelayMs } : {}),
   });
 
   // #1354: never surface issues the user already has an open PR for. Uses


### PR DESCRIPTION
Fixes #1452. Implements option (a) from the issue.

The token-gated blocks in search.e2e.test.ts and daily.e2e.test.ts never ran in CI (Actions doesn't auto-export GITHUB_TOKEN) AND never passed even locally: daily returned the CONFIGURATION error envelope on a fresh HOME (no username), and search hit GitHub's /search/issues secondary rate limit through scout's 30s/90s inter-phase delays (~100s/run, past the harness timeouts). Rather than red the per-PR matrix, they now run in a nightly single-leg workflow.

## What changed

- **New `.github/workflows/nightly-e2e.yml`**: 07:00 UTC cron + workflow_dispatch, ubuntu/node-22, `permissions: contents: read` (read-only is all these suites need — documented), `concurrency` guard against overlapping runs, builds the bundle before tests (the #1366 gate), runs only the two e2e suites with `--no-file-parallelism` and `GITHUB_TOKEN` + `OSS_AUTOPILOT_NIGHTLY=1` in the step env.
- **daily fix**: a `beforeAll` seeds `init costajohnt --json` into the test HOME so the run reaches its success path; the repo owner is a stable public account and the assertions validate envelope shape, not which PRs return. One shared live run across the eight structural assertions instead of one per test.
- **search fix**: a small env-gated affordance in `search.ts` (`OSS_AUTOPILOT_SCOUT_INTER_PHASE_DELAY_MS` / `_BROAD_PHASE_DELAY_MS`) collapses scout's per-call delays — unset in production → `undefined` → scout's 30s/90s defaults, so prod behavior is byte-identical (scout's SearchOptions already accepts these per-call). The suite sets them to 0 and shares one live `search` run across assertions (only the count-argument test makes a second call), so a rate-limit hiccup can touch at most two runs, not seven.
- **timeouts** raised to a 120s live-API budget; **loud-skip guard**: `it.runIf(IS_NIGHTLY)` fails when the nightly marker is set but no token is present, so the workflow can't silently skip the tests it exists for. Per-PR CI and local runs (no marker) are unaffected.

## Verified locally (the crux)

- **Live, with a token + marker**: `2 files / 18 tests passed`, 164s wall (serialized), zero rate-limit errors.
- **No token, no marker** (per-PR CI path): `2 passed | 16 skipped` — clean skip, CI unbroken.
- **No token, with marker** (nightly safety): the loud-skip guard `× nightly workflow must provide a GitHub token` fails as designed.

Gate: YAML valid, root eslint, prettier, typecheck, full core (2951 passed | 17 skipped — token-gated blocks skip without a token) + 247 mcp green.