### PR TITLE
Consolidate vet-list verdicts onto the deterministic verify-issue classifier (#1494)

### DIFF
--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -45,7 +45,7 @@ You are an Issue Scout helping contributors find valuable OSS contribution oppor
 - `mcp__plugin_oss-autopilot_oss-autopilot__search` — multi-strategy issue discovery.
 - `mcp__plugin_oss-autopilot_oss-autopilot__verify-issue` — deterministic state + linked-PR claim check. ALWAYS the first call for any specific issue URL.
 - `mcp__plugin_oss-autopilot_oss-autopilot__vet` — deep-vet one issue.
-- `mcp__plugin_oss-autopilot_oss-autopilot__vet-list` — re-vet all saved results (`prune: true` removes unavailable items).
+- `mcp__plugin_oss-autopilot_oss-autopilot__vet-list` — re-vet all saved results (`prune: true` removes unavailable items). Runs `verify-issue` per entry, so each row's `listStatus` and `verification` carry the authoritative verdict (#1494).
 - `mcp__plugin_oss-autopilot_oss-autopilot__status` — tracked PRs, history, cached repo scores.
 
 **CLI fallback** (only when MCP is unavailable):
@@ -109,7 +109,7 @@ Remember to filter by `excludedRepos` manually.
 
 Before ANY other analysis of a specific issue URL (a single-issue vet, or a search candidate you are about to recommend), call `verify-issue`. Its fields are ground truth fetched via GraphQL — trust them over anything you infer from comments, timelines, or issue prose. Never report `Open: yes/no` or "taken by PR #N" from your own reading; report what `verify-issue` returned.
 
-Whole-list re-vets are the one exception by necessity: `vet-list` does NOT run `verify-issue` per entry, so its `listStatus` values are heuristic (REST-level availability checks without closing-vs-mention awareness). Treat a `vet-list` flag as a triage signal, and run `verify-issue` on the flagged entry's URL before acting on it (marking done, dropping, or recommending).
+Whole-list re-vets carry the same ground truth: as of #1494 `vet-list` runs `verify-issue` per entry, so each row's `listStatus` is derived from the deterministic verdict (closing-vs-mention aware) and the row's `verification` sub-object holds the same fields a single-issue `verify-issue` returns. Trust a `vet-list` row's verdict directly — no per-entry re-check is needed. The only exception is a row whose `verification` is absent (verify itself errored for that entry, and `listStatus` fell back to scout's heuristic): re-run `verify-issue` on that URL before acting on it.
 
 Route on `verdict` with short-circuit semantics:
 
@@ -125,7 +125,7 @@ The `linkedPRs` array distinguishes `closing` (the PR's `closingIssuesReferences
 
 ### Linked-PR classification
 
-**Precedence:** when this table and the Step 0 `verify-issue` verdict disagree on whether an issue is open or taken, the `verify-issue` verdict WINS. `vet`'s classifier has no closing-vs-cross-referenced awareness, so e.g. `other_open` here can be a mere mention that Step 0 already classified `at-risk` (still available). Use this table only for the supplementary signals Step 0 does not carry (friction history, maintainer-preference hints), never to overturn an availability verdict.
+**Precedence:** when this table and the `verify-issue` verdict disagree on whether an issue is open or taken, the `verify-issue` verdict WINS. `vet`'s classifier has no closing-vs-cross-referenced awareness, so e.g. `other_open` here can be a mere mention that the verdict already classified `at-risk` (still available). Use this table only for the supplementary signals the verdict does not carry (friction history, maintainer-preference hints), never to overturn an availability verdict. The authoritative verdict comes from Step 0 for single-issue work, and from each row's own `verification` for `vet-list` results (#1494) — both are the same deterministic check.
 
 The `vet` response includes a `linkedPRClassification` when scout exposes the raw linked-PR metadata. Route on the value (not substrings):
 

--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -109,7 +109,7 @@ Remember to filter by `excludedRepos` manually.
 
 Before ANY other analysis of a specific issue URL (a single-issue vet, or a search candidate you are about to recommend), call `verify-issue`. Its fields are ground truth fetched via GraphQL — trust them over anything you infer from comments, timelines, or issue prose. Never report `Open: yes/no` or "taken by PR #N" from your own reading; report what `verify-issue` returned.
 
-Whole-list re-vets carry the same ground truth: as of #1494 `vet-list` runs `verify-issue` per entry, so each row's `listStatus` is derived from the deterministic verdict (closing-vs-mention aware) and the row's `verification` sub-object holds the same fields a single-issue `verify-issue` returns. Trust a `vet-list` row's verdict directly — no per-entry re-check is needed. The only exception is a row whose `verification` is absent (verify itself errored for that entry, and `listStatus` fell back to scout's heuristic): re-run `verify-issue` on that URL before acting on it.
+Whole-list re-vets carry the same ground truth: as of #1494 `vet-list` runs `verify-issue` per entry, so each row's `listStatus` is derived from the deterministic verdict (closing-vs-mention aware) and the row's `verification` sub-object holds the same fields a single-issue `verify-issue` returns. Trust a `vet-list` row's verdict directly — no per-entry re-check is needed. The one exception is a row carrying a `verifyError` field (the authoritative check failed for that entry, so `verification` is absent and `listStatus` came from scout's weaker heuristic): re-run `verify-issue` on that URL before acting on it.
 
 Route on `verdict` with short-circuit semantics:
 

--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -612,7 +612,9 @@ export const commands: CLICommandDef[] = [
             (data) => {
               console.log(`\nRe-vetted ${data.summary.total} issues:\n`);
               console.log(`  Still available: ${data.summary.stillAvailable}`);
+              console.log(`  At risk:         ${data.summary.atRisk}`);
               console.log(`  Claimed:         ${data.summary.claimed}`);
+              console.log(`  Own open PR:     ${data.summary.ownOpenPr}`);
               console.log(`  Closed:          ${data.summary.closed}`);
               console.log(`  Has PR:          ${data.summary.hasPR}`);
               console.log(`  Stalled PR:      ${data.summary.hasStalledPR}`);
@@ -625,7 +627,14 @@ export const commands: CLICommandDef[] = [
                     : result.listStatus === 'error'
                       ? '\u274c'
                       : '\u26a0\ufe0f';
-                const annotation = result.listStatus === 'has_stalled_pr' ? ' (stalled PR, revive opportunity)' : '';
+                const annotation =
+                  result.listStatus === 'has_stalled_pr'
+                    ? ' (stalled PR, revive opportunity)'
+                    : result.listStatus === 'at_risk'
+                      ? ' (at risk, mention only)'
+                      : result.listStatus === 'own_open_pr'
+                        ? ' (you already have an open PR)'
+                        : '';
                 console.log(
                   `${status} [${result.listStatus}] ${result.issue.repo}#${result.issue.number}: ${result.issue.title}${annotation}`,
                 );

--- a/packages/core/src/commands/__golden__/vet-list.empty.json
+++ b/packages/core/src/commands/__golden__/vet-list.empty.json
@@ -7,6 +7,8 @@
     "closed": 0,
     "hasPR": 0,
     "hasStalledPR": 0,
+    "atRisk": 0,
+    "ownOpenPr": 0,
     "errors": 0
   }
 }

--- a/packages/core/src/commands/__golden__/vet-list.mixed.json
+++ b/packages/core/src/commands/__golden__/vet-list.mixed.json
@@ -35,42 +35,56 @@
         "letter": "B",
         "reason": "3-day avg response"
       },
-      "listStatus": "still_available"
+      "listStatus": "still_available",
+      "verification": {
+        "verdict": "available",
+        "verdictReason": "verdict: available",
+        "state": "open",
+        "stateReason": null,
+        "assignees": [],
+        "linkedPRs": []
+      }
     },
     {
       "issue": {
         "repo": "owner/repo-b",
         "number": 2,
-        "title": "Already claimed",
+        "title": "issue 2",
         "url": "https://github.com/owner/repo-b/issues/2",
         "labels": []
       },
       "recommendation": "skip",
       "reasonsToApprove": [],
       "reasonsToSkip": [
-        "Issue is already claimed by another user"
+        "open PR by rival closes this issue"
       ],
-      "projectHealth": {
-        "repo": "owner/repo-b",
-        "lastCommitAt": "2026-04-15T00:00:00.000Z",
-        "daysSinceLastCommit": 3,
-        "openIssuesCount": 10,
-        "avgIssueResponseDays": 0,
-        "ciStatus": "passing",
-        "isActive": true
-      },
-      "vettingResult": {
-        "passedAllChecks": false,
-        "checks": {},
-        "notes": []
-      },
-      "linkedPRClassification": "none",
-      "slmTriage": null,
+      "projectHealth": {},
+      "vettingResult": {},
       "grade": {
-        "letter": "B",
-        "reason": "3-day avg response"
+        "letter": "F",
+        "reason": "unknown maintainer responsiveness, merge rate, activity"
       },
-      "listStatus": "claimed"
+      "listStatus": "claimed",
+      "verification": {
+        "verdict": "taken",
+        "verdictReason": "open PR by rival closes this issue",
+        "state": "open",
+        "stateReason": null,
+        "assignees": [],
+        "linkedPRs": [
+          {
+            "number": 99,
+            "url": "https://github.com/owner/repo/pull/99",
+            "title": "a closing PR",
+            "state": "open",
+            "isDraft": false,
+            "author": "rival",
+            "isOwn": false,
+            "linkType": "closing",
+            "updatedAt": "2026-06-01T00:00:00.000Z"
+          }
+        ]
+      }
     },
     {
       "issue": {
@@ -93,15 +107,144 @@
       },
       "listStatus": "error",
       "errorMessage": "Network timeout"
+    },
+    {
+      "issue": {
+        "repo": "owner/repo-d",
+        "number": 4,
+        "title": "At risk",
+        "url": "https://github.com/owner/repo-d/issues/4",
+        "labels": []
+      },
+      "recommendation": "needs_review",
+      "reasonsToApprove": [
+        "Looks reasonable"
+      ],
+      "reasonsToSkip": [
+        "Open PR mentions this issue"
+      ],
+      "projectHealth": {
+        "repo": "owner/repo-d",
+        "lastCommitAt": "2026-04-15T00:00:00.000Z",
+        "daysSinceLastCommit": 3,
+        "openIssuesCount": 10,
+        "avgIssueResponseDays": 0,
+        "ciStatus": "passing",
+        "isActive": true
+      },
+      "vettingResult": {
+        "passedAllChecks": false,
+        "checks": {},
+        "notes": []
+      },
+      "linkedPRClassification": "none",
+      "slmTriage": null,
+      "grade": {
+        "letter": "B",
+        "reason": "3-day avg response"
+      },
+      "listStatus": "at_risk",
+      "verification": {
+        "verdict": "at-risk",
+        "verdictReason": "open PR cross-references this issue (mention only)",
+        "state": "open",
+        "stateReason": null,
+        "assignees": [],
+        "linkedPRs": [
+          {
+            "number": 41,
+            "url": "https://github.com/owner/repo-d/pull/41",
+            "title": "a closing PR",
+            "state": "open",
+            "isDraft": false,
+            "author": "rival",
+            "isOwn": false,
+            "linkType": "cross-referenced",
+            "updatedAt": "2026-06-01T00:00:00.000Z"
+          }
+        ]
+      }
+    },
+    {
+      "issue": {
+        "repo": "owner/repo-e",
+        "number": 5,
+        "title": "issue 5",
+        "url": "https://github.com/owner/repo-e/issues/5",
+        "labels": []
+      },
+      "recommendation": "skip",
+      "reasonsToApprove": [],
+      "reasonsToSkip": [
+        "you already have an open PR for this issue"
+      ],
+      "projectHealth": {},
+      "vettingResult": {},
+      "grade": {
+        "letter": "F",
+        "reason": "unknown maintainer responsiveness, merge rate, activity"
+      },
+      "listStatus": "own_open_pr",
+      "verification": {
+        "verdict": "own-open-pr",
+        "verdictReason": "you already have an open PR for this issue",
+        "state": "open",
+        "stateReason": null,
+        "assignees": [],
+        "linkedPRs": [
+          {
+            "number": 51,
+            "url": "https://github.com/owner/repo-e/pull/51",
+            "title": "a closing PR",
+            "state": "open",
+            "isDraft": false,
+            "author": "costajohnt",
+            "isOwn": true,
+            "linkType": "closing",
+            "updatedAt": "2026-06-01T00:00:00.000Z"
+          }
+        ]
+      }
+    },
+    {
+      "issue": {
+        "repo": "owner/repo-f",
+        "number": 6,
+        "title": "issue 6",
+        "url": "https://github.com/owner/repo-f/issues/6",
+        "labels": []
+      },
+      "recommendation": "skip",
+      "reasonsToApprove": [],
+      "reasonsToSkip": [
+        "verdict: closed"
+      ],
+      "projectHealth": {},
+      "vettingResult": {},
+      "grade": {
+        "letter": "F",
+        "reason": "unknown maintainer responsiveness, merge rate, activity"
+      },
+      "listStatus": "closed",
+      "verification": {
+        "verdict": "closed",
+        "verdictReason": "verdict: closed",
+        "state": "closed",
+        "stateReason": "completed",
+        "assignees": [],
+        "linkedPRs": []
+      }
     }
   ],
   "summary": {
-    "total": 3,
+    "total": 6,
     "stillAvailable": 1,
     "claimed": 1,
-    "closed": 0,
+    "closed": 1,
     "hasPR": 0,
     "hasStalledPR": 0,
+    "atRisk": 1,
+    "ownOpenPr": 1,
     "errors": 1
   }
 }

--- a/packages/core/src/commands/__golden__/vet-list.mixed.json
+++ b/packages/core/src/commands/__golden__/vet-list.mixed.json
@@ -97,7 +97,7 @@
       "recommendation": "skip",
       "reasonsToApprove": [],
       "reasonsToSkip": [
-        "Error: Network timeout"
+        "Error: Issue not found: owner/repo-c#3. Check the URL."
       ],
       "projectHealth": {},
       "vettingResult": {},
@@ -106,7 +106,8 @@
         "reason": "unknown maintainer responsiveness, merge rate, activity"
       },
       "listStatus": "error",
-      "errorMessage": "Network timeout"
+      "errorMessage": "Issue not found: owner/repo-c#3. Check the URL.",
+      "verifyError": "Issue not found: owner/repo-c#3. Check the URL."
     },
     {
       "issue": {

--- a/packages/core/src/commands/__golden__/vet-list.mixed.json
+++ b/packages/core/src/commands/__golden__/vet-list.mixed.json
@@ -97,7 +97,7 @@
       "recommendation": "skip",
       "reasonsToApprove": [],
       "reasonsToSkip": [
-        "Error: Issue not found: owner/repo-c#3. Check the URL."
+        "Error: Issue not found: owner/repo-c#3. Check the URL — it may point at a pull request or a deleted/private issue."
       ],
       "projectHealth": {},
       "vettingResult": {},
@@ -106,8 +106,8 @@
         "reason": "unknown maintainer responsiveness, merge rate, activity"
       },
       "listStatus": "error",
-      "errorMessage": "Issue not found: owner/repo-c#3. Check the URL.",
-      "verifyError": "Issue not found: owner/repo-c#3. Check the URL."
+      "errorMessage": "Issue not found: owner/repo-c#3. Check the URL — it may point at a pull request or a deleted/private issue.",
+      "verifyError": "Issue not found: owner/repo-c#3. Check the URL — it may point at a pull request or a deleted/private issue."
     },
     {
       "issue": {

--- a/packages/core/src/commands/vet-list.contract.test.ts
+++ b/packages/core/src/commands/vet-list.contract.test.ts
@@ -1,9 +1,11 @@
 /**
- * --json contract test for the `vet-list` command (#965, #986).
+ * --json contract test for the `vet-list` command (#965, #986, #1494).
  *
- * Batch vetting over the curated issue list. Snapshots a mixed-status
- * batch so all five list-status outcomes are pinned:
- *   still_available / claimed / closed / has_pr / error
+ * As of #1494 vet-list verifies each entry FIRST (deterministic GraphQL) and
+ * derives the list status from that verdict, only falling back to scout's
+ * heuristic when verify itself errors. The mixed-status fixture pins every
+ * outcome of the new taxonomy:
+ *   still_available / at_risk / claimed / own_open_pr / closed / error
  *
  * Update on intentional shape changes with:
  *   npx vitest run -u src/commands/vet-list.contract.test.ts
@@ -16,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   getRepoScore: vi.fn(),
   detectIssueList: vi.fn(),
   runParseList: vi.fn(),
+  verifyIssuesBatch: vi.fn(),
 }));
 
 vi.mock('./scout-bridge.js', async () => {
@@ -36,6 +39,10 @@ vi.mock('../core/index.js', async () => {
   const actual = await vi.importActual<typeof import('../core/index.js')>('../core/index.js');
   return {
     ...actual,
+    // parseGitHubUrl + classifyLinkedPR stay real (from actual).
+    getOctokit: () => ({}),
+    requireGitHubToken: () => 'fake-token',
+    verifyIssuesBatch: mocks.verifyIssuesBatch,
     getStateManager: () => ({
       getRepoScore: mocks.getRepoScore,
       getState: () => ({ config: { githubUsername: 'costajohnt' } }),
@@ -44,6 +51,7 @@ vi.mock('../core/index.js', async () => {
 });
 
 import { runVetList } from './vet-list.js';
+import type { BatchVerificationResult, IssueAvailabilityVerdict } from '../core/index.js';
 
 const HEALTH_APPROVE = {
   repo: 'owner/repo-a',
@@ -55,6 +63,47 @@ const HEALTH_APPROVE = {
   isActive: true,
 };
 
+/** Build a successful verification batch entry for the given issue. */
+function verified(
+  repo: string,
+  number: number,
+  verdict: IssueAvailabilityVerdict,
+  overrides: Partial<NonNullable<BatchVerificationResult['verification']>> = {},
+): BatchVerificationResult {
+  const [owner, name] = repo.split('/');
+  return {
+    params: { owner, repo: name, number },
+    verification: {
+      url: `https://github.com/${repo}/issues/${number}`,
+      owner,
+      repo: name,
+      number,
+      title: `issue ${number}`,
+      state: verdict === 'closed' ? 'closed' : 'open',
+      stateReason: verdict === 'closed' ? 'completed' : null,
+      closedAt: null,
+      assignees: [],
+      linkedPRs: [],
+      verdict,
+      verdictReason: `verdict: ${verdict}`,
+      userLogin: 'costajohnt',
+      ...overrides,
+    },
+  };
+}
+
+const CLOSING_PR = {
+  number: 99,
+  url: 'https://github.com/owner/repo/pull/99',
+  title: 'a closing PR',
+  state: 'open' as const,
+  isDraft: false,
+  author: 'rival',
+  isOwn: false,
+  linkType: 'closing' as const,
+  updatedAt: '2026-06-01T00:00:00.000Z',
+};
+
 describe('vet-list --json contract', () => {
   beforeEach(() => {
     vi.resetAllMocks();
@@ -64,12 +113,49 @@ describe('vet-list --json contract', () => {
         { repo: 'owner/repo-a', number: 1, title: 'Still available', url: 'https://github.com/owner/repo-a/issues/1' },
         { repo: 'owner/repo-b', number: 2, title: 'Already claimed', url: 'https://github.com/owner/repo-b/issues/2' },
         { repo: 'owner/repo-c', number: 3, title: 'Will error', url: 'https://github.com/owner/repo-c/issues/3' },
+        { repo: 'owner/repo-d', number: 4, title: 'At risk', url: 'https://github.com/owner/repo-d/issues/4' },
+        { repo: 'owner/repo-e', number: 5, title: 'My open PR', url: 'https://github.com/owner/repo-e/issues/5' },
+        { repo: 'owner/repo-f', number: 6, title: 'Closed upstream', url: 'https://github.com/owner/repo-f/issues/6' },
       ],
     });
     mocks.getRepoScore.mockReturnValue({ mergedPRCount: 4, closedWithoutMergeCount: 1, avgResponseDays: 3 });
   });
 
   it('mixed-status batch output matches the golden shape', async () => {
+    // Verify FIRST: one entry per available issue, aligned by order. #3 errors
+    // (forces the scout fallback path); the rest carry deterministic verdicts.
+    mocks.verifyIssuesBatch.mockResolvedValue([
+      verified('owner/repo-a', 1, 'available'),
+      verified('owner/repo-b', 2, 'taken', {
+        verdictReason: 'open PR by rival closes this issue',
+        linkedPRs: [CLOSING_PR],
+      }),
+      { params: { owner: 'owner', repo: 'repo-c', number: 3 }, error: new Error('verify failed') },
+      verified('owner/repo-d', 4, 'at-risk', {
+        verdictReason: 'open PR cross-references this issue (mention only)',
+        linkedPRs: [
+          { ...CLOSING_PR, number: 41, linkType: 'cross-referenced', url: 'https://github.com/owner/repo-d/pull/41' },
+        ],
+      }),
+      verified('owner/repo-e', 5, 'own-open-pr', {
+        verdictReason: 'you already have an open PR for this issue',
+        linkedPRs: [
+          {
+            ...CLOSING_PR,
+            number: 51,
+            author: 'costajohnt',
+            isOwn: true,
+            url: 'https://github.com/owner/repo-e/pull/51',
+          },
+        ],
+      }),
+      verified('owner/repo-f', 6, 'closed'),
+    ] satisfies BatchVerificationResult[]);
+
+    // Scout is only consulted for the in-play (available/at-risk) issues and
+    // the verify-error fallback — never for closed/taken/own_open_pr. With
+    // concurrency 1 the calls are deterministic: #1 (available), #3 (fallback,
+    // errors), #4 (at-risk).
     mocks.vetIssue
       .mockResolvedValueOnce({
         issue: {
@@ -85,21 +171,21 @@ describe('vet-list --json contract', () => {
         projectHealth: HEALTH_APPROVE,
         vettingResult: { passedAllChecks: true, checks: {}, notes: [] },
       })
+      .mockRejectedValueOnce(new Error('Network timeout'))
       .mockResolvedValueOnce({
         issue: {
-          repo: 'owner/repo-b',
-          number: 2,
-          title: 'Already claimed',
-          url: 'https://github.com/owner/repo-b/issues/2',
+          repo: 'owner/repo-d',
+          number: 4,
+          title: 'At risk',
+          url: 'https://github.com/owner/repo-d/issues/4',
           labels: [],
         },
-        recommendation: 'skip' as const,
-        reasonsToApprove: [],
-        reasonsToSkip: ['Issue is already claimed by another user'],
-        projectHealth: { ...HEALTH_APPROVE, repo: 'owner/repo-b' },
+        recommendation: 'needs_review' as const,
+        reasonsToApprove: ['Looks reasonable'],
+        reasonsToSkip: ['Open PR mentions this issue'],
+        projectHealth: { ...HEALTH_APPROVE, repo: 'owner/repo-d' },
         vettingResult: { passedAllChecks: false, checks: {}, notes: [] },
-      })
-      .mockRejectedValueOnce(new Error('Network timeout'));
+      });
 
     const result = await runVetList({ concurrency: 1 });
     await expect(JSON.stringify(result, null, 2)).toMatchFileSnapshot('./__golden__/vet-list.mixed.json');

--- a/packages/core/src/commands/vet-list.contract.test.ts
+++ b/packages/core/src/commands/vet-list.contract.test.ts
@@ -135,7 +135,9 @@ describe('vet-list --json contract', () => {
       }),
       {
         params: { owner: 'owner', repo: 'repo-c', number: 3 },
-        error: new ValidationError('Issue not found: owner/repo-c#3. Check the URL.'),
+        error: new ValidationError(
+          'Issue not found: owner/repo-c#3. Check the URL — it may point at a pull request or a deleted/private issue.',
+        ),
       },
       verified('owner/repo-d', 4, 'at-risk', {
         verdictReason: 'open PR cross-references this issue (mention only)',

--- a/packages/core/src/commands/vet-list.contract.test.ts
+++ b/packages/core/src/commands/vet-list.contract.test.ts
@@ -51,6 +51,7 @@ vi.mock('../core/index.js', async () => {
 });
 
 import { runVetList } from './vet-list.js';
+import { ValidationError } from '../core/errors.js';
 import type { BatchVerificationResult, IssueAvailabilityVerdict } from '../core/index.js';
 
 const HEALTH_APPROVE = {
@@ -122,15 +123,20 @@ describe('vet-list --json contract', () => {
   });
 
   it('mixed-status batch output matches the golden shape', async () => {
-    // Verify FIRST: one entry per available issue, aligned by order. #3 errors
-    // (forces the scout fallback path); the rest carry deterministic verdicts.
+    // Verify FIRST: one entry per available issue, aligned by order. #3 fails
+    // with a definitive ValidationError (deleted/private issue) — it becomes an
+    // error row WITHOUT re-grading via scout, tagged with verifyError. The rest
+    // carry deterministic verdicts.
     mocks.verifyIssuesBatch.mockResolvedValue([
       verified('owner/repo-a', 1, 'available'),
       verified('owner/repo-b', 2, 'taken', {
         verdictReason: 'open PR by rival closes this issue',
         linkedPRs: [CLOSING_PR],
       }),
-      { params: { owner: 'owner', repo: 'repo-c', number: 3 }, error: new Error('verify failed') },
+      {
+        params: { owner: 'owner', repo: 'repo-c', number: 3 },
+        error: new ValidationError('Issue not found: owner/repo-c#3. Check the URL.'),
+      },
       verified('owner/repo-d', 4, 'at-risk', {
         verdictReason: 'open PR cross-references this issue (mention only)',
         linkedPRs: [
@@ -152,10 +158,10 @@ describe('vet-list --json contract', () => {
       verified('owner/repo-f', 6, 'closed'),
     ] satisfies BatchVerificationResult[]);
 
-    // Scout is only consulted for the in-play (available/at-risk) issues and
-    // the verify-error fallback — never for closed/taken/own_open_pr. With
-    // concurrency 1 the calls are deterministic: #1 (available), #3 (fallback,
-    // errors), #4 (at-risk).
+    // Scout is only consulted for the in-play (available/at-risk) issues —
+    // never for closed/taken/own_open_pr, and never for the definitive
+    // ValidationError row (#3). With concurrency 1 the calls are deterministic:
+    // #1 (available), #4 (at-risk).
     mocks.vetIssue
       .mockResolvedValueOnce({
         issue: {
@@ -171,7 +177,6 @@ describe('vet-list --json contract', () => {
         projectHealth: HEALTH_APPROVE,
         vettingResult: { passedAllChecks: true, checks: {}, notes: [] },
       })
-      .mockRejectedValueOnce(new Error('Network timeout'))
       .mockResolvedValueOnce({
         issue: {
           repo: 'owner/repo-d',

--- a/packages/core/src/commands/vet-list.test.ts
+++ b/packages/core/src/commands/vet-list.test.ts
@@ -451,6 +451,54 @@ describe('runVetList', () => {
     expect(result.results[0].verification).toBeUndefined();
   });
 
+  it('tags non-issue (PR) URLs as not verified, still falling back to scout (#1494)', async () => {
+    mockDetectIssueList.mockReturnValue({
+      path: '/tmp/issues.md',
+      source: 'configured',
+      availableCount: 1,
+      completedCount: 0,
+    });
+    // parse-list also accepts PR URLs; verify-issue can't classify them, so they
+    // are never enrolled in the verify batch.
+    mockRunParseList.mockResolvedValue({
+      available: [
+        {
+          repo: 'owner/repo',
+          number: 7,
+          title: 'A PR link',
+          tier: 'Pursue',
+          url: 'https://github.com/owner/repo/pull/7',
+        },
+      ],
+      completed: [],
+      availableCount: 1,
+      completedCount: 0,
+    });
+    mockVerifyIssuesBatch.mockResolvedValue([]); // no issue targets enrolled
+    mockVetIssue.mockResolvedValueOnce({
+      issue: {
+        repo: 'owner/repo',
+        number: 7,
+        title: 'A PR link',
+        url: 'https://github.com/owner/repo/pull/7',
+        labels: [],
+      },
+      recommendation: 'approve' as const,
+      reasonsToApprove: ['OK'],
+      reasonsToSkip: [],
+      projectHealth: {},
+      vettingResult: {},
+    });
+
+    const result = await runVetList({ concurrency: 1 });
+
+    expect(result.results[0].listStatus).toBe('still_available');
+    expect(result.results[0].verification).toBeUndefined();
+    expect(result.results[0].verifyError).toContain('not a verifiable issue URL');
+    // Scout is still consulted for the PR URL — pre-#1494 behavior preserved.
+    expect(mockVetIssue).toHaveBeenCalledWith('https://github.com/owner/repo/pull/7');
+  });
+
   it('should throw when no issue list is found and no path provided', async () => {
     mockDetectIssueList.mockReturnValue(undefined);
 

--- a/packages/core/src/commands/vet-list.test.ts
+++ b/packages/core/src/commands/vet-list.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { VetOutput } from '../formatters/json.js';
 
 const mockVetIssue = vi.fn();
+const mockVerifyIssuesBatch = vi.hoisted(() => vi.fn());
 
 vi.mock('./scout-bridge.js', async () => {
   const actual = await vi.importActual<typeof import('./scout-bridge.js')>('./scout-bridge.js');
@@ -21,6 +22,10 @@ vi.mock('../core/index.js', async () => {
   const actual = await vi.importActual<typeof import('../core/index.js')>('../core/index.js');
   return {
     ...actual,
+    // parseGitHubUrl stays real (from actual) so verify targets resolve.
+    getOctokit: () => ({}),
+    requireGitHubToken: () => 'fake-token',
+    verifyIssuesBatch: mockVerifyIssuesBatch,
     getStateManager: () => ({
       getRepoScore: () => undefined,
       getState: () => ({ config: { githubUsername: 'costajohnt' } }),
@@ -299,6 +304,105 @@ describe('extractSkipReason', () => {
 describe('runVetList', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: verify errors for every entry, exercising the scout-heuristic
+    // fallback path so the plumbing tests below (detect/parse/concurrency/prune)
+    // keep their pre-#1494 behavior. The verdict-primary path has its own tests
+    // here and full coverage in vet-list.contract.test.ts.
+    mockVerifyIssuesBatch.mockImplementation(
+      async (_octokit: unknown, items: Array<{ owner: string; repo: string; number: number }>) =>
+        items.map((params) => ({ params, error: new Error('verify unavailable in test') })),
+    );
+  });
+
+  it('uses the verify verdict and skips scout for ruled-out issues (#1494)', async () => {
+    mockDetectIssueList.mockReturnValue({
+      path: '/tmp/issues.md',
+      source: 'configured',
+      availableCount: 2,
+      completedCount: 0,
+    });
+    mockRunParseList.mockResolvedValue({
+      available: [
+        {
+          repo: 'owner/repo',
+          number: 1,
+          title: 'Closed one',
+          tier: 'Pursue',
+          url: 'https://github.com/owner/repo/issues/1',
+        },
+        {
+          repo: 'other/lib',
+          number: 2,
+          title: 'Available one',
+          tier: 'Maybe',
+          url: 'https://github.com/other/lib/issues/2',
+        },
+      ],
+      completed: [],
+      availableCount: 2,
+      completedCount: 0,
+    });
+    mockVerifyIssuesBatch.mockResolvedValue([
+      {
+        params: { owner: 'owner', repo: 'repo', number: 1 },
+        verification: {
+          url: 'https://github.com/owner/repo/issues/1',
+          owner: 'owner',
+          repo: 'repo',
+          number: 1,
+          title: 'Closed one',
+          state: 'closed',
+          stateReason: 'completed',
+          closedAt: null,
+          assignees: [],
+          linkedPRs: [],
+          verdict: 'closed',
+          verdictReason: 'issue closed (completed)',
+          userLogin: 'costajohnt',
+        },
+      },
+      {
+        params: { owner: 'other', repo: 'lib', number: 2 },
+        verification: {
+          url: 'https://github.com/other/lib/issues/2',
+          owner: 'other',
+          repo: 'lib',
+          number: 2,
+          title: 'Available one',
+          state: 'open',
+          stateReason: null,
+          closedAt: null,
+          assignees: [],
+          linkedPRs: [],
+          verdict: 'available',
+          verdictReason: 'open, unassigned, no claiming PRs',
+          userLogin: 'costajohnt',
+        },
+      },
+    ]);
+    mockVetIssue.mockResolvedValueOnce({
+      issue: {
+        repo: 'other/lib',
+        number: 2,
+        title: 'Available one',
+        url: 'https://github.com/other/lib/issues/2',
+        labels: [],
+      },
+      recommendation: 'approve' as const,
+      reasonsToApprove: ['OK'],
+      reasonsToSkip: [],
+      projectHealth: {},
+      vettingResult: {},
+    });
+
+    const result = await runVetList({ concurrency: 1 });
+
+    expect(result.results[0].listStatus).toBe('closed');
+    expect(result.results[0].verification?.verdict).toBe('closed');
+    expect(result.results[1].listStatus).toBe('still_available');
+    // Scout was consulted only for the available issue, not the closed one.
+    expect(mockVetIssue).toHaveBeenCalledTimes(1);
+    expect(mockVetIssue).toHaveBeenCalledWith('https://github.com/other/lib/issues/2');
   });
 
   it('should throw when no issue list is found and no path provided', async () => {
@@ -326,6 +430,8 @@ describe('runVetList', () => {
       closed: 0,
       hasPR: 0,
       hasStalledPR: 0,
+      atRisk: 0,
+      ownOpenPr: 0,
       errors: 0,
     });
   });

--- a/packages/core/src/commands/vet-list.test.ts
+++ b/packages/core/src/commands/vet-list.test.ts
@@ -405,6 +405,52 @@ describe('runVetList', () => {
     expect(mockVetIssue).toHaveBeenCalledWith('https://github.com/other/lib/issues/2');
   });
 
+  it('tags scout-fallback rows with verifyError when verify failed transiently (#1494)', async () => {
+    mockDetectIssueList.mockReturnValue({
+      path: '/tmp/issues.md',
+      source: 'configured',
+      availableCount: 1,
+      completedCount: 0,
+    });
+    mockRunParseList.mockResolvedValue({
+      available: [
+        {
+          repo: 'owner/repo',
+          number: 1,
+          title: 'Fix bug',
+          tier: 'Pursue',
+          url: 'https://github.com/owner/repo/issues/1',
+        },
+      ],
+      completed: [],
+      availableCount: 1,
+      completedCount: 0,
+    });
+    // beforeEach default: verify errors transiently for every entry.
+    mockVetIssue.mockResolvedValueOnce({
+      issue: {
+        repo: 'owner/repo',
+        number: 1,
+        title: 'Fix bug',
+        url: 'https://github.com/owner/repo/issues/1',
+        labels: [],
+      },
+      recommendation: 'approve' as const,
+      reasonsToApprove: ['OK'],
+      reasonsToSkip: [],
+      projectHealth: {},
+      vettingResult: {},
+    });
+
+    const result = await runVetList({ concurrency: 1 });
+
+    // Heuristic still drives listStatus, but verifyError makes the failed
+    // authoritative check visible and verification stays absent.
+    expect(result.results[0].listStatus).toBe('still_available');
+    expect(result.results[0].verifyError).toBe('verify unavailable in test');
+    expect(result.results[0].verification).toBeUndefined();
+  });
+
   it('should throw when no issue list is found and no path provided', async () => {
     mockDetectIssueList.mockReturnValue(undefined);
 

--- a/packages/core/src/commands/vet-list.test.ts
+++ b/packages/core/src/commands/vet-list.test.ts
@@ -499,6 +499,126 @@ describe('runVetList', () => {
     expect(mockVetIssue).toHaveBeenCalledWith('https://github.com/owner/repo/pull/7');
   });
 
+  it('keeps the verification when scout grading throws on an in-play issue (#1494)', async () => {
+    mockDetectIssueList.mockReturnValue({
+      path: '/tmp/issues.md',
+      source: 'configured',
+      availableCount: 1,
+      completedCount: 0,
+    });
+    mockRunParseList.mockResolvedValue({
+      available: [
+        {
+          repo: 'owner/repo',
+          number: 4,
+          title: 'At risk',
+          tier: 'Pursue',
+          url: 'https://github.com/owner/repo/issues/4',
+        },
+      ],
+      completed: [],
+      availableCount: 1,
+      completedCount: 0,
+    });
+    mockVerifyIssuesBatch.mockResolvedValue([
+      {
+        params: { owner: 'owner', repo: 'repo', number: 4 },
+        verification: {
+          url: 'https://github.com/owner/repo/issues/4',
+          owner: 'owner',
+          repo: 'repo',
+          number: 4,
+          title: 'At risk',
+          state: 'open',
+          stateReason: null,
+          closedAt: null,
+          assignees: [],
+          linkedPRs: [],
+          verdict: 'at-risk',
+          verdictReason: 'open PR cross-references this issue',
+          userLogin: 'costajohnt',
+        },
+      },
+    ]);
+    // Verify succeeded (at-risk → in play), but scout grading then fails.
+    mockVetIssue.mockRejectedValueOnce(new Error('grading blew up'));
+
+    const result = await runVetList({ concurrency: 1 });
+
+    // The row is an error (grading failed) BUT the authoritative verdict facts
+    // survive, and there is no verifyError (verify itself succeeded).
+    expect(result.results[0].listStatus).toBe('error');
+    expect(result.results[0].errorMessage).toBe('grading blew up');
+    expect(result.results[0].verification?.verdict).toBe('at-risk');
+    expect(result.results[0].verifyError).toBeUndefined();
+  });
+
+  it('lets the verify verdict override scout when they disagree (#1494)', async () => {
+    mockDetectIssueList.mockReturnValue({
+      path: '/tmp/issues.md',
+      source: 'configured',
+      availableCount: 1,
+      completedCount: 0,
+    });
+    mockRunParseList.mockResolvedValue({
+      available: [
+        {
+          repo: 'owner/repo',
+          number: 1,
+          title: 'Available',
+          tier: 'Pursue',
+          url: 'https://github.com/owner/repo/issues/1',
+        },
+      ],
+      completed: [],
+      availableCount: 1,
+      completedCount: 0,
+    });
+    mockVerifyIssuesBatch.mockResolvedValue([
+      {
+        params: { owner: 'owner', repo: 'repo', number: 1 },
+        verification: {
+          url: 'https://github.com/owner/repo/issues/1',
+          owner: 'owner',
+          repo: 'repo',
+          number: 1,
+          title: 'Available',
+          state: 'open',
+          stateReason: null,
+          closedAt: null,
+          assignees: [],
+          linkedPRs: [],
+          verdict: 'available',
+          verdictReason: 'open, unassigned, no claiming PRs',
+          userLogin: 'costajohnt',
+        },
+      },
+    ]);
+    // Scout's heuristic would say "closed" — but the verdict is authoritative.
+    mockVetIssue.mockResolvedValueOnce({
+      issue: {
+        repo: 'owner/repo',
+        number: 1,
+        title: 'Available',
+        url: 'https://github.com/owner/repo/issues/1',
+        labels: [],
+      },
+      recommendation: 'skip' as const,
+      reasonsToApprove: [],
+      reasonsToSkip: ['Issue is closed'],
+      projectHealth: {},
+      vettingResult: {},
+    });
+
+    const result = await runVetList({ concurrency: 1 });
+
+    // Verdict wins: still_available, NOT closed (which the old heuristic gave).
+    expect(result.results[0].listStatus).toBe('still_available');
+    expect(result.results[0].verification?.verdict).toBe('available');
+    // Scout's recommendation still flows through for context.
+    expect(result.results[0].recommendation).toBe('skip');
+  });
+
   it('should throw when no issue list is found and no path provided', async () => {
     mockDetectIssueList.mockReturnValue(undefined);
 

--- a/packages/core/src/commands/vet-list.ts
+++ b/packages/core/src/commands/vet-list.ts
@@ -5,7 +5,12 @@
 
 import * as fs from 'node:fs';
 import { adaptScoutLinkedPR, buildCandidateLinkedPR, createAutopilotScout } from './scout-bridge.js';
-import { type VetListOutput, type VetOutput, type VetListItemStatus } from '../formatters/json.js';
+import {
+  type VetListOutput,
+  type VetOutput,
+  type VetListItemStatus,
+  type ParsedIssueItem,
+} from '../formatters/json.js';
 import { runParseList, pruneIssueList } from './parse-list.js';
 import { detectIssueList } from './startup.js';
 import { computeSuccessGrade, gradeFromCandidate } from '../core/issue-grading.js';
@@ -202,7 +207,6 @@ function ruledOutVetOutput(v: IssueVerification): VetOutput {
  * @returns Consolidated vetting results with list status for each issue
  */
 type VetListResult = VetListOutput['results'][number];
-type ParsedIssueItem = { repo: string; number: number; title: string; url: string };
 
 function toMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -240,7 +244,7 @@ export async function runVetList(options: VetListOptions = {}): Promise<VetListO
     };
   }
 
-  const items: ParsedIssueItem[] = parsed.available;
+  const items = parsed.available;
 
   // 2. Verify FIRST (#1494): one deterministic GraphQL check per entry, in a
   //    bounded batch. The verdict is closing-vs-mention aware, so it carries

--- a/packages/core/src/commands/vet-list.ts
+++ b/packages/core/src/commands/vet-list.ts
@@ -9,6 +9,7 @@ import { type VetListOutput, type VetOutput, type VetListItemStatus } from '../f
 import { runParseList, pruneIssueList } from './parse-list.js';
 import { detectIssueList } from './startup.js';
 import { computeSuccessGrade, gradeFromCandidate } from '../core/issue-grading.js';
+import { ValidationError } from '../core/errors.js';
 import {
   getStateManager,
   classifyLinkedPR,
@@ -203,6 +204,10 @@ function ruledOutVetOutput(v: IssueVerification): VetOutput {
 type VetListResult = VetListOutput['results'][number];
 type ParsedIssueItem = { repo: string; number: number; title: string; url: string };
 
+function toMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 export async function runVetList(options: VetListOptions = {}): Promise<VetListOutput> {
   const concurrency = options.concurrency ?? 5;
 
@@ -297,7 +302,7 @@ export async function runVetList(options: VetListOptions = {}): Promise<VetListO
   }
 
   function errorRow(item: ParsedIssueItem, error: unknown): VetListResult {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = toMessage(error);
     return {
       issue: { repo: item.repo, number: item.number, title: item.title, url: item.url, labels: [] },
       recommendation: 'skip',
@@ -315,14 +320,27 @@ export async function runVetList(options: VetListOptions = {}): Promise<VetListO
     item: ParsedIssueItem,
     verification: BatchVerificationResult | undefined,
   ): Promise<VetListResult> {
-    // Verify errored (or the URL didn't parse): fall back to scout's heuristic,
-    // exactly as before #1494. No `verification` sub-object on these rows.
+    // Verify errored (or the URL didn't parse): the authoritative check is not
+    // available for this row. Surface that explicitly via `verifyError` so the
+    // fallback's `listStatus` is never mistaken for a confirmed verdict.
     if (!verification || verification.verification === undefined) {
+      const verifyError = verification?.error;
+
+      // A ValidationError means the issue definitively doesn't exist (deleted,
+      // private, or the URL points at a PR). Don't re-grade it via scout — that
+      // could mislabel a dead issue as available. Report it as an error row.
+      if (verifyError instanceof ValidationError) {
+        return { ...errorRow(item, verifyError), verifyError: toMessage(verifyError) };
+      }
+
+      // Transient verify failure (rate limit, network, truncated timeline): fall
+      // back to scout's heuristic, but tag the row so it's re-verified later.
+      const verifyErrorTag = verifyError === undefined ? {} : { verifyError: toMessage(verifyError) };
       try {
         const { vetResult, skipReason } = await runScoutVet(item);
-        return { ...vetResult, listStatus: classifyListStatus(vetResult, skipReason) };
+        return { ...vetResult, listStatus: classifyListStatus(vetResult, skipReason), ...verifyErrorTag };
       } catch (error) {
-        return errorRow(item, error);
+        return { ...errorRow(item, error), ...verifyErrorTag };
       }
     }
 

--- a/packages/core/src/commands/vet-list.ts
+++ b/packages/core/src/commands/vet-list.ts
@@ -320,9 +320,11 @@ export async function runVetList(options: VetListOptions = {}): Promise<VetListO
     item: ParsedIssueItem,
     verification: BatchVerificationResult | undefined,
   ): Promise<VetListResult> {
-    // Verify errored (or the URL didn't parse): the authoritative check is not
-    // available for this row. Surface that explicitly via `verifyError` so the
-    // fallback's `listStatus` is never mistaken for a confirmed verdict.
+    // No authoritative verdict for this row: either verify errored, or the URL
+    // was never enrolled (parse-list also accepts PR URLs, which `verify-issue`
+    // can't classify). Either way `listStatus` falls back to scout's heuristic,
+    // so we ALWAYS tag the row with `verifyError` — the explicit signal that the
+    // status is not authoritative and must be re-verified before acting.
     if (!verification || verification.verification === undefined) {
       const verifyError = verification?.error;
 
@@ -333,9 +335,15 @@ export async function runVetList(options: VetListOptions = {}): Promise<VetListO
         return { ...errorRow(item, verifyError), verifyError: toMessage(verifyError) };
       }
 
-      // Transient verify failure (rate limit, network, truncated timeline): fall
-      // back to scout's heuristic, but tag the row so it's re-verified later.
-      const verifyErrorTag = verifyError === undefined ? {} : { verifyError: toMessage(verifyError) };
+      // Transient verify failure (rate limit, network, truncated timeline), or a
+      // non-issue URL that was never sent to verify. Fall back to scout's
+      // heuristic, tagged so the row is re-verified later.
+      const verifyErrorTag = {
+        verifyError:
+          verifyError === undefined
+            ? `not verified: ${item.url} is not a verifiable issue URL`
+            : toMessage(verifyError),
+      };
       try {
         const { vetResult, skipReason } = await runScoutVet(item);
         return { ...vetResult, listStatus: classifyListStatus(vetResult, skipReason), ...verifyErrorTag };

--- a/packages/core/src/commands/vet-list.ts
+++ b/packages/core/src/commands/vet-list.ts
@@ -9,7 +9,17 @@ import { type VetListOutput, type VetOutput, type VetListItemStatus } from '../f
 import { runParseList, pruneIssueList } from './parse-list.js';
 import { detectIssueList } from './startup.js';
 import { computeSuccessGrade, gradeFromCandidate } from '../core/issue-grading.js';
-import { getStateManager, classifyLinkedPR } from '../core/index.js';
+import {
+  getStateManager,
+  classifyLinkedPR,
+  getOctokit,
+  requireGitHubToken,
+  parseGitHubUrl,
+  verifyIssuesBatch,
+  type BatchVerificationResult,
+  type IssueAvailabilityVerdict,
+  type IssueVerification,
+} from '../core/index.js';
 
 const UNKNOWN_GRADE = computeSuccessGrade({ avgResponseDays: null, mergeRate: null, daysSinceLastCommit: null });
 
@@ -123,6 +133,66 @@ export function classifyListStatus(vetResult: VetOutput, skipReason?: ScoutSkipR
 }
 
 /**
+ * Map a deterministic verify-issue verdict onto the vet-list status taxonomy
+ * (#1494). This is the authoritative path: the GraphQL verdict knows the
+ * closing-vs-mention distinction (#1353) that scout's substring heuristic
+ * cannot, so `at_risk` (mention only) no longer collapses into `claimed`.
+ */
+export function listStatusFromVerdict(verdict: IssueAvailabilityVerdict): VetListItemStatus {
+  switch (verdict) {
+    case 'closed': {
+      return 'closed';
+    }
+    case 'own-open-pr': {
+      return 'own_open_pr';
+    }
+    case 'taken': {
+      return 'claimed';
+    }
+    case 'at-risk': {
+      return 'at_risk';
+    }
+    case 'available': {
+      return 'still_available';
+    }
+  }
+}
+
+/**
+ * Verdicts that conclusively rule an issue out as a new opportunity. For these
+ * we skip scout's grade/health vet entirely — there is nothing to grade — and
+ * build the result row straight from the verification.
+ */
+const RULED_OUT_VERDICTS: ReadonlySet<IssueAvailabilityVerdict> = new Set(['closed', 'taken', 'own-open-pr']);
+
+/** The per-row `verification` sub-object: the authoritative facts behind the
+ * status, projected from the full {@link IssueVerification}. */
+function toVerificationSummary(v: IssueVerification): NonNullable<VetListOutput['results'][number]['verification']> {
+  return {
+    verdict: v.verdict,
+    verdictReason: v.verdictReason,
+    state: v.state,
+    stateReason: v.stateReason,
+    assignees: v.assignees,
+    linkedPRs: v.linkedPRs,
+  };
+}
+
+/** Minimal VetOutput for a ruled-out issue (no scout vet was run). The
+ * verification carries the real reason; scout-derived fields are left empty. */
+function ruledOutVetOutput(v: IssueVerification): VetOutput {
+  return {
+    issue: { repo: `${v.owner}/${v.repo}`, number: v.number, title: v.title, url: v.url, labels: [] },
+    recommendation: 'skip',
+    reasonsToApprove: [],
+    reasonsToSkip: [v.verdictReason],
+    projectHealth: {},
+    vettingResult: {},
+    grade: UNKNOWN_GRADE,
+  };
+}
+
+/**
  * Re-vet all available issues in a curated issue list.
  * Reads the list file, extracts available (non-done) issues,
  * and vets each in parallel with concurrency control.
@@ -130,6 +200,9 @@ export function classifyListStatus(vetResult: VetOutput, skipReason?: ScoutSkipR
  * @param options - Vet-list options
  * @returns Consolidated vetting results with list status for each issue
  */
+type VetListResult = VetListOutput['results'][number];
+type ParsedIssueItem = { repo: string; number: number; title: string; url: string };
+
 export async function runVetList(options: VetListOptions = {}): Promise<VetListOutput> {
   const concurrency = options.concurrency ?? 5;
 
@@ -148,80 +221,145 @@ export async function runVetList(options: VetListOptions = {}): Promise<VetListO
   if (parsed.available.length === 0) {
     return {
       results: [],
-      summary: { total: 0, stillAvailable: 0, claimed: 0, closed: 0, hasPR: 0, hasStalledPR: 0, errors: 0 },
+      summary: {
+        total: 0,
+        stillAvailable: 0,
+        claimed: 0,
+        closed: 0,
+        hasPR: 0,
+        hasStalledPR: 0,
+        atRisk: 0,
+        ownOpenPr: 0,
+        errors: 0,
+      },
     };
   }
 
-  // 2. Vet each available issue in parallel with concurrency limit
+  const items: ParsedIssueItem[] = parsed.available;
+
+  // 2. Verify FIRST (#1494): one deterministic GraphQL check per entry, in a
+  //    bounded batch. The verdict is closing-vs-mention aware, so it carries
+  //    the authoritative status — and ruling issues out here means we skip
+  //    scout's search-driven vet (a net REDUCTION in /search/issues calls).
+  const octokit = getOctokit(requireGitHubToken());
+  const verifyTargets: Array<{ index: number; params: { owner: string; repo: string; number: number } }> = [];
+  items.forEach((item, i) => {
+    const ghUrl = parseGitHubUrl(item.url);
+    if (ghUrl && ghUrl.type === 'issues') {
+      verifyTargets.push({ index: i, params: { owner: ghUrl.owner, repo: ghUrl.repo, number: ghUrl.number } });
+    }
+  });
+  const batch = await verifyIssuesBatch(
+    octokit,
+    verifyTargets.map((t) => t.params),
+    { concurrency },
+  );
+  const verificationByIndex = new Map<number, BatchVerificationResult>();
+  verifyTargets.forEach((t, k) => verificationByIndex.set(t.index, batch[k]));
+
+  // 3. Vet only the issues still in play; build each row.
   const scout = await createAutopilotScout();
-  const results: VetListOutput['results'] = [];
 
-  // Simple concurrency limiter
-  const items = parsed.available;
-  let index = 0;
+  /** Run scout's grade/health vet for an issue (the search-driven path). */
+  async function runScoutVet(item: ParsedIssueItem): Promise<{ vetResult: VetOutput; skipReason?: ScoutSkipReason }> {
+    const candidate = await scout.vetIssue(item.url);
+    const grade = gradeFromCandidate({
+      repo: candidate.issue.repo,
+      projectHealth: candidate.projectHealth,
+      getRepoScore: (repo) => getStateManager().getRepoScore(repo),
+    });
+    const userLogin = getStateManager().getState().config.githubUsername;
+    const linkedPRClassification = classifyLinkedPR({
+      linkedPR: adaptScoutLinkedPR(candidate.vettingResult.linkedPR),
+      userLogin,
+    });
+    const linkedPR = buildCandidateLinkedPR(candidate.vettingResult.linkedPR);
+    const vetResult: VetOutput = {
+      issue: {
+        repo: candidate.issue.repo,
+        number: candidate.issue.number,
+        title: candidate.issue.title,
+        url: candidate.issue.url,
+        labels: candidate.issue.labels,
+      },
+      recommendation: candidate.recommendation,
+      reasonsToApprove: candidate.reasonsToApprove,
+      reasonsToSkip: candidate.reasonsToSkip,
+      projectHealth: candidate.projectHealth,
+      vettingResult: candidate.vettingResult,
+      antiLLMPolicy: candidate.antiLLMPolicy,
+      linkedPRClassification,
+      ...(linkedPR ? { linkedPR } : {}),
+      slmTriage: candidate.slmTriage ?? null,
+      grade,
+    };
+    return { vetResult, skipReason: extractSkipReason(candidate) };
+  }
 
-  async function processNext(): Promise<void> {
-    while (index < items.length) {
-      const item = items[index++];
+  function errorRow(item: ParsedIssueItem, error: unknown): VetListResult {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      issue: { repo: item.repo, number: item.number, title: item.title, url: item.url, labels: [] },
+      recommendation: 'skip',
+      reasonsToApprove: [],
+      reasonsToSkip: [`Error: ${message}`],
+      projectHealth: {},
+      vettingResult: {},
+      grade: UNKNOWN_GRADE,
+      listStatus: 'error',
+      errorMessage: message,
+    };
+  }
+
+  async function processItem(
+    item: ParsedIssueItem,
+    verification: BatchVerificationResult | undefined,
+  ): Promise<VetListResult> {
+    // Verify errored (or the URL didn't parse): fall back to scout's heuristic,
+    // exactly as before #1494. No `verification` sub-object on these rows.
+    if (!verification || verification.verification === undefined) {
       try {
-        const candidate = await scout.vetIssue(item.url);
-        const grade = gradeFromCandidate({
-          repo: candidate.issue.repo,
-          projectHealth: candidate.projectHealth,
-          getRepoScore: (repo) => getStateManager().getRepoScore(repo),
-        });
-        const userLogin = getStateManager().getState().config.githubUsername;
-        const linkedPRClassification = classifyLinkedPR({
-          linkedPR: adaptScoutLinkedPR(candidate.vettingResult.linkedPR),
-          userLogin,
-        });
-        const linkedPR = buildCandidateLinkedPR(candidate.vettingResult.linkedPR);
-        const vetResult: VetOutput = {
-          issue: {
-            repo: candidate.issue.repo,
-            number: candidate.issue.number,
-            title: candidate.issue.title,
-            url: candidate.issue.url,
-            labels: candidate.issue.labels,
-          },
-          recommendation: candidate.recommendation,
-          reasonsToApprove: candidate.reasonsToApprove,
-          reasonsToSkip: candidate.reasonsToSkip,
-          projectHealth: candidate.projectHealth,
-          vettingResult: candidate.vettingResult,
-          antiLLMPolicy: candidate.antiLLMPolicy,
-          linkedPRClassification,
-          ...(linkedPR ? { linkedPR } : {}),
-          slmTriage: candidate.slmTriage ?? null,
-          grade,
-        };
-
-        results.push({
-          ...vetResult,
-          listStatus: classifyListStatus(vetResult, extractSkipReason(candidate)),
-        });
+        const { vetResult, skipReason } = await runScoutVet(item);
+        return { ...vetResult, listStatus: classifyListStatus(vetResult, skipReason) };
       } catch (error) {
-        // Per-issue errors don't fail the batch
-        results.push({
-          issue: { repo: item.repo, number: item.number, title: item.title, url: item.url, labels: [] },
-          recommendation: 'skip',
-          reasonsToApprove: [],
-          reasonsToSkip: [`Error: ${error instanceof Error ? error.message : String(error)}`],
-          projectHealth: {},
-          vettingResult: {},
-          grade: UNKNOWN_GRADE,
-          listStatus: 'error',
-          errorMessage: error instanceof Error ? error.message : String(error),
-        });
+        return errorRow(item, error);
       }
+    }
+
+    const v = verification.verification;
+    const summary = toVerificationSummary(v);
+    const listStatus = listStatusFromVerdict(v.verdict);
+
+    // Conclusively ruled out — skip the scout vet entirely.
+    if (RULED_OUT_VERDICTS.has(v.verdict)) {
+      return { ...ruledOutVetOutput(v), listStatus, verification: summary };
+    }
+
+    // available / at-risk: still worth grading. The verdict stays authoritative
+    // for listStatus; scout only supplies grade/health/recommendation.
+    try {
+      const { vetResult } = await runScoutVet(item);
+      return { ...vetResult, listStatus, verification: summary };
+    } catch (error) {
+      // Verify succeeded, so keep its verdict facts even though grading failed.
+      return { ...errorRow(item, error), verification: summary };
     }
   }
 
-  // Start `concurrency` workers
+  const results: VetListResult[] = new Array<VetListResult>(items.length);
+  let index = 0;
+  async function processNext(): Promise<void> {
+    while (index < items.length) {
+      const i = index++;
+      results[i] = await processItem(items[i], verificationByIndex.get(i));
+    }
+  }
+
+  // Start `concurrency` workers (bounds the scout-vet fan-out).
   const workers = Array.from({ length: Math.min(concurrency, items.length) }, () => processNext());
   await Promise.all(workers);
 
-  // 3. Compute summary
+  // 4. Compute summary
   const summary = {
     total: results.length,
     stillAvailable: results.filter((r) => r.listStatus === 'still_available').length,
@@ -229,6 +367,8 @@ export async function runVetList(options: VetListOptions = {}): Promise<VetListO
     closed: results.filter((r) => r.listStatus === 'closed').length,
     hasPR: results.filter((r) => r.listStatus === 'has_pr').length,
     hasStalledPR: results.filter((r) => r.listStatus === 'has_stalled_pr').length,
+    atRisk: results.filter((r) => r.listStatus === 'at_risk').length,
+    ownOpenPr: results.filter((r) => r.listStatus === 'own_open_pr').length,
     errors: results.filter((r) => r.listStatus === 'error').length,
   };
 

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -109,6 +109,9 @@ export {
 export {
   classifyIssueAvailability,
   fetchIssueVerification,
+  verifyIssuesBatch,
+  MAX_VERIFY_CONCURRENCY,
+  type BatchVerificationResult,
   type IssueAvailabilityVerdict,
   type IssueVerification,
   type LinkedPRLinkType,

--- a/packages/core/src/core/issue-verification.test.ts
+++ b/packages/core/src/core/issue-verification.test.ts
@@ -3,7 +3,13 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { classifyIssueAvailability, fetchIssueVerification, type VerifiedLinkedPR } from './issue-verification.js';
+import {
+  classifyIssueAvailability,
+  fetchIssueVerification,
+  verifyIssuesBatch,
+  MAX_VERIFY_CONCURRENCY,
+  type VerifiedLinkedPR,
+} from './issue-verification.js';
 import type { Octokit } from '@octokit/rest';
 
 const USER = 'octocat';
@@ -411,5 +417,130 @@ describe('fetchIssueVerification', () => {
     const boom = new Error('API rate limit exceeded');
     const octokit = { graphql: vi.fn().mockRejectedValue(boom) } as unknown as Octokit;
     await expect(fetchIssueVerification(octokit, params)).rejects.toThrow(/rate limit/);
+  });
+});
+
+describe('verifyIssuesBatch', () => {
+  /** Single-page GraphQL response for an issue keyed by its number. */
+  function issueResponse(
+    number: number,
+    overrides: { state?: 'OPEN' | 'CLOSED'; stateReason?: string | null; assignees?: string[] } = {},
+  ) {
+    return {
+      viewer: { login: USER },
+      repository: {
+        issue: {
+          number,
+          title: `issue ${number}`,
+          url: `https://github.com/foo/bar/issues/${number}`,
+          state: overrides.state ?? 'OPEN',
+          stateReason: overrides.stateReason ?? null,
+          closedAt: null,
+          assignees: { nodes: (overrides.assignees ?? []).map((login) => ({ login })) },
+          timelineItems: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+        },
+      },
+    };
+  }
+
+  const item = (number: number) => ({ owner: 'foo', repo: 'bar', number });
+
+  it('returns an empty array for no items without touching the API', async () => {
+    const graphql = vi.fn();
+    const octokit = { graphql } as unknown as Octokit;
+
+    const results = await verifyIssuesBatch(octokit, []);
+
+    expect(results).toEqual([]);
+    expect(graphql).not.toHaveBeenCalled();
+  });
+
+  it('verifies each item and aligns results with the input order', async () => {
+    const byNumber: Record<number, unknown> = {
+      1: issueResponse(1), // open, unassigned -> available
+      2: issueResponse(2, { state: 'CLOSED', stateReason: 'COMPLETED' }), // closed
+      3: issueResponse(3, { assignees: ['rival'] }), // taken
+    };
+    const graphql = vi.fn(async (_q: string, vars: { number: number }) => byNumber[vars.number]);
+    const octokit = { graphql } as unknown as Octokit;
+
+    const results = await verifyIssuesBatch(octokit, [item(1), item(2), item(3)], { concurrency: 3 });
+
+    expect(results).toHaveLength(3);
+    expect(results.map((r) => r.params.number)).toEqual([1, 2, 3]);
+    expect(results[0].verification?.verdict).toBe('available');
+    expect(results[1].verification?.verdict).toBe('closed');
+    expect(results[2].verification?.verdict).toBe('taken');
+    expect(results.every((r) => r.error === undefined)).toBe(true);
+  });
+
+  it('isolates per-item failures without aborting the batch', async () => {
+    const graphql = vi.fn(async (_q: string, vars: { number: number }) => {
+      if (vars.number === 2) throw new Error('boom on 2');
+      return issueResponse(vars.number);
+    });
+    const octokit = { graphql } as unknown as Octokit;
+
+    const results = await verifyIssuesBatch(octokit, [item(1), item(2), item(3)], { concurrency: 3 });
+
+    expect(results[0].verification?.verdict).toBe('available');
+    expect(results[0].error).toBeUndefined();
+    expect(results[1].verification).toBeUndefined();
+    expect(results[1].error).toBeInstanceOf(Error);
+    expect((results[1].error as Error).message).toBe('boom on 2');
+    expect(results[2].verification?.verdict).toBe('available');
+  });
+
+  it('surfaces a NOT_FOUND as that item’s error, leaving siblings intact', async () => {
+    const gqlError = Object.assign(new Error('Could not resolve to an Issue'), {
+      errors: [{ type: 'NOT_FOUND', path: ['repository', 'issue'] }],
+    });
+    const graphql = vi.fn(async (_q: string, vars: { number: number }) => {
+      if (vars.number === 9) throw gqlError;
+      return issueResponse(vars.number);
+    });
+    const octokit = { graphql } as unknown as Octokit;
+
+    const results = await verifyIssuesBatch(octokit, [item(9), item(1)], { concurrency: 2 });
+
+    expect(results[0].error).toMatchObject({ name: 'ValidationError' });
+    expect(results[1].verification?.verdict).toBe('available');
+  });
+
+  it('never runs more than MAX_VERIFY_CONCURRENCY in flight, even when more is requested', async () => {
+    let active = 0;
+    let maxActive = 0;
+    const graphql = vi.fn(async (_q: string, vars: { number: number }) => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      active--;
+      return issueResponse(vars.number);
+    });
+    const octokit = { graphql } as unknown as Octokit;
+
+    const items = Array.from({ length: 12 }, (_, i) => item(i + 1));
+    const results = await verifyIssuesBatch(octokit, items, { concurrency: 100 });
+
+    expect(results).toHaveLength(12);
+    expect(maxActive).toBe(MAX_VERIFY_CONCURRENCY);
+  });
+
+  it('floors a zero/negative concurrency request at a single worker', async () => {
+    let active = 0;
+    let maxActive = 0;
+    const graphql = vi.fn(async (_q: string, vars: { number: number }) => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      active--;
+      return issueResponse(vars.number);
+    });
+    const octokit = { graphql } as unknown as Octokit;
+
+    const results = await verifyIssuesBatch(octokit, [item(1), item(2), item(3)], { concurrency: 0 });
+
+    expect(results).toHaveLength(3);
+    expect(maxActive).toBe(1);
   });
 });

--- a/packages/core/src/core/issue-verification.test.ts
+++ b/packages/core/src/core/issue-verification.test.ts
@@ -543,4 +543,25 @@ describe('verifyIssuesBatch', () => {
     expect(results).toHaveLength(3);
     expect(maxActive).toBe(1);
   });
+
+  it('treats a non-finite concurrency request as the default cap', async () => {
+    let active = 0;
+    let maxActive = 0;
+    const graphql = vi.fn(async (_q: string, vars: { number: number }) => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 3));
+      active--;
+      return issueResponse(vars.number);
+    });
+    const octokit = { graphql } as unknown as Octokit;
+
+    const items = Array.from({ length: 8 }, (_, i) => item(i + 1));
+    const results = await verifyIssuesBatch(octokit, items, { concurrency: Number.NaN });
+
+    expect(results).toHaveLength(8);
+    // NaN is not finite -> falls back to MAX_VERIFY_CONCURRENCY rather than
+    // collapsing to zero/one workers.
+    expect(maxActive).toBe(MAX_VERIFY_CONCURRENCY);
+  });
 });

--- a/packages/core/src/core/issue-verification.ts
+++ b/packages/core/src/core/issue-verification.ts
@@ -410,3 +410,76 @@ export async function fetchIssueVerification(octokit: Octokit, params: VerifyIss
     userLogin,
   };
 }
+
+// ── Batched verification ───────────────────────────────────────────────
+
+/**
+ * Hard ceiling on concurrent in-flight verifications. Each issue runs its own
+ * GraphQL round-trip (point-heavy, with timeline pagination), so we never run
+ * more than this many at once regardless of what the caller requests. The
+ * single-issue path already leans on ThrottledOctokit's secondary-rate-limit
+ * backoff — this cap keeps us from spraying enough parallel queries to trip it.
+ */
+export const MAX_VERIFY_CONCURRENCY = 5;
+
+/**
+ * Per-item outcome of a batched verification run. Aligned by index with the
+ * input `items`. Error isolation: one item's failure lands as `{ error }` and
+ * never aborts the batch, so a single NOT_FOUND (or transient network error)
+ * does not poison every other entry — unlike an aliased mega-query would.
+ */
+export interface BatchVerificationResult {
+  params: VerifyIssueParams;
+  /** Present when verification succeeded for this item. */
+  verification?: IssueVerification;
+  /** Present when `fetchIssueVerification` threw for this item. */
+  error?: unknown;
+}
+
+/**
+ * Verify many issues with bounded concurrent fan-out of the single-issue
+ * {@link fetchIssueVerification}.
+ *
+ * This is a deliberately thin worker pool, NOT one aliased GraphQL query:
+ * per-issue timeline cursors make aliasing unmanageable, and all-or-nothing
+ * failure (one bad issue poisoning the batch) is exactly what we want to
+ * avoid. No retry layer is added here — `octokit` is expected to be a
+ * ThrottledOctokit whose backoff already covers secondary rate limits.
+ *
+ * @param octokit - Throttled Octokit instance (see `getOctokit`).
+ * @param items - Issues to verify; results align with this order.
+ * @param options.concurrency - Desired parallelism; capped at
+ *   {@link MAX_VERIFY_CONCURRENCY} and floored at 1.
+ */
+export async function verifyIssuesBatch(
+  octokit: Octokit,
+  items: readonly VerifyIssueParams[],
+  options: { concurrency?: number } = {},
+): Promise<BatchVerificationResult[]> {
+  const results: BatchVerificationResult[] = new Array<BatchVerificationResult>(items.length);
+  if (items.length === 0) return results;
+
+  const requested = options.concurrency ?? MAX_VERIFY_CONCURRENCY;
+  // Floor at 1 so a 0/negative/NaN request can never produce zero workers
+  // (which would leave the results array full of holes).
+  const concurrency = Math.max(
+    1,
+    Math.min(Number.isFinite(requested) ? requested : MAX_VERIFY_CONCURRENCY, MAX_VERIFY_CONCURRENCY, items.length),
+  );
+
+  let index = 0;
+  async function worker(): Promise<void> {
+    while (index < items.length) {
+      const i = index++;
+      const params = items[i];
+      try {
+        results[i] = { params, verification: await fetchIssueVerification(octokit, params) };
+      } catch (error) {
+        results[i] = { params, error };
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: concurrency }, () => worker()));
+  return results;
+}

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -1356,9 +1356,18 @@ export interface VetListOutput {
       listStatus: VetListItemStatus;
       errorMessage?: string;
       /**
+       * Set when the deterministic verify-issue check itself failed for this
+       * entry (#1494). Its presence is the explicit signal that `listStatus`
+       * is NOT authoritative — it came from the scout heuristic fallback (or is
+       * `error`), and the row should be re-verified before acting on it. Pairs
+       * with an absent `verification`; never set when `verification` is present.
+       */
+      verifyError?: string;
+      /**
        * The deterministic verify-issue facts behind `listStatus` (#1494).
        * Present whenever verification succeeded for the entry; absent only when
-       * verify itself errored (then `listStatus` comes from the scout fallback).
+       * verify itself errored (then `listStatus` comes from the scout fallback
+       * and `verifyError` records why).
        */
       verification?: {
         verdict: IssueAvailabilityVerdict;

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -24,6 +24,7 @@ import type {
 import type { ContributionStats } from '../core/stats.js';
 import type { PRCheckFailure } from '../core/pr-monitor.js';
 import type { CIFormatterDiagnosis, FormatterDetectionResult } from '../core/formatter-detection.js';
+import type { IssueAvailabilityVerdict, IssueVerification, VerifiedLinkedPR } from '../core/issue-verification.js';
 
 // Re-export the daily aggregation types from their canonical home in core/types.
 // External consumers and downstream tests have historically imported them from
@@ -1325,13 +1326,28 @@ export interface CheckIntegrationOutput {
 }
 
 /**
- * Status of a re-vetted issue from the curated list (#764).
+ * Status of a re-vetted issue from the curated list (#764, #1494).
  *
- * `has_stalled_pr` (scout 0.9.0 #97) distinguishes open-but-stalled linked
- * PRs from cleanly-claimed `has_pr` issues — the issue is still actionable
- * as a revive opportunity rather than something to drop.
+ * As of #1494 the status is driven by the deterministic verify-issue verdict
+ * (closing-vs-mention aware) rather than scout's substring heuristic:
+ * - `at_risk` — verify found an open *mention* (cross-reference, not a closing
+ *   PR) or a merged closing PR awaiting issue close. Previously collapsed into
+ *   `claimed`/`has_pr`; the point of #1353.
+ * - `own_open_pr` — the authenticated user already has an open closing PR.
+ *
+ * `has_pr` / `has_stalled_pr` (scout 0.9.0 #97) now only arise on the fallback
+ * path when verify itself errored and we drop back to scout's heuristic; they
+ * are kept for back-compat.
  */
-export type VetListItemStatus = 'still_available' | 'claimed' | 'closed' | 'has_pr' | 'has_stalled_pr' | 'error';
+export type VetListItemStatus =
+  | 'still_available'
+  | 'claimed'
+  | 'closed'
+  | 'has_pr'
+  | 'has_stalled_pr'
+  | 'at_risk'
+  | 'own_open_pr'
+  | 'error';
 
 /** Output of the vet-list command (#764). */
 export interface VetListOutput {
@@ -1339,6 +1355,19 @@ export interface VetListOutput {
     VetOutput & {
       listStatus: VetListItemStatus;
       errorMessage?: string;
+      /**
+       * The deterministic verify-issue facts behind `listStatus` (#1494).
+       * Present whenever verification succeeded for the entry; absent only when
+       * verify itself errored (then `listStatus` comes from the scout fallback).
+       */
+      verification?: {
+        verdict: IssueAvailabilityVerdict;
+        verdictReason: string;
+        state: IssueVerification['state'];
+        stateReason: IssueVerification['stateReason'];
+        assignees: string[];
+        linkedPRs: VerifiedLinkedPR[];
+      };
     }
   >;
   summary: {
@@ -1349,6 +1378,10 @@ export interface VetListOutput {
     hasPR: number;
     /** Open linked PRs that haven't been touched in 30+ days (scout 0.9.0 #97). Surfaced as revive opportunities, not auto-dropped. */
     hasStalledPR: number;
+    /** Open mention-only cross-references or a merged closing PR awaiting issue close (#1494 / #1353). */
+    atRisk: number;
+    /** The authenticated user already has an open closing PR (#1494 / #1354). */
+    ownOpenPr: number;
     errors: number;
   };
   pruneResult?: {

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -458,7 +458,7 @@ export function registerTools(server: McpServer): void {
     'vet-list',
     {
       description:
-        'Re-vet all available issues in the curated issue list for freshness. Checks if issues are still open, unassigned, and have no linked PRs.',
+        'Re-vet all available issues in the curated issue list for freshness. Runs the deterministic verify-issue check per entry (closing-vs-mention aware), so each row carries the authoritative availability verdict and a verification sub-object — no per-entry re-check needed.',
       inputSchema: {
         issueListPath: z.string().optional().describe('Path to issue list file (auto-detected if not specified)'),
         concurrency: z.number().optional().describe('Max parallel vet operations (default: 5)'),


### PR DESCRIPTION
Closes #1494.

## What

vet-list now runs the deterministic `verify-issue` GraphQL check per entry (in a bounded batch) and derives each row's `listStatus` from that verdict, instead of scout's substring heuristic. The verdict is closing-vs-mention aware (#1353), so a mention no longer collapses into "claimed", and the issue-scout agent no longer needs to re-check flagged entries.

Built in three stages, one commit each (plus two review-fix commits), reviewable commit-by-commit:

1. `verifyIssuesBatch` (core) — bounded concurrent fan-out of the existing single-issue `fetchIssueVerification`. Cap at min(concurrency, 5), floor at 1, per-item error isolation, no second retry layer (leans on ThrottledOctokit's backoff). Ships with unit tests.
2. (keystone) verify-FIRST short-circuit in `runVetList` — verify first; skip `scout.vetIssue` for issues verify rules out (closed / taken / own-open-pr); run scout's grade/health vet only for available / at-risk. listStatus derives from the verdict; scout only supplies grade/health for in-play issues. Net REDUCTION in `/search/issues` calls (verify spends GraphQL points, a separate budget).
3. (docs) unwind the agent/MCP contract that said vet-list does not verify per entry.

## Output contract (additive, back-compat)

- `VetListItemStatus` gains `at_risk` (mention-only / merged-closing, the point of #1353) and `own_open_pr` (#1354). `has_pr` / `has_stalled_pr` are kept for the fallback path.
- Each row carries a `verification` sub-object (verdict, verdictReason, state, stateReason, assignees, linkedPRs); absent only when verify itself errored.
- When verify fails for a row (transient error, or a non-issue/PR URL that can't be verified), the row falls back to scout's heuristic and carries an explicit `verifyError` field — the signal that listStatus is not authoritative and the row should be re-verified. A definitive ValidationError (deleted/private issue, or a PR URL) becomes an error row without re-grading.
- `summary` gains `atRisk` and `ownOpenPr`; the CLI surfaces them.
- Results are written by input index, so row order is stable regardless of concurrency.

## Tests / verification

- Core suite: 2960 passing. MCP suite: 247 passing. typecheck, lint, format, docs-contract, agents-contract, and the reference.md regen-diff gate all clean.
- Contract goldens regenerated to exercise all statuses (still_available / at_risk / claimed / own_open_pr / closed / error + the verifyError fallback).
- Manual `vet-list --json` smoke against a small real list: verdicts populated from live GraphQL, ruled-out (closed) issues short-circuited without a scout vet, no rate-limit noise.
- Reviewed with code-reviewer + silent-failure-hunter + a devil's-advocate pass; the verifyError surfacing and the non-issue-URL tagging both came out of that review.