### PR TITLE
Carry dashboard staleness headers on POST mutator responses (#1487)

### DIFF
--- a/packages/core/src/commands/dashboard-server.test.ts
+++ b/packages/core/src/commands/dashboard-server.test.ts
@@ -1518,11 +1518,28 @@ describe('dashboard-server', () => {
       expect(result.headers['x-dashboard-stale-reason']).toContain('first line second line');
     });
 
-    it('adopts a NEWER pulled lastDigest after a successful gist refresh (item 6)', async () => {
-      // Cross-machine scenario: another machine ran its daily check and the
-      // gist pull just replaced state — the rebuild must use the pulled
-      // digest, not the long-lived cachedDigest baked at server start.
-      const pulledDigest = makeDigest({
+    // Reset the shared server's cachedDigest to a known baseline via a full
+    // refresh (handleRefresh replaces cachedDigest unconditionally). Lets each
+    // adopt/not-adopt case seed its own digest so the pair survives
+    // vitest --shuffle instead of depending on definition-order execution
+    // sharing one server instance + mocked clock.
+    async function seedCachedDigest(digest: DailyDigest): Promise<void> {
+      mockStateManager.isGistMode.mockReturnValue(false);
+      mockStateManager.refreshFromGist.mockResolvedValue(false);
+      mockStateManager.getState.mockReturnValue(makeState({ lastDigest: digest }));
+      vi.mocked(getGitHubToken).mockReturnValue('test-token');
+      vi.mocked(fetchDashboardData).mockResolvedValue({
+        digest,
+        commentedIssues: [],
+        allMergedPRs: [],
+        allClosedPRs: [],
+        partialFailures: [],
+      });
+      await sendRequest('POST', '/api/refresh');
+    }
+
+    const otherMachineDigest = (): DailyDigest =>
+      makeDigest({
         generatedAt: '2026-02-01T00:00:00Z',
         recentlyMergedPRs: [
           {
@@ -1534,23 +1551,42 @@ describe('dashboard-server', () => {
           },
         ],
       });
-      mockStateManager.getState.mockReturnValue(makeState({ lastDigest: pulledDigest }));
-      mockStateManager.isGistMode.mockReturnValue(true);
-      mockStateManager.refreshFromGist.mockResolvedValue(true);
 
-      const result = await sendRequest('GET', '/api/data');
+    it('adopts a NEWER pulled lastDigest after a successful gist refresh (item 6)', async () => {
+      // Self-seed an OLD cachedDigest so this case does not depend on whatever
+      // ran before it under --shuffle.
+      await seedCachedDigest(makeDigest({ generatedAt: '2026-01-01T00:00:00Z' }));
+      try {
+        // Cross-machine scenario: another machine ran its daily check and the
+        // gist pull just replaced state — the rebuild must use the pulled
+        // digest, not the long-lived cachedDigest baked at server start.
+        const pulledDigest = otherMachineDigest();
+        mockStateManager.getState.mockReturnValue(makeState({ lastDigest: pulledDigest }));
+        mockStateManager.isGistMode.mockReturnValue(true);
+        mockStateManager.refreshFromGist.mockResolvedValue(true);
 
-      expect(result.statusCode).toBe(200);
-      const body = JSON.parse(result.body);
-      expect(body.recentlyMergedPRs.map((pr: { url: string }) => pr.url)).toContain(
-        'https://github.com/other/machine/pull/777',
-      );
+        const result = await sendRequest('GET', '/api/data');
+
+        expect(result.statusCode).toBe(200);
+        const body = JSON.parse(result.body);
+        expect(body.recentlyMergedPRs.map((pr: { url: string }) => pr.url)).toContain(
+          'https://github.com/other/machine/pull/777',
+        );
+      } finally {
+        // Restore the default cachedDigest so a shuffle that runs this case
+        // last does not leave a 2026-02-01 digest for downstream tests.
+        await seedCachedDigest(makeDigest());
+        mockStateManager.isGistMode.mockReturnValue(false);
+      }
     });
 
     it('does NOT adopt an OLDER pulled lastDigest (item 6)', async () => {
-      // cachedDigest is now the 2026-02-01 digest adopted by the previous
-      // case — the server instance is shared across the file. A pull that
-      // resurrects an older digest must not roll the dashboard back.
+      // Self-seed the NEWER cachedDigest this case compares against, instead
+      // of depending on the prior 'adopts a NEWER' test having run first — the
+      // pair shared one server instance, so under --shuffle this test
+      // previously saw whatever digest the run order happened to leave.
+      await seedCachedDigest(otherMachineDigest());
+      // A pull that resurrects an older digest must not roll the dashboard back.
       const olderDigest = makeDigest({
         generatedAt: '2026-01-20T00:00:00Z',
         recentlyMergedPRs: [
@@ -1574,23 +1610,88 @@ describe('dashboard-server', () => {
         const body = JSON.parse(result.body);
         const urls = body.recentlyMergedPRs.map((pr: { url: string }) => pr.url);
         expect(urls).not.toContain('https://github.com/stale/machine/pull/1');
-        // Still the adopted newer digest from the previous test.
+        // Still the self-seeded newer digest.
         expect(urls).toContain('https://github.com/other/machine/pull/777');
       } finally {
-        // Restore the default cachedDigest for the rest of the file via a
-        // full refresh (handleRefresh replaces cachedDigest unconditionally).
+        // Restore the default cachedDigest for the rest of the file.
+        await seedCachedDigest(makeDigest());
         mockStateManager.isGistMode.mockReturnValue(false);
-        mockStateManager.getState.mockReturnValue(makeState({ lastDigest: makeDigest() }));
-        vi.mocked(getGitHubToken).mockReturnValue('test-token');
-        vi.mocked(fetchDashboardData).mockResolvedValue({
-          digest: makeDigest(),
-          commentedIssues: [],
-          allMergedPRs: [],
-          allClosedPRs: [],
-          partialFailures: [],
-        });
-        await sendRequest('POST', '/api/refresh');
       }
+    });
+
+    // ── #1487: POST responses carry the stale header too ──────────────────
+    // The setters used to be GET-only, but the SPA clears its `stale` flag on
+    // ANY applied response. A POST /api/refresh or /api/action that succeeds
+    // while the gist stays stale must still surface the staleness, or the SPA
+    // flips back to "healthy" until the next GET.
+
+    it('POST /api/refresh carries X-Dashboard-Stale when state is stale (#1487)', async () => {
+      // The bug scenario: the GitHub fetch succeeds but the gist pull failed,
+      // so getStateStaleness() still reports divergence after the refresh.
+      mockStateManager.isGistMode.mockReturnValue(true);
+      mockStateManager.refreshFromGist.mockResolvedValue(false);
+      mockStateManager.getStateStaleness.mockReturnValue({
+        source: 'cache',
+        reason: 'gist pull failed: 503',
+        lastSuccessfulRefresh: '2026-01-15T11:00:00Z',
+        detectedAt: '2026-01-15T12:00:00Z',
+      });
+      vi.mocked(getGitHubToken).mockReturnValue('test-token');
+      vi.mocked(fetchDashboardData).mockResolvedValue({
+        digest: makeDigest(),
+        commentedIssues: [],
+        allMergedPRs: [],
+        allClosedPRs: [],
+        partialFailures: [],
+      });
+
+      const result = await sendRequest('POST', '/api/refresh');
+
+      expect(result.statusCode).toBe(200);
+      expect(result.headers['x-dashboard-stale']).toBe('1');
+      expect(result.headers['x-dashboard-stale-reason']).toContain('gist pull failed: 503');
+    });
+
+    it('POST /api/action carries X-Dashboard-Stale when state is stale (#1487)', async () => {
+      // A dismiss succeeds locally while the gist stays unreachable — the
+      // mutation response must not let the SPA clear a previously-stale flag.
+      mockStateManager.getStateStaleness.mockReturnValue({
+        source: 'cache',
+        reason: 'gist pull failed: 503',
+        lastSuccessfulRefresh: '2026-01-15T11:00:00Z',
+        detectedAt: '2026-01-15T12:00:00Z',
+      });
+
+      const result = await sendRequest(
+        'POST',
+        '/api/action',
+        JSON.stringify({ action: 'dismiss_issue_response', url: 'https://github.com/owner/repo/issues/5' }),
+      );
+
+      expect(result.statusCode).toBe(200);
+      expect(result.headers['x-dashboard-stale']).toBe('1');
+      expect(result.headers['x-dashboard-stale-reason']).toContain('gist pull failed: 503');
+    });
+
+    it('POST /api/refresh does NOT carry X-Dashboard-Stale when state is healthy (#1487)', async () => {
+      // The successful manual refresh clears a prior background-refresh error
+      // (mirrors the background path) and getStateStaleness is null, so the
+      // SPA correctly drops the stale flag.
+      mockStateManager.getStateStaleness.mockReturnValue(null);
+      vi.mocked(getGitHubToken).mockReturnValue('test-token');
+      vi.mocked(fetchDashboardData).mockResolvedValue({
+        digest: makeDigest(),
+        commentedIssues: [],
+        allMergedPRs: [],
+        allClosedPRs: [],
+        partialFailures: [],
+      });
+
+      const result = await sendRequest('POST', '/api/refresh');
+
+      expect(result.statusCode).toBe(200);
+      expect(result.headers['x-dashboard-stale']).toBeUndefined();
+      expect(result.headers['x-dashboard-stale-reason']).toBeUndefined();
     });
 
     it('GET /api/data un-halts a permanently-failed gist recovery after an external state edit (item 5)', async () => {

--- a/packages/core/src/commands/dashboard-server.ts
+++ b/packages/core/src/commands/dashboard-server.ts
@@ -309,17 +309,6 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
         // signal) lives inside reloadState too — do NOT add a second
         // maybeRecoverGist call here or recovery would double-run per poll.
         const stateChanged = await reloadState();
-        // Gist-mode staleness (#1446 item 2): refreshFromGist() returns
-        // false on BOTH "no change" and "fetch failed", so the boolean can't
-        // signal failure. getStateStaleness() is the API built for exactly
-        // this — StateManager sets the marker when in-memory state diverged
-        // from the canonical Gist (refresh failure, invalid payload,
-        // degraded bootstrap) and clears it on a successful pull.
-        const staleness = gistSync.stateManager.getStateStaleness();
-        if (staleness !== null) {
-          res.setHeader('X-Dashboard-Stale', '1');
-          res.setHeader('X-Dashboard-Stale-Reason', sanitizeHeaderValue(`state-stale: ${staleness.reason}`));
-        }
         // Also rebuild when the vetted issue list file was edited outside this server (#924)
         const currentIssueListMtimeMs = getIssueListMtimeMs();
         const issueListChanged = currentIssueListMtimeMs !== cache.issueListMtimeMs;
@@ -333,17 +322,10 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
             res.setHeader('X-Dashboard-Stale', '1');
           }
         }
-        // Surface staleness from a failed background refresh too (#1205) so
-        // token expiry / GitHub outage produces a client-visible signal
-        // rather than silent stale data. Only set the header when a failure
-        // is recorded — successful refreshes clear it.
-        if (cache.lastBackgroundRefreshError !== null) {
-          res.setHeader('X-Dashboard-Stale', '1');
-          res.setHeader(
-            'X-Dashboard-Stale-Reason',
-            sanitizeHeaderValue(`background-refresh-failed: ${cache.lastBackgroundRefreshError}`),
-          );
-        }
+        // Gist-divergence + background-refresh staleness (#1446 item 2, #1205)
+        // via the shared helper so this GET and the POST mutators emit the
+        // same headers (#1487). The rebuild-failure flag above is GET-only.
+        applyStalenessHeaders(res);
         sendJson(res, 200, cache.jsonData);
         return;
       }
@@ -453,6 +435,40 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
     // degraded banner clears without waiting for another edit.
     if (gistSync.stateManager.isGistMode()) changed = true;
     return changed;
+  }
+
+  /**
+   * Emit the X-Dashboard-Stale / X-Dashboard-Stale-Reason headers from the
+   * two server-lived staleness sources so EVERY response — GET /api/data and
+   * the POST mutators — reflects the same truth (#1487).
+   *
+   * Before this the setters were GET-only, but the SPA's applyResult clears
+   * its `stale` flag on ANY successfully-applied response. A dashboard whose
+   * gist pulls keep failing while POST /api/refresh and /api/action succeed
+   * would flip back to "healthy" until the next GET (mount or CSRF re-prime).
+   * Carrying the headers on the POST paths keeps the flag honest.
+   *
+   * Reads the same two probes the GET path used inline: the StateManager's
+   * gist-divergence marker (getStateStaleness, #1446 item 2) — set on a
+   * refresh failure / invalid payload / degraded bootstrap and cleared on a
+   * successful pull — and the cache's last background-refresh error (#1205).
+   * When both are set the background-refresh reason wins, matching the prior
+   * GET ordering. The GET path's third, transient source — an inline rebuild
+   * failure (#994) — is specific to that handler and stays inline there.
+   */
+  function applyStalenessHeaders(res: http.ServerResponse): void {
+    const staleness = gistSync.stateManager.getStateStaleness();
+    if (staleness !== null) {
+      res.setHeader('X-Dashboard-Stale', '1');
+      res.setHeader('X-Dashboard-Stale-Reason', sanitizeHeaderValue(`state-stale: ${staleness.reason}`));
+    }
+    if (cache.lastBackgroundRefreshError !== null) {
+      res.setHeader('X-Dashboard-Stale', '1');
+      res.setHeader(
+        'X-Dashboard-Stale-Reason',
+        sanitizeHeaderValue(`background-refresh-failed: ${cache.lastBackgroundRefreshError}`),
+      );
+    }
   }
 
   async function handleAction(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
@@ -575,6 +591,10 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
     // refresh clears it.
     cache.rebuild(gistSync.stateManager.getState());
 
+    // Carry the same staleness signal a GET would (#1487): a mutation that
+    // succeeds locally while the gist stays unreachable must not let the SPA
+    // clear a previously-stale flag.
+    applyStalenessHeaders(res);
     sendJson(res, 200, cache.jsonData);
   }
 
@@ -598,6 +618,14 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
       const result = await fetchDashboardData(currentToken);
       cache.adoptFetchResult(result);
       cache.rebuild(gistSync.stateManager.getState(), result.allMergedPRs, result.allClosedPRs);
+      // This manual refresh just fetched GitHub successfully, so a prior
+      // background-refresh failure is no longer current (#1487) — clear it as
+      // the background success path does, then emit the staleness headers. A
+      // gist-divergence marker that survived a failed pull inside reloadState
+      // still surfaces via getStateStaleness, so the SPA stays honest even
+      // when the GitHub fetch succeeds but the gist remains unreachable.
+      cache.lastBackgroundRefreshError = null;
+      applyStalenessHeaders(res);
       sendJson(res, 200, cache.jsonData);
     } catch (error) {
       // No server-side retry here (unlike handleAction): a refresh re-run is a

--- a/packages/dashboard/src/hooks/use-dashboard.test.ts
+++ b/packages/dashboard/src/hooks/use-dashboard.test.ts
@@ -341,6 +341,31 @@ describe('useDashboard', () => {
       expect(result.current.stale).toBe(false);
       expect(result.current.staleReason).toBe(null);
     });
+
+    it('keeps stale set when a POST /api/refresh response carries the stale header (#1487)', async () => {
+      // The #1487 fix makes the server set X-Dashboard-Stale on POST responses
+      // too. Mount healthy, then a background-stale POST refresh: applyResult
+      // must thread the POST's header into `stale`, not clear it because the
+      // response happened to be a POST.
+      const data = makeDashboardData();
+      mockFetchOk(data); // mount GET /api/data — healthy
+
+      const { result } = renderHook(() => useDashboard());
+      await vi.waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.stale).toBe(false);
+
+      // Manual refresh succeeds (POST) but the gist is still stale.
+      mockFetchOk(data, 'test-token', {
+        'X-Dashboard-Stale': '1',
+        'X-Dashboard-Stale-Reason': 'state-stale: gist pull failed: 503',
+      });
+      await act(async () => {
+        await result.current.refresh();
+      });
+
+      expect(result.current.stale).toBe(true);
+      expect(result.current.staleReason).toBe('state-stale: gist pull failed: 503');
+    });
   });
 
   describe('auto-refresh failure counter (#1446)', () => {


### PR DESCRIPTION
Closes #1487.

## Problem

Follow-up from the #1446 review. Every `X-Dashboard-Stale` / `X-Dashboard-Stale-Reason` setter was GET-only, but the SPA's `applyResult` clears the stale flag on **any** successfully-applied response and its background refresh is a **POST**. So a dashboard whose gist pulls keep failing while `POST /api/refresh` and `/api/action` succeed flips back to "healthy" until the next GET (mount or CSRF re-prime). Low-moderate visibility, no data loss (the SPA-side `autoRefreshFailures` counter covers the common token-expiry case independently).

## Fix

- Extract `applyStalenessHeaders(res)` from the inline GET logic. It reads the same two probes the GET path used: the StateManager gist-divergence marker (`getStateStaleness`, #1446) and the cache's last background-refresh error (#1205). Background-refresh reason wins when both are set, matching the prior GET ordering. The GET-only inline rebuild-failure flag (#994) stays inline.
- Call it on the POST mutator success paths (`handleAction`, `handleRefresh`), before `sendJson`, so a mutation that succeeds locally while the gist stays unreachable can't clear a real stale flag.
- `handleRefresh` clears `cache.lastBackgroundRefreshError` after a confirmed-successful GitHub fetch (mirrors the background success path). Gist-divergence staleness still surfaces via `getStateStaleness`, so a fetch that succeeds while the gist is unreachable stays honest.

## Tests

- `dashboard-server.test.ts`: POST `/api/refresh` and `/api/action` carry the header when state is stale; healthy state carries no header.
- `use-dashboard.test.ts`: the SPA threads a POST stale header into `stale`/`staleReason` instead of clearing it.
- Optional #1446 item: the adopt/not-adopt `lastDigest` test pair is now self-seeding, so it survives `vitest --shuffle`.

## Verification

core typecheck + full suite (2966), dashboard typecheck, mcp suite (247), lint, format all green. `use-dashboard.test.ts` (21) and `dashboard-server.test.ts` (120) pass; the adopt/not-adopt pair verified under `--shuffle`. Reviewed with code-reviewer + silent-failure-hunter (both clean: the helper extraction is behavior-equivalent including reason precedence, and clearing `lastBackgroundRefreshError` does not mask gist-divergence).

Note: a separate, pre-existing `--shuffle` fragility remains in the `#1433` degraded-gist test pair (fails on `main` too, same shared-instance pattern); out of scope here, could be a follow-up.

This recovers work that was sitting uncommitted in the working tree.