### PR TITLE
Self-heal the merged-PR ledger when stranded behind a watermark (#1504)

### DIFF
--- a/packages/core/src/commands/dashboard-data.test.ts
+++ b/packages/core/src/commands/dashboard-data.test.ts
@@ -975,6 +975,61 @@ describe('fetchDashboardData', () => {
     expect(mockSetLastDigest).toHaveBeenCalled();
   });
 
+  describe('merged-ledger backfill self-heal (#1504)', () => {
+    function digestWithMergedCount(total: number): DailyDigest {
+      return makeDailyDigest({
+        generatedAt: '2026-03-11T10:00:00Z',
+        openPRs: [],
+        summary: { totalActivePRs: 0, totalNeedingAttention: 0, totalMergedAllTime: total, mergeRate: 80 },
+      });
+    }
+
+    it('drops the watermark for a full backfill when the ledger trails the known merged count', async () => {
+      mockGetState.mockReturnValue(makeDefaultState({ lastDigest: digestWithMergedCount(124) }));
+      // Only 3 stored, watermark sits at the newest — the stranded-history case.
+      mockGetMergedPRs.mockReturnValue([
+        { url: 'https://github.com/o/r/pull/3', title: 'c', mergedAt: '2026-06-15T00:00:00Z' },
+        { url: 'https://github.com/o/r/pull/2', title: 'b', mergedAt: '2026-06-13T00:00:00Z' },
+        { url: 'https://github.com/o/r/pull/1', title: 'a', mergedAt: '2026-06-12T00:00:00Z' },
+      ]);
+      mockGetMergedPRWatermark.mockReturnValue('2026-06-15T00:00:00Z');
+
+      await fetchDashboardData('test-token');
+
+      // since-arg (3rd) must be undefined → full backfill, NOT the recent watermark.
+      expect(mockFetchMergedPRsSince).toHaveBeenCalled();
+      expect(mockFetchMergedPRsSince.mock.calls[0][2]).toBeUndefined();
+    });
+
+    it('keeps the incremental watermark once the ledger has caught up', async () => {
+      mockGetState.mockReturnValue(makeDefaultState({ lastDigest: digestWithMergedCount(124) }));
+      // 200 stored >= 124 known → no backfill needed.
+      mockGetMergedPRs.mockReturnValue(
+        Array.from({ length: 200 }, (_, i) => ({
+          url: `https://github.com/o/r/pull/${i}`,
+          title: `pr ${i}`,
+          mergedAt: '2026-06-15T00:00:00Z',
+        })),
+      );
+      mockGetMergedPRWatermark.mockReturnValue('2026-06-15T00:00:00Z');
+
+      await fetchDashboardData('test-token');
+
+      expect(mockFetchMergedPRsSince.mock.calls[0][2]).toBe('2026-06-15T00:00:00Z');
+    });
+
+    it('does not force a backfill when there is no known count yet (no digest)', async () => {
+      mockGetState.mockReturnValue(makeDefaultState({ lastDigest: null }));
+      mockGetMergedPRs.mockReturnValue([]);
+      mockGetMergedPRWatermark.mockReturnValue('2026-06-15T00:00:00Z');
+
+      await fetchDashboardData('test-token');
+
+      // 0 < 0 is false → keep the watermark, no spurious full refetch every poll.
+      expect(mockFetchMergedPRsSince.mock.calls[0][2]).toBe('2026-06-15T00:00:00Z');
+    });
+  });
+
   describe('partitions on post-override status (#1416)', () => {
     const PR_URL = 'https://github.com/owner/repo/pull/7';
 

--- a/packages/core/src/commands/dashboard-data.ts
+++ b/packages/core/src/commands/dashboard-data.ts
@@ -310,6 +310,32 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
   const watermark = stateManager.getMergedPRWatermark();
   const closedWatermark = stateManager.getClosedPRWatermark();
 
+  // Self-heal a ledger stranded behind a recent watermark (#1504). The
+  // incremental fetch only asks for merges newer than the newest stored one,
+  // so once the recent-merge feed (daily's recentlyMergedPRs) seeds the ledger
+  // before any full historical fetch ran, the older history can never be
+  // recovered. When the stored detail count is materially below the known
+  // all-time merged count, drop the watermark for a one-shot full backfill
+  // (bounded by the existing pagination cap); once the ledger catches up the
+  // watermark resumes incremental fetching. Closed PRs are not seeded ahead of
+  // their backfill in practice, so only merged needs the guard.
+  const storedMergedCount = stateManager.getMergedPRs().length;
+  const knownMergedAllTime = stateManager.getState().lastDigest?.summary?.totalMergedAllTime ?? 0;
+  // A full backfill can only ever return up to fetchMergedPRsSince's pagination
+  // cap (MAX_PAGINATION_PAGES * 100 = 300). Stop forcing one once the ledger has
+  // reached that ceiling, so a contributor whose star-filtered all-time count
+  // legitimately exceeds 300 doesn't trigger a full refetch on every poll.
+  const MERGED_BACKFILL_CEILING = 300;
+  const mergedNeedsBackfill = storedMergedCount < knownMergedAllTime && storedMergedCount < MERGED_BACKFILL_CEILING;
+  const mergedFetchSince = mergedNeedsBackfill ? undefined : watermark;
+  if (mergedNeedsBackfill) {
+    warn(
+      MODULE,
+      `Merged-PR ledger has ${storedMergedCount} of ~${knownMergedAllTime} known merges; ` +
+        'running a full backfill (watermark dropped) to recover history (#1504).',
+    );
+  }
+
   // Track which non-critical sub-fetches degraded to fallbacks so the SPA
   // can surface a "partial data" banner instead of silently showing zeros.
   // Rate-limit / auth errors still rethrow via isRateLimitOrAuthError —
@@ -358,7 +384,7 @@ export async function fetchDashboardData(token: string): Promise<DashboardFetchR
         failures: [{ issueUrl: 'N/A', error: `Issue conversation fetch failed: ${msg}` }],
       };
     }),
-    fetchMergedPRsSince(octokit, config, watermark).catch(
+    fetchMergedPRsSince(octokit, config, mergedFetchSince).catch(
       trackingCatch('fetch merged PRs for storage', [] as StoredMergedPR[]),
     ),
     fetchClosedPRsSince(octokit, config, closedWatermark).catch(


### PR DESCRIPTION
Closes #1504.

## Problem

The dashboard merged-PRs **page** showed only a handful of PRs (3 locally) while the headline count showed 124. Root cause: the detail ledger (`state.mergedPRs`) is filled by a **watermark-incremental** fetch — `fetchMergedPRsSince(watermark)` where `watermark` is the newest already-stored merge. `daily`'s recent-merge feed seeds the ledger, advancing the watermark past those seeds, so `merged:>{watermark}` can never recover the older history. After a state reset that empties the ledger (e.g. the #1438 gist migration), it stays stranded at just the recent merges.

Verified by the asymmetry in real state: the **closed** ledger backfilled fine (0 → 54) because it had no early seed (empty watermark → full fetch), while **merged** stuck at 3 because it was seeded first.

## Fix

In `fetchDashboardData`: when the stored ledger is materially below the known all-time merged count (`lastDigest.summary.totalMergedAllTime`) **and** below the 300-result pagination ceiling, drop the watermark for a one-shot full backfill; otherwise stay incremental.

- **Self-terminating:** the count query and the detail fetch share the same `-user:<self>` scope (`is:pr is:merged author:u -user:u`); the detail backfill is merely unfiltered-by-stars, so it always reaches ≥ the star-filtered count → the condition flips false after one backfill. The `< 300` ceiling covers the case where a star-filtered count legitimately exceeds the fetch cap.
- **Lossless / safe:** `addMergedPRs` dedupes by URL, so re-fetching overlaps is harmless; the fetch stays inside the `Promise.all` `trackingCatch` (rate-limit/auth rethrow and abort; transient → `[]` + `partialFailures`), and `addMergedPRs([])` is a no-op, so a failed backfill never wipes the ledger.

## Verification

- New unit tests: drops the watermark when the ledger trails the count; keeps the watermark once caught up; no spurious backfill when there's no digest yet.
- Full core suite (2969), mcp (247), typecheck, lint, format all green.
- Ran the heal against a real stranded ledger: **3 → 209** merged records recovered in one backfill, then it reverts to incremental.

Note: the page (unfiltered detail) and the headline (star-filtered `repoScores[].mergedPRCount` aggregate) are different populations, so they won't be identical (e.g. 209 vs 124). Fully reconciling the two metrics is a separate follow-up; this PR fixes the "stuck at 3" regression.

Reviewed manually (pr-review-toolkit agents were unavailable on a transient 529): self-termination, prior-digest read stability, lossless dedupe, and the degrade-safe failure path all confirmed.