### PR TITLE
chore(deps): bump @oss-scout/core to 1.2.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "@octokit/plugin-throttling": "^11.0.3",
     "@octokit/rest": "^22.0.1",
-    "@oss-scout/core": "^1.1.0",
+    "@oss-scout/core": "^1.2.0",
     "commander": "^15.0.0",
     "zod": "^4.4.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@oss-scout/core':
-        specifier: ^1.1.0
-        version: 1.1.0(@octokit/core@7.0.6)
+        specifier: ^1.2.0
+        version: 1.2.0(@octokit/core@7.0.6)
       commander:
         specifier: ^15.0.0
         version: 15.0.0
@@ -692,8 +692,8 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@oss-scout/core@1.1.0':
-    resolution: {integrity: sha512-QDaLX0GlrNzrIawJumv7IutoZKGkUZq99P4EOOQtt/SGCd5HgSJZsNkRikYK80MNSxQ7yhTnFF06l9J22I9ddA==}
+  '@oss-scout/core@1.2.0':
+    resolution: {integrity: sha512-yZRbbhUZwQyib5CHNMew46sH8yy2cef39NovoyEB3NCAVsKqO6kNnsf/12XOzbHI4w0azPtMG/MwKikeZWbaXQ==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
@@ -3321,7 +3321,7 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@oss-scout/core@1.1.0(@octokit/core@7.0.6)':
+  '@oss-scout/core@1.2.0(@octokit/core@7.0.6)':
     dependencies:
       '@octokit/plugin-throttling': 11.0.3(@octokit/core@7.0.6)
       '@octokit/rest': 22.0.1


### PR DESCRIPTION
## Summary

Bump `@oss-scout/core` 1.1.0 → 1.2.0 to pull in the broadened contributed-repo discovery from oss-scout#244.

Phase 0 (repos the user has merged/open PRs in) previously fetched only the 5 newest open issues per repo with a 90-day activity cutoff, so repeated searches kept returning the same shrinking set and never reached the backlog. 1.2.0 fetches 30/repo (free — one `listForRepo` call regardless of page size) and uses a 365-day window, so older-but-open issues in known repos surface and get vetted.

## Changes

- `packages/core/package.json`: `@oss-scout/core` `^1.1.0` → `^1.2.0`
- `pnpm-lock.yaml`: resolves `@oss-scout/core@1.2.0`

The bundled CLI (`dist/cli.bundle.cjs`) is gitignored and rebuilt in CI; locally rebuilt and confirmed the new Phase 0 depth/age logic is baked in.

## Verification

- Full core suite: 2969 pass. The only 2 failures (`state-gist-init`) are pre-existing and environmental (ambient token has gist scope), unrelated to this bump — they reproduce on `main`.
