### PR TITLE
fix(gist): stop sending unsupported If-Match header on Gist PATCH (#1510)

### DIFF
--- a/packages/core/src/core/gist-state-store.concurrency.test.ts
+++ b/packages/core/src/core/gist-state-store.concurrency.test.ts
@@ -1,25 +1,23 @@
 /**
- * Concurrency stress tests for GistStateStore (#1191).
+ * Concurrency stress tests for GistStateStore (#1191, #1510).
  *
- * The production push path implements optimistic concurrency via ETag /
- * `If-Match` and a single merge-and-retry on 412 (gist-state-store.ts:401-429).
- * The existing tests cover the happy path and a single collision; this file
- * exercises sustained contention by driving N stores against one stateful
- * mock Gist that increments its ETag on every update and rejects writes whose
- * `If-Match` doesn't match the current ETag.
+ * HISTORY: the production push path used to implement optimistic concurrency
+ * via ETag / `If-Match` and a single merge-and-retry on 412. That mechanism
+ * was removed in #1510 because the Gist `PATCH` endpoint rejects conditional
+ * request headers with HTTP 400, which made every Gist write fail. Writes are
+ * now unconditional, so cross-machine contention resolves last-write-wins
+ * rather than surfacing 412 / GistConcurrencyError.
  *
- * Key observations from the production code:
- * - `push()` does NOT field-merge. On 412 it re-fetches (which wipes the
- *   cache, line 506) then re-applies the staged dirty contents on top
- *   (lines 408-423). For two writers to both survive a contended push, each
- *   must re-read the freshly-fetched state and re-apply its own mutation
- *   to the new base — same loop the app-level code already runs.
- * - The merge-and-retry is single-shot: after the second 412, push throws
- *   `GistConcurrencyError` (line 427) without further retries. This file
- *   pins that retry bound.
- * - `cachedFiles` and `dirtyFiles` are public readonly handles on the store
- *   (gist-state-store.ts:122-123), so the test can mutate them as the app
- *   layer does without reaching into private fields.
+ * The stateful mock below still tracks an ETag and a (now never-triggered)
+ * `If-Match` precondition so it can assert the production code does NOT send
+ * the header. These tests therefore exercise convergence under last-write-wins
+ * for DISJOINT files (the common real-world case: each machine owns its own
+ * guidelines doc). The defensive 412 merge path that remains in production is
+ * unit-tested directly in gist-state-store.test.ts via injected 412 responses.
+ *
+ * `cachedFiles` and `dirtyFiles` are public readonly handles on the store, so
+ * the test can mutate them as the app layer does without reaching into private
+ * fields.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -301,61 +299,23 @@ describe('GistStateStore concurrency (#1191)', () => {
     expect(mock.counts.update).toBeGreaterThanOrEqual(N);
     expect(mock.counts.update).toBeLessThanOrEqual(16 * N);
 
-    // Every update sent an If-Match header — the mock always issues an ETag
-    // and bootstrap captures it.
+    // No update sent an If-Match header — the Gist PATCH endpoint rejects
+    // conditional request headers with HTTP 400, so #1510 dropped them.
     const updateMock = vi.mocked(mock.octokit.gists.update);
     for (const call of updateMock.mock.calls) {
       const [params] = call as [{ headers?: Record<string, string> }];
-      expect(params.headers?.['if-match']).toBeTruthy();
+      expect(params.headers).toBeUndefined();
     }
   });
 
-  it('a writer that loses two consecutive races surfaces GistConcurrencyError', async () => {
-    const mock = makeStatefulGistMock(GIST_ID, makeInitialStateJson());
-
-    const victim = new GistStateStore(mock.octokit);
-    const ghostA = new GistStateStore(mock.octokit);
-    const ghostB = new GistStateStore(mock.octokit);
-    await Promise.all([victim.bootstrap(), ghostA.bootstrap(), ghostB.bootstrap()]);
-
-    // Phase 1: ghost A pushes a guidelines file. Bumps mock ETag, leaving
-    // victim's lastFetchedEtag stale.
-    await tryWriteDocument(ghostA, 'guidelines--ghost-a.md', 'a content');
-
-    // Phase 2: stage the victim's mutation. Doesn't touch the wire yet.
-    victim.setDocument('guidelines--victim.md', 'victim content');
-
-    // Phase 3: hook the mock so the get call inside victim's mid-push refresh
-    // (gist-state-store.ts:415) does NOT resolve until ghostB's full push has
-    // landed. The captured `response` snapshot still has the pre-ghostB ETag
-    // and content, so victim's fetchAndCache writes a stale ETag into
-    // `lastFetchedEtag`. Victim's inner retry at line 424 then 412s against
-    // ghostB's bumped canonical ETag. That's how we force two consecutive
-    // 412s for the same writer in single-threaded JS.
-    const realGet = mock.octokit.gists.get;
-    let getCallCount = 0;
-    mock.octokit.gists.get = vi.fn(async (params) => {
-      getCallCount++;
-      const response = await realGet(params);
-      if (getCallCount === 1) {
-        await tryWriteDocument(ghostB, 'guidelines--ghost-b.md', 'b content');
-      }
-      return response;
-    });
-
-    await expect(victim.push()).rejects.toBeInstanceOf(GistConcurrencyError);
-
-    // Pinned retry bound: push() makes exactly two attempts before throwing
-    // (gist-state-store.ts:425-428). Local mutation stays staged so the caller
-    // can refresh + retry at app level.
-    expect(victim.dirtyFiles.has('guidelines--victim.md')).toBe(true);
-
-    // Both ghosts landed; the victim did not.
-    const finalFiles = mock.readAllFiles();
-    expect(finalFiles['guidelines--ghost-a.md']).toBe('a content');
-    expect(finalFiles['guidelines--ghost-b.md']).toBe('b content');
-    expect(finalFiles['guidelines--victim.md']).toBeUndefined();
-  });
+  // NOTE (#1510): the former "loses two consecutive races surfaces
+  // GistConcurrencyError", "two writers modifying state.json — second fails
+  // loud", and "mixed dirty set" tests were removed here. Each relied on the
+  // Gist PATCH returning 412 in response to a stale `If-Match`. That header is
+  // no longer sent (the endpoint rejects it with HTTP 400), so contended
+  // writes now resolve last-write-wins rather than failing loud. The defensive
+  // 412 merge path that survives in production is still unit-tested with
+  // injected 412 responses in gist-state-store.test.ts.
 
   it('after a contended push sequence, refreshFromGist returns the canonical state', async () => {
     const mock = makeStatefulGistMock(GIST_ID, makeInitialStateJson());
@@ -377,103 +337,23 @@ describe('GistStateStore concurrency (#1191)', () => {
     }
   });
 
-  // Pins the per-file conflict policy from #1235: state.json fails loud
-  // when its remote copy moved under the writer (preserving the
-  // StateManager optimistic-concurrency contract documented in
-  // state.ts:285-296). Two writers each modifying state.json on the same
-  // base no longer clobber silently — the second writer's push throws
-  // GistConcurrencyError and leaves the canonical state holding the first
-  // writer's edit.
-  it('two writers modifying state.json on the same base — second push fails loud (#1235)', async () => {
+  // Disjoint freeform writers keep last-write-wins: each writer owns a
+  // distinct guidelines file, so even though no `If-Match` is sent (#1510),
+  // the Gist `files` partial-update semantics mean neither write clobbers the
+  // other and both land.
+  it('two writers writing distinct guidelines files both land (last-write-wins)', async () => {
     const mock = makeStatefulGistMock(GIST_ID, makeInitialStateJson());
     const a = new GistStateStore(mock.octokit);
     const b = new GistStateStore(mock.octokit);
     await Promise.all([a.bootstrap(), b.bootstrap()]);
 
-    // a writes URL_a; b writes URL_b. Both based on the same bootstrap-time
-    // base state (no URLs).
-    const stateA = JSON.parse(a.cachedFiles.get(STATE_FILE_NAME)!) as Record<string, unknown>;
-    (stateA.config as { shelvedPRUrls: string[] }).shelvedPRUrls.push('url-a');
-    a.setState(JSON.stringify(stateA, null, 2));
-    await a.push();
-
-    const stateB = JSON.parse(b.cachedFiles.get(STATE_FILE_NAME)!) as Record<string, unknown>;
-    (stateB.config as { shelvedPRUrls: string[] }).shelvedPRUrls.push('url-b');
-    b.setState(JSON.stringify(stateB, null, 2));
-    // b's first push 412s. The merge re-fetches and finds the remote
-    // state.json has changed since b's baseline (a's url-a edit), so the
-    // store surfaces GistConcurrencyError instead of clobbering.
-    await expect(b.push()).rejects.toBeInstanceOf(GistConcurrencyError);
-
-    // Canonical state retains a's write.
-    const finalState = mock.readState() as { config: { shelvedPRUrls: string[] } };
-    expect(finalState.config.shelvedPRUrls).toEqual(['url-a']);
-
-    // b's local mutation is preserved in memory so the caller can refresh
-    // and reapply manually if desired.
-    expect(b.dirtyFiles.has(STATE_FILE_NAME)).toBe(true);
-    const bStaged = JSON.parse(b.cachedFiles.get(STATE_FILE_NAME)!) as {
-      config: { shelvedPRUrls: string[] };
-    };
-    expect(bStaged.config.shelvedPRUrls).toEqual(['url-b']);
-  });
-
-  // Companion to the test above: per-file policy means freeform documents
-  // (guidelines, etc.) keep last-write-wins on the same merge re-apply
-  // path (#1235). A writer racing on a guidelines file with no concurrent
-  // state.json change still succeeds via the existing merge-and-retry.
-  it('guidelines writes keep last-write-wins even when a state.json baseline changed (#1235)', async () => {
-    const mock = makeStatefulGistMock(GIST_ID, makeInitialStateJson());
-    const a = new GistStateStore(mock.octokit);
-    const b = new GistStateStore(mock.octokit);
-    await Promise.all([a.bootstrap(), b.bootstrap()]);
-
-    // a writes a guidelines file. Bumps mock ETag so b's lastFetchedEtag
-    // is now stale, but state.json has not changed remotely.
     await tryWriteDocument(a, 'guidelines--writer-a.md', 'a content');
 
-    // b stages a different guidelines file. Its first push 412s; the
-    // merge refresh sees state.json baseline unchanged (a only touched
-    // a guidelines file), so b's push succeeds on the inner retry.
     b.setDocument('guidelines--writer-b.md', 'b content');
     await b.push();
 
     const finalFiles = mock.readAllFiles();
     expect(finalFiles['guidelines--writer-a.md']).toBe('a content');
     expect(finalFiles['guidelines--writer-b.md']).toBe('b content');
-  });
-
-  // Concurrent state.json + guidelines writes from a single store: when a
-  // peer writes state.json between the writer's last fetch and its push,
-  // the writer's state.json edit must fail loud even though guidelines
-  // would otherwise be safe to reapply. This pins that the per-file check
-  // gates the whole push, not just the state.json file (#1235).
-  it('mixed dirty set surfaces GistConcurrencyError when state.json conflicted (#1235)', async () => {
-    const mock = makeStatefulGistMock(GIST_ID, makeInitialStateJson());
-    const peer = new GistStateStore(mock.octokit);
-    const writer = new GistStateStore(mock.octokit);
-    await Promise.all([peer.bootstrap(), writer.bootstrap()]);
-
-    // Peer pushes a state.json change, bumping the canonical ETag and
-    // moving state.json off the writer's baseline.
-    const peerState = JSON.parse(peer.cachedFiles.get(STATE_FILE_NAME)!) as Record<string, unknown>;
-    (peerState.config as { shelvedPRUrls: string[] }).shelvedPRUrls.push('peer-url');
-    peer.setState(JSON.stringify(peerState, null, 2));
-    await peer.push();
-
-    // Writer stages BOTH a guidelines file and a state.json edit on the
-    // pre-peer base. The 412 merge refresh sees state.json moved under
-    // it; per #1235 the whole push fails loud.
-    const writerState = JSON.parse(writer.cachedFiles.get(STATE_FILE_NAME)!) as Record<string, unknown>;
-    (writerState.config as { shelvedPRUrls: string[] }).shelvedPRUrls.push('writer-url');
-    writer.setDocument('guidelines--writer.md', 'writer content');
-    writer.setState(JSON.stringify(writerState, null, 2));
-    await expect(writer.push()).rejects.toBeInstanceOf(GistConcurrencyError);
-
-    // Canonical state retains peer's write; writer's guidelines did NOT
-    // land (the failed push aborted the whole batch).
-    const finalState = mock.readState() as { config: { shelvedPRUrls: string[] } };
-    expect(finalState.config.shelvedPRUrls).toEqual(['peer-url']);
-    expect(mock.readAllFiles()['guidelines--writer.md']).toBeUndefined();
   });
 });

--- a/packages/core/src/core/gist-state-store.concurrency.test.ts
+++ b/packages/core/src/core/gist-state-store.concurrency.test.ts
@@ -1,19 +1,20 @@
 /**
  * Concurrency stress tests for GistStateStore (#1191, #1510).
  *
- * HISTORY: the production push path used to implement optimistic concurrency
- * via ETag / `If-Match` and a single merge-and-retry on 412. That mechanism
- * was removed in #1510 because the Gist `PATCH` endpoint rejects conditional
- * request headers with HTTP 400, which made every Gist write fail. Writes are
- * now unconditional, so cross-machine contention resolves last-write-wins
- * rather than surfacing 412 / GistConcurrencyError.
+ * HISTORY: the push path used to enforce optimistic concurrency by replaying
+ * the fetched ETag as an `If-Match` header so the Gist API would reject a
+ * stale write with 412. That never worked against real GitHub — the Gist
+ * `PATCH` endpoint rejects conditional request headers with HTTP 400 (#1510).
+ * The header was dropped and concurrency is now enforced client-side: when
+ * `state.json` is dirty, `push()` re-reads the Gist and compares the remote
+ * `state.json` against the baseline from the last fetch, throwing
+ * GistConcurrencyError if it moved under the writer (#1235). Freeform
+ * documents keep last-write-wins (the Gist `files` param is a partial update).
  *
- * The stateful mock below still tracks an ETag and a (now never-triggered)
- * `If-Match` precondition so it can assert the production code does NOT send
- * the header. These tests therefore exercise convergence under last-write-wins
- * for DISJOINT files (the common real-world case: each machine owns its own
- * guidelines doc). The defensive 412 merge path that remains in production is
- * unit-tested directly in gist-state-store.test.ts via injected 412 responses.
+ * The stateful mock below tracks an ETag and a (now never-triggered)
+ * `If-Match` precondition so the convergence test can assert production never
+ * sends the header. `get` always returns the current canonical content, which
+ * is what drives the read-before-write conflict detection.
  *
  * `cachedFiles` and `dirtyFiles` are public readonly handles on the store, so
  * the test can mutate them as the app layer does without reaching into private
@@ -309,13 +310,11 @@ describe('GistStateStore concurrency (#1191)', () => {
   });
 
   // NOTE (#1510): the former "loses two consecutive races surfaces
-  // GistConcurrencyError", "two writers modifying state.json — second fails
-  // loud", and "mixed dirty set" tests were removed here. Each relied on the
-  // Gist PATCH returning 412 in response to a stale `If-Match`. That header is
-  // no longer sent (the endpoint rejects it with HTTP 400), so contended
-  // writes now resolve last-write-wins rather than failing loud. The defensive
-  // 412 merge path that survives in production is still unit-tested with
-  // injected 412 responses in gist-state-store.test.ts.
+  // GistConcurrencyError" test was removed here. It relied on the writer
+  // hitting two consecutive 412s through the mid-push refresh — a path that
+  // only existed under the dropped `If-Match` server-side concurrency. The
+  // state.json fail-loud guarantee it protected is now covered by the two
+  // read-before-write tests below.
 
   it('after a contended push sequence, refreshFromGist returns the canonical state', async () => {
     const mock = makeStatefulGistMock(GIST_ID, makeInitialStateJson());
@@ -355,5 +354,75 @@ describe('GistStateStore concurrency (#1191)', () => {
     const finalFiles = mock.readAllFiles();
     expect(finalFiles['guidelines--writer-a.md']).toBe('a content');
     expect(finalFiles['guidelines--writer-b.md']).toBe('b content');
+  });
+
+  // Pins the per-file conflict policy from #1235 under the read-before-write
+  // mechanism (#1510): when two writers modify state.json on the same base,
+  // the second writer's pre-write re-read sees the first writer's edit on
+  // remote, so it fails loud (GistConcurrencyError) instead of clobbering.
+  it('two writers modifying state.json on the same base — second push fails loud (#1235)', async () => {
+    const mock = makeStatefulGistMock(GIST_ID, makeInitialStateJson());
+    const a = new GistStateStore(mock.octokit);
+    const b = new GistStateStore(mock.octokit);
+    await Promise.all([a.bootstrap(), b.bootstrap()]);
+
+    // a writes url-a; b writes url-b. Both based on the same bootstrap-time
+    // base state (no URLs).
+    const stateA = JSON.parse(a.cachedFiles.get(STATE_FILE_NAME)!) as Record<string, unknown>;
+    (stateA.config as { shelvedPRUrls: string[] }).shelvedPRUrls.push('url-a');
+    a.setState(JSON.stringify(stateA, null, 2));
+    await a.push();
+
+    const stateB = JSON.parse(b.cachedFiles.get(STATE_FILE_NAME)!) as Record<string, unknown>;
+    (stateB.config as { shelvedPRUrls: string[] }).shelvedPRUrls.push('url-b');
+    b.setState(JSON.stringify(stateB, null, 2));
+    // b's pre-write re-read finds the remote state.json has changed since b's
+    // baseline (a's url-a edit), so the store surfaces GistConcurrencyError
+    // instead of clobbering.
+    await expect(b.push()).rejects.toBeInstanceOf(GistConcurrencyError);
+
+    // Canonical state retains a's write.
+    const finalState = mock.readState() as { config: { shelvedPRUrls: string[] } };
+    expect(finalState.config.shelvedPRUrls).toEqual(['url-a']);
+
+    // b's local mutation is preserved in memory so the caller can refresh and
+    // reapply manually if desired.
+    expect(b.dirtyFiles.has(STATE_FILE_NAME)).toBe(true);
+    const bStaged = JSON.parse(b.cachedFiles.get(STATE_FILE_NAME)!) as {
+      config: { shelvedPRUrls: string[] };
+    };
+    expect(bStaged.config.shelvedPRUrls).toEqual(['url-b']);
+  });
+
+  // Companion: a mixed dirty set (state.json + a guidelines file) fails loud as
+  // a whole when state.json conflicted — the pre-write check gates the entire
+  // push, so the guidelines file does not land either (#1235, #1510).
+  it('mixed dirty set surfaces GistConcurrencyError when state.json conflicted (#1235)', async () => {
+    const mock = makeStatefulGistMock(GIST_ID, makeInitialStateJson());
+    const peer = new GistStateStore(mock.octokit);
+    const writer = new GistStateStore(mock.octokit);
+    await Promise.all([peer.bootstrap(), writer.bootstrap()]);
+
+    // Peer pushes a state.json change, moving state.json off the writer's
+    // baseline.
+    const peerState = JSON.parse(peer.cachedFiles.get(STATE_FILE_NAME)!) as Record<string, unknown>;
+    (peerState.config as { shelvedPRUrls: string[] }).shelvedPRUrls.push('peer-url');
+    peer.setState(JSON.stringify(peerState, null, 2));
+    await peer.push();
+
+    // Writer stages BOTH a guidelines file and a state.json edit on the
+    // pre-peer base. The pre-write re-read sees state.json moved under it; per
+    // #1235 the whole push fails loud.
+    const writerState = JSON.parse(writer.cachedFiles.get(STATE_FILE_NAME)!) as Record<string, unknown>;
+    (writerState.config as { shelvedPRUrls: string[] }).shelvedPRUrls.push('writer-url');
+    writer.setDocument('guidelines--writer.md', 'writer content');
+    writer.setState(JSON.stringify(writerState, null, 2));
+    await expect(writer.push()).rejects.toBeInstanceOf(GistConcurrencyError);
+
+    // Canonical state retains peer's write; writer's guidelines did NOT land
+    // (the failed push aborted the whole batch).
+    const finalState = mock.readState() as { config: { shelvedPRUrls: string[] } };
+    expect(finalState.config.shelvedPRUrls).toEqual(['peer-url']);
+    expect(mock.readAllFiles()['guidelines--writer.md']).toBeUndefined();
   });
 });

--- a/packages/core/src/core/gist-state-store.test.ts
+++ b/packages/core/src/core/gist-state-store.test.ts
@@ -1074,8 +1074,11 @@ describe('GistStateStore', () => {
     });
   });
 
-  describe('ETag-based optimistic concurrency (#1115)', () => {
-    it('captures the ETag from a fetch and sends If-Match on the next push', async () => {
+  describe('ETag-based optimistic concurrency (#1115, #1510)', () => {
+    it('never sends an If-Match header on the write even when an ETag was fetched (#1510)', async () => {
+      // The Gist PATCH endpoint rejects conditional request headers with HTTP
+      // 400, so the captured ETag must not be replayed as `If-Match` on the
+      // write. Reads may still capture the ETag, but the write is unconditional.
       const gistId = 'etag-capture';
       const stateJson = makeStateJson();
       fs.writeFileSync(path.join(tmpDir, 'gist-id'), gistId);
@@ -1094,11 +1097,13 @@ describe('GistStateStore', () => {
       const ok = await store.push();
 
       expect(ok).toBe(true);
+      // Exactly gist_id + files — no `headers`/`if-match` field.
       expect(octokit.gists.update).toHaveBeenCalledWith({
         gist_id: gistId,
         files: { [STATE_FILE_NAME]: { content: stateJson } },
-        headers: { 'if-match': 'W/"abc123"' },
       });
+      const [params] = octokit.gists.update.mock.calls[0] as [{ headers?: Record<string, string> }];
+      expect(params.headers).toBeUndefined();
     });
 
     it('omits the If-Match header when the SDK does not surface an ETag (test mocks)', async () => {
@@ -1155,17 +1160,16 @@ describe('GistStateStore', () => {
       const ok = await store.push();
 
       expect(ok).toBe(true);
-      // First call sent If-Match: v1, second call sent If-Match: v2 (post-refresh).
+      // Both attempts are unconditional — no `If-Match` header is ever sent
+      // (#1510), even on the defensive 412 retry path.
       expect(octokit.gists.update).toHaveBeenCalledTimes(2);
       expect(octokit.gists.update).toHaveBeenNthCalledWith(1, {
         gist_id: gistId,
         files: { [STATE_FILE_NAME]: { content: stateJson } },
-        headers: { 'if-match': 'W/"v1"' },
       });
       expect(octokit.gists.update).toHaveBeenNthCalledWith(2, {
         gist_id: gistId,
         files: { [STATE_FILE_NAME]: { content: stateJson } },
-        headers: { 'if-match': 'W/"v2"' },
       });
     });
 

--- a/packages/core/src/core/gist-state-store.test.ts
+++ b/packages/core/src/core/gist-state-store.test.ts
@@ -1125,30 +1125,20 @@ describe('GistStateStore', () => {
       });
     });
 
-    it('refreshes and retries once on 412 when state.json baseline is unchanged', async () => {
-      // The 412 may be triggered by a peer writing a guidelines file (or
-      // any non-state.json file) — state.json's content is byte-identical
-      // before and after the refresh. Per #1235 the per-file fail-loud
-      // check passes and the inner retry proceeds normally.
-      const gistId = 'etag-merge';
+    it('re-reads before a state.json write and proceeds when state.json is unchanged', async () => {
+      // With no If-Match available (#1510), push() re-reads the Gist before a
+      // state.json write and compares the remote against its baseline. When
+      // state.json is byte-identical there is no conflict, so the write goes
+      // through unconditionally.
+      const gistId = 'reread-unchanged';
       const stateJson = makeStateJson({ lastRunAt: '2025-01-01T00:00:00.000Z' });
       fs.writeFileSync(path.join(tmpDir, 'gist-id'), gistId);
 
-      // Bootstrap fetch returns the state with ETag #1.
-      octokit.gists.get.mockResolvedValueOnce({
-        ...makeGistResponse(gistId, stateJson),
-        headers: { etag: 'W/"v1"' },
-      });
-      // First update: 412 (another machine pushed something else).
-      const conflictErr = Object.assign(new Error('Precondition failed'), { status: 412 });
-      octokit.gists.update.mockRejectedValueOnce(conflictErr);
-      // Refresh fetch returns identical state.json content with a new
-      // ETag — modeling a peer write that didn't touch state.json.
-      octokit.gists.get.mockResolvedValueOnce({
-        ...makeGistResponse(gistId, stateJson),
-        headers: { etag: 'W/"v2"' },
-      });
-      // Second update: succeeds with the new ETag.
+      // Bootstrap fetch (etag v1), then the pre-write re-read (etag v2), both
+      // returning identical state.json.
+      octokit.gists.get
+        .mockResolvedValueOnce({ ...makeGistResponse(gistId, stateJson), headers: { etag: 'W/"v1"' } })
+        .mockResolvedValueOnce({ ...makeGistResponse(gistId, stateJson), headers: { etag: 'W/"v2"' } });
       octokit.gists.update.mockResolvedValueOnce({
         ...makeGistResponse(gistId, stateJson),
         headers: { etag: 'W/"v3"' },
@@ -1160,39 +1150,53 @@ describe('GistStateStore', () => {
       const ok = await store.push();
 
       expect(ok).toBe(true);
-      // Both attempts are unconditional — no `If-Match` header is ever sent
-      // (#1510), even on the defensive 412 retry path.
-      expect(octokit.gists.update).toHaveBeenCalledTimes(2);
-      expect(octokit.gists.update).toHaveBeenNthCalledWith(1, {
-        gist_id: gistId,
-        files: { [STATE_FILE_NAME]: { content: stateJson } },
-      });
-      expect(octokit.gists.update).toHaveBeenNthCalledWith(2, {
+      // get called twice (bootstrap + pre-write re-read); update called once,
+      // unconditionally (no If-Match header).
+      expect(octokit.gists.get).toHaveBeenCalledTimes(2);
+      expect(octokit.gists.update).toHaveBeenCalledTimes(1);
+      expect(octokit.gists.update).toHaveBeenCalledWith({
         gist_id: gistId,
         files: { [STATE_FILE_NAME]: { content: stateJson } },
       });
     });
 
+    it('does not re-read for a freeform-only write (last-write-wins)', async () => {
+      // Freeform documents keep last-write-wins: the Gist `files` parameter is
+      // a partial update, so a guidelines-only push needs no pre-write
+      // re-read and cannot clobber another file.
+      const gistId = 'reread-skip-freeform';
+      const stateJson = makeStateJson();
+      fs.writeFileSync(path.join(tmpDir, 'gist-id'), gistId);
+
+      octokit.gists.get.mockResolvedValueOnce({
+        ...makeGistResponse(gistId, stateJson),
+        headers: { etag: 'W/"v1"' },
+      });
+      octokit.gists.update.mockResolvedValueOnce(makeGistResponse(gistId, stateJson));
+
+      const store = new GistStateStore(octokit);
+      await store.bootstrap();
+      store.setDocument('guidelines--owner--repo.md', '# Guidelines');
+      const ok = await store.push();
+
+      expect(ok).toBe(true);
+      // Only the bootstrap fetch — no pre-write re-read for a freeform write.
+      expect(octokit.gists.get).toHaveBeenCalledTimes(1);
+      expect(octokit.gists.update).toHaveBeenCalledTimes(1);
+    });
+
     it('throws GistConcurrencyError when state.json moved remotely (#1235)', async () => {
-      // Same shape as the test above, except the refresh returns a
-      // CHANGED state.json. Per #1235 the per-file fail-loud check fires
-      // before the inner retry, so the writer sees GistConcurrencyError
+      // The pre-write re-read returns a CHANGED state.json, so the fail-loud
+      // check fires before any write — the writer sees GistConcurrencyError
       // instead of clobbering the remote edit.
-      const gistId = 'etag-state-changed';
+      const gistId = 'reread-state-changed';
       const initialStateJson = makeStateJson({ lastRunAt: '2025-01-01T00:00:00.000Z' });
       const remoteStateJson = makeStateJson({ lastRunAt: '2025-06-01T00:00:00.000Z' });
       fs.writeFileSync(path.join(tmpDir, 'gist-id'), gistId);
 
-      octokit.gists.get.mockResolvedValueOnce({
-        ...makeGistResponse(gistId, initialStateJson),
-        headers: { etag: 'W/"v1"' },
-      });
-      const conflictErr = Object.assign(new Error('Precondition failed'), { status: 412 });
-      octokit.gists.update.mockRejectedValueOnce(conflictErr);
-      octokit.gists.get.mockResolvedValueOnce({
-        ...makeGistResponse(gistId, remoteStateJson),
-        headers: { etag: 'W/"v2"' },
-      });
+      octokit.gists.get
+        .mockResolvedValueOnce({ ...makeGistResponse(gistId, initialStateJson), headers: { etag: 'W/"v1"' } })
+        .mockResolvedValueOnce({ ...makeGistResponse(gistId, remoteStateJson), headers: { etag: 'W/"v2"' } });
 
       const store = new GistStateStore(octokit);
       await store.bootstrap();
@@ -1201,30 +1205,22 @@ describe('GistStateStore', () => {
       const { GistConcurrencyError } = await import('./errors.js');
       await expect(store.push()).rejects.toThrow(GistConcurrencyError);
 
-      // The store made exactly one update attempt — the second never
-      // fired because the per-file check threw first.
-      expect(octokit.gists.update).toHaveBeenCalledTimes(1);
-      // Local state.json mutation is preserved in cachedFiles for the
-      // caller to retry against the refreshed baseline.
+      // The write never fired — the pre-write check threw first.
+      expect(octokit.gists.update).not.toHaveBeenCalled();
+      // Local state.json mutation is preserved in cachedFiles for the caller
+      // to refresh and reapply against the new baseline.
       expect(store.dirtyFiles.has(STATE_FILE_NAME)).toBe(true);
       expect(store.cachedFiles.get(STATE_FILE_NAME)).toBe(initialStateJson);
     });
 
-    it('throws GistConcurrencyError when the merged push also returns 412', async () => {
-      const gistId = 'etag-double-conflict';
+    it('throws GistConcurrencyError when the pre-write re-read fails', async () => {
+      const gistId = 'reread-network-fail';
       const stateJson = makeStateJson();
       fs.writeFileSync(path.join(tmpDir, 'gist-id'), gistId);
 
-      octokit.gists.get.mockResolvedValueOnce({
-        ...makeGistResponse(gistId, stateJson),
-        headers: { etag: 'W/"v1"' },
-      });
-      const conflictErr = Object.assign(new Error('Precondition failed'), { status: 412 });
-      octokit.gists.update.mockRejectedValueOnce(conflictErr).mockRejectedValueOnce(conflictErr);
-      octokit.gists.get.mockResolvedValueOnce({
-        ...makeGistResponse(gistId, stateJson),
-        headers: { etag: 'W/"v2"' },
-      });
+      octokit.gists.get
+        .mockResolvedValueOnce({ ...makeGistResponse(gistId, stateJson), headers: { etag: 'W/"v1"' } })
+        .mockRejectedValueOnce(new Error('Network error'));
 
       const store = new GistStateStore(octokit);
       await store.bootstrap();
@@ -1232,58 +1228,24 @@ describe('GistStateStore', () => {
 
       const { GistConcurrencyError } = await import('./errors.js');
       await expect(store.push()).rejects.toThrow(GistConcurrencyError);
+      // No write attempted when the conflict check could not complete.
+      expect(octokit.gists.update).not.toHaveBeenCalled();
     });
 
-    it('throws GistConcurrencyError when the merge refresh itself fails', async () => {
-      const gistId = 'etag-refresh-fail';
-      const stateJson = makeStateJson();
-      fs.writeFileSync(path.join(tmpDir, 'gist-id'), gistId);
-
-      octokit.gists.get.mockResolvedValueOnce({
-        ...makeGistResponse(gistId, stateJson),
-        headers: { etag: 'W/"v1"' },
-      });
-      const conflictErr = Object.assign(new Error('Precondition failed'), { status: 412 });
-      octokit.gists.update.mockRejectedValueOnce(conflictErr);
-      // Refresh blows up entirely
-      octokit.gists.get.mockRejectedValueOnce(new Error('Network error'));
-
-      const store = new GistStateStore(octokit);
-      await store.bootstrap();
-      store.markDirty(STATE_FILE_NAME);
-
-      const { GistConcurrencyError } = await import('./errors.js');
-      await expect(store.push()).rejects.toThrow(GistConcurrencyError);
-    });
-
-    it('on corrupt remote during 412 merge, rolls back ETag/baseline and propagates GistCorruptError (#1235)', async () => {
-      // Models the failure mode where a peer pushes between our last
-      // fetch and our push, AND that peer's state.json fails schema
-      // validation. The merge fetch's parse step throws GistCorruptError
-      // after `cachedFiles`/`lastFetchedEtag` were already mutated
-      // mid-fetchAndCache. The rollback in push() restores the prior
-      // values and re-throws the corrupt error so callers don't retry
+    it('on corrupt remote during the pre-write re-read, rolls back ETag/baseline and propagates GistCorruptError (#1235)', async () => {
+      // The pre-write re-read returns a corrupt state.json, so
+      // parseStateFromCache throws GistCorruptError after `cachedFiles` /
+      // `lastFetchedEtag` were already mutated mid-fetchAndCache. push() rolls
+      // those back and re-throws the corrupt error so callers don't retry
       // against a corrupt remote.
-      const gistId = 'etag-corrupt-mid-merge';
+      const gistId = 'reread-corrupt';
       const initialStateJson = makeStateJson({ lastRunAt: '2025-01-01T00:00:00.000Z' });
       fs.writeFileSync(path.join(tmpDir, 'gist-id'), gistId);
 
-      // Bootstrap fetch returns valid state with ETag v1.
-      octokit.gists.get.mockResolvedValueOnce({
-        ...makeGistResponse(gistId, initialStateJson),
-        headers: { etag: 'W/"v1"' },
-      });
-      // First update: 412.
-      const conflictErr = Object.assign(new Error('Precondition failed'), { status: 412 });
-      octokit.gists.update.mockRejectedValueOnce(conflictErr);
-      // Refresh fetch returns corrupt state.json (unparseable JSON) so
-      // parseStateFromCache throws GistCorruptError mid-fetchAndCache,
-      // after the cache and ETag have already been mutated.
       const corruptStateRaw = '{"unterminated json';
-      octokit.gists.get.mockResolvedValueOnce({
-        ...makeGistResponse(gistId, corruptStateRaw),
-        headers: { etag: 'W/"v2"' },
-      });
+      octokit.gists.get
+        .mockResolvedValueOnce({ ...makeGistResponse(gistId, initialStateJson), headers: { etag: 'W/"v1"' } })
+        .mockResolvedValueOnce({ ...makeGistResponse(gistId, corruptStateRaw), headers: { etag: 'W/"v2"' } });
 
       const store = new GistStateStore(octokit);
       await store.bootstrap();
@@ -1292,11 +1254,12 @@ describe('GistStateStore', () => {
       const { GistCorruptError } = await import('./errors.js');
       await expect(store.push()).rejects.toThrow(GistCorruptError);
 
-      // Rollback invariants: lastFetchedEtag and cached state.json must
-      // be restored to their pre-refresh values so a follow-up push
-      // does not blindly succeed against the corrupt remote.
+      // Rollback invariants: lastFetchedEtag and cached state.json must be
+      // restored to their pre-read values so a follow-up push does not blindly
+      // succeed against the corrupt remote.
       expect((store as unknown as { lastFetchedEtag: string | null }).lastFetchedEtag).toBe('W/"v1"');
       expect(store.cachedFiles.get(STATE_FILE_NAME)).toBe(initialStateJson);
+      expect(octokit.gists.update).not.toHaveBeenCalled();
     });
   });
 
@@ -1395,6 +1358,9 @@ describe('GistStateStore', () => {
         },
       });
       octokit.gists.update.mockResolvedValue(makeGistResponse(newGistId, seededJson));
+      // The push() pre-write re-read (state.json is dirty) fetches the gist;
+      // return the seeded state.json so the baseline comparison sees no change.
+      octokit.gists.get.mockResolvedValue(makeGistResponse(newGistId, seededJson));
 
       // ── Bootstrap with migration ──────────────────────────────────
       const store = new GistStateStore(octokit);

--- a/packages/core/src/core/gist-state-store.ts
+++ b/packages/core/src/core/gist-state-store.ts
@@ -14,17 +14,25 @@
  *  6. Cache all Gist file contents in memory for session-scoped reads
  *  7. Write state to a local cache file for fallback
  *
- * Concurrency model (#1115, #1235):
+ * Concurrency model (#1115, #1235, #1510):
  *
  *  Each fetch captures the response's `ETag` and stores it as
- *  `lastFetchedEtag`. The next `push()` sends that ETag back as
- *  `If-Match` so the GitHub Gist API rejects the write with 412 Precondition
- *  Failed if another machine pushed in the interval.
+ *  `lastFetchedEtag`. Originally this ETag was replayed as an `If-Match`
+ *  header on `push()` so the GitHub Gist API would reject a stale write with
+ *  412 Precondition Failed. That mechanism never worked against real GitHub:
+ *  the Gist `PATCH` endpoint rejects conditional request headers on unsafe
+ *  methods with HTTP 400 ("Conditional request headers are not allowed in
+ *  unsafe requests unless supported by the endpoint"), which made every Gist
+ *  write fail (#1510). The `If-Match` header is therefore no longer sent, and
+ *  cross-machine writes are effectively last-write-wins.
  *
- *  On 412, the store attempts a single merge: it re-fetches the Gist
- *  (refreshing the ETag), re-applies the in-memory dirty content on top of
- *  the now-current remote state, and pushes once more. If that second push
- *  also returns 412, `push()` throws {@link GistConcurrencyError}.
+ *  The 412 merge path described below is retained as defensive handling but
+ *  is unreachable in normal operation now that no conditional header is sent.
+ *  If a 412 ever does surface, the store attempts a single merge: it
+ *  re-fetches the Gist (refreshing the ETag), re-applies the in-memory dirty
+ *  content on top of the now-current remote state, and pushes once more. If
+ *  that second push also returns 412, `push()` throws
+ *  {@link GistConcurrencyError}.
  *
  *  Per-file conflict policy on the merge re-apply step:
  *
@@ -184,10 +192,13 @@ export class GistStateStore {
   private baselineFiles: Map<string, string> = new Map();
   /**
    * ETag captured from the most recent successful Gist fetch (#1115).
-   * Sent back as `If-Match` on `update` so concurrent writes from another
-   * machine surface as 412 Precondition Failed instead of silently winning
-   * the last-write-wins race. `null` when the SDK didn't surface the header
-   * (e.g. test mocks without headers) — in that case we skip the check.
+   *
+   * Historically replayed as `If-Match` on `update` to detect concurrent
+   * writes, but the Gist `PATCH` endpoint rejects conditional headers with
+   * HTTP 400 (#1510), so it is no longer sent on writes. Still captured on
+   * reads (and on the response of a successful write) so the defensive 412
+   * merge path can roll it back correctly. `null` when the SDK didn't
+   * surface the header (e.g. test mocks without headers).
    */
   private lastFetchedEtag: string | null = null;
   private readonly octokit: OctokitLike;
@@ -464,13 +475,15 @@ export class GistStateStore {
    * Push all dirty files to the backing Gist.
    *
    * Behavior:
-   *  - When an ETag is available from the previous fetch, sends `If-Match`
-   *    so a 412 surfaces if another machine pushed since we last fetched.
-   *  - On 412, attempts a single merge: re-fetches the Gist (refreshing the
-   *    ETag), re-applies the in-memory dirty content on top of the remote,
-   *    and pushes once more. If the second push also 412s, throws
-   *    {@link GistConcurrencyError} — the caller can decide whether to
-   *    refreshFromGist + retry.
+   *  - Writes are sent WITHOUT a conditional `If-Match` header (#1510). The
+   *    Gist `PATCH` endpoint rejects conditional headers on unsafe methods
+   *    with HTTP 400, so replaying the fetched ETag broke every write.
+   *    Cross-machine writes are therefore last-write-wins.
+   *  - The 412 merge path below is retained as defensive handling but is
+   *    unreachable against real GitHub now that `If-Match` is never sent.
+   *    If a 412 ever does surface, it re-fetches, re-applies the in-memory
+   *    dirty content, and pushes once more; a second 412 throws
+   *    {@link GistConcurrencyError}.
    *  - On any other error, retries once (existing behavior). If the retry
    *    also fails, returns `false`.
    *
@@ -499,18 +512,22 @@ export class GistStateStore {
       return out;
     };
 
-    /** Attempt a single push, capturing the response ETag for the next push. */
-    const attempt = async (
-      etag: string | null,
-    ): Promise<{ ok: true } | { ok: false; status?: number; err: unknown }> => {
+    /**
+     * Attempt a single push, capturing the response ETag for the next push.
+     *
+     * Deliberately does NOT send an `If-Match` conditional header (#1510).
+     * GitHub's REST API rejects conditional request headers on unsafe methods
+     * (`PATCH /gists/{id}` among them) with HTTP 400 ("Conditional request
+     * headers are not allowed in unsafe requests unless supported by the
+     * endpoint"), which made every Gist write fail. Reads still capture the
+     * ETag, but it is no longer replayed on the write.
+     */
+    const attempt = async (): Promise<{ ok: true } | { ok: false; status?: number; err: unknown }> => {
       try {
         const params: Parameters<OctokitLike['gists']['update']>[0] = {
           gist_id: this.gistId as string,
           files: buildFiles(),
         };
-        if (etag) {
-          params.headers = { 'if-match': etag };
-        }
         const response = await this.octokit.gists.update(params);
         // Refresh our cached ETag so the next push uses the post-update value.
         const newEtag = extractEtag(response.headers);
@@ -522,10 +539,14 @@ export class GistStateStore {
       }
     };
 
-    // ── Phase 1: best-shot push with current ETag ─────────────────────
-    let result = await attempt(this.lastFetchedEtag);
+    // ── Phase 1: best-shot push ───────────────────────────────────────
+    let result = await attempt();
 
     // ── Phase 2: ETag mismatch — try to merge once ────────────────────
+    // Defensive only: the write no longer sends `If-Match` (#1510), so a
+    // real GitHub Gist PATCH cannot return 412. This block is retained for
+    // the (currently unreachable) case where the endpoint surfaces a 412 by
+    // some other means; downstream callers still handle GistConcurrencyError.
     if (!result.ok && result.status === 412) {
       const expectedEtag = this.lastFetchedEtag;
       debug(MODULE, `push hit 412 (ETag mismatch); attempting merge — refreshing and retrying once`);
@@ -591,7 +612,7 @@ export class GistStateStore {
       }
       // Re-apply our staged dirty contents on top of the refreshed remote.
       reapplyStaged();
-      result = await attempt(this.lastFetchedEtag);
+      result = await attempt();
       if (!result.ok && result.status === 412) {
         warn(MODULE, 'Second push after merge also returned 412; surfacing GistConcurrencyError');
         throw new GistConcurrencyError(expectedEtag, this.lastFetchedEtag);
@@ -601,7 +622,7 @@ export class GistStateStore {
     // ── Phase 3: any other failure — retry once (existing behavior) ───
     if (!result.ok) {
       debug(MODULE, `push failed on first attempt, retrying: ${result.err}`);
-      result = await attempt(this.lastFetchedEtag);
+      result = await attempt();
       if (!result.ok) {
         warn(MODULE, `push failed after retry, giving up: ${result.err}`);
         return false;

--- a/packages/core/src/core/gist-state-store.ts
+++ b/packages/core/src/core/gist-state-store.ts
@@ -16,41 +16,34 @@
  *
  * Concurrency model (#1115, #1235, #1510):
  *
- *  Each fetch captures the response's `ETag` and stores it as
- *  `lastFetchedEtag`. Originally this ETag was replayed as an `If-Match`
- *  header on `push()` so the GitHub Gist API would reject a stale write with
- *  412 Precondition Failed. That mechanism never worked against real GitHub:
- *  the Gist `PATCH` endpoint rejects conditional request headers on unsafe
- *  methods with HTTP 400 ("Conditional request headers are not allowed in
- *  unsafe requests unless supported by the endpoint"), which made every Gist
- *  write fail (#1510). The `If-Match` header is therefore no longer sent, and
- *  cross-machine writes are effectively last-write-wins.
+ *  Optimistic concurrency was originally enforced by replaying the fetched
+ *  `ETag` as an `If-Match` header on `push()`, so the GitHub Gist API would
+ *  reject a stale write with 412 Precondition Failed. That never worked
+ *  against real GitHub: the Gist `PATCH` endpoint rejects conditional request
+ *  headers on unsafe methods with HTTP 400 ("Conditional request headers are
+ *  not allowed in unsafe requests unless supported by the endpoint"), which
+ *  made every Gist write fail (#1510). The `If-Match` header is no longer
+ *  sent.
  *
- *  The 412 merge path described below is retained as defensive handling but
- *  is unreachable in normal operation now that no conditional header is sent.
- *  If a 412 ever does surface, the store attempts a single merge: it
- *  re-fetches the Gist (refreshing the ETag), re-applies the in-memory dirty
- *  content on top of the now-current remote state, and pushes once more. If
- *  that second push also returns 412, `push()` throws
- *  {@link GistConcurrencyError}.
+ *  Concurrency is now enforced client-side with a read-before-write check.
+ *  Each fetch snapshots every file's content as a per-file baseline (the Gist
+ *  API only exposes one ETag for the whole gist, so we cannot detect a
+ *  per-file conflict from headers alone). On `push()`:
  *
- *  Per-file conflict policy on the merge re-apply step:
- *
- *   - `state.json` is fail-loud. The `StateManager` contract advertises
- *     optimistic compare-and-swap (state.ts:285-296), so silently clobbering
- *     a concurrent remote write would violate it. To detect concurrent
- *     writes without per-file ETags (the Gist API only exposes one ETag for
- *     the whole gist), we snapshot each file's content at fetch time. If
- *     the post-refresh `state.json` differs from the snapshot we held
- *     before the refresh, another machine wrote it: `push()` throws
- *     `GistConcurrencyError` instead of overwriting.
+ *   - `state.json` is fail-loud. When it is dirty, `push()` re-reads the Gist
+ *     first and compares the remote `state.json` against the baseline from
+ *     our last fetch. If it moved under us, another machine wrote it:
+ *     `push()` throws {@link GistConcurrencyError} instead of overwriting,
+ *     honoring the `StateManager` optimistic compare-and-swap contract
+ *     (state.ts). The local mutation stays in memory so the caller can
+ *     `refreshFromGist()` and reapply. A small TOCTOU window remains between
+ *     the re-read and the write (the Gist API offers no atomic conditional
+ *     write), but it is far narrower than the last-fetch-to-push window the
+ *     dropped `If-Match` covered.
  *   - Freeform documents (e.g. per-repo guidelines) keep last-write-wins.
  *     The `setDocument` / `setGuidelines` callers' intent on a manual write
- *     is "overwrite". Local dirty content is reapplied on top of the
- *     refreshed remote.
- *
- *  In both cases, when the second push also 412s, local mutations stay in
- *  memory so the caller can decide whether to refresh and retry.
+ *     is "overwrite", and the Gist `files` parameter is a partial update, so
+ *     a freeform-only push needs no re-read and cannot clobber another file.
  */
 
 import * as fs from 'node:fs';
@@ -181,13 +174,14 @@ export class GistStateStore {
   readonly cachedFiles: Map<string, string> = new Map();
   readonly dirtyFiles: Set<string> = new Set();
   /**
-   * Per-file content snapshot captured at fetch time (#1235). The Gist API
-   * exposes a single ETag for the whole gist, so we cannot use `If-Match`
-   * to detect a per-file conflict on the 412 merge re-apply. Holding the
-   * baseline content lets us compare it against the freshly-fetched remote
-   * and decide whether `state.json` changed under us. Updated only by
-   * `fetchAndCache` and successful `push()`; not mutated by `setState` /
-   * `setDocument` so the baseline reflects the remote, not local edits.
+   * Per-file content snapshot captured at fetch time (#1235, #1510). The Gist
+   * API exposes a single ETag for the whole gist and rejects `If-Match` on
+   * writes, so we detect a per-file conflict by content comparison instead:
+   * the read-before-write check in `push()` compares this baseline against
+   * the freshly re-read remote to decide whether `state.json` changed under
+   * us. Updated only by `fetchAndCache` and successful `push()`; not mutated
+   * by `setState` / `setDocument` so the baseline reflects the remote, not
+   * local edits.
    */
   private baselineFiles: Map<string, string> = new Map();
   /**
@@ -195,10 +189,11 @@ export class GistStateStore {
    *
    * Historically replayed as `If-Match` on `update` to detect concurrent
    * writes, but the Gist `PATCH` endpoint rejects conditional headers with
-   * HTTP 400 (#1510), so it is no longer sent on writes. Still captured on
-   * reads (and on the response of a successful write) so the defensive 412
-   * merge path can roll it back correctly. `null` when the SDK didn't
-   * surface the header (e.g. test mocks without headers).
+   * HTTP 400 (#1510), so it is no longer sent on writes — concurrency is now
+   * detected by the read-before-write content comparison in `push()`. The
+   * ETag is still captured on reads (and on a successful write response) and
+   * carried on {@link GistConcurrencyError} for diagnostics / rollback.
+   * `null` when the SDK didn't surface the header (e.g. test mocks).
    */
   private lastFetchedEtag: string | null = null;
   private readonly octokit: OctokitLike;
@@ -477,19 +472,30 @@ export class GistStateStore {
    * Behavior:
    *  - Writes are sent WITHOUT a conditional `If-Match` header (#1510). The
    *    Gist `PATCH` endpoint rejects conditional headers on unsafe methods
-   *    with HTTP 400, so replaying the fetched ETag broke every write.
-   *    Cross-machine writes are therefore last-write-wins.
-   *  - The 412 merge path below is retained as defensive handling but is
-   *    unreachable against real GitHub now that `If-Match` is never sent.
-   *    If a 412 ever does surface, it re-fetches, re-applies the in-memory
-   *    dirty content, and pushes once more; a second 412 throws
-   *    {@link GistConcurrencyError}.
-   *  - On any other error, retries once (existing behavior). If the retry
-   *    also fails, returns `false`.
+   *    with HTTP 400, so the server cannot enforce optimistic concurrency.
+   *  - Optimistic concurrency is instead enforced client-side: when
+   *    `state.json` is among the dirty files, `push()` re-reads the Gist
+   *    first and compares the remote `state.json` against the baseline
+   *    captured at our last fetch. If it moved under us, another machine
+   *    wrote concurrently and `push()` throws {@link GistConcurrencyError}
+   *    instead of clobbering — preserving the StateManager compare-and-swap
+   *    contract (#1235). The local mutation stays in memory so the caller
+   *    can `refreshFromGist()` and reapply. There is a small unavoidable
+   *    TOCTOU window between the re-read and the write (the Gist API offers
+   *    no atomic conditional write), but it is far narrower than the
+   *    last-fetch-to-push window the dropped `If-Match` covered.
+   *  - Freeform documents (guidelines, etc.) keep last-write-wins: the Gist
+   *    `files` parameter is a partial update, so a freeform-only push needs
+   *    no re-read and cannot clobber another file.
+   *  - On any push error, retries once. If the retry also fails, returns
+   *    `false`.
    *
    * Returns `true` on success (or when there is nothing to push).
-   * Returns `false` if a non-conflict push fails on both attempts.
-   * Throws {@link GistConcurrencyError} on unresolvable conflicts (#1115).
+   * Returns `false` if a push fails on both attempts.
+   * Throws {@link GistConcurrencyError} when `state.json` moved remotely
+   * since our last fetch (#1235, #1510).
+   * Throws {@link GistCorruptError} when the pre-write re-read finds a
+   * corrupt remote (so the caller does not retry against it).
    * Throws if the Gist ID has not been resolved yet (bootstrap not called).
    */
   async push(): Promise<boolean> {
@@ -539,87 +545,74 @@ export class GistStateStore {
       }
     };
 
-    // ── Phase 1: best-shot push ───────────────────────────────────────
-    let result = await attempt();
-
-    // ── Phase 2: ETag mismatch — try to merge once ────────────────────
-    // Defensive only: the write no longer sends `If-Match` (#1510), so a
-    // real GitHub Gist PATCH cannot return 412. This block is retained for
-    // the (currently unreachable) case where the endpoint surfaces a 412 by
-    // some other means; downstream callers still handle GistConcurrencyError.
-    if (!result.ok && result.status === 412) {
-      const expectedEtag = this.lastFetchedEtag;
-      debug(MODULE, `push hit 412 (ETag mismatch); attempting merge — refreshing and retrying once`);
-      // Snapshot the dirty contents before refresh (fetchAndCache wipes the cache).
+    // ── Optimistic-concurrency check (#1510) ──────────────────────────
+    // The Gist PATCH endpoint rejects conditional `If-Match` headers, so we
+    // enforce optimistic concurrency client-side: re-read the Gist and
+    // compare its `state.json` against the baseline captured at our last
+    // fetch. If it changed under us, another machine wrote concurrently —
+    // fail loud rather than clobber (#1235). We only pay the round-trip when
+    // `state.json` is dirty; freeform documents (guidelines, etc.) keep
+    // last-write-wins because the Gist `files` parameter is a partial update.
+    if (this.dirtyFiles.has(STATE_FILE_NAME)) {
+      // Snapshot the staged dirty contents before the re-read — fetchAndCache
+      // clears and repopulates the cache from the remote.
       const stagedContents: Record<string, string> = {};
       for (const filename of this.dirtyFiles) {
         const content = this.cachedFiles.get(filename);
         if (content !== undefined) stagedContents[filename] = content;
       }
-      // Snapshot the full cache and baseline before refresh so a partial
-      // failure inside fetchAndCache (e.g. parse throws after the cache
-      // was already cleared and repopulated) can be rolled back without
-      // leaving the store with a stale ETag pointing at corrupt or
-      // half-populated state (#1235).
-      const preRefreshCache = new Map(this.cachedFiles);
-      const preRefreshBaseline = new Map(this.baselineFiles);
-      const preRefreshEtag = this.lastFetchedEtag;
+      // Snapshot the full cache, baseline, and ETag so a failed re-read
+      // (e.g. a parse throwing after the cache was already cleared) can be
+      // rolled back without leaving the store half-populated (#1235).
+      const preReadCache = new Map(this.cachedFiles);
+      const preReadBaseline = new Map(this.baselineFiles);
+      const preReadEtag = this.lastFetchedEtag;
+      const baselineStateJson = preReadBaseline.get(STATE_FILE_NAME);
       const reapplyStaged = (): void => {
         for (const [filename, content] of Object.entries(stagedContents)) {
           this.cachedFiles.set(filename, content);
         }
       };
+
       try {
         await this.fetchAndCache(this.gistId);
-      } catch (refreshErr) {
-        warn(MODULE, `Merge refresh after 412 failed: ${refreshErr}`);
-        // Roll back any partial mutation from fetchAndCache so the
-        // caller's retry path sees the prior state (with local
-        // mutations re-applied on top).
+      } catch (readErr) {
+        warn(MODULE, `Pre-write re-read failed: ${readErr}`);
+        // Roll back any partial mutation so the caller's retry path sees the
+        // prior in-memory state with local mutations re-applied on top.
         this.cachedFiles.clear();
-        for (const [filename, content] of preRefreshCache) {
+        for (const [filename, content] of preReadCache) {
           this.cachedFiles.set(filename, content);
         }
-        this.baselineFiles = preRefreshBaseline;
-        this.lastFetchedEtag = preRefreshEtag;
+        this.baselineFiles = preReadBaseline;
+        this.lastFetchedEtag = preReadEtag;
         reapplyStaged();
-        // Preserve the GistCorruptError type so callers don't retry
-        // against a corrupt remote (which a CONCURRENCY_ERROR would
-        // invite). Other failure types continue to surface as a
-        // concurrency error — the gist content is still likely fine.
-        if (refreshErr instanceof GistCorruptError) throw refreshErr;
-        throw new GistConcurrencyError(expectedEtag, null);
+        // Preserve GistCorruptError so callers don't retry against a corrupt
+        // remote. Any other failure surfaces as a concurrency error — the
+        // gist content is still likely fine, the caller can refresh + retry.
+        if (readErr instanceof GistCorruptError) throw readErr;
+        throw new GistConcurrencyError(preReadEtag, null);
       }
-      // Per-file conflict policy (#1235):
-      //  - state.json must fail loud when its remote copy moved under us;
-      //    silently overwriting would violate the StateManager
-      //    optimistic-concurrency contract (state.ts:285-296).
-      //  - Freeform documents (guidelines, etc.) keep last-write-wins —
-      //    `setDocument` callers' intent on a manual write is "overwrite".
-      if (stagedContents[STATE_FILE_NAME] !== undefined) {
-        const baselineBeforeRefresh = preRefreshBaseline.get(STATE_FILE_NAME);
-        const remoteAfterRefresh = this.cachedFiles.get(STATE_FILE_NAME);
-        if (baselineBeforeRefresh !== remoteAfterRefresh) {
-          warn(
-            MODULE,
-            'state.json changed remotely while a push was in flight; surfacing GistConcurrencyError instead of clobbering (#1235)',
-          );
-          // Preserve local state.json (and other staged dirty files) in
-          // memory so the caller can refresh and reapply if appropriate.
-          reapplyStaged();
-          throw new GistConcurrencyError(expectedEtag, this.lastFetchedEtag);
-        }
+
+      const remoteStateJson = this.cachedFiles.get(STATE_FILE_NAME);
+      if (baselineStateJson !== remoteStateJson) {
+        warn(
+          MODULE,
+          'state.json changed remotely since our last fetch; surfacing GistConcurrencyError instead of clobbering (#1235, #1510)',
+        );
+        // Preserve local state.json (and other staged dirty files) in memory
+        // so the caller can refresh and reapply if appropriate.
+        reapplyStaged();
+        throw new GistConcurrencyError(preReadEtag, this.lastFetchedEtag);
       }
-      // Re-apply our staged dirty contents on top of the refreshed remote.
+
+      // No conflict — re-apply our staged dirty contents on top of the
+      // refreshed remote so the write carries our edits.
       reapplyStaged();
-      result = await attempt();
-      if (!result.ok && result.status === 412) {
-        warn(MODULE, 'Second push after merge also returned 412; surfacing GistConcurrencyError');
-        throw new GistConcurrencyError(expectedEtag, this.lastFetchedEtag);
-      }
     }
 
-    // ── Phase 3: any other failure — retry once (existing behavior) ───
+    // ── Write (unconditional) with a single retry on transient failure ─
+    let result = await attempt();
     if (!result.ok) {
       debug(MODULE, `push failed on first attempt, retrying: ${result.err}`);
       result = await attempt();
@@ -629,9 +622,9 @@ export class GistStateStore {
       }
     }
 
-    // Success: flush dirty set and write local cache. Refresh the
-    // per-file baseline to reflect what we just wrote — the next 412
-    // merge re-apply check compares against this.
+    // Success: flush dirty set and write local cache. Refresh the per-file
+    // baseline to reflect what we just wrote — the next pre-write conflict
+    // check compares against this.
     this.dirtyFiles.clear();
     this.baselineFiles = new Map(this.cachedFiles);
 

--- a/packages/core/src/core/state.test.ts
+++ b/packages/core/src/core/state.test.ts
@@ -1227,3 +1227,35 @@ describe('maybeCheckpoint (#1370)', () => {
     expect(warning).toMatch(/socket hang up/);
   });
 });
+
+describe('StateManager.checkpoint gistDegraded (#1510)', () => {
+  const makeMockGistStore = (push: ReturnType<typeof vi.fn>) => ({
+    setState: vi.fn(),
+    push,
+  });
+
+  it('flips gistDegraded to true when push fails after retries', async () => {
+    const manager = new StateManager(true);
+    const mockGistStore = makeMockGistStore(vi.fn().mockResolvedValue(false));
+    (manager as unknown as { gistStore: unknown }).gistStore = mockGistStore;
+
+    expect(manager.isGistDegraded()).toBe(false);
+
+    const pushed = await manager.checkpoint();
+
+    expect(pushed).toBe(false);
+    expect(manager.isGistDegraded()).toBe(true);
+    expect(mockGistStore.setState).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves gistDegraded false on a successful push', async () => {
+    const manager = new StateManager(true);
+    const mockGistStore = makeMockGistStore(vi.fn().mockResolvedValue(true));
+    (manager as unknown as { gistStore: unknown }).gistStore = mockGistStore;
+
+    const pushed = await manager.checkpoint();
+
+    expect(pushed).toBe(true);
+    expect(manager.isGistDegraded()).toBe(false);
+  });
+});

--- a/packages/core/src/core/state.ts
+++ b/packages/core/src/core/state.ts
@@ -382,7 +382,15 @@ export class StateManager {
   async checkpoint(): Promise<boolean> {
     if (!this.gistStore) return true; // not in Gist mode
     this.gistStore.setState(JSON.stringify(this.state, null, 2));
-    return this.gistStore.push();
+    const pushed = await this.gistStore.push();
+    // A push that fails after its internal retry means the Gist is no longer
+    // the authoritative copy of our in-memory state — surface that as degraded
+    // so `state --show`, the daily check, and doctor stop reporting healthy
+    // (#1510). A later successful refresh/checkpoint can clear it.
+    if (!pushed) {
+      this.gistDegraded = true;
+    }
+    return pushed;
   }
 
   /** Whether this StateManager is backed by a Gist. */


### PR DESCRIPTION
## Summary

Fixes Gist persistence writes failing deterministically with HTTP 400.

Gist mode used ETag-based optimistic concurrency (added in #1115): it cached the ETag from a GET and replayed it as a conditional `If-Match` header on the `PATCH /gists/{id}` write. GitHub's REST API rejects conditional request headers on unsafe methods ("Conditional request headers are not allowed in unsafe requests unless supported by the endpoint"), so every Gist push 400'd. That made Gist mode unusable for writes and blocked `guidelines store` (extract-learnings) and `state --sync`.

The fix drops the unsupported header and re-implements optimistic concurrency client-side, so the `state.json` fail-loud contract from #1235 is preserved rather than degraded to last-write-wins.

## Changes

- Stop sending the `If-Match` conditional header on the `PATCH /gists/{id}` write (the 400 root cause). Reads still capture the ETag.
- Enforce optimistic concurrency with a read-before-write check: when `state.json` is dirty, `push()` re-reads the Gist and compares the remote `state.json` against the baseline from the last fetch. If it moved under us, throw `GistConcurrencyError` instead of clobbering; the local mutation stays in memory so the caller can `refreshFromGist()` and reapply. A small TOCTOU window remains (the Gist API has no atomic conditional write) but it is far narrower than the last-fetch-to-push window the old header nominally covered.
- Freeform documents (guidelines, etc.) keep last-write-wins and skip the re-read, since the Gist `files` parameter is a partial update and cannot clobber another file.
- Flip `gistDegraded` to true when `checkpoint()`'s push fails after retries, so `state --show`, the daily check, and doctor stop reporting healthy after a failed sync.

## Related Issues

Closes #1510

## Checklist

- [x] Tests pass (`pnpm test`) (core 2970 passed; the 2 failing `state-gist-init` tests are pre-existing and reproduce on `main`, caused by a real GitHub token without gist scope leaking into local-mode assertions)
- [x] Commits follow conventional format (`feat:`, `fix:`, `chore:`)
- [x] No manual version bumps or CHANGELOG edits (automated via release-please)
