### PR TITLE
fix(test): make state-gist-init hermetic, stop reading real ~/.oss-autopilot

### DIFF
--- a/packages/core/src/core/state-gist-init.test.ts
+++ b/packages/core/src/core/state-gist-init.test.ts
@@ -44,6 +44,23 @@ vi.mock('./paths.js', async (importOriginal) => {
     },
     getLegacyStatePath: () => path.join(mockTmpDir, 'legacy-data', 'state.json'),
     getLegacyBackupDir: () => path.join(mockTmpDir, 'legacy-data', 'backups'),
+    // Without these, `peekGistArtifacts()` (the ENOENT fallback inside
+    // `ensureGistPersistence`) reads the developer's real `~/.oss-autopilot/`
+    // state-cache.json / gist-id. On a machine that ever enabled gist mode the
+    // cache carries `persistence: gist`, so the "local-mode" tests below would
+    // (a) misclassify as gist and (b) make a live `GET /gists` call that 401s
+    // when the ambient token lacks gist scope. Redirect both into the tmp dir
+    // so the suite is hermetic regardless of the host's gist artifacts.
+    getStateCachePath: () => {
+      if (!mockTmpDir) throw new Error('mockTmpDir not set');
+      if (!fs.existsSync(mockTmpDir)) fs.mkdirSync(mockTmpDir, { recursive: true, mode: 0o700 });
+      return path.join(mockTmpDir, 'state-cache.json');
+    },
+    getGistIdPath: () => {
+      if (!mockTmpDir) throw new Error('mockTmpDir not set');
+      if (!fs.existsSync(mockTmpDir)) fs.mkdirSync(mockTmpDir, { recursive: true, mode: 0o700 });
+      return path.join(mockTmpDir, 'gist-id');
+    },
   };
 });
 


### PR DESCRIPTION
## Summary

The `state-gist-init.test.ts` mock of `./paths.js` overrode `getDataDir`/`getStatePath`/`getBackupDir` but not `getStateCachePath`/`getGistIdPath`. So the ENOENT fallback inside `ensureGistPersistence` (`peekGistArtifacts`) read the developer's **real** `~/.oss-autopilot/state-cache.json` and `gist-id`.

On any machine that ever enabled gist mode, that cache carries `persistence: gist`, so the two "local-mode" tests (a) misclassified as gist and (b) made a live `GET /gists` call that 401s when the ambient token lacks gist scope. CI passed only because its home dir is clean — making this a real latent test-isolation bug, not environmental noise.

## Changes

- Redirect `getStateCachePath` and `getGistIdPath` into the per-test tmp dir in the `vi.mock('./paths.js')` factory, matching the pattern already used in `gist-state-store.test.ts`.

## Related Issues

(No issue filed; surfaced while verifying #1510. Affects local `pnpm test` only.)

## Checklist

- [x] Tests pass (`pnpm test`) — full core suite now 2972 passed, 0 failed (was 2 failed locally)
- [x] Commits follow conventional format
- [x] No manual version bumps or CHANGELOG edits