### PR TITLE
chore(deps): bump @oss-scout/core to 1.2.1

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "@octokit/plugin-throttling": "^11.0.3",
     "@octokit/rest": "^22.0.1",
-    "@oss-scout/core": "^1.2.0",
+    "@oss-scout/core": "^1.2.1",
     "commander": "^15.0.0",
     "zod": "^4.4.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@oss-scout/core':
-        specifier: ^1.2.0
-        version: 1.2.0(@octokit/core@7.0.6)
+        specifier: ^1.2.1
+        version: 1.2.1(@octokit/core@7.0.6)
       commander:
         specifier: ^15.0.0
         version: 15.0.0
@@ -692,8 +692,8 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@oss-scout/core@1.2.0':
-    resolution: {integrity: sha512-yZRbbhUZwQyib5CHNMew46sH8yy2cef39NovoyEB3NCAVsKqO6kNnsf/12XOzbHI4w0azPtMG/MwKikeZWbaXQ==}
+  '@oss-scout/core@1.2.1':
+    resolution: {integrity: sha512-7hWL3BOJ9cIXV226iAibBkBY34/zLxboJ1YzdDqrxCw3Oqjvc0foTbNSyAY+mmllqBq74fjeJET63HxiHzMhzQ==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
@@ -3321,7 +3321,7 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@oss-scout/core@1.2.0(@octokit/core@7.0.6)':
+  '@oss-scout/core@1.2.1(@octokit/core@7.0.6)':
     dependencies:
       '@octokit/plugin-throttling': 11.0.3(@octokit/core@7.0.6)
       '@octokit/rest': 22.0.1


### PR DESCRIPTION
## Summary

Bump `@oss-scout/core` 1.2.0 → 1.2.1 to pull in the Phase 0 budget cap (oss-scout#246).

After the depth bump (1.2.0), Phase 0 consumed the entire result budget, so the starred and broad search phases stopped running — every search round returned only contributed-repo results. 1.2.1 caps Phase 0's share (conditionally, so contributed-only users don't under-fill), restoring Phase 1 (starred) search.

## Changes

- `@oss-scout/core` `^1.2.0` → `^1.2.1` + lockfile.
- Bundle is gitignored / CI-built; locally rebuilt and confirmed the installed scout 1.2.1 carries the cap logic.

## Verification

- Full core suite: 2970 pass. The 2 `state-gist-init` failures are pre-existing/environmental (ambient token gist scope), unrelated to this bump.
