### PR TITLE
fix(search): populate starred-repo cache so scout's starred phase fires

### DIFF
--- a/packages/core/src/commands/search.contract.test.ts
+++ b/packages/core/src/commands/search.contract.test.ts
@@ -42,6 +42,13 @@ vi.mock('../core/index.js', async () => {
   };
 });
 
+// The starred-repo refresh has its own test (starred-repos.test.ts); stub it
+// here so the contract test stays offline and independent of the minimal
+// state-manager mock above (which has no starred methods).
+vi.mock('../core/starred-repos.js', () => ({
+  refreshStarredReposIfStale: vi.fn().mockResolvedValue(0),
+}));
+
 import { runSearch } from './search.js';
 import { SearchOutputSchema } from '../formatters/json.js';
 import { schemaIssues } from '../core/test-utils.js';

--- a/packages/core/src/commands/search.test.ts
+++ b/packages/core/src/commands/search.test.ts
@@ -24,6 +24,13 @@ vi.mock('../core/index.js', async () => {
   };
 });
 
+// The starred-repo refresh has its own test (starred-repos.test.ts); stub it
+// here so runSearch tests stay offline and independent of the state-manager
+// mock shape used per-test.
+vi.mock('../core/starred-repos.js', () => ({
+  refreshStarredReposIfStale: vi.fn().mockResolvedValue(0),
+}));
+
 import { getStateManager } from '../core/index.js';
 import { createAutopilotScout, type ScoutBridgeDiagnostics } from './scout-bridge.js';
 import { runSearch } from './search.js';

--- a/packages/core/src/commands/search.ts
+++ b/packages/core/src/commands/search.ts
@@ -14,6 +14,7 @@ import { classifyLinkedPR, getStateManager } from '../core/index.js';
 import { type SearchOutput } from '../formatters/json.js';
 import { gradeFromCandidate } from '../core/issue-grading.js';
 import { computeStrategy } from '../core/strategy.js';
+import { refreshStarredReposIfStale } from '../core/starred-repos.js';
 import { debug, warn } from '../core/logger.js';
 
 export { type SearchOutput } from '../formatters/json.js';
@@ -103,8 +104,17 @@ export async function runSearch(options: SearchOptions): Promise<SearchOutput> {
   // means scout searched with an empty skip list, so explicitly-skipped
   // issues may resurface — the envelope must say so, not just stderr.
   const bridgeDiagnostics: ScoutBridgeDiagnostics = {};
-  const scout = await createAutopilotScout(bridgeDiagnostics);
   const stateManager = getStateManager();
+
+  // Populate the starred-repo cache before the scout is created. Scout's
+  // discovery runs a starred-repo search phase, but it only fires when
+  // config.starredRepos is non-empty, and createAutopilotScout snapshots that
+  // config into the ScoutState. Without this refresh the starred phase is a
+  // silent no-op and discovery recycles the merged-PR repos every run. Fails
+  // soft, so a GitHub hiccup never blocks the search.
+  await refreshStarredReposIfStale(stateManager);
+
+  const scout = await createAutopilotScout(bridgeDiagnostics);
 
   // Derive personalization from local history (#1244). `computeStrategy`
   // returns null below the merged-PR floor — in that case we pass nothing

--- a/packages/core/src/core/starred-repos.test.ts
+++ b/packages/core/src/core/starred-repos.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for starred-repo cache refresh.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetOctokit = vi.fn();
+const mockRequireGitHubToken = vi.fn(() => 'test-token');
+
+vi.mock('./github.js', () => ({
+  getOctokit: (token: string) => mockGetOctokit(token),
+}));
+
+vi.mock('./auth.js', () => ({
+  requireGitHubToken: () => mockRequireGitHubToken(),
+}));
+
+import { refreshStarredReposIfStale, type StarredReposState } from './starred-repos.js';
+
+/** Build a fake octokit whose paginate.iterator yields the given pages. */
+function fakeOctokit(pages: Array<Array<{ full_name?: string }>>): unknown {
+  return {
+    activity: { listReposStarredByAuthenticatedUser: vi.fn() },
+    paginate: {
+      iterator: async function* () {
+        for (const data of pages) {
+          yield { data };
+        }
+      },
+    },
+  };
+}
+
+function makeState(overrides: Partial<StarredReposState> & { stale: boolean; cached?: string[] }): {
+  state: StarredReposState;
+  setStarredRepos: ReturnType<typeof vi.fn>;
+} {
+  let cached = overrides.cached ?? [];
+  const setStarredRepos = vi.fn((repos: string[]) => {
+    cached = repos;
+  });
+  const state: StarredReposState = {
+    isStarredReposStale: () => overrides.stale,
+    getStarredRepos: () => cached,
+    setStarredRepos,
+  };
+  return { state, setStarredRepos };
+}
+
+describe('refreshStarredReposIfStale', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireGitHubToken.mockReturnValue('test-token');
+  });
+
+  it('propagates a missing-token error instead of swallowing it', async () => {
+    mockRequireGitHubToken.mockImplementation(() => {
+      throw new Error('GitHub authentication required');
+    });
+    const { state, setStarredRepos } = makeState({ stale: true, cached: [] });
+
+    await expect(refreshStarredReposIfStale(state)).rejects.toThrow(
+      'GitHub authentication required',
+    );
+    expect(mockGetOctokit).not.toHaveBeenCalled();
+    expect(setStarredRepos).not.toHaveBeenCalled();
+  });
+
+  it('fetches and caches starred repos when the cache is stale', async () => {
+    mockGetOctokit.mockReturnValue(
+      fakeOctokit([
+        [{ full_name: 'a/one' }, { full_name: 'b/two' }],
+        [{ full_name: 'c/three' }],
+      ]),
+    );
+    const { state, setStarredRepos } = makeState({ stale: true });
+
+    const count = await refreshStarredReposIfStale(state);
+
+    expect(count).toBe(3);
+    expect(setStarredRepos).toHaveBeenCalledWith(['a/one', 'b/two', 'c/three']);
+  });
+
+  it('skips the fetch entirely when the cache is fresh', async () => {
+    const { state, setStarredRepos } = makeState({
+      stale: false,
+      cached: ['x/y', 'z/w'],
+    });
+
+    const count = await refreshStarredReposIfStale(state);
+
+    expect(count).toBe(2);
+    expect(mockGetOctokit).not.toHaveBeenCalled();
+    expect(setStarredRepos).not.toHaveBeenCalled();
+  });
+
+  it('drops entries without a full_name', async () => {
+    mockGetOctokit.mockReturnValue(
+      fakeOctokit([[{ full_name: 'a/one' }, {}, { full_name: 'b/two' }]]),
+    );
+    const { state, setStarredRepos } = makeState({ stale: true });
+
+    await refreshStarredReposIfStale(state);
+
+    expect(setStarredRepos).toHaveBeenCalledWith(['a/one', 'b/two']);
+  });
+
+  it('keeps the existing cache when the fetch returns zero repos', async () => {
+    // A transient/partial empty response must not wipe a good cache and stamp it
+    // fresh for 24h, which would silently re-disable the starred phase.
+    mockGetOctokit.mockReturnValue(fakeOctokit([[]]));
+    const { state, setStarredRepos } = makeState({
+      stale: true,
+      cached: ['kept/repo'],
+    });
+
+    const count = await refreshStarredReposIfStale(state);
+
+    expect(count).toBe(1);
+    expect(setStarredRepos).not.toHaveBeenCalled();
+  });
+
+  it('fails soft and keeps the existing cache when the fetch throws', async () => {
+    mockGetOctokit.mockImplementation(() => {
+      throw new Error('GitHub down');
+    });
+    const { state, setStarredRepos } = makeState({
+      stale: true,
+      cached: ['old/repo'],
+    });
+
+    const count = await refreshStarredReposIfStale(state);
+
+    expect(count).toBe(1);
+    expect(setStarredRepos).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/core/starred-repos.test.ts
+++ b/packages/core/src/core/starred-repos.test.ts
@@ -59,19 +59,14 @@ describe('refreshStarredReposIfStale', () => {
     });
     const { state, setStarredRepos } = makeState({ stale: true, cached: [] });
 
-    await expect(refreshStarredReposIfStale(state)).rejects.toThrow(
-      'GitHub authentication required',
-    );
+    await expect(refreshStarredReposIfStale(state)).rejects.toThrow('GitHub authentication required');
     expect(mockGetOctokit).not.toHaveBeenCalled();
     expect(setStarredRepos).not.toHaveBeenCalled();
   });
 
   it('fetches and caches starred repos when the cache is stale', async () => {
     mockGetOctokit.mockReturnValue(
-      fakeOctokit([
-        [{ full_name: 'a/one' }, { full_name: 'b/two' }],
-        [{ full_name: 'c/three' }],
-      ]),
+      fakeOctokit([[{ full_name: 'a/one' }, { full_name: 'b/two' }], [{ full_name: 'c/three' }]]),
     );
     const { state, setStarredRepos } = makeState({ stale: true });
 
@@ -95,9 +90,7 @@ describe('refreshStarredReposIfStale', () => {
   });
 
   it('drops entries without a full_name', async () => {
-    mockGetOctokit.mockReturnValue(
-      fakeOctokit([[{ full_name: 'a/one' }, {}, { full_name: 'b/two' }]]),
-    );
+    mockGetOctokit.mockReturnValue(fakeOctokit([[{ full_name: 'a/one' }, {}, { full_name: 'b/two' }]]));
     const { state, setStarredRepos } = makeState({ stale: true });
 
     await refreshStarredReposIfStale(state);

--- a/packages/core/src/core/starred-repos.ts
+++ b/packages/core/src/core/starred-repos.ts
@@ -29,20 +29,15 @@ export interface StarredReposState {
 }
 
 /** Page through the authenticated user's stars, collecting `owner/repo` names. */
-async function collectStarredRepoNames(
-  octokit: ReturnType<typeof getOctokit>,
-): Promise<string[]> {
+async function collectStarredRepoNames(octokit: ReturnType<typeof getOctokit>): Promise<string[]> {
   const repos: string[] = [];
   let page = 0;
-  for await (const response of octokit.paginate.iterator(
-    octokit.activity.listReposStarredByAuthenticatedUser,
-    {
-      per_page: PER_PAGE,
-      // Default media type returns the repo object directly (with full_name);
-      // the star+timestamp media type would wrap it in { repo, starred_at }.
-      headers: { accept: 'application/vnd.github.v3+json' },
-    },
-  )) {
+  for await (const response of octokit.paginate.iterator(octokit.activity.listReposStarredByAuthenticatedUser, {
+    per_page: PER_PAGE,
+    // Default media type returns the repo object directly (with full_name);
+    // the star+timestamp media type would wrap it in { repo, starred_at }.
+    headers: { accept: 'application/vnd.github.v3+json' },
+  })) {
     for (const repo of response.data as Array<{ full_name?: string }>) {
       if (repo.full_name) repos.push(repo.full_name);
     }
@@ -61,9 +56,7 @@ async function collectStarredRepoNames(
  * number of repos cached after the call (freshly fetched, or the existing list
  * when fresh / on error).
  */
-export async function refreshStarredReposIfStale(
-  state: StarredReposState,
-): Promise<number> {
+export async function refreshStarredReposIfStale(state: StarredReposState): Promise<number> {
   if (!state.isStarredReposStale()) {
     return state.getStarredRepos().length;
   }

--- a/packages/core/src/core/starred-repos.ts
+++ b/packages/core/src/core/starred-repos.ts
@@ -1,0 +1,101 @@
+/**
+ * Starred-repo cache refresh.
+ *
+ * Scout's discovery runs a starred-repo search phase (Phase 1), but it only
+ * fires when `config.starredRepos` is non-empty. The autopilot never populated
+ * that cache — `init` imports PR history only — so the starred phase was a
+ * silent no-op for every user and discovery kept recycling the merged-PR repos.
+ * This module fetches the user's stars from GitHub and fills the cache so the
+ * phase has input.
+ */
+
+import { getOctokit } from './github.js';
+import { requireGitHubToken } from './auth.js';
+import { debug, warn } from './logger.js';
+
+const MODULE = 'starred-repos';
+
+/** Page size for the starred-repos listing (GitHub max is 100). */
+const PER_PAGE = 100;
+
+/** Cap pages so an account that starred thousands of repos can't stall discovery. */
+const MAX_PAGES = 5;
+
+/** Minimal state surface this refresh needs — keeps it unit-testable. */
+export interface StarredReposState {
+  isStarredReposStale(): boolean;
+  getStarredRepos(): string[];
+  setStarredRepos(repos: string[]): void;
+}
+
+/** Page through the authenticated user's stars, collecting `owner/repo` names. */
+async function collectStarredRepoNames(
+  octokit: ReturnType<typeof getOctokit>,
+): Promise<string[]> {
+  const repos: string[] = [];
+  let page = 0;
+  for await (const response of octokit.paginate.iterator(
+    octokit.activity.listReposStarredByAuthenticatedUser,
+    {
+      per_page: PER_PAGE,
+      // Default media type returns the repo object directly (with full_name);
+      // the star+timestamp media type would wrap it in { repo, starred_at }.
+      headers: { accept: 'application/vnd.github.v3+json' },
+    },
+  )) {
+    for (const repo of response.data as Array<{ full_name?: string }>) {
+      if (repo.full_name) repos.push(repo.full_name);
+    }
+    page += 1;
+    if (page >= MAX_PAGES) break;
+  }
+  return repos;
+}
+
+/**
+ * Refresh the cached starred-repo list from GitHub when the cache is stale
+ * (>24h) or empty, so scout's starred-repo search phase has repos to query.
+ *
+ * Fails soft: a fetch error logs a warning and leaves the existing cache
+ * untouched, so a transient GitHub failure never blocks a search. Returns the
+ * number of repos cached after the call (freshly fetched, or the existing list
+ * when fresh / on error).
+ */
+export async function refreshStarredReposIfStale(
+  state: StarredReposState,
+): Promise<number> {
+  if (!state.isStarredReposStale()) {
+    return state.getStarredRepos().length;
+  }
+
+  // A missing token is a configuration error, not a transient fetch failure —
+  // let it propagate so the caller surfaces the actionable auth message rather
+  // than silently degrading to an empty starred phase.
+  const token = requireGitHubToken();
+
+  // Only the network fetch is fail-soft: a transient GitHub error must not block
+  // the search. Token resolution (above) and the state write (below) stay
+  // outside the catch so genuine config/persistence faults aren't masked.
+  let repos: string[];
+  try {
+    repos = await collectStarredRepoNames(getOctokit(token));
+  } catch (err) {
+    warn(
+      MODULE,
+      `Failed to refresh starred repos; continuing with cached list (${state.getStarredRepos().length}): ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return state.getStarredRepos().length;
+  }
+
+  // A successful-but-empty response (transient/partial API result) must not wipe
+  // a populated cache and then stamp it fresh for 24h — that would silently
+  // re-disable the very phase this refresh exists to feed. Keep the old list.
+  if (repos.length === 0) {
+    debug(MODULE, 'Starred-repo fetch returned 0; keeping existing cache');
+    return state.getStarredRepos().length;
+  }
+
+  state.setStarredRepos(repos);
+  debug(MODULE, `Refreshed starred repos from GitHub: ${repos.length} cached`);
+  return repos.length;
+}


### PR DESCRIPTION
## Summary

Scout's discovery runs a starred-repo search phase (Phase 1), but it only fires when `config.starredRepos` is non-empty. The autopilot never populated that cache (`init` imports PR history only), so the phase was a silent no-op and discovery kept recycling the merged-PR repos every run. The `setStarredRepos` / `isStarredReposStale` plumbing already existed but was dead code, never called from production.

This adds a `refreshStarredReposIfStale()` step that fills the cache from the user's GitHub stars, so the starred phase actually has repos to search.

## Changes

- New `core/starred-repos.ts` with `refreshStarredReposIfStale()`. It paginates `activity.listReposStarredByAuthenticatedUser` and calls the existing `setStarredRepos()`, gated on the existing 24h `isStarredReposStale()` check.
- `runSearch` calls it before `createAutopilotScout`, because `buildScoutState` snapshots `config.starredRepos` into the ScoutState at creation time.
- Error handling is deliberate. A missing token propagates as the existing `ConfigurationError` (matching `runSearch`'s documented contract) rather than being swallowed. Only the network fetch is fail-soft so a transient GitHub error never blocks a search. A successful but empty response does not overwrite a populated cache (which would otherwise wipe it and stamp it fresh for 24h, re-disabling the phase).
- Unit tests for the helper plus a stub in the existing search tests.

Verified live before and after. Before, the phase log read `Phase 1: Searching issues in 0 starred repos` and was skipped. After, it reads `Phase 1: Searching issues in 87 starred repos` and all four phases fire, surfacing candidates from repos that never appeared while only the merged-PR phase was active.

## Related Issues

(none filed; found while debugging repeated identical search results)

## Checklist

- [x] Tests pass (`pnpm test`) for the affected package (23 tests in the two files; full core suite green except pre-existing gist-scope env failures unrelated to this change)
- [x] Commits follow conventional format (`feat:`, `fix:`, `chore:`)
- [x] No manual version bumps or CHANGELOG edits (automated via release-please)

## Follow-ups (not in this PR)

- Surface a `starredRefreshFailed` flag in the `SearchOutput` envelope to match the existing `skipListUnavailable` / `rateLimitWarning` degradation-reporting convention.
- Seed stars during `init` so a brand-new user's first search isn't the trigger.
