### PR TITLE
feat(grading): replace A/B/C/F success grade with a 1-10 score

### DIFF
--- a/agents/issue-scout.md
+++ b/agents/issue-scout.md
@@ -121,7 +121,7 @@ Route on `verdict` with short-circuit semantics:
 
 The `linkedPRs` array distinguishes `closing` (the PR's `closingIssuesReferences` names this issue — a real claim) from `cross-referenced` (timeline mention only). Only `closing` PRs may drive a Taken verdict. `isOwn: true` flags the authenticated user's own PRs.
 
-**Primary:** call `vet` (MCP tool or CLI). It runs the full checklist: availability (assignment, linked PRs, author classification via `linked-pr-classification.ts`), contribution guidelines (CONTRIBUTING.md, CLA, PR templates), existing PR analysis, issue quality, repo health — and returns `grade: {letter, reason}` alongside the score.
+**Primary:** call `vet` (MCP tool or CLI). It runs the full checklist: availability (assignment, linked PRs, author classification via `linked-pr-classification.ts`), contribution guidelines (CONTRIBUTING.md, CLA, PR templates), existing PR analysis, issue quality, repo health — and returns `grade: {score, reason}` (1-10) alongside the viability score.
 
 ### Linked-PR classification
 
@@ -190,7 +190,7 @@ The composite score is **issue quality + repo quality + relationship modifiers**
 
 **Two different 1–10 "repo scores" exist — do not present them as the same number.** The cached `repoScore` you surface from `search` / `status` is the **history score**: the user's own merge outcomes in that repo (`docs/repo-scores.md` §History score). `repo-evaluator`'s `repo-vet` computes the **health score**: the fresh weighted rubric over the repo's current public signals (`rubricScore` in its output). They diverge whenever repo health changed since the user's last merge there — a 9 history score does not imply a healthy repo today. When quoting a number, name which one it is. See [`docs/repo-scores.md`](../docs/repo-scores.md).
 
-**Success likelihood grade (#858):** CLI returns `grade: {letter: 'A'|'B'|'C'|'F', reason}` in `vet --json`. Display verbatim — e.g. `A (~2-day avg response)`, `F (unresponsive maintainers)`. Algorithm and source: [`docs/repo-scores.md` §Success Likelihood Grade](../docs/repo-scores.md#success-likelihood-grade).
+**Success likelihood score (#858):** CLI returns `grade: {score, reason}` (1-10) in `vet --json`. Display verbatim — e.g. `10/10 (~2-day avg response)`, `1/10 (unresponsive maintainers)`. Algorithm and source: [`docs/repo-scores.md` §Success Likelihood Score](../docs/repo-scores.md#success-likelihood-score).
 
 ## Output Format
 
@@ -199,9 +199,9 @@ The composite score is **issue quality + repo quality + relationship modifiers**
 
 ### From Your Starred/Trusted Repos ⭐
 
-#### 1. [acme/widgets#123](https://…) — title (Score: 12, Grade: A)
+#### 1. [acme/widgets#123](https://…) — title (Score: 12, Success: 10/10)
 **Your history:** merged 2 PRs here — great relationship!
-**Success likelihood:** A (merges 85% of PRs, 2-day avg response)
+**Success likelihood:** 10/10 (merges 85% of PRs, 2-day avg response)
 **Why:** clarity [yes/somewhat/no] · scope [yes/maybe/no] · active [yes/somewhat/no] · no linked PRs [yes/no]
 **Quick start:** [1–2 sentences on how to approach]
 
@@ -209,9 +209,9 @@ The composite score is **issue quality + repo quality + relationship modifiers**
 
 ### New Repos to Explore 🔍
 
-#### 2. [cool-org/toolkit#456](…) — title (Score: 7, Grade: B)
+#### 2. [cool-org/toolkit#456](…) — title (Score: 7, Success: 7/10)
 **Your history:** no prior relationship
-**Success likelihood:** B (60% merge rate, 8-day avg response)
+**Success likelihood:** 7/10 (60% merge rate, 8-day avg response)
 **Why:** …
 **Note:** consider running repo-evaluator before committing.
 

--- a/commands/oss-search.md
+++ b/commands/oss-search.md
@@ -73,7 +73,7 @@ Task(general-purpose, "Run the CLI search command and return the raw JSON output
      issue: { repo, repoUrl, number, title, url, labels },
      recommendation: "approve" | "skip" | "needs_review",
      viabilityScore: number,
-     grade: { letter: "A" | "B" | "C" | "F", reason: string },
+     grade: { score: number /* 1-10 */, reason: string },
      searchPriority: "merged_pr" | "preferred_org" | "starred" | "normal",
      reasonsToApprove: string[],
      reasonsToSkip: string[],

--- a/docs/repo-scores.md
+++ b/docs/repo-scores.md
@@ -18,7 +18,7 @@ A repo where you merged four PRs two years ago can carry a history score of 9 wh
 - `rubricScore` — the fresh **health score** (the field name predates this page and is kept for back-compat).
 - `historyScore` — the cached **history score** for the same repo, included when the user has one in local state; absent otherwise.
 
-The success-likelihood grade (`grade: {letter, reason}`) is a third, letter-valued signal: on the multi-issue `search` surface it is derived from history-side signals only (repo health is not fetched per candidate there), while `vet` re-grades with freshly fetched health. Same letter scale, different inputs — see [Success Likelihood Grade](#success-likelihood-grade).
+The success-likelihood score (`grade: {score, reason}`) is a third signal on a 1-10 scale: on the multi-issue `search` surface it is derived from history-side signals only (repo health is not fetched per candidate there), while `vet` re-grades with freshly fetched health. Same 1-10 scale, different inputs — see [Success Likelihood Score](#success-likelihood-score).
 
 ## History score (yours)
 
@@ -121,9 +121,9 @@ Issue-scout adds two scout-specific layers on top of it (issue quality and user-
 
 **Tooling note:** "time to first review" is *not* available from `gh pr list --json`. If you want that metric, fetch `gh api repos/OWNER/REPO/pulls/PULL_NUMBER/reviews` per PR — otherwise omit the metric. Don't fabricate it from list metadata.
 
-### Success Likelihood Grade
+### Success Likelihood Score
 
-The CLI returns `grade: {letter, reason}` (`'A' | 'B' | 'C' | 'F'`) in `vet --json`. Algorithm: worst-of-three (PR speed, merge rate, responsiveness), with unknown values degrading one step. Source: `packages/core/src/core/issue-grading.ts`. Display the grade verbatim — e.g., `A (~2-day avg response)`, `F (unresponsive maintainers)`.
+The CLI returns `grade: {score, reason}` (a 1-10 number) in `vet --json`. Algorithm: each signal (PR speed, merge rate, responsiveness) lands in a band — 10 / 7 / 4 / 1 (best→worst) — the overall score is the worst of the three, dropping one band if any value is unknown. Source: `packages/core/src/core/issue-grading.ts`. Display the score verbatim — e.g., `10/10 (~2-day avg response)`, `1/10 (unresponsive maintainers)`.
 
 ### Red Flags
 

--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -545,7 +545,7 @@ export const commands: CLICommandDef[] = [
               console.log(`\nVetting issue: ${issueUrl}\n`);
               console.log(`[${recommendation.toUpperCase()}] ${issue.repo}#${issue.number}: ${issue.title}`);
               console.log(`  URL: ${issue.url}`);
-              console.log(`  Success grade: ${grade.letter} (${grade.reason})`);
+              console.log(`  Success score: ${grade.score}/10 (${grade.reason})`);
               if (reasonsToApprove.length > 0) console.log(`  Approve: ${reasonsToApprove.join(', ')}`);
               if (reasonsToSkip.length > 0) console.log(`  Skip: ${reasonsToSkip.join(', ')}`);
             },

--- a/packages/core/src/commands/__golden__/search.json
+++ b/packages/core/src/commands/__golden__/search.json
@@ -20,7 +20,7 @@
       "searchPriority": "merged_pr",
       "viabilityScore": 88,
       "grade": {
-        "letter": "B",
+        "score": 7,
         "reason": "~2-day avg response, unknown activity"
       },
       "repoScore": {
@@ -52,7 +52,7 @@
       "searchPriority": "normal",
       "viabilityScore": 60,
       "grade": {
-        "letter": "F",
+        "score": 1,
         "reason": "unknown maintainer responsiveness, merge rate, activity"
       }
     },
@@ -73,7 +73,7 @@
       "searchPriority": "normal",
       "viabilityScore": 12,
       "grade": {
-        "letter": "F",
+        "score": 1,
         "reason": "unknown maintainer responsiveness, merge rate, activity"
       }
     }

--- a/packages/core/src/commands/__golden__/vet-list.mixed.json
+++ b/packages/core/src/commands/__golden__/vet-list.mixed.json
@@ -32,7 +32,7 @@
       "linkedPRClassification": "none",
       "slmTriage": null,
       "grade": {
-        "letter": "B",
+        "score": 7,
         "reason": "3-day avg response"
       },
       "listStatus": "still_available",
@@ -61,7 +61,7 @@
       "projectHealth": {},
       "vettingResult": {},
       "grade": {
-        "letter": "F",
+        "score": 1,
         "reason": "unknown maintainer responsiveness, merge rate, activity"
       },
       "listStatus": "claimed",
@@ -102,7 +102,7 @@
       "projectHealth": {},
       "vettingResult": {},
       "grade": {
-        "letter": "F",
+        "score": 1,
         "reason": "unknown maintainer responsiveness, merge rate, activity"
       },
       "listStatus": "error",
@@ -141,7 +141,7 @@
       "linkedPRClassification": "none",
       "slmTriage": null,
       "grade": {
-        "letter": "B",
+        "score": 7,
         "reason": "3-day avg response"
       },
       "listStatus": "at_risk",
@@ -182,7 +182,7 @@
       "projectHealth": {},
       "vettingResult": {},
       "grade": {
-        "letter": "F",
+        "score": 1,
         "reason": "unknown maintainer responsiveness, merge rate, activity"
       },
       "listStatus": "own_open_pr",
@@ -223,7 +223,7 @@
       "projectHealth": {},
       "vettingResult": {},
       "grade": {
-        "letter": "F",
+        "score": 1,
         "reason": "unknown maintainer responsiveness, merge rate, activity"
       },
       "listStatus": "closed",

--- a/packages/core/src/commands/__golden__/vet.approve.json
+++ b/packages/core/src/commands/__golden__/vet.approve.json
@@ -39,7 +39,7 @@
   "linkedPRClassification": "none",
   "slmTriage": null,
   "grade": {
-    "letter": "B",
+    "score": 7,
     "reason": "4-day avg response"
   }
 }

--- a/packages/core/src/commands/__golden__/vet.skip.json
+++ b/packages/core/src/commands/__golden__/vet.skip.json
@@ -38,7 +38,7 @@
   "linkedPRClassification": "none",
   "slmTriage": null,
   "grade": {
-    "letter": "F",
+    "score": 1,
     "reason": "unknown maintainer responsiveness, merge rate, activity"
   }
 }

--- a/packages/core/src/commands/features.test.ts
+++ b/packages/core/src/commands/features.test.ts
@@ -189,8 +189,8 @@ describe('runFeatures', () => {
     const result = await runFeatures({ maxResults: 5 });
 
     // Repo has no autopilot-tracked score and projectHealth is sentinel-unknown,
-    // so the grader degrades to 'F' — same policy as runSearch (#1043).
-    expect(result.quickWins[0].grade.letter).toBe('F');
+    // so the grader scores 1 — same policy as runSearch (#1043).
+    expect(result.quickWins[0].grade.score).toBe(1);
   });
 
   it('returns the scout-side message verbatim when no anchors qualify', async () => {

--- a/packages/core/src/commands/search.contract.test.ts
+++ b/packages/core/src/commands/search.contract.test.ts
@@ -135,7 +135,9 @@ describe('search --json contract', () => {
       expect(candidate.viabilityScore).toBeGreaterThanOrEqual(0);
       expect(candidate.viabilityScore).toBeLessThanOrEqual(100);
       expect(candidate.issue.url).toMatch(/^https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/\d+$/);
-      expect(candidate.grade.letter).toMatch(/^[A-CF]$/);
+      expect(Number.isFinite(candidate.grade.score)).toBe(true);
+      expect(candidate.grade.score).toBeGreaterThanOrEqual(1);
+      expect(candidate.grade.score).toBeLessThanOrEqual(10);
     }
 
     expect(schemaIssues(SearchOutputSchema, result)).toEqual([]);

--- a/packages/core/src/commands/search.test.ts
+++ b/packages/core/src/commands/search.test.ts
@@ -301,8 +301,8 @@ describe('runSearch', () => {
     const result = await runSearch({ maxResults: 5 });
 
     // Repo has no autopilot-tracked score, scout-side signals are treated as
-    // unknown — every signal missing degrades to F per issue-grading policy.
-    expect(result.candidates[0].grade.letter).toBe('F');
+    // unknown — every signal missing scores 1 per issue-grading policy.
+    expect(result.candidates[0].grade.score).toBe(1);
     expect(result.candidates[0].grade.reason).toMatch(/unknown/i);
   });
 
@@ -341,9 +341,9 @@ describe('runSearch', () => {
 
     const result = await runSearch({ maxResults: 5 });
 
-    // High merge rate (20/23 ≈ 87%) + fast response → at worst C after the
-    // one-step degrade for unknown commit activity. Assert it beat F.
-    expect(result.candidates[0].grade.letter).not.toBe('F');
+    // High merge rate (20/23 ≈ 87%) + fast response → at worst 4 after the
+    // one-band drop for unknown commit activity. Assert it beat the floor of 1.
+    expect(result.candidates[0].grade.score).toBeGreaterThan(1);
   });
 
   it('surfaces a linkedPR slice with isStalled=true for an open PR last updated >30 days ago', async () => {

--- a/packages/core/src/commands/vet-list.test.ts
+++ b/packages/core/src/commands/vet-list.test.ts
@@ -75,7 +75,7 @@ function makeVetOutput(overrides: Partial<VetOutput> = {}): VetOutput {
     reasonsToSkip: [],
     projectHealth: { stars: 500 },
     vettingResult: { isViable: true },
-    grade: { letter: 'B', reason: 'test fixture' },
+    grade: { score: 7, reason: 'test fixture' },
     ...overrides,
   };
 }

--- a/packages/core/src/commands/vet.test.ts
+++ b/packages/core/src/commands/vet.test.ts
@@ -63,7 +63,7 @@ describe('runVet', () => {
       antiLLMPolicy: undefined,
       linkedPRClassification: 'none',
       slmTriage: null,
-      grade: { letter: 'A', reason: expect.stringMatching(/respons|merge|commit/i) },
+      grade: { score: 10, reason: expect.stringMatching(/respons|merge|commit/i) },
     });
   });
 
@@ -81,8 +81,8 @@ describe('runVet', () => {
 
     const result = await runVet({ issueUrl: TEST_ISSUE_URL });
 
-    // Two A signals + one unknown → degraded to B
-    expect(result.grade.letter).toBe('B');
+    // Two 10 signals + one unknown → dropped one band to 7
+    expect(result.grade.score).toBe(7);
     expect(result.grade.reason).toMatch(/unknown/i);
   });
 

--- a/packages/core/src/core/issue-grading.test.ts
+++ b/packages/core/src/core/issue-grading.test.ts
@@ -1,51 +1,54 @@
 import { describe, it, expect } from 'vitest';
 import { computeSuccessGrade, deriveGradeSignals } from './issue-grading.js';
 
+// Success score is on a 1-10 scale (#249 follow-up). The three signal bands
+// map to 10 / 7 / 4 / 1 (best→worst); the overall score is the worst of the
+// three and drops one band if any signal is unknown.
 describe('computeSuccessGrade', () => {
   describe('responsiveness signal', () => {
-    it('grades A when maintainers respond in under 3 days', () => {
+    it('scores 10 when maintainers respond in under 3 days', () => {
       const result = computeSuccessGrade({
         avgResponseDays: 2,
         mergeRate: 0.9,
         daysSinceLastCommit: 1,
       });
-      expect(result.letter).toBe('A');
+      expect(result.score).toBe(10);
     });
 
-    it('grades B for 3–14 day responsiveness', () => {
+    it('scores 7 for 3–14 day responsiveness', () => {
       const result = computeSuccessGrade({
         avgResponseDays: 10,
         mergeRate: 0.9,
         daysSinceLastCommit: 1,
       });
-      expect(result.letter).toBe('B');
+      expect(result.score).toBe(7);
     });
 
-    it('grades C for 14–60 day responsiveness', () => {
+    it('scores 4 for 14–60 day responsiveness', () => {
       const result = computeSuccessGrade({
         avgResponseDays: 40,
         mergeRate: 0.9,
         daysSinceLastCommit: 1,
       });
-      expect(result.letter).toBe('C');
+      expect(result.score).toBe(4);
     });
 
-    it('grades F when responsiveness exceeds 60 days', () => {
+    it('scores 1 when responsiveness exceeds 60 days', () => {
       const result = computeSuccessGrade({
         avgResponseDays: 90,
         mergeRate: 0.9,
         daysSinceLastCommit: 1,
       });
-      expect(result.letter).toBe('F');
+      expect(result.score).toBe(1);
     });
 
-    it('grades exactly 60 days as C (boundary inclusive)', () => {
+    it('scores exactly 60 days as 4 (boundary inclusive)', () => {
       const result = computeSuccessGrade({
         avgResponseDays: 60,
         mergeRate: 0.9,
         daysSinceLastCommit: 1,
       });
-      expect(result.letter).toBe('C');
+      expect(result.score).toBe(4);
     });
 
     it('treats NaN, negative, or infinite response days as unknown', () => {
@@ -54,133 +57,134 @@ describe('computeSuccessGrade', () => {
         mergeRate: 0.9,
         daysSinceLastCommit: 1,
       });
-      expect(result.letter).toBe('B');
+      // Known signals score 10; one unknown drops one band → 7.
+      expect(result.score).toBe(7);
       expect(result.reason).toMatch(/unknown/i);
     });
   });
 
   describe('merge-rate signal', () => {
-    it('grades A when merge rate exceeds 70%', () => {
+    it('scores 10 when merge rate exceeds 70%', () => {
       const result = computeSuccessGrade({
         avgResponseDays: 1,
         mergeRate: 0.85,
         daysSinceLastCommit: 1,
       });
-      expect(result.letter).toBe('A');
+      expect(result.score).toBe(10);
     });
 
-    it('grades B for 40–70% merge rate', () => {
+    it('scores 7 for 40–70% merge rate', () => {
       const result = computeSuccessGrade({
         avgResponseDays: 1,
         mergeRate: 0.55,
         daysSinceLastCommit: 1,
       });
-      expect(result.letter).toBe('B');
+      expect(result.score).toBe(7);
     });
 
-    it('grades C for 10–40% merge rate', () => {
+    it('scores 4 for 10–40% merge rate', () => {
       const result = computeSuccessGrade({
         avgResponseDays: 1,
         mergeRate: 0.2,
         daysSinceLastCommit: 1,
       });
-      expect(result.letter).toBe('C');
+      expect(result.score).toBe(4);
     });
 
-    it('grades F below 10% merge rate', () => {
+    it('scores 1 below 10% merge rate', () => {
       const result = computeSuccessGrade({
         avgResponseDays: 1,
         mergeRate: 0.05,
         daysSinceLastCommit: 1,
       });
-      expect(result.letter).toBe('F');
+      expect(result.score).toBe(1);
     });
   });
 
   describe('activity signal', () => {
-    it('grades A for commits within 7 days', () => {
+    it('scores 10 for commits within 7 days', () => {
       const result = computeSuccessGrade({
         avgResponseDays: 1,
         mergeRate: 0.9,
         daysSinceLastCommit: 3,
       });
-      expect(result.letter).toBe('A');
+      expect(result.score).toBe(10);
     });
 
-    it('grades B for commits 7–30 days', () => {
+    it('scores 7 for commits 7–30 days', () => {
       const result = computeSuccessGrade({
         avgResponseDays: 1,
         mergeRate: 0.9,
         daysSinceLastCommit: 20,
       });
-      expect(result.letter).toBe('B');
+      expect(result.score).toBe(7);
     });
 
-    it('grades C for commits 30–90 days', () => {
+    it('scores 4 for commits 30–90 days', () => {
       const result = computeSuccessGrade({
         avgResponseDays: 1,
         mergeRate: 0.9,
         daysSinceLastCommit: 60,
       });
-      expect(result.letter).toBe('C');
+      expect(result.score).toBe(4);
     });
 
-    it('grades F for no commits in 90+ days', () => {
+    it('scores 1 for no commits in 90+ days', () => {
       const result = computeSuccessGrade({
         avgResponseDays: 1,
         mergeRate: 0.9,
         daysSinceLastCommit: 120,
       });
-      expect(result.letter).toBe('F');
+      expect(result.score).toBe(1);
     });
   });
 
   describe('worst-of-three aggregation', () => {
-    it('lets a single F dominate', () => {
+    it('lets a single low signal dominate', () => {
       const result = computeSuccessGrade({
         avgResponseDays: 1,
         mergeRate: 0.05,
         daysSinceLastCommit: 1,
       });
-      expect(result.letter).toBe('F');
+      expect(result.score).toBe(1);
     });
 
-    it('picks worst across mixed letters', () => {
+    it('picks worst across mixed scores', () => {
       const result = computeSuccessGrade({
         avgResponseDays: 10,
         mergeRate: 0.2,
         daysSinceLastCommit: 3,
       });
-      expect(result.letter).toBe('C');
+      expect(result.score).toBe(4);
     });
   });
 
   describe('unknown-degrades rule', () => {
-    it('degrades A to B when one signal is unknown', () => {
+    it('drops 10 to 7 when one signal is unknown', () => {
       const result = computeSuccessGrade({
         avgResponseDays: null,
         mergeRate: 0.9,
         daysSinceLastCommit: 1,
       });
-      expect(result.letter).toBe('B');
+      expect(result.score).toBe(7);
     });
 
-    it('degrades C to F when one signal is unknown', () => {
+    it('drops 4 to 1 when one signal is unknown', () => {
       const result = computeSuccessGrade({
         avgResponseDays: 40,
         mergeRate: null,
         daysSinceLastCommit: 1,
       });
-      expect(result.letter).toBe('F');
+      expect(result.score).toBe(1);
     });
 
-    it('leaves F at F when a signal is unknown', () => {
+    it('leaves 1 at 1 when a signal is unknown', () => {
       const result = computeSuccessGrade({
         avgResponseDays: 90,
         mergeRate: null,
         daysSinceLastCommit: 1,
       });
-      expect(result.letter).toBe('F');
+      expect(result.score).toBe(1);
     });
 
     it('treats multiple unknowns the same as a single unknown', () => {
@@ -189,8 +193,18 @@ describe('computeSuccessGrade', () => {
         mergeRate: null,
         daysSinceLastCommit: 1,
       });
-      // Known signal is A, degrade once for unknowns → B
-      expect(result.letter).toBe('B');
+      // Known signal scores 10, drop one band for unknowns → 7
+      expect(result.score).toBe(7);
+    });
+
+    it('scores 1 when every signal is unknown', () => {
+      const result = computeSuccessGrade({
+        avgResponseDays: null,
+        mergeRate: null,
+        daysSinceLastCommit: null,
+      });
+      expect(result.score).toBe(1);
+      expect(result.reason).toMatch(/unknown/i);
     });
   });
 
@@ -264,23 +278,23 @@ describe('computeSuccessGrade', () => {
   });
 
   describe('reason string', () => {
-    it('mentions the driving signal for a failing grade', () => {
+    it('mentions the driving signal for a low score', () => {
       const result = computeSuccessGrade({
         avgResponseDays: 90,
         mergeRate: 0.9,
         daysSinceLastCommit: 1,
       });
-      expect(result.letter).toBe('F');
+      expect(result.score).toBe(1);
       expect(result.reason).toMatch(/respons/i);
     });
 
-    it('mentions the driving signal for a C', () => {
+    it('mentions the driving signal for a mid score', () => {
       const result = computeSuccessGrade({
         avgResponseDays: 40,
         mergeRate: 0.9,
         daysSinceLastCommit: 1,
       });
-      expect(result.letter).toBe('C');
+      expect(result.score).toBe(4);
       expect(result.reason).toMatch(/40.*day|respons/i);
     });
 
@@ -290,7 +304,7 @@ describe('computeSuccessGrade', () => {
         mergeRate: null,
         daysSinceLastCommit: 1,
       });
-      expect(result.letter).toBe('B');
+      expect(result.score).toBe(7);
       expect(result.reason).toMatch(/unknown|missing/i);
     });
   });

--- a/packages/core/src/core/issue-grading.ts
+++ b/packages/core/src/core/issue-grading.ts
@@ -1,19 +1,17 @@
 /**
- * Issue success-likelihood grade (#858).
+ * Issue success-likelihood score (#858, rescaled to 1-10 per #249 follow-up).
  *
  * Predicts the probability that a contribution to a given repo will be
  * accepted and merged, using signals already collected during vetting.
  *
- * The grade is letter-based (A/B/C/F — no D). Each signal is graded
- * independently; the overall grade is the worst of the three, and is
- * further degraded one step if any signal is unknown (missing data is
- * treated as a risk, not ignored). This matches the policy previously
- * described as prose in agents/issue-scout.md.
+ * The score is on a 1-10 scale. Each signal lands in one of four bands —
+ * 10 / 7 / 4 / 1 (best→worst) — graded independently; the overall score is
+ * the worst of the three, and drops one band if any signal is unknown
+ * (missing data is treated as a risk, not ignored). This matches the policy
+ * previously described as prose in agents/issue-scout.md.
  */
 
 import type { ProjectHealth } from '@oss-scout/core';
-
-export type GradeLetter = 'A' | 'B' | 'C' | 'F';
 
 export interface GradeSignals {
   /** Average maintainer response time in days; null if unknown. */
@@ -25,22 +23,27 @@ export interface GradeSignals {
 }
 
 export interface GradeResult {
-  letter: GradeLetter;
-  /** Short human-readable explanation of what drove the grade. */
+  /** Success-likelihood score on a 1-10 scale (higher is better). */
+  score: number;
+  /** Short human-readable explanation of what drove the score. */
   reason: string;
 }
 
-type SignalGrade = { letter: GradeLetter; detail: string };
+type SignalScore = { score: number; detail: string };
 
-const SEVERITY: Record<GradeLetter, number> = { A: 0, B: 1, C: 2, F: 3 };
-const LETTERS: readonly GradeLetter[] = ['A', 'B', 'C', 'F'];
+// Band values, best→worst. A signal always resolves to one of these, so
+// degradeOneStep can step down the ladder by index.
+const BANDS: readonly number[] = [10, 7, 4, 1];
 
-function worst(grades: SignalGrade[]): SignalGrade {
-  return grades.reduce((acc, g) => (SEVERITY[g.letter] > SEVERITY[acc.letter] ? g : acc));
+function worst(scores: SignalScore[]): SignalScore {
+  return scores.reduce((acc, s) => (s.score < acc.score ? s : acc));
 }
 
-function degradeOneStep(letter: GradeLetter): GradeLetter {
-  return LETTERS[Math.min(SEVERITY[letter] + 1, LETTERS.length - 1)];
+function degradeOneStep(score: number): number {
+  const i = BANDS.indexOf(score);
+  // Unrecognized score (shouldn't happen) is treated as already-worst.
+  if (i === -1) return BANDS[BANDS.length - 1];
+  return BANDS[Math.min(i + 1, BANDS.length - 1)];
 }
 
 /**
@@ -55,26 +58,26 @@ function sanitize(value: number | null | undefined, min: number, max: number): n
   return value;
 }
 
-function gradeResponsiveness(avgResponseDays: number): SignalGrade {
-  if (avgResponseDays < 3) return { letter: 'A', detail: `~${Math.round(avgResponseDays)}-day avg response` };
-  if (avgResponseDays < 14) return { letter: 'B', detail: `${Math.round(avgResponseDays)}-day avg response` };
-  if (avgResponseDays <= 60) return { letter: 'C', detail: `${Math.round(avgResponseDays)}-day avg response` };
-  return { letter: 'F', detail: 'unresponsive maintainers' };
+function gradeResponsiveness(avgResponseDays: number): SignalScore {
+  if (avgResponseDays < 3) return { score: 10, detail: `~${Math.round(avgResponseDays)}-day avg response` };
+  if (avgResponseDays < 14) return { score: 7, detail: `${Math.round(avgResponseDays)}-day avg response` };
+  if (avgResponseDays <= 60) return { score: 4, detail: `${Math.round(avgResponseDays)}-day avg response` };
+  return { score: 1, detail: 'unresponsive maintainers' };
 }
 
-function gradeMergeRate(mergeRate: number): SignalGrade {
+function gradeMergeRate(mergeRate: number): SignalScore {
   const pct = Math.round(mergeRate * 100);
-  if (mergeRate > 0.7) return { letter: 'A', detail: `merges ${pct}% of PRs` };
-  if (mergeRate >= 0.4) return { letter: 'B', detail: `merges ${pct}% of PRs` };
-  if (mergeRate >= 0.1) return { letter: 'C', detail: `merges ${pct}% of PRs` };
-  return { letter: 'F', detail: `merges ${pct}% of PRs` };
+  if (mergeRate > 0.7) return { score: 10, detail: `merges ${pct}% of PRs` };
+  if (mergeRate >= 0.4) return { score: 7, detail: `merges ${pct}% of PRs` };
+  if (mergeRate >= 0.1) return { score: 4, detail: `merges ${pct}% of PRs` };
+  return { score: 1, detail: `merges ${pct}% of PRs` };
 }
 
-function gradeActivity(daysSinceLastCommit: number): SignalGrade {
-  if (daysSinceLastCommit < 7) return { letter: 'A', detail: 'commits in last week' };
-  if (daysSinceLastCommit < 30) return { letter: 'B', detail: 'commits in last month' };
-  if (daysSinceLastCommit < 90) return { letter: 'C', detail: 'commits in last 90 days' };
-  return { letter: 'F', detail: `no commits in ${daysSinceLastCommit}+ days` };
+function gradeActivity(daysSinceLastCommit: number): SignalScore {
+  if (daysSinceLastCommit < 7) return { score: 10, detail: 'commits in last week' };
+  if (daysSinceLastCommit < 30) return { score: 7, detail: 'commits in last month' };
+  if (daysSinceLastCommit < 90) return { score: 4, detail: 'commits in last 90 days' };
+  return { score: 1, detail: `no commits in ${daysSinceLastCommit}+ days` };
 }
 
 /**
@@ -142,7 +145,7 @@ export function deriveGradeSignals(params: {
  * rubric. The fresh side only enters through `projectHealth`, and only when
  * scout actually fetched it: the `search` surface passes a `checkFailed`
  * sentinel (health not fetched per candidate), so search grades purely from
- * history-side signals, while `vet` re-grades with fresh health. Same letter
+ * history-side signals, while `vet` re-grades with fresh health. Same 1-10
  * scale, different inputs — the two surfaces can legitimately disagree.
  */
 export function gradeFromCandidate(params: {
@@ -186,7 +189,7 @@ export function gradeFromCandidate(params: {
 }
 
 export function computeSuccessGrade(signals: GradeSignals): GradeResult {
-  const graded: SignalGrade[] = [];
+  const graded: SignalScore[] = [];
   const unknowns: string[] = [];
 
   const resp = sanitize(signals.avgResponseDays, 0, Number.MAX_SAFE_INTEGER);
@@ -201,17 +204,17 @@ export function computeSuccessGrade(signals: GradeSignals): GradeResult {
   if (act === null) unknowns.push('activity');
   else graded.push(gradeActivity(act));
 
-  // No signal available at all — give F so callers see missing data as a
-  // strong negative rather than a neutral grade.
+  // No signal available at all — score the lowest band so callers see missing
+  // data as a strong negative rather than a neutral score.
   if (graded.length === 0) {
-    return { letter: 'F', reason: `unknown ${unknowns.join(', ')}` };
+    return { score: BANDS[BANDS.length - 1], reason: `unknown ${unknowns.join(', ')}` };
   }
 
   const worstKnown = worst(graded);
-  const finalLetter = unknowns.length > 0 ? degradeOneStep(worstKnown.letter) : worstKnown.letter;
+  const finalScore = unknowns.length > 0 ? degradeOneStep(worstKnown.score) : worstKnown.score;
 
   const reasonParts = [worstKnown.detail];
   if (unknowns.length > 0) reasonParts.push(`unknown ${unknowns.join(', ')}`);
 
-  return { letter: finalLetter, reason: reasonParts.join(', ') };
+  return { score: finalScore, reason: reasonParts.join(', ') };
 }

--- a/packages/core/src/formatters/json.test.ts
+++ b/packages/core/src/formatters/json.test.ts
@@ -498,7 +498,7 @@ describe('SearchOutputSchema (#1147)', () => {
       reasonsToSkip: [],
       searchPriority: 'starred' as const,
       viabilityScore: 88,
-      grade: { letter: 'A' as const, reason: 'fast merges' },
+      grade: { score: 10, reason: 'fast merges' },
       repoScore: {
         score: 9.2,
         mergedPRCount: 3,
@@ -524,11 +524,11 @@ describe('SearchOutputSchema (#1147)', () => {
     expect(formatJson(SearchOutputSchema, data).success).toBe(true);
   });
 
-  it('rejects drift: invalid grade letter', () => {
+  it('rejects drift: out-of-range grade score', () => {
     const candidate = makeSearchCandidate();
-    (candidate.grade as { letter: string; reason: string }).letter = 'D';
+    (candidate.grade as { score: number; reason: string }).score = 0;
     const data = { candidates: [candidate], excludedRepos: [], aiPolicyBlocklist: [] };
-    expect(() => formatJson(SearchOutputSchema, data)).toThrow(/contract drift.*letter/i);
+    expect(() => formatJson(SearchOutputSchema, data)).toThrow(/contract drift.*score/i);
   });
 
   it('rejects drift: missing reasonsToApprove', () => {

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -632,7 +632,7 @@ const SearchCandidateSchema = z.object({
   searchPriority: SearchPrioritySchema,
   viabilityScore: z.number(),
   grade: z.object({
-    letter: z.enum(['A', 'B', 'C', 'F']),
+    score: z.number().min(1).max(10),
     reason: z.string(),
   }),
   repoScore: z
@@ -1125,12 +1125,13 @@ export interface SearchCandidate {
   /** 0-100 scale composite viability score. Sanitized on the boundary (#1043): out-of-contract values are coerced to 0 and logged. */
   viabilityScore: number;
   /**
-   * Letter grade (A/B/C/F) computed from the autopilot-tracked repoScore.
-   * Scout's `search` does not emit per-candidate projectHealth, so scout-side
-   * signals are treated as unknown; unscored repos grade 'F'. See #1043.
+   * Success-likelihood score (1-10) computed from the autopilot-tracked
+   * repoScore. Scout's `search` does not emit per-candidate projectHealth, so
+   * scout-side signals are treated as unknown; unscored repos score 1. See
+   * #1043.
    */
   grade: {
-    letter: 'A' | 'B' | 'C' | 'F';
+    score: number;
     reason: string;
   };
   repoScore?: {
@@ -1458,9 +1459,9 @@ export interface VetOutput {
     reasons: string[];
     modelVersion: string;
   } | null;
-  /** Success-likelihood grade (#858): predicts whether a PR will merge. */
+  /** Success-likelihood score (#858, 1-10): predicts whether a PR will merge. */
   grade: {
-    letter: 'A' | 'B' | 'C' | 'F';
+    score: number;
     reason: string;
   };
 }


### PR DESCRIPTION
## What

Replaces the A/B/C/F success-likelihood grade with a 1-10 score. The letter was a confusing third quality signal alongside `repoScore` (already 1-10) and `viabilityScore` (0-100).

## How

`computeSuccessGrade` now returns `{ score: 1-10, reason }` instead of `{ letter, reason }`, using the same three signals (responsiveness, merge rate, activity) and the same policy: each signal band maps to 10 / 7 / 4 / 1 (best→worst), the overall score is the worst of the three, and any unknown signal drops it one band. A faithful translation, not a re-tuning.

Updated: the JSON contract (`grade.letter` → `grade.score`), the CLI display (`Success score: 7/10`), 4 golden snapshots, and the scout/docs references.

## Tests

All affected tests updated and passing (grading, search, vet, vet-list, features, json, contract). The only 2 failures in the full suite are pre-existing gist-token-scope tests that fail without this change.
