### PR TITLE
fix(scout): surface a missing skip file instead of silently using an empty skip list (#1528)

### DIFF
--- a/commands/oss-search.md
+++ b/commands/oss-search.md
@@ -67,6 +67,8 @@ Task(general-purpose, "Run the CLI search command and return the raw JSON output
 **Parsing the response:**
 
 1. Check the JSON `success` field. If `success: false`, display the `error` field and offer retry/done.
+1a. **Skip-list health (#1528):** If `data.skipListUnavailable` is `true`, the configured skip file could not be loaded (missing or unreadable at its resolved path), so scout searched with an EMPTY skip list and previously-skipped issues may reappear in these results. Warn the user prominently before presenting candidates:
+   > ⚠️ Skip list could not be loaded — already-skipped issues may reappear. Check `skippedIssuesPath` (a relative path resolves against the current directory) or run `/oss` from the directory that contains your skip file. See stderr for the exact resolved path.
 2. If `success: true`, each entry in `data.candidates` has this shape:
    ```
    {

--- a/packages/core/src/commands/scout-bridge.test.ts
+++ b/packages/core/src/commands/scout-bridge.test.ts
@@ -343,6 +343,24 @@ describe('buildScoutState', () => {
     expect(result.skippedIssues).toEqual([]);
   });
 
+  it('sets diagnostics.skipListUnavailable when the configured skip file is missing (#1528)', () => {
+    const state = makeAgentState({
+      config: { skippedIssuesPath: 'open-source/skipped-issues.md' },
+    });
+    mockGetStateManager.mockReturnValue(makeStateManagerMock({ state, config: state.config }));
+    mockLoadSkippedIssuesDetailed.mockReturnValueOnce({
+      issues: [],
+      notFound: true,
+      resolvedPath: '/somewhere/open-source/skipped-issues.md',
+    });
+
+    const diagnostics: ScoutBridgeDiagnostics = {};
+    const result = buildScoutState(diagnostics);
+
+    expect(diagnostics.skipListUnavailable).toBe(true);
+    expect(result.skippedIssues).toEqual([]);
+  });
+
   it('leaves diagnostics.skipListUnavailable unset when the skip file loads cleanly (#1448)', () => {
     const state = makeAgentState({
       config: { skippedIssuesPath: '/vault/open-source/skipped-issues.md' },

--- a/packages/core/src/commands/scout-bridge.ts
+++ b/packages/core/src/commands/scout-bridge.ts
@@ -31,9 +31,11 @@ export const SEARCH_DIVERSITY_RATIO = 0.2;
  */
 export interface ScoutBridgeDiagnostics {
   /**
-   * Set when a configured skipped-issues file exists but could not be read.
-   * The scout state was built with an EMPTY skip list, so explicitly-skipped
-   * issues may resurface in results.
+   * Set when a configured skipped-issues file could not be loaded — either it
+   * exists but is unreadable (#1448), or a path is configured but no file
+   * exists at the resolved location (#1528, the relative-path-vs-CWD case). The
+   * scout state was built with an EMPTY skip list, so explicitly-skipped issues
+   * may resurface in results.
    */
   skipListUnavailable?: boolean;
 }
@@ -89,19 +91,22 @@ export function buildCandidateLinkedPR(scoutLinkedPR: ScoutLinkedPR | null | und
  * Build a ScoutState from the current AgentState.
  * Maps oss-autopilot's config and state fields to oss-scout's state format.
  *
- * @param diagnostics - Optional collector for degradation signals (#1448);
- *   `skipListUnavailable` is set when the skipped-issues file exists but
- *   could not be read.
+ * @param diagnostics - Optional collector for degradation signals (#1448,
+ *   #1528); `skipListUnavailable` is set when the configured skipped-issues
+ *   file is unreadable or missing at its resolved path.
  */
 export function buildScoutState(diagnostics?: ScoutBridgeDiagnostics): ScoutState {
   const state = getStateManager().getState();
   const { config } = state;
 
-  // Read failure (not absence) of the skip file means scout will see an empty
-  // skip list and may resurface explicitly-skipped issues — flag it so the
-  // search envelope can carry the signal instead of only stderr (#1448).
+  // A configured skip file that is unreadable (#1448) OR missing (#1528) leaves
+  // scout with an empty skip list and may resurface explicitly-skipped issues
+  // — flag both so the search envelope carries the signal instead of failing
+  // silently. The missing case is the common one: a relative skippedIssuesPath
+  // resolves against the CWD, so running /oss outside the directory that holds
+  // it found nothing and the skip list loaded empty without any warning.
   const skippedIssuesLoad = loadSkippedIssuesDetailed(config.skippedIssuesPath);
-  if (skippedIssuesLoad.readError !== undefined && diagnostics) {
+  if ((skippedIssuesLoad.readError !== undefined || skippedIssuesLoad.notFound) && diagnostics) {
     diagnostics.skipListUnavailable = true;
   }
 

--- a/packages/core/src/commands/skip-file-parser.test.ts
+++ b/packages/core/src/commands/skip-file-parser.test.ts
@@ -270,4 +270,33 @@ describe('loadSkippedIssuesDetailed', () => {
     expect(result.issues).toHaveLength(1);
     expect(result.issues[0].url).toBe('https://github.com/owncast/owncast/issues/4883');
   });
+
+  it('flags notFound (not readError) and warns with a resolved path when a configured file is missing (#1528)', () => {
+    mockExistsSync.mockReturnValue(false);
+
+    const result = loadSkippedIssuesDetailed('/missing/path.md');
+
+    expect(result.issues).toEqual([]);
+    expect(result.readError).toBeUndefined();
+    expect(result.notFound).toBe(true);
+    expect(result.resolvedPath).toBe('/missing/path.md');
+    // A configured-but-missing skip list must be loud, not silent.
+    expect(mockWarn).toHaveBeenCalled();
+  });
+
+  it('resolves a relative configured path to absolute for the lookup (#1528)', () => {
+    mockExistsSync.mockReturnValue(false);
+
+    const result = loadSkippedIssuesDetailed('open-source/skipped-issues.md');
+
+    expect(result.notFound).toBe(true);
+    expect(result.resolvedPath?.startsWith('/')).toBe(true);
+    expect(result.resolvedPath?.endsWith('open-source/skipped-issues.md')).toBe(true);
+  });
+
+  it('does not flag notFound or warn when no path is configured', () => {
+    const result = loadSkippedIssuesDetailed(undefined);
+    expect(result.notFound).toBeUndefined();
+    expect(mockWarn).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/commands/skip-file-parser.ts
+++ b/packages/core/src/commands/skip-file-parser.ts
@@ -14,6 +14,7 @@
  */
 
 import * as fs from 'node:fs';
+import * as nodePath from 'node:path';
 import type { SkippedIssue } from '@oss-scout/core';
 import { warn } from '../core/logger.js';
 import { errorMessage } from '../core/errors.js';
@@ -102,6 +103,22 @@ export interface SkippedIssuesLoadResult {
    * exist, or the read succeeded.
    */
   readError?: string;
+  /**
+   * Set when a path WAS configured but no file exists at the resolved location
+   * (#1528). `issues` is `[]`. This is the silent-failure mode that resurfaced
+   * already-skipped issues: a relative `skippedIssuesPath` resolves against the
+   * process CWD, so running from the wrong directory found nothing and the skip
+   * list loaded empty without any signal. Callers raise the same
+   * `skipListUnavailable` diagnostic for this as for `readError`. Absent when
+   * the path is unset or the file was found.
+   */
+  notFound?: boolean;
+  /**
+   * The absolute path the loader actually checked (relative paths resolved
+   * against CWD). Present whenever a path was configured, so diagnostics can
+   * show exactly where the lookup looked. Absent when no path was configured.
+   */
+  resolvedPath?: string;
 }
 
 /**
@@ -113,17 +130,34 @@ export interface SkippedIssuesLoadResult {
  */
 export function loadSkippedIssuesDetailed(path: string | undefined): SkippedIssuesLoadResult {
   if (!path) return { issues: [] };
-  if (!fs.existsSync(path)) return { issues: [] };
+
+  // Resolve to absolute so a relative `skippedIssuesPath` is interpreted
+  // against the CWD explicitly (#1528) and the diagnostics can report the
+  // exact location that was checked.
+  const resolvedPath = nodePath.resolve(path);
+
+  if (!fs.existsSync(resolvedPath)) {
+    // A configured-but-missing skip file used to be silent, which resurfaced
+    // already-skipped issues whenever `/oss` ran from a directory other than
+    // the one holding a relative skip path. Make it loud.
+    warn(
+      'skip-file-parser',
+      `Configured skipped-issues file not found at ${resolvedPath} (cwd ${process.cwd()}); ` +
+        `proceeding with an EMPTY skip list — previously skipped issues may resurface. ` +
+        `Use an absolute skippedIssuesPath, or run from the directory that contains "${path}".`,
+    );
+    return { issues: [], notFound: true, resolvedPath };
+  }
 
   let content: string;
   try {
-    content = fs.readFileSync(path, 'utf8');
+    content = fs.readFileSync(resolvedPath, 'utf8');
   } catch (err) {
-    warn('skip-file-parser', `Failed to read skipped-issues file at ${path}: ${errorMessage(err)}`);
-    return { issues: [], readError: errorMessage(err) };
+    warn('skip-file-parser', `Failed to read skipped-issues file at ${resolvedPath}: ${errorMessage(err)}`);
+    return { issues: [], readError: errorMessage(err), resolvedPath };
   }
 
-  return { issues: parseSkippedIssuesContent(content) };
+  return { issues: parseSkippedIssuesContent(content), resolvedPath };
 }
 
 /**


### PR DESCRIPTION
## Problem

`config.skippedIssuesPath` is typically a relative path (e.g. `open-source/skipped-issues.md`), resolved against the process CWD. When `/oss` runs from any directory other than the one holding that file, `loadSkippedIssuesDetailed` found nothing and returned an EMPTY skip list **silently** — so scout searched with no skip list and resurfaced issues the user had already skipped. The existing `skipListUnavailable` diagnostic only fired when the file existed but was unreadable, never for the far more common missing-file case.

## Fix

- `loadSkippedIssuesDetailed` now resolves the path to absolute, distinguishes "configured but missing" (`notFound`) from "no path configured", returns the `resolvedPath`, and warns with the resolved path + cwd.
- `buildScoutState` raises `skipListUnavailable` for the missing case too (not just unreadable).
- The oss-search workflow surfaces the warning to the user before presenting candidates.

## Tests

New tests in `skip-file-parser.test.ts` (missing → `notFound` + resolved path + warn; relative path resolved to absolute; unset path stays quiet) and `scout-bridge.test.ts` (diagnostic set on missing). Full suite green except the 2 pre-existing gist-token-scope failures.

Addresses the silent-empty-skip-list half of #1528. (Persisting a seen-set across separate runs is tracked separately.)
