### PR TITLE
chore(deps): clear high CVE blocking CI audit (linkify-it >=5.0.1)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2146,8 +2146,8 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
-  linkify-it@5.0.0:
-    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+  linkify-it@5.0.1:
+    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -4771,7 +4771,7 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
-  linkify-it@5.0.0:
+  linkify-it@5.0.1:
     dependencies:
       uc.micro: 2.1.0
 
@@ -4809,7 +4809,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
-      linkify-it: 5.0.0
+      linkify-it: 5.0.1
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,3 +34,7 @@ overrides:
   # Clears the high TLS-validation / WebSocket-DoS / SOCKS5 advisories in
   # undici <7.28.0 (GHSA-vmh5-mc38-953g, GHSA-vxpw-j846-p89q, GHSA-vh2q-...).
   undici: '>=7.28.0'
+  # Dev-only, transitive via @oss-autopilot/core -> typedoc -> markdown-it.
+  # Quadratic-complexity ReDoS advisory GHSA-22p9-wv53-3rq4 in linkify-it
+  # <=5.0.0; patched in 5.0.1.
+  linkify-it: '>=5.0.1'


### PR DESCRIPTION
## Problem

CI's `Security audit` step (`pnpm audit --audit-level=high`, inside the "Lint and format" job) started failing on every branch — main included — even though no dependency changed. A new advisory was published: **GHSA-22p9-wv53-3rq4**, quadratic-complexity ReDoS in `linkify-it` `<=5.0.0`. Because the audit step gates the job, downstream test jobs show "skipping" and all open PRs are blocked.

`linkify-it` is **dev-only and transitive**: `@oss-autopilot/core → typedoc → markdown-it → linkify-it`. Not shipped.

## Fix

Pin `linkify-it: '>=5.0.1'` in `pnpm-workspace.yaml` `overrides` — the active override location since #1454 (pnpm v10 no longer reads the `pnpm.overrides` field in package.json). Lockfile updated; `linkify-it@5.0.1` resolves.

`pnpm audit --audit-level=high` now exits 0 (remaining findings are 1 low + 3 moderate, below the gate).
