### PR TITLE
feat(scout): persist a search seen-set so result rotation survives across runs (#1528)

### DIFF
--- a/packages/core/src/commands/scout-bridge.test.ts
+++ b/packages/core/src/commands/scout-bridge.test.ts
@@ -287,13 +287,28 @@ describe('buildScoutState', () => {
     expect(result.openPRs).toEqual([]);
   });
 
-  it('should always set savedResults to an empty array', () => {
+  it('sets savedResults to an empty array when the seen-set is empty', () => {
     const state = makeAgentState();
     mockGetStateManager.mockReturnValue(makeStateManagerMock({ state, config: state.config }));
 
     const result = buildScoutState();
 
     expect(result.savedResults).toEqual([]);
+  });
+
+  it('maps the search seen-set into savedResults for rotation (#1528)', () => {
+    const lastSeenAt = '2026-06-20T00:00:00.000Z';
+    const state = makeAgentState({
+      searchSeen: [{ url: 'https://github.com/o/r/issues/1', lastSeenAt }],
+    });
+    mockGetStateManager.mockReturnValue(makeStateManagerMock({ state, config: state.config }));
+
+    const result = buildScoutState();
+
+    expect(result.savedResults).toHaveLength(1);
+    // Only issueUrl + lastSeenAt drive scout's rotation; both must round-trip.
+    expect(result.savedResults[0].issueUrl).toBe('https://github.com/o/r/issues/1');
+    expect(result.savedResults[0].lastSeenAt).toBe(lastSeenAt);
   });
 
   it('should populate skippedIssues from the parsed skip file', () => {

--- a/packages/core/src/commands/scout-bridge.ts
+++ b/packages/core/src/commands/scout-bridge.ts
@@ -199,7 +199,26 @@ export function buildScoutState(diagnostics?: ScoutBridgeDiagnostics): ScoutStat
       title: pr.title,
       openedAt: pr.createdAt,
     })),
-    savedResults: [],
+    // Seen-set for result rotation (#1528). Scout's search() excludes issues
+    // whose lastSeenAt is within its rotation TTL, so consecutive searches
+    // surface fresh candidates instead of the same set. Autopilot runs scout
+    // in persistence:'provided', so this durable AgentState-backed list is what
+    // makes the rotation survive between separate /oss invocations. Only
+    // issueUrl + lastSeenAt drive the exclusion; the remaining SavedCandidate
+    // fields are unused by rotation and filled with neutral placeholders.
+    savedResults: (state.searchSeen ?? []).map((s) => ({
+      issueUrl: s.url,
+      repo: '',
+      number: 0,
+      title: '',
+      labels: [],
+      recommendation: 'skip' as const,
+      viabilityScore: 0,
+      searchPriority: 'normal' as const,
+      firstSeenAt: s.lastSeenAt,
+      lastSeenAt: s.lastSeenAt,
+      lastScore: 0,
+    })),
     skippedIssues: skippedIssuesLoad.issues,
     lastRunAt: state.lastRunAt,
   };

--- a/packages/core/src/commands/search.contract.test.ts
+++ b/packages/core/src/commands/search.contract.test.ts
@@ -38,6 +38,8 @@ vi.mock('../core/index.js', async () => {
       // A minimal-merged-PR state ensures computeStrategy returns null and the
       // search behaves exactly as before personalization (#1244).
       getState: () => ({ mergedPRs: [], closedPRs: [], repoScores: {}, lastDigest: null }),
+      getSearchSeen: () => [],
+      setSearchSeen: () => {},
     }),
   };
 });

--- a/packages/core/src/commands/search.test.ts
+++ b/packages/core/src/commands/search.test.ts
@@ -33,7 +33,7 @@ vi.mock('../core/starred-repos.js', () => ({
 
 import { getStateManager } from '../core/index.js';
 import { createAutopilotScout, type ScoutBridgeDiagnostics } from './scout-bridge.js';
-import { runSearch } from './search.js';
+import { runSearch, recordSearchSeen, SEARCH_SEEN_RETENTION_DAYS } from './search.js';
 
 const mockGetStateManager = vi.mocked(getStateManager);
 
@@ -48,6 +48,8 @@ describe('runSearch', () => {
         },
       }),
       getRepoScore: vi.fn().mockReturnValue(null),
+      getSearchSeen: vi.fn().mockReturnValue([]),
+      setSearchSeen: vi.fn(),
     } as any);
   });
 
@@ -178,6 +180,8 @@ describe('runSearch', () => {
         signals: { isResponsive: true },
         lastMergedAt: '2026-01-10T00:00:00Z',
       }),
+      getSearchSeen: vi.fn().mockReturnValue([]),
+      setSearchSeen: vi.fn(),
     } as any);
 
     const result = await runSearch({ maxResults: 5 });
@@ -337,6 +341,8 @@ describe('runSearch', () => {
         avgResponseDays: 2,
         signals: { isResponsive: true },
       }),
+      getSearchSeen: vi.fn().mockReturnValue([]),
+      setSearchSeen: vi.fn(),
     } as any);
 
     const result = await runSearch({ maxResults: 5 });
@@ -484,6 +490,8 @@ describe('runSearch', () => {
           config: { excludeRepos: [], aiPolicyBlocklist: [], ...(githubUsername ? { githubUsername } : {}) },
         }),
         getRepoScore: vi.fn().mockReturnValue(null),
+        getSearchSeen: vi.fn().mockReturnValue([]),
+        setSearchSeen: vi.fn(),
       } as any);
     }
 
@@ -550,5 +558,63 @@ describe('runSearch', () => {
       expect(result.hiddenOwnPRCount).toBe(0);
       expect(result.candidates).toHaveLength(1);
     });
+  });
+});
+
+describe('recordSearchSeen (#1528)', () => {
+  function fakeStateManager(initial: Array<{ url: string; lastSeenAt: string }>) {
+    let seen = initial;
+    return {
+      getSearchSeen: () => seen,
+      setSearchSeen: vi.fn((s: Array<{ url: string; lastSeenAt: string }>) => {
+        seen = s;
+      }),
+      _current: () => seen,
+    } as unknown as ReturnType<typeof getStateManager> & {
+      _current: () => Array<{ url: string; lastSeenAt: string }>;
+      setSearchSeen: ReturnType<typeof vi.fn>;
+    };
+  }
+
+  const U1 = 'https://github.com/o/r/issues/1';
+  const U2 = 'https://github.com/o/r/issues/2';
+
+  it('adds newly surfaced URLs with a recent timestamp and persists', () => {
+    const sm = fakeStateManager([]);
+    recordSearchSeen(sm, [U1, U2]);
+
+    const seen = (sm as unknown as { _current: () => Array<{ url: string; lastSeenAt: string }> })._current();
+    expect(seen.map((e) => e.url).sort()).toEqual([U1, U2]);
+    for (const e of seen) {
+      expect(Date.now() - Date.parse(e.lastSeenAt)).toBeLessThan(60_000);
+    }
+    expect((sm as unknown as { setSearchSeen: ReturnType<typeof vi.fn> }).setSearchSeen).toHaveBeenCalledOnce();
+  });
+
+  it('refreshes the timestamp of an already-seen URL', () => {
+    const old = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
+    const sm = fakeStateManager([{ url: U1, lastSeenAt: old }]);
+
+    recordSearchSeen(sm, [U1]);
+
+    const entry = (sm as unknown as { _current: () => Array<{ url: string; lastSeenAt: string }> })._current()[0];
+    expect(Date.parse(entry.lastSeenAt)).toBeGreaterThan(Date.parse(old));
+  });
+
+  it('culls entries older than the retention window (empty surfaced still culls)', () => {
+    const stale = new Date(Date.now() - (SEARCH_SEEN_RETENTION_DAYS + 1) * 24 * 60 * 60 * 1000).toISOString();
+    const fresh = new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString();
+    const sm = fakeStateManager([
+      { url: 'https://github.com/o/r/issues/stale', lastSeenAt: stale },
+      { url: 'https://github.com/o/r/issues/fresh', lastSeenAt: fresh },
+    ]);
+
+    recordSearchSeen(sm, []);
+
+    const urls = (sm as unknown as { _current: () => Array<{ url: string; lastSeenAt: string }> })
+      ._current()
+      .map((e) => e.url);
+    expect(urls).toContain('https://github.com/o/r/issues/fresh');
+    expect(urls).not.toContain('https://github.com/o/r/issues/stale');
   });
 });

--- a/packages/core/src/commands/search.ts
+++ b/packages/core/src/commands/search.ts
@@ -99,6 +99,36 @@ function readScoutDelayOverride(envVar: string): number | undefined {
   return parsed;
 }
 
+/**
+ * Retention window for the search seen-set (#1528). Entries older than this are
+ * culled so the list stays bounded. Set well beyond oss-scout's rotation TTL
+ * (default 7 days) so an entry scout would still exclude is never dropped early.
+ */
+export const SEARCH_SEEN_RETENTION_DAYS = 30;
+
+/**
+ * Record the issues surfaced by a search into the durable seen-set (#1528) so
+ * the next search rotates past them, and cull entries older than
+ * {@link SEARCH_SEEN_RETENTION_DAYS}. Re-surfacing an issue refreshes its
+ * timestamp. No-op-safe: an empty `surfacedUrls` still culls stale entries.
+ */
+export function recordSearchSeen(stateManager: ReturnType<typeof getStateManager>, surfacedUrls: string[]): void {
+  const now = Date.now();
+  const nowIso = new Date(now).toISOString();
+  const cutoff = now - SEARCH_SEEN_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+
+  const byUrl = new Map(stateManager.getSearchSeen().map((e) => [e.url, e]));
+  for (const url of surfacedUrls) {
+    byUrl.set(url, { url, lastSeenAt: nowIso });
+  }
+
+  const next = [...byUrl.values()].filter((e) => {
+    const seen = Date.parse(e.lastSeenAt);
+    return Number.isNaN(seen) ? false : seen >= cutoff;
+  });
+  stateManager.setSearchSeen(next);
+}
+
 export async function runSearch(options: SearchOptions): Promise<SearchOutput> {
   // Collect bridge-level degradation signals (#1448): an unreadable skip file
   // means scout searched with an empty skip list, so explicitly-skipped
@@ -148,6 +178,14 @@ export async function runSearch(options: SearchOptions): Promise<SearchOutput> {
     ...(interPhaseDelayMs !== undefined ? { interPhaseDelayMs } : {}),
     ...(broadPhaseDelayMs !== undefined ? { broadPhaseDelayMs } : {}),
   });
+
+  // Record everything scout surfaced this round into the durable seen-set so
+  // the next search rotates past it (#1528). Done before the own-PR filter so
+  // hidden-but-surfaced issues also rotate out. Persists to AgentState.
+  recordSearchSeen(
+    stateManager,
+    result.candidates.map((c) => c.issue.url),
+  );
 
   // #1354: never surface issues the user already has an open PR for. Uses
   // scout's structured linked-PR metadata when present; candidates without it

--- a/packages/core/src/core/state-schema.ts
+++ b/packages/core/src/core/state-schema.ts
@@ -433,6 +433,21 @@ export const DailyDigestSchema = z.object({
 
 // ── 8. Root schema ───────────────────────────────────────────────────
 
+/**
+ * One entry in the search seen-set (#1528). Records that an issue URL was
+ * surfaced by a recent `search` so the next search can rotate past it instead
+ * of returning the same candidates every time. oss-scout's `search()` excludes
+ * URLs whose `lastSeenAt` is within its rotation TTL (default 7 days); this is
+ * the durable backing store that lets that exclusion survive between separate
+ * `/oss` invocations (autopilot runs scout in `persistence: 'provided'` mode,
+ * so scout persists nothing itself). Deliberately lean — only the two fields
+ * scout's rotation reads — so the state file stays small.
+ */
+export const SearchSeenEntrySchema = z.object({
+  url: z.string(),
+  lastSeenAt: z.string(),
+});
+
 export const AgentStateSchema = z.object({
   version: z.literal(4),
   gistId: z.string().optional(),
@@ -488,6 +503,15 @@ export const AgentStateSchema = z.object({
    * Restart / Discard when present.
    */
   workflowState: WorkflowStateSchema.optional(),
+
+  /**
+   * Durable search seen-set for result rotation (#1528). Issue URLs surfaced
+   * by recent searches, with the timestamp they were last surfaced. Fed into
+   * oss-scout as `savedResults` so its rotation excludes recently-surfaced
+   * issues, and updated after each search. Culled past the rotation window so
+   * it cannot grow without bound.
+   */
+  searchSeen: z.array(SearchSeenEntrySchema).default([]),
 });
 
 // ── Inferred types ───────────────────────────────────────────────────
@@ -497,6 +521,7 @@ export type FetchedPRStatus = z.infer<typeof FetchedPRStatusSchema>;
 export type ProjectCategory = z.infer<typeof ProjectCategorySchema>;
 export type IssueScope = z.infer<typeof IssueScopeSchema>;
 export type DiffTool = z.infer<typeof DiffToolSchema>;
+export type SearchSeenEntry = z.infer<typeof SearchSeenEntrySchema>;
 export type RepoSignals = z.infer<typeof RepoSignalsSchema>;
 export type RepoScore = z.infer<typeof RepoScoreSchema>;
 export type StoredMergedPR = z.infer<typeof StoredMergedPRSchema>;

--- a/packages/core/src/core/state.ts
+++ b/packages/core/src/core/state.ts
@@ -16,6 +16,7 @@ import {
   FetchedPRStatus,
   StoredMergedPR,
   StoredClosedPR,
+  SearchSeenEntry,
 } from './types.js';
 import { AgentStateSchema } from './state-schema.js';
 import {
@@ -972,6 +973,24 @@ export class StateManager {
    * @param status - The overridden status
    * @param lastActivityAt - ISO timestamp of PR's last activity when override was set
    */
+  /**
+   * The durable search seen-set (#1528) — issue URLs surfaced by recent
+   * searches, fed into oss-scout for result rotation. Returns `[]` when none
+   * recorded yet.
+   */
+  getSearchSeen(): SearchSeenEntry[] {
+    return this.state.searchSeen ?? [];
+  }
+
+  /**
+   * Replace the search seen-set (#1528). Callers merge the just-surfaced URLs
+   * and cull stale entries before calling this; the manager only persists.
+   */
+  setSearchSeen(seen: SearchSeenEntry[]): void {
+    this.state.searchSeen = seen;
+    this.autoSave();
+  }
+
   setStatusOverride(url: string, status: FetchedPRStatus, lastActivityAt: string): void {
     if (!this.state.config.statusOverrides) {
       this.state.config.statusOverrides = {};

--- a/packages/core/src/core/test-utils.ts
+++ b/packages/core/src/core/test-utils.ts
@@ -217,6 +217,10 @@ export function makeStateManagerMock(
     setStatusOverride: () => {},
     clearStatusOverride: () => false,
     getStatusOverride: () => undefined,
+    getSearchSeen: () => state.searchSeen ?? [],
+    setSearchSeen: (seen: AgentState['searchSeen']) => {
+      state.searchSeen = seen;
+    },
     getRepoScore: () => undefined,
     updateRepoScore: () => {},
     incrementMergedCount: () => {},

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -46,6 +46,7 @@ export type {
   MergedPR,
   DailyDigest,
   AgentState,
+  SearchSeenEntry,
 } from './state-schema.js';
 
 // ── Ephemeral types (never persisted, hand-written) ──────────────────


### PR DESCRIPTION
## What

Makes search-result rotation actually work through `/oss` by giving oss-scout a durable seen-set to exclude against. Companion to the oss-scout rotation fix (#249 → costajohnt/oss-scout#250).

## Why

oss-scout's `search()` excludes issues whose `lastSeenAt` is within a rotation TTL so consecutive searches surface fresh candidates. But autopilot runs scout in `persistence: 'provided'` and `buildScoutState` hardcoded `savedResults: []`, so scout had nothing to exclude and never persisted what it surfaced — every `/oss` search returned the same set.

## How

- New `AgentState.searchSeen` (`{ url, lastSeenAt }[]`), defaulted, lean by design.
- `buildScoutState` maps it into scout's `savedResults` (only `issueUrl` + `lastSeenAt` drive rotation; other fields are neutral placeholders).
- After each search, `recordSearchSeen` records the surfaced URLs (refreshing timestamps) and culls entries older than `SEARCH_SEEN_RETENTION_DAYS` (30, well beyond scout's 7-day TTL) so the list stays bounded.
- `StateManager` gains `getSearchSeen` / `setSearchSeen`.

## Tests

New unit tests for `recordSearchSeen` (add / refresh / cull) and the `buildScoutState` seen-set→savedResults mapping; shared test mocks updated. Full suite green except the 2 pre-existing gist-token-scope failures.

Closes the rotation-persistence half of #1528. Depends on costajohnt/oss-scout#250 being released and the `@oss-scout/core` dependency bumped before rotation is visible end-to-end.
