### PR TITLE
fix(deps): bump @oss-scout/core to 1.2.2 (search result rotation)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "@octokit/plugin-throttling": "^11.0.3",
     "@octokit/rest": "^22.0.1",
-    "@oss-scout/core": "^1.2.1",
+    "@oss-scout/core": "^1.2.2",
     "commander": "^15.0.0",
     "zod": "^4.4.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@oss-scout/core':
-        specifier: ^1.2.1
-        version: 1.2.1(@octokit/core@7.0.6)
+        specifier: ^1.2.2
+        version: 1.2.2(@octokit/core@7.0.6)
       commander:
         specifier: ^15.0.0
         version: 15.0.0
@@ -692,8 +692,8 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@oss-scout/core@1.2.1':
-    resolution: {integrity: sha512-7hWL3BOJ9cIXV226iAibBkBY34/zLxboJ1YzdDqrxCw3Oqjvc0foTbNSyAY+mmllqBq74fjeJET63HxiHzMhzQ==}
+  '@oss-scout/core@1.2.2':
+    resolution: {integrity: sha512-vC0fsASi8cnhUGMzjz5L+Eo3DAYej/LMORmTXgZKdn8RQIloQw968vIriG131VlF9Hh/t5/mtByxlNLx+Ij9Gw==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
@@ -3321,7 +3321,7 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@oss-scout/core@1.2.1(@octokit/core@7.0.6)':
+  '@oss-scout/core@1.2.2(@octokit/core@7.0.6)':
     dependencies:
       '@octokit/plugin-throttling': 11.0.3(@octokit/core@7.0.6)
       '@octokit/rest': 22.0.1


### PR DESCRIPTION
## What

Bumps `@oss-scout/core` to `^1.2.2` (lockfile → 1.2.2).

## Why

oss-scout 1.2.2 (costajohnt/oss-scout#250) adds search result **rotation**: `search()` now excludes recently-surfaced issues so consecutive searches return fresh candidates. Autopilot already persists the seen-set (#1532) that scout's rotation reads, but it was pinned to scout 1.2.1 which lacks the exclusion. This bump is the last hop that makes rotation work end-to-end through `/oss`.

Non-breaking: autopilot passes no new scout options, so scout's defaults apply (7-day rotation TTL). Typecheck + scout-bridge/search tests pass against 1.2.2.
