### PR TITLE
fix(commands): rebuild stale CLI bundle before standalone bundle calls

### DIFF
--- a/commands/oss-guidelines.md
+++ b/commands/oss-guidelines.md
@@ -19,6 +19,8 @@ the full extraction.
 
 ## What it does
 
+> **Bundle freshness:** the steps below prefer the MCP tools (no bundle needed). If you fall back to a `cli.bundle.cjs` call, first ensure the bundle reflects the installed plugin version — the plugin ships no prebuilt bundle, so a stale one can persist after an update. Run `"${CLAUDE_PLUGIN_ROOT}/scripts/build-cli-if-stale.sh" "${CLAUDE_PLUGIN_ROOT}"` once before the first bundle call (exit 2 = build failed: stop and surface it). Skip this entirely when using the MCP tools.
+
 1. **Resolve the target repo.**
    - If an argument was passed, use it verbatim.
    - Otherwise, enumerate repos with stored guidelines via the

--- a/commands/oss-search.md
+++ b/commands/oss-search.md
@@ -36,6 +36,20 @@ Route based on choice:
 
 ## Run Search
 
+### Pre-Search: Ensure the CLI bundle is current
+
+The plugin ships **no** prebuilt bundle (`packages/*/dist/` is gitignored), so a stale or missing `cli.bundle.cjs` from a previous version can persist in the plugin cache after an update. `/oss` rebuilds on startup, but this command runs the bundle directly — so rebuild it here first, or a freshly-updated plugin would run old code (e.g. the pre-1-10 grade or pre-skip-list-fix behavior). Run the canonical helper before any bundle invocation:
+
+```bash
+CLI_BUILD_RC=0
+"${CLAUDE_PLUGIN_ROOT}/scripts/build-cli-if-stale.sh" "${CLAUDE_PLUGIN_ROOT}" >/tmp/oss-search-cli-build.log 2>&1 || CLI_BUILD_RC=$?
+if [ "$CLI_BUILD_RC" = "2" ]; then
+  echo "CLI_BUILD_FAILED"; tail -5 /tmp/oss-search-cli-build.log
+fi
+```
+
+If the output contains `CLI_BUILD_FAILED` (helper exit code 2), the bundle is stale and could not be rebuilt — **stop**, show the build error, and suggest `cd "${CLAUDE_PLUGIN_ROOT}/packages/core" && npm install && npm run bundle`. Do NOT run the search against a stale bundle. Exit codes 0 (current) and 1 (rebuilt) are both fine — proceed.
+
 ### Pre-Search: Cull Skip File
 
 If a skipped issues file exists (from startup data's `skippedIssuesPath`, or probe `skipped-issues.md` in the same directory as the issue list), auto-cull entries older than 90 days:


### PR DESCRIPTION
## Problem

The plugin ships **no** prebuilt CLI bundle — `packages/*/dist/` is gitignored, so the bundle is built on-machine by `scripts/build-cli-if-stale.sh`. That helper runs in `/oss` (startup) and `/setup-oss`, but **not** in `/oss-search`, which `node`s `cli.bundle.cjs` directly. So after a plugin update, a stale (or missing) bundle from the previous version persists in the plugin cache and `/oss-search` runs old code until the user happens to run `/oss`.

Observed live: right after updating to 3.15.0, `/oss-search` returned candidates with the **old grade shape** (no 1-10 score) and pre-skip-list-fix behavior, because the cached bundle was months old. Running the rebuild made the new code take effect.

## Fix

- `/oss-search`: add a "Pre-Search: Ensure the CLI bundle is current" step that runs the canonical `build-cli-if-stale.sh` before any bundle invocation; stop on a failed rebuild (exit 2) instead of searching against a stale bundle.
- `/oss-guidelines`: it is MCP-first and only uses the bundle as a fallback, so it gets a conditional note to rebuild before a CLI fallback (skipped when using MCP).

No change to `/oss-dashboard` (already has an inline build-if-stale guard) or `/oss` (builds via startup). Command-layer markdown only.
