### PR TITLE
fix(deps): bump @oss-scout/core to 1.2.3 (linked-PR quality gate)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "@octokit/plugin-throttling": "^11.0.3",
     "@octokit/rest": "^22.0.1",
-    "@oss-scout/core": "^1.2.2",
+    "@oss-scout/core": "^1.2.3",
     "commander": "^15.0.0",
     "zod": "^4.4.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@oss-scout/core':
-        specifier: ^1.2.2
-        version: 1.2.2(@octokit/core@7.0.6)
+        specifier: ^1.2.3
+        version: 1.2.3(@octokit/core@7.0.6)
       commander:
         specifier: ^15.0.0
         version: 15.0.0
@@ -692,8 +692,8 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@oss-scout/core@1.2.2':
-    resolution: {integrity: sha512-vC0fsASi8cnhUGMzjz5L+Eo3DAYej/LMORmTXgZKdn8RQIloQw968vIriG131VlF9Hh/t5/mtByxlNLx+Ij9Gw==}
+  '@oss-scout/core@1.2.3':
+    resolution: {integrity: sha512-jMwcTU8rkb7qlDfE1G9DDZRIUoRgQriwNz9GkF5VNHORgx0wub8QCG1Pehq8/3QnVvBQ+1KI5SFH7iqH/a6Xuw==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
@@ -3321,7 +3321,7 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@oss-scout/core@1.2.2(@octokit/core@7.0.6)':
+  '@oss-scout/core@1.2.3(@octokit/core@7.0.6)':
     dependencies:
       '@octokit/plugin-throttling': 11.0.3(@octokit/core@7.0.6)
       '@octokit/rest': 22.0.1


### PR DESCRIPTION
## What

Bumps `@oss-scout/core` to `^1.2.3` (lockfile → 1.2.3).

## Why

oss-scout 1.2.3 (costajohnt/oss-scout#252) adds the #249 part-B linked-PR quality gate: an issue whose cross-referenced PR is already **merged** (resolved) or **closed** (abandoned) now recommends `skip` with a specific reason, instead of surfacing as `needs_review` noise. This bump brings that into `/oss-search`.

Non-breaking: autopilot passes no new scout options. Typecheck + scout-bridge/search tests pass against 1.2.3.
