### PR TITLE
fix(setup): make skipBroadWhenSufficientResults and two other keys settable

### DIFF
--- a/packages/core/src/commands/setup.test.ts
+++ b/packages/core/src/commands/setup.test.ts
@@ -20,7 +20,7 @@ vi.mock('./validation.js', () => ({
   validateGitHubUsername: vi.fn(),
 }));
 
-import { getStateManager, maybeCheckpoint } from '../core/index.js';
+import { getStateManager, maybeCheckpoint, getSetupKeys } from '../core/index.js';
 import { runSetup, runCheckSetup } from './setup.js';
 import type { SetupSetOutput, SetupRequiredOutput } from './setup.js';
 
@@ -176,6 +176,58 @@ describe('runSetup', () => {
   it('should handle dormantDays setting', async () => {
     await runSetup({ set: ['dormantDays=14'] });
     expect(mockUpdateConfig).toHaveBeenCalledWith({ dormantThresholdDays: 14 });
+  });
+
+  // Regression: every key the registry advertises as `settableVia: 'setup'` must
+  // have a switch handler in runSetup. Three keys (skipBroadWhenSufficientResults,
+  // healthCheckFreshnessMinutes, reviewMaxPasses) shipped advertised-but-unhandled,
+  // so `setup --set <key>=…` hit the `default` branch and threw the self-referential
+  // "Unknown setting … Did you mean <same key>?" error. Probe with '1' (a valid
+  // value for the numeric keys, harmless for the rest): a handled key never yields
+  // the unknown-key error; an unhandled key always does.
+  it('handles every settableVia:setup registry key (no unknown-key error)', async () => {
+    const unhandled: string[] = [];
+    for (const key of getSetupKeys()) {
+      try {
+        await runSetup({ set: [`${key}=1`] });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (/Unknown setting|Did you mean/.test(message)) {
+          unhandled.push(key);
+        }
+      }
+    }
+    expect(unhandled).toEqual([]);
+  });
+
+  it('should handle skipBroadWhenSufficientResults setting', async () => {
+    const result = (await runSetup({ set: ['skipBroadWhenSufficientResults=5'] })) as SetupSetOutput;
+    expect(mockUpdateConfig).toHaveBeenCalledWith({ skipBroadWhenSufficientResults: 5 });
+    expect(result.settings.skipBroadWhenSufficientResults).toBe('5');
+  });
+
+  it('should allow skipBroadWhenSufficientResults=0 (always run broad phase)', async () => {
+    await runSetup({ set: ['skipBroadWhenSufficientResults=0'] });
+    expect(mockUpdateConfig).toHaveBeenCalledWith({ skipBroadWhenSufficientResults: 0 });
+  });
+
+  it('should reject a negative skipBroadWhenSufficientResults', async () => {
+    await expect(runSetup({ set: ['skipBroadWhenSufficientResults=-1'] })).rejects.toThrow(/non-negative integer/);
+    expect(mockUpdateConfig).not.toHaveBeenCalled();
+  });
+
+  it('should handle healthCheckFreshnessMinutes setting', async () => {
+    await runSetup({ set: ['healthCheckFreshnessMinutes=45'] });
+    expect(mockUpdateConfig).toHaveBeenCalledWith({ healthCheckFreshnessMinutes: 45 });
+  });
+
+  it('should reject a non-positive healthCheckFreshnessMinutes', async () => {
+    await expect(runSetup({ set: ['healthCheckFreshnessMinutes=0'] })).rejects.toThrow(/positive integer/);
+  });
+
+  it('should handle reviewMaxPasses setting', async () => {
+    await runSetup({ set: ['reviewMaxPasses=4'] });
+    expect(mockUpdateConfig).toHaveBeenCalledWith({ reviewMaxPasses: 4 });
   });
 
   it('should handle approachingDays setting', async () => {

--- a/packages/core/src/commands/setup.ts
+++ b/packages/core/src/commands/setup.ts
@@ -32,6 +32,14 @@ function parsePositiveInt(value: string, settingName: string): number {
   return parsed;
 }
 
+function parseNonNegativeInt(value: string, settingName: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new ValidationError(`Invalid value for ${settingName}: "${value}". Must be a non-negative integer.`);
+  }
+  return parsed;
+}
+
 interface SetupOptions {
   reset?: boolean;
   set?: string[];
@@ -380,6 +388,26 @@ export async function runSetup(options: SetupOptions): Promise<SetupOutput> {
           case 'diffToolCustomCommand': {
             stateManager.updateConfig({ diffToolCustomCommand: value || undefined });
             results[key] = value || '(cleared)';
+            break;
+          }
+          case 'skipBroadWhenSufficientResults': {
+            // 0 is valid and meaningful ("always run the broad phase"), so this
+            // key allows zero unlike the positive-int keys above.
+            const threshold = parseNonNegativeInt(value, 'skipBroadWhenSufficientResults');
+            stateManager.updateConfig({ skipBroadWhenSufficientResults: threshold });
+            results[key] = String(threshold);
+            break;
+          }
+          case 'healthCheckFreshnessMinutes': {
+            const minutes = parsePositiveInt(value, 'healthCheckFreshnessMinutes');
+            stateManager.updateConfig({ healthCheckFreshnessMinutes: minutes });
+            results[key] = String(minutes);
+            break;
+          }
+          case 'reviewMaxPasses': {
+            const passes = parsePositiveInt(value, 'reviewMaxPasses');
+            stateManager.updateConfig({ reviewMaxPasses: passes });
+            results[key] = String(passes);
             break;
           }
           case 'complete': {

--- a/packages/core/src/core/state-gist-init.test.ts
+++ b/packages/core/src/core/state-gist-init.test.ts
@@ -44,6 +44,20 @@ vi.mock('./paths.js', async (importOriginal) => {
     },
     getLegacyStatePath: () => path.join(mockTmpDir, 'legacy-data', 'state.json'),
     getLegacyBackupDir: () => path.join(mockTmpDir, 'legacy-data', 'backups'),
+    // `peekGistArtifacts()` reads these; without redirecting them the ...actual
+    // versions resolve against the real ~/.oss-autopilot (their internal
+    // getDataDir reference is not the mocked one), so the suite fails on any
+    // machine with a real gist config. Point them into mockTmpDir like the rest.
+    getStateCachePath: () => {
+      if (!mockTmpDir) throw new Error('mockTmpDir not set');
+      if (!fs.existsSync(mockTmpDir)) fs.mkdirSync(mockTmpDir, { recursive: true, mode: 0o700 });
+      return path.join(mockTmpDir, 'state-cache.json');
+    },
+    getGistIdPath: () => {
+      if (!mockTmpDir) throw new Error('mockTmpDir not set');
+      if (!fs.existsSync(mockTmpDir)) fs.mkdirSync(mockTmpDir, { recursive: true, mode: 0o700 });
+      return path.join(mockTmpDir, 'gist-id');
+    },
   };
 });
 


### PR DESCRIPTION
## Summary

Three config keys marked `settableVia: 'setup'` in the registry had no case in `runSetup`'s `--set` switch, so setting any of them hit the `default` branch and threw the self-referential error `Unknown setting "<key>". Did you mean "<same key>"?`:

- `skipBroadWhenSufficientResults` (the v3.16.0 broad-phase flag)
- `healthCheckFreshnessMinutes`
- `reviewMaxPasses`

This adds the three handlers with integer validation (`skipBroadWhenSufficientResults` allows `0` = always run the broad phase; the other two require a positive int), plus a regression guard test asserting every `getSetupKeys()` key is handled so an advertised-but-unhandled key can't ship again.

## Test hermeticity fix

`state-gist-init.test.ts` mocked `./paths.js` for `getDataDir`/`getStatePath`/`getBackupDir` but not `getStateCachePath`/`getGistIdPath`, which `peekGistArtifacts()` reads. Their `...actual` implementations resolve against the real `~/.oss-autopilot`, so two tests failed on any machine with a real gist config (green in CI, red on the local pre-push gate). Both are now redirected into the test tmp dir like the other path helpers.

## Verification

- `pnpm --filter @oss-autopilot/core test` → 2974 passed
- typecheck, eslint (0 errors), prettier all clean
