### PR TITLE
feat(monitor): batch per-PR enrichment via GraphQL to cut daily REST usage ~6x

### DIFF
--- a/packages/core/src/core/ci-analysis.ts
+++ b/packages/core/src/core/ci-analysis.ts
@@ -342,6 +342,53 @@ export function mergeStatuses(
   return unknownCIStatus();
 }
 
+/** Minimal check-run shape consumed by {@link computeCIStatus} — shared by the
+ *  REST (`checks.listForRef`) and GraphQL (`statusCheckRollup`) enrichment paths. */
+export interface RawCheckRun {
+  name: string;
+  conclusion: string | null;
+  status: string;
+  /** ISO timestamp used to pick the most recent run when a name repeats. */
+  started_at?: string | null;
+}
+
+/** Minimal combined-status shape consumed by {@link computeCIStatus} — mirrors
+ *  `repos.getCombinedStatusForRef` and GraphQL `commit.status`. */
+export interface RawCombinedStatus {
+  state: string;
+  statuses: Array<{ state: string; context: string; description: string | null }>;
+}
+
+/**
+ * Compute a {@link CIStatusResult} from raw check runs and combined-status data.
+ *
+ * Extracted so the REST path ({@link getCIStatus}) and the batched GraphQL
+ * enrichment path (`pr-graphql.ts`) share identical status derivation — the
+ * only difference between the two is where the raw check-run / combined-status
+ * data comes from, guaranteeing CI-status parity by construction.
+ *
+ * Deduplicates check runs by name (keeping the most recent run per name), then
+ * merges the check-run and combined-status analyses.
+ */
+export function computeCIStatus(checkRuns: RawCheckRun[], combinedStatus: RawCombinedStatus): CIStatusResult {
+  // Deduplicate check runs by name, keeping only the most recent run per unique name.
+  // GitHub returns all historical runs (including re-runs), so without deduplication
+  // a superseded failure will incorrectly flag the PR as failing even after a re-run passes.
+  const latestCheckRunsByName = new Map<string, RawCheckRun>();
+  for (const check of checkRuns) {
+    const existing = latestCheckRunsByName.get(check.name);
+    if (!existing || new Date(check.started_at ?? 0) > new Date(existing.started_at ?? 0)) {
+      latestCheckRunsByName.set(check.name, check);
+    }
+  }
+  const deduped = [...latestCheckRunsByName.values()];
+
+  const checkRunAnalysis = analyzeCheckRuns(deduped);
+  const combinedAnalysis = analyzeCombinedStatus(combinedStatus);
+
+  return mergeStatuses(checkRunAnalysis, combinedAnalysis, deduped.length);
+}
+
 /**
  * Get CI status for a commit SHA by querying both the combined status API and check runs API.
  * Returns the merged status and names of any failing checks for diagnostics.
@@ -377,22 +424,7 @@ export async function getCIStatus(octokit: Octokit, owner: string, repo: string,
     const combinedStatus = statusResponse.data;
     const allCheckRuns = checksResponse?.data?.check_runs || [];
 
-    // Deduplicate check runs by name, keeping only the most recent run per unique name.
-    // GitHub returns all historical runs (including re-runs), so without deduplication
-    // a superseded failure will incorrectly flag the PR as failing even after a re-run passes.
-    const latestCheckRunsByName = new Map<string, (typeof allCheckRuns)[0]>();
-    for (const check of allCheckRuns) {
-      const existing = latestCheckRunsByName.get(check.name);
-      if (!existing || new Date(check.started_at ?? 0) > new Date(existing.started_at ?? 0)) {
-        latestCheckRunsByName.set(check.name, check);
-      }
-    }
-    const checkRuns = [...latestCheckRunsByName.values()];
-
-    const checkRunAnalysis = analyzeCheckRuns(checkRuns);
-    const combinedAnalysis = analyzeCombinedStatus(combinedStatus);
-
-    return mergeStatuses(checkRunAnalysis, combinedAnalysis, checkRuns.length);
+    return computeCIStatus(allCheckRuns, combinedStatus);
   } catch (error) {
     const statusCode = getHttpStatusCode(error);
 

--- a/packages/core/src/core/pr-assembly.ts
+++ b/packages/core/src/core/pr-assembly.ts
@@ -1,0 +1,203 @@
+/**
+ * Shared PR assembly — turns normalized PR signals into a {@link FetchedPR}.
+ *
+ * Extracted from `PRMonitor.fetchPRDetails` (#1272 lineage) so the REST
+ * enrichment path and the batched GraphQL enrichment path (`pr-graphql.ts`)
+ * share ONE status-determination pipeline. Both paths normalize their raw
+ * data into {@link PRSignals} and call {@link assembleFetchedPR}, which
+ * guarantees the computed {@link FetchedPRStatus} (CI state, review decision,
+ * merge conflicts, unresponded maintainer comments) is byte-for-byte identical
+ * regardless of the transport used to fetch the data.
+ */
+
+import { daysBetween } from './dates.js';
+import { FetchedPR, CIStatusResult } from './types.js';
+import { determineStatus } from './status-determination.js';
+import {
+  type ReviewComment,
+  determineReviewDecision,
+  getLatestChangesRequestedDate,
+  checkUnrespondedComments,
+  getFirstMaintainerResponseAt,
+} from './review-analysis.js';
+import { analyzeChecklist } from './checklist-analysis.js';
+import { extractMaintainerActionHints } from './maintainer-analysis.js';
+import { categorizeCIStatus, classifyFailingChecks } from './ci-analysis.js';
+import { computeDisplayLabel } from './display-utils.js';
+
+/** Issue comment in the shape `checkUnrespondedComments`/`getFirstMaintainerResponseAt` read. */
+export interface AssemblyComment {
+  user?: { login?: string } | null;
+  body?: string | null;
+  created_at: string;
+}
+
+/** Submitted review in the shape the review-analysis helpers read. */
+export interface AssemblyReview {
+  user?: { login?: string } | null;
+  body?: string | null;
+  submitted_at?: string | null;
+  state?: string | null;
+  id?: number;
+}
+
+/**
+ * Normalized, transport-agnostic PR signals consumed by {@link assembleFetchedPR}.
+ * Produced by either the REST path (from `pulls.get` + list endpoints + CI
+ * analysis) or the GraphQL path (from a batched query mapped back into these
+ * REST-equivalent shapes).
+ */
+export interface PRSignals {
+  prUrl: string;
+  owner: string;
+  repo: string;
+  number: number;
+  id: number;
+  title: string;
+  /** PR body; empty string when absent (matches REST `body || ''`). */
+  body: string;
+  createdAt: string;
+  updatedAt: string;
+  /** True when the PR has a merge conflict (REST `mergeable === false || mergeable_state === 'dirty'`). */
+  hasMergeConflict: boolean;
+  comments: AssemblyComment[];
+  reviews: AssemblyReview[];
+  reviewComments: ReviewComment[];
+  ciStatus: CIStatusResult;
+}
+
+/** Config subset the assembly needs — the fields `determineStatus` and comment analysis consume. */
+export interface AssemblyConfig {
+  githubUsername: string;
+  dormantThresholdDays: number;
+  approachingDormantDays: number;
+}
+
+/** HEAD-commit metadata used to decide whether maintainer feedback has been addressed. */
+export interface CommitInfo {
+  date?: string;
+  /** GitHub login of the HEAD commit author. */
+  author?: string;
+}
+
+/**
+ * Assemble a {@link FetchedPR} from normalized signals.
+ *
+ * `getCommitInfo` is invoked lazily — and only when the status logic actually
+ * needs the HEAD commit date (an unresponded maintainer comment or a
+ * changes-requested review). The REST path uses this to avoid an extra
+ * `repos.getCommit` call; the GraphQL path already has the commit in the batch
+ * and simply returns it. Because `determineStatus` consults the commit date
+ * only in those same branches, always-providing it (GraphQL) versus
+ * lazily-providing it (REST) yields an identical result.
+ */
+export async function assembleFetchedPR(
+  signals: PRSignals,
+  config: AssemblyConfig,
+  getCommitInfo: () => Promise<CommitInfo | undefined>,
+): Promise<FetchedPR> {
+  const { comments, reviews, reviewComments } = signals;
+
+  // Determine review decision (delegated to review-analysis module)
+  const reviewDecision = determineReviewDecision(reviews);
+
+  const mergeConflict = signals.hasMergeConflict;
+
+  // Check if there's an unresponded maintainer comment (delegated to review-analysis module)
+  const { hasUnrespondedComment, lastMaintainerComment } = checkUnrespondedComments(
+    comments,
+    reviews,
+    reviewComments,
+    config.githubUsername,
+  );
+
+  // Earliest maintainer response, computed from the comment/review timeline (#1461).
+  const firstMaintainerResponseAt = getFirstMaintainerResponseAt(comments, reviews, config.githubUsername);
+
+  // We need the commit date when hasUnrespondedComment is true (to distinguish
+  // "needs_response" from "waiting_on_maintainer") OR when reviewDecision is
+  // "changes_requested" (to detect needs_changes: review requested changes but
+  // no new commits pushed). Fetched lazily so the REST path skips the call when
+  // it isn't needed.
+  const needCommitDate = hasUnrespondedComment || reviewDecision === 'changes_requested';
+  const commitInfo = needCommitDate ? await getCommitInfo() : undefined;
+  const latestCommitDate = commitInfo?.date;
+  const latestCommitAuthor = commitInfo?.author;
+
+  // Analyze PR body for incomplete checklists (delegated to checklist-analysis module)
+  const { hasIncompleteChecklist, checklistStats } = analyzeChecklist(signals.body || '');
+
+  // Extract maintainer action hints from comments (delegated to maintainer-analysis module)
+  const maintainerActionHints = extractMaintainerActionHints(lastMaintainerComment?.body, reviewDecision);
+
+  // Calculate days since activity
+  const daysSinceActivity = daysBetween(new Date(signals.updatedAt), new Date());
+
+  // Find the date of the latest changes_requested review (delegated to review-analysis module)
+  const latestChangesRequestedDate = getLatestChangesRequestedDate(reviews);
+
+  const { status: ciStatus, failingCheckNames, failingCheckConclusions } = signals.ciStatus;
+
+  // Classify failing checks (delegated to ci-analysis module)
+  const classifiedChecks = classifyFailingChecks(failingCheckNames, failingCheckConclusions);
+
+  // Aggregate 5-state CI categorization (#1272).
+  const ciCategorization = categorizeCIStatus({ ciStatus, failingCheckNames, classifiedChecks });
+
+  // Determine status
+  const hasActionableCIFailure = ciStatus === 'failing' && classifiedChecks.some((c) => c.category === 'actionable');
+  const { status, actionReason, waitReason, stalenessTier, actionReasons } = determineStatus({
+    ciStatus,
+    hasMergeConflict: mergeConflict,
+    hasUnrespondedComment,
+    hasIncompleteChecklist,
+    reviewDecision,
+    daysSinceActivity,
+    dormantThreshold: config.dormantThresholdDays,
+    approachingThreshold: config.approachingDormantDays,
+    latestCommitDate,
+    latestCommitAuthor,
+    contributorUsername: config.githubUsername,
+    lastMaintainerCommentDate: lastMaintainerComment?.createdAt,
+    latestChangesRequestedDate,
+    hasActionableCIFailure,
+  });
+
+  const pr: FetchedPR = {
+    id: signals.id,
+    url: signals.prUrl,
+    repo: `${signals.owner}/${signals.repo}`,
+    number: signals.number,
+    title: signals.title,
+    status,
+    actionReason,
+    waitReason,
+    stalenessTier,
+    actionReasons,
+    createdAt: signals.createdAt,
+    updatedAt: signals.updatedAt,
+    firstMaintainerResponseAt,
+    daysSinceActivity,
+    ciStatus,
+    failingCheckNames,
+    classifiedChecks,
+    ciCategorization,
+    hasMergeConflict: mergeConflict,
+    reviewDecision,
+    hasUnrespondedComment,
+    lastMaintainerComment,
+    latestCommitDate,
+    hasIncompleteChecklist,
+    checklistStats,
+    maintainerActionHints,
+    displayLabel: '', // computed below
+    displayDescription: '', // computed below
+  };
+
+  // Compute display labels (#79) — delegated to display-utils module
+  const { displayLabel, displayDescription } = computeDisplayLabel(pr);
+  pr.displayLabel = displayLabel;
+  pr.displayDescription = displayDescription;
+
+  return pr;
+}

--- a/packages/core/src/core/pr-graphql.test.ts
+++ b/packages/core/src/core/pr-graphql.test.ts
@@ -1,0 +1,588 @@
+/**
+ * Tests for the batched GraphQL PR enrichment path (pr-graphql.ts) and its
+ * status parity with the REST path (pr-assembly.ts).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { buildBatchQuery, normalizePRNode, batchFetchPRDetails, BATCH_SIZE, type PRRef } from './pr-graphql.js';
+import { assembleFetchedPR, type PRSignals, type AssemblyConfig } from './pr-assembly.js';
+import { computeCIStatus } from './ci-analysis.js';
+
+const CONFIG: AssemblyConfig = {
+  githubUsername: 'contributor',
+  dormantThresholdDays: 30,
+  approachingDormantDays: 25,
+};
+
+const ref = (owner: string, repo: string, number: number): PRRef => ({
+  owner,
+  repo,
+  number,
+  url: `https://github.com/${owner}/${repo}/pull/${number}`,
+});
+
+/** Minimal well-formed GraphQL PR node with sensible empty defaults. */
+function makeNode(overrides: Record<string, unknown> = {}): any {
+  return {
+    databaseId: 12345,
+    number: 7,
+    title: 'Add feature',
+    url: 'https://github.com/o/r/pull/7',
+    state: 'OPEN',
+    isDraft: false,
+    mergeable: 'MERGEABLE',
+    body: '',
+    createdAt: '2026-02-01T00:00:00Z',
+    updatedAt: '2026-02-07T00:00:00Z',
+    comments: { totalCount: 0, nodes: [] },
+    reviews: { totalCount: 0, nodes: [] },
+    reviewThreads: { totalCount: 0, nodes: [] },
+    commits: {
+      nodes: [
+        {
+          commit: {
+            oid: 'abc123',
+            authoredDate: '2026-02-06T00:00:00Z',
+            author: { user: { login: 'contributor' } },
+            status: null,
+            statusCheckRollup: null,
+          },
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+describe('buildBatchQuery', () => {
+  it('parameterizes owner/repo/number and aliases each PR', () => {
+    const { query, variables } = buildBatchQuery([ref('facebook', 'react', 1), ref('vuejs', 'core', 42)]);
+
+    // Aliases and variable references present
+    expect(query).toContain('pr0: repository(owner: $o0, name: $r0)');
+    expect(query).toContain('pullRequest(number: $n0)');
+    expect(query).toContain('pr1: repository(owner: $o1, name: $r1)');
+    expect(query).toContain('pullRequest(number: $n1)');
+    expect(query).toContain('query batchPRDetails($o0: String!, $r0: String!, $n0: Int!');
+
+    // Values travel as variables, never interpolated into the query body
+    expect(variables).toEqual({
+      o0: 'facebook',
+      r0: 'react',
+      n0: 1,
+      o1: 'vuejs',
+      r1: 'core',
+      n1: 42,
+    });
+    expect(query).not.toContain('facebook');
+    expect(query).not.toContain('vuejs');
+  });
+});
+
+describe('normalizePRNode', () => {
+  it('maps a clean node into REST-equivalent signals', () => {
+    const node = makeNode({
+      mergeable: 'CONFLICTING',
+      body: 'Fixes #1',
+      comments: {
+        totalCount: 1,
+        nodes: [{ author: { login: 'maintainer' }, body: 'please rebase', createdAt: '2026-02-03T00:00:00Z' }],
+      },
+      reviews: {
+        totalCount: 1,
+        nodes: [
+          {
+            databaseId: 900,
+            state: 'CHANGES_REQUESTED',
+            body: 'fix this',
+            submittedAt: '2026-02-05T00:00:00Z',
+            author: { login: 'maintainer' },
+          },
+        ],
+      },
+    });
+
+    const outcome = normalizePRNode(node);
+    expect(outcome.kind).toBe('ok');
+    if (outcome.kind !== 'ok') return;
+    const d = outcome.data;
+
+    expect(d.id).toBe(12345);
+    expect(d.body).toBe('Fixes #1');
+    expect(d.hasMergeConflict).toBe(true); // CONFLICTING
+    expect(d.comments).toEqual([
+      { user: { login: 'maintainer' }, body: 'please rebase', created_at: '2026-02-03T00:00:00Z' },
+    ]);
+    expect(d.reviews).toEqual([
+      {
+        user: { login: 'maintainer' },
+        body: 'fix this',
+        submitted_at: '2026-02-05T00:00:00Z',
+        state: 'CHANGES_REQUESTED',
+        id: 900,
+      },
+    ]);
+    expect(d.commitInfo).toEqual({ date: '2026-02-06T00:00:00Z', author: 'contributor' });
+    expect(d.headSha).toBe('abc123');
+  });
+
+  it('maps review threads to inline review comments with review + reply ids', () => {
+    const node = makeNode({
+      reviewThreads: {
+        totalCount: 1,
+        nodes: [
+          {
+            comments: {
+              totalCount: 2,
+              nodes: [
+                {
+                  databaseId: 1,
+                  body: 'nit',
+                  createdAt: '2026-02-04T00:00:00Z',
+                  author: { login: 'maintainer' },
+                  replyTo: null,
+                  pullRequestReview: { databaseId: 900 },
+                },
+                {
+                  databaseId: 2,
+                  body: 'ack',
+                  createdAt: '2026-02-04T01:00:00Z',
+                  author: { login: 'contributor' },
+                  replyTo: { databaseId: 1 },
+                  pullRequestReview: { databaseId: 901 },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    const outcome = normalizePRNode(node);
+    if (outcome.kind !== 'ok') throw new Error('expected ok');
+    expect(outcome.data.reviewComments).toEqual([
+      {
+        id: 1,
+        user: { login: 'maintainer' },
+        body: 'nit',
+        created_at: '2026-02-04T00:00:00Z',
+        in_reply_to_id: undefined,
+        pull_request_review_id: 900,
+      },
+      {
+        id: 2,
+        user: { login: 'contributor' },
+        body: 'ack',
+        created_at: '2026-02-04T01:00:00Z',
+        in_reply_to_id: 1,
+        pull_request_review_id: 901,
+      },
+    ]);
+  });
+
+  it('drops PENDING (draft) reviews to match REST listReviews', () => {
+    const node = makeNode({
+      reviews: {
+        totalCount: 2,
+        nodes: [
+          { databaseId: 1, state: 'PENDING', body: 'draft', submittedAt: null, author: { login: 'contributor' } },
+          {
+            databaseId: 2,
+            state: 'APPROVED',
+            body: '',
+            submittedAt: '2026-02-05T00:00:00Z',
+            author: { login: 'maintainer' },
+          },
+        ],
+      },
+    });
+    const outcome = normalizePRNode(node);
+    if (outcome.kind !== 'ok') throw new Error('expected ok');
+    expect(outcome.data.reviews).toHaveLength(1);
+    expect(outcome.data.reviews[0].state).toBe('APPROVED');
+  });
+
+  it('signals overflow when any connection exceeds its cap', () => {
+    expect(normalizePRNode(makeNode({ comments: { totalCount: 101, nodes: [] } })).kind).toBe('overflow');
+    expect(normalizePRNode(makeNode({ reviews: { totalCount: 51, nodes: [] } })).kind).toBe('overflow');
+    expect(normalizePRNode(makeNode({ reviewThreads: { totalCount: 51, nodes: [] } })).kind).toBe('overflow');
+    expect(
+      normalizePRNode(
+        makeNode({
+          reviewThreads: { totalCount: 1, nodes: [{ comments: { totalCount: 21, nodes: [] } }] },
+        }),
+      ).kind,
+    ).toBe('overflow');
+  });
+
+  it('signals overflow when the CI status-check rollup exceeds its cap', () => {
+    // A failing check beyond the 100-context cap would otherwise be silently
+    // dropped and mislabel the PR as passing — so overflow → REST.
+    const node = makeNode({
+      commits: {
+        nodes: [
+          {
+            commit: {
+              oid: 'abc',
+              authoredDate: '2026-02-06T00:00:00Z',
+              author: { user: { login: 'contributor' } },
+              status: null,
+              statusCheckRollup: { contexts: { totalCount: 101, nodes: [] } },
+            },
+          },
+        ],
+      },
+    });
+    expect(normalizePRNode(node).kind).toBe('overflow');
+  });
+
+  it('signals missing for a null node or a node without a databaseId', () => {
+    expect(normalizePRNode(null).kind).toBe('missing');
+    expect(normalizePRNode(undefined).kind).toBe('missing');
+    expect(normalizePRNode(makeNode({ databaseId: null })).kind).toBe('missing');
+  });
+
+  it('maps check runs from the rollup and combined statuses from commit.status', () => {
+    const node = makeNode({
+      commits: {
+        nodes: [
+          {
+            commit: {
+              oid: 'abc',
+              authoredDate: '2026-02-06T00:00:00Z',
+              author: { user: { login: 'contributor' } },
+              status: {
+                state: 'SUCCESS',
+                contexts: [{ context: 'ci/travis', state: 'SUCCESS', description: 'passed' }],
+              },
+              statusCheckRollup: {
+                contexts: {
+                  totalCount: 2,
+                  nodes: [
+                    {
+                      __typename: 'CheckRun',
+                      name: 'build',
+                      conclusion: 'FAILURE',
+                      status: 'COMPLETED',
+                      startedAt: '2026-02-06T00:00:00Z',
+                    },
+                    // StatusContext entries in the rollup are ignored here (read from commit.status)
+                    { __typename: 'StatusContext', context: 'ci/travis', state: 'SUCCESS', description: 'passed' },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+    const outcome = normalizePRNode(node);
+    if (outcome.kind !== 'ok') throw new Error('expected ok');
+    // Failing check run dominates -> failing
+    expect(outcome.data.ciStatus.status).toBe('failing');
+    expect(outcome.data.ciStatus.failingCheckNames).toEqual(['build']);
+  });
+});
+
+describe('batchFetchPRDetails', () => {
+  it('routes every PR to REST when the client has no graphql method', async () => {
+    const octokit = {} as any;
+    const refs = [ref('o', 'r', 1), ref('o', 'r', 2)];
+    const result = await batchFetchPRDetails(octokit, refs);
+    expect(result.resolved.size).toBe(0);
+    expect(result.restFallbackUrls).toEqual(refs.map((r) => r.url));
+  });
+
+  it('resolves PRs returned by a successful batch query', async () => {
+    const graphql = vi.fn().mockResolvedValue({
+      pr0: { pullRequest: makeNode({ databaseId: 1 }) },
+      pr1: { pullRequest: makeNode({ databaseId: 2 }) },
+    });
+    const octokit = { graphql } as any;
+    const refs = [ref('o', 'r', 1), ref('o', 'r', 2)];
+
+    const result = await batchFetchPRDetails(octokit, refs);
+    expect(result.resolved.size).toBe(2);
+    expect(result.resolved.get(refs[0].url)?.id).toBe(1);
+    expect(result.restFallbackUrls).toEqual([]);
+    expect(graphql).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back only the failed PR on a partial-data GraphQL error', async () => {
+    // octokit's GraphqlResponseError attaches resolved aliases to `.data`.
+    const err = Object.assign(new Error('one node errored'), {
+      data: { pr0: { pullRequest: makeNode({ databaseId: 1 }) }, pr1: { pullRequest: null } },
+    });
+    const graphql = vi.fn().mockRejectedValue(err);
+    const octokit = { graphql } as any;
+    const refs = [ref('o', 'r', 1), ref('o', 'r', 2)];
+
+    const result = await batchFetchPRDetails(octokit, refs);
+    expect(result.resolved.size).toBe(1);
+    expect(result.resolved.get(refs[0].url)?.id).toBe(1);
+    expect(result.restFallbackUrls).toEqual([refs[1].url]);
+  });
+
+  it('falls back the whole batch on a non-partial GraphQL error', async () => {
+    const graphql = vi.fn().mockRejectedValue(new Error('network blip'));
+    const octokit = { graphql } as any;
+    const refs = [ref('o', 'r', 1), ref('o', 'r', 2)];
+
+    const result = await batchFetchPRDetails(octokit, refs);
+    expect(result.resolved.size).toBe(0);
+    expect(result.restFallbackUrls).toEqual(refs.map((r) => r.url));
+  });
+
+  it('routes cap-overflow PRs to REST while keeping clean PRs', async () => {
+    const graphql = vi.fn().mockResolvedValue({
+      pr0: { pullRequest: makeNode({ databaseId: 1, comments: { totalCount: 200, nodes: [] } }) },
+      pr1: { pullRequest: makeNode({ databaseId: 2 }) },
+    });
+    const octokit = { graphql } as any;
+    const refs = [ref('o', 'r', 1), ref('o', 'r', 2)];
+
+    const result = await batchFetchPRDetails(octokit, refs);
+    expect(result.resolved.size).toBe(1);
+    expect(result.resolved.has(refs[1].url)).toBe(true);
+    expect(result.restFallbackUrls).toEqual([refs[0].url]);
+  });
+
+  it('rethrows fatal (rate-limit / auth) errors', async () => {
+    const err = Object.assign(new Error('Bad credentials'), { status: 401 });
+    const graphql = vi.fn().mockRejectedValue(err);
+    const octokit = { graphql } as any;
+
+    await expect(batchFetchPRDetails(octokit, [ref('o', 'r', 1)])).rejects.toThrow('Bad credentials');
+  });
+
+  it('rethrows a GraphQL-native RATE_LIMITED error (HTTP 200, no status, errors[])', async () => {
+    // GitHub's primary GraphQL rate limit: HTTP 200 with an errors[] entry and no
+    // numeric status — must NOT be silently absorbed into the REST fallback.
+    const err = Object.assign(new Error('API rate limit exceeded'), {
+      errors: [{ type: 'RATE_LIMITED', message: 'API rate limit exceeded for installation' }],
+      data: null,
+    });
+    const graphql = vi.fn().mockRejectedValue(err);
+    const octokit = { graphql } as any;
+
+    await expect(batchFetchPRDetails(octokit, [ref('o', 'r', 1)])).rejects.toThrow('rate limit exceeded');
+  });
+
+  it('rethrows RATE_LIMITED even when partial data is attached', async () => {
+    const err = Object.assign(new Error('rate limited mid-batch'), {
+      errors: [{ type: 'RATE_LIMITED' }],
+      data: { pr0: { pullRequest: makeNode({ databaseId: 1 }) }, pr1: { pullRequest: null } },
+    });
+    const graphql = vi.fn().mockRejectedValue(err);
+    const octokit = { graphql } as any;
+
+    await expect(batchFetchPRDetails(octokit, [ref('o', 'r', 1), ref('o', 'r', 2)])).rejects.toThrow(
+      'rate limited mid-batch',
+    );
+  });
+
+  it('splits large ref sets into multiple batches', async () => {
+    const graphql = vi.fn().mockImplementation((_q: string, vars: Record<string, unknown>) => {
+      // Echo back a node per alias present in the variables.
+      const resp: Record<string, unknown> = {};
+      let i = 0;
+      while (`o${i}` in vars) {
+        resp[`pr${i}`] = { pullRequest: makeNode({ databaseId: 1000 + i }) };
+        i++;
+      }
+      return Promise.resolve(resp);
+    });
+    const octokit = { graphql } as any;
+    const refs = Array.from({ length: BATCH_SIZE * 2 + 1 }, (_, i) => ref('o', 'r', i + 1));
+
+    const result = await batchFetchPRDetails(octokit, refs);
+    expect(result.resolved.size).toBe(refs.length);
+    expect(graphql).toHaveBeenCalledTimes(3); // ceil(21/10)
+  });
+});
+
+describe('GraphQL vs REST status parity', () => {
+  /**
+   * Same underlying PR, expressed once as a GraphQL node and once as
+   * hand-written REST-equivalent signals. Both go through assembleFetchedPR;
+   * the resulting FetchedPR must be identical. This is the acceptance criterion:
+   * the transport must not change the computed status.
+   */
+  async function assembleFromGraphQL(node: any) {
+    const outcome = normalizePRNode(node);
+    if (outcome.kind !== 'ok') throw new Error('expected ok');
+    const d = outcome.data;
+    const signals: PRSignals = {
+      prUrl: 'https://github.com/o/r/pull/7',
+      owner: 'o',
+      repo: 'r',
+      number: 7,
+      id: d.id,
+      title: d.title === '' ? 'PR' : d.title,
+      body: d.body,
+      createdAt: d.createdAt,
+      updatedAt: d.updatedAt,
+      hasMergeConflict: d.hasMergeConflict,
+      comments: d.comments,
+      reviews: d.reviews,
+      reviewComments: d.reviewComments,
+      ciStatus: d.ciStatus,
+    };
+    return assembleFetchedPR(signals, CONFIG, async () => d.commitInfo);
+  }
+
+  it('produces identical results for a changes-requested + failing-CI PR', async () => {
+    const node = makeNode({
+      title: 'PR',
+      comments: {
+        totalCount: 1,
+        nodes: [{ author: { login: 'contributor' }, body: 'ready', createdAt: '2026-02-01T00:00:00Z' }],
+      },
+      reviews: {
+        totalCount: 1,
+        nodes: [
+          {
+            databaseId: 900,
+            state: 'CHANGES_REQUESTED',
+            body: 'please fix',
+            submittedAt: '2026-02-05T00:00:00Z',
+            author: { login: 'maintainer' },
+          },
+        ],
+      },
+      commits: {
+        nodes: [
+          {
+            commit: {
+              oid: 'sha1',
+              authoredDate: '2026-02-04T00:00:00Z', // before the review -> not addressed
+              author: { user: { login: 'contributor' } },
+              status: null,
+              statusCheckRollup: {
+                contexts: {
+                  totalCount: 1,
+                  nodes: [
+                    {
+                      __typename: 'CheckRun',
+                      name: 'test',
+                      conclusion: 'FAILURE',
+                      status: 'COMPLETED',
+                      startedAt: '2026-02-05T01:00:00Z',
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const prGraphql = await assembleFromGraphQL(node);
+
+    // Hand-written REST-equivalent signals for the SAME PR.
+    const restSignals: PRSignals = {
+      prUrl: 'https://github.com/o/r/pull/7',
+      owner: 'o',
+      repo: 'r',
+      number: 7,
+      id: 12345,
+      title: 'PR',
+      body: '',
+      createdAt: '2026-02-01T00:00:00Z',
+      updatedAt: '2026-02-07T00:00:00Z',
+      hasMergeConflict: false,
+      comments: [{ user: { login: 'contributor' }, body: 'ready', created_at: '2026-02-01T00:00:00Z' }],
+      reviews: [
+        {
+          user: { login: 'maintainer' },
+          body: 'please fix',
+          submitted_at: '2026-02-05T00:00:00Z',
+          state: 'CHANGES_REQUESTED',
+          id: 900,
+        },
+      ],
+      reviewComments: [],
+      ciStatus: computeCIStatus(
+        [{ name: 'test', conclusion: 'failure', status: 'completed', started_at: '2026-02-05T01:00:00Z' }],
+        { state: 'success', statuses: [] },
+      ),
+    };
+    const prRest = await assembleFetchedPR(restSignals, CONFIG, async () => ({
+      date: '2026-02-04T00:00:00Z',
+      author: 'contributor',
+    }));
+
+    expect(prGraphql).toEqual(prRest);
+    expect(prGraphql.status).toBe('needs_addressing');
+    // The changes-requested review body also counts as an unresponded maintainer
+    // comment, so needs_response is the primary reason; needs_changes/failing_ci
+    // are secondary.
+    expect(prGraphql.actionReason).toBe('needs_response');
+    expect(prGraphql.actionReasons).toEqual(['needs_response', 'needs_changes', 'failing_ci']);
+    expect(prGraphql.ciStatus).toBe('failing');
+    expect(prGraphql.reviewDecision).toBe('changes_requested');
+  });
+
+  it('produces identical results for an approved + passing PR (merge conflict)', async () => {
+    const node = makeNode({
+      title: 'PR',
+      mergeable: 'CONFLICTING',
+      reviews: {
+        totalCount: 1,
+        nodes: [
+          {
+            databaseId: 5,
+            state: 'APPROVED',
+            body: 'lgtm',
+            submittedAt: '2026-02-06T00:00:00Z',
+            author: { login: 'maintainer' },
+          },
+        ],
+      },
+      commits: {
+        nodes: [
+          {
+            commit: {
+              oid: 'sha2',
+              authoredDate: '2026-02-06T00:00:00Z',
+              author: { user: { login: 'contributor' } },
+              status: { state: 'SUCCESS', contexts: [{ context: 'ci', state: 'SUCCESS', description: null }] },
+              statusCheckRollup: null,
+            },
+          },
+        ],
+      },
+    });
+    const prGraphql = await assembleFromGraphQL(node);
+
+    const restSignals: PRSignals = {
+      prUrl: 'https://github.com/o/r/pull/7',
+      owner: 'o',
+      repo: 'r',
+      number: 7,
+      id: 12345,
+      title: 'PR',
+      body: '',
+      createdAt: '2026-02-01T00:00:00Z',
+      updatedAt: '2026-02-07T00:00:00Z',
+      hasMergeConflict: true,
+      comments: [],
+      reviews: [
+        { user: { login: 'maintainer' }, body: 'lgtm', submitted_at: '2026-02-06T00:00:00Z', state: 'APPROVED', id: 5 },
+      ],
+      reviewComments: [],
+      ciStatus: computeCIStatus([], {
+        state: 'success',
+        statuses: [{ context: 'ci', state: 'success', description: null }],
+      }),
+    };
+    const prRest = await assembleFetchedPR(restSignals, CONFIG, async () => undefined);
+
+    expect(prGraphql).toEqual(prRest);
+    // Merge conflict takes priority in the needs_addressing tree.
+    expect(prGraphql.status).toBe('needs_addressing');
+    expect(prGraphql.actionReason).toBe('merge_conflict');
+    expect(prGraphql.hasMergeConflict).toBe(true);
+  });
+});

--- a/packages/core/src/core/pr-graphql.ts
+++ b/packages/core/src/core/pr-graphql.ts
@@ -1,0 +1,456 @@
+/**
+ * Batched GraphQL enrichment of open-PR details.
+ *
+ * The REST enrichment path (`PRMonitor.fetchPRDetails`) makes ~6 REST calls per
+ * PR — `pulls.get`, paginated `issues.listComments`, `pulls.listReviews`,
+ * paginated `pulls.listReviewComments`, CI status (combined-status + check-runs),
+ * and a conditional `repos.getCommit`. For 30 open PRs that is ~180 core-quota
+ * REST requests every daily run.
+ *
+ * `batchFetchPRDetails` collapses that into a handful of aliased GraphQL queries
+ * (one per batch of {@link BATCH_SIZE} PRs) drawn from GitHub's SEPARATE GraphQL
+ * point bucket (5000 points/hr; a multi-alias PR query costs ~1 point). Each PR's
+ * data is mapped back into the same REST-equivalent shapes the shared
+ * {@link PRSignals} pipeline consumes, so status determination is unchanged.
+ *
+ * Fallbacks (all route the affected PR back to the REST path):
+ *  - GraphQL unavailable (no `.graphql` on the client) → every PR to REST.
+ *  - A batch-level GraphQL error: fatal errors (401 / rate limit) rethrow; a
+ *    partial-data error keeps the aliases that resolved and sends the rest to REST.
+ *  - A PR that hit a `last:`/`first:` connection cap (comments > 100, reviews > 50,
+ *    review threads > 50, or any thread's comments > 20) → REST, so pagination is
+ *    complete and unresponded-comment detection stays correct.
+ *  - A missing / inaccessible / malformed PR node → REST.
+ */
+
+import type { Octokit } from '@octokit/rest';
+import { CIStatusResult } from './types.js';
+import { computeCIStatus, type RawCheckRun, type RawCombinedStatus } from './ci-analysis.js';
+import type { ReviewComment } from './review-analysis.js';
+import type { AssemblyComment, AssemblyReview, CommitInfo } from './pr-assembly.js';
+import { isRateLimitOrAuthError, errorMessage } from './errors.js';
+import { warn } from './logger.js';
+
+const MODULE = 'pr-graphql';
+
+/** PRs per aliased GraphQL query. GitHub recommends modest batch sizes; ~10 keeps
+ *  each query cheap (~1 point) and well under node/complexity limits. */
+export const BATCH_SIZE = 10;
+
+/** Connection page caps requested per PR. A PR exceeding any of these is sent to
+ *  the REST path (which paginates fully) rather than silently truncated. */
+export const COMMENTS_CAP = 100;
+export const REVIEWS_CAP = 50;
+export const REVIEW_THREADS_CAP = 50;
+export const THREAD_COMMENTS_CAP = 20;
+/** Status-check rollup contexts requested per commit. A PR with more distinct CI
+ *  contexts than this is sent to REST so a failing check beyond the cap can't be
+ *  silently dropped and mislabel the PR as passing. */
+export const CI_CONTEXTS_CAP = 100;
+
+/** A single PR to enrich. */
+export interface PRRef {
+  owner: string;
+  repo: string;
+  number: number;
+  /** Original PR URL — used as the map key and to thread back into REST fallback. */
+  url: string;
+}
+
+/**
+ * Normalized PR data produced from a GraphQL node, in the REST-equivalent shapes
+ * the {@link assembleFetchedPR} pipeline consumes. `commitInfo` is always present
+ * (the batch fetches it for free) but is only consulted when the status logic
+ * needs it.
+ */
+export interface NormalizedPRData {
+  id: number;
+  title: string;
+  body: string;
+  createdAt: string;
+  updatedAt: string;
+  hasMergeConflict: boolean;
+  headSha: string;
+  comments: AssemblyComment[];
+  reviews: AssemblyReview[];
+  reviewComments: ReviewComment[];
+  ciStatus: CIStatusResult;
+  commitInfo: CommitInfo;
+}
+
+/** Outcome of a batched fetch: PRs resolved via GraphQL, plus the URLs that must
+ *  fall back to the REST path (overflow, missing, or GraphQL-unavailable). */
+export interface BatchPRResult {
+  /** Keyed by {@link PRRef.url}. */
+  resolved: Map<string, NormalizedPRData>;
+  /** URLs the caller must enrich via the existing REST path. */
+  restFallbackUrls: string[];
+}
+
+// ── GraphQL response node shapes ─────────────────────────────────────
+
+interface GraphQLActor {
+  login: string;
+}
+
+interface GraphQLCheckRunNode {
+  __typename: 'CheckRun';
+  name: string;
+  conclusion: string | null;
+  status: string | null;
+  startedAt: string | null;
+}
+
+interface GraphQLStatusContextNode {
+  __typename: 'StatusContext';
+  context: string;
+  state: string;
+  description: string | null;
+}
+
+type GraphQLRollupContextNode = GraphQLCheckRunNode | GraphQLStatusContextNode | { __typename: string };
+
+interface GraphQLCommitNode {
+  oid: string;
+  authoredDate: string | null;
+  author: { user: GraphQLActor | null } | null;
+  status: {
+    state: string;
+    contexts: Array<{ context: string; state: string; description: string | null }>;
+  } | null;
+  statusCheckRollup: {
+    contexts: { totalCount: number; nodes: GraphQLRollupContextNode[] };
+  } | null;
+}
+
+interface GraphQLPullRequestNode {
+  databaseId: number | null;
+  number: number;
+  title: string;
+  url: string;
+  mergeable: 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN';
+  body: string | null;
+  createdAt: string;
+  updatedAt: string;
+  comments: {
+    totalCount: number;
+    nodes: Array<{ author: GraphQLActor | null; body: string | null; createdAt: string }>;
+  };
+  reviews: {
+    totalCount: number;
+    nodes: Array<{
+      databaseId: number | null;
+      state: string;
+      body: string | null;
+      submittedAt: string | null;
+      author: GraphQLActor | null;
+    }>;
+  };
+  reviewThreads: {
+    totalCount: number;
+    nodes: Array<{
+      comments: {
+        totalCount: number;
+        nodes: Array<{
+          databaseId: number | null;
+          body: string | null;
+          createdAt: string;
+          author: GraphQLActor | null;
+          replyTo: { databaseId: number | null } | null;
+          pullRequestReview: { databaseId: number | null } | null;
+        }>;
+      };
+    }>;
+  };
+  commits: {
+    nodes: Array<{ commit: GraphQLCommitNode }>;
+  };
+}
+
+/** Shape of the aliased batch response: `{ pr0: { pullRequest }, pr1: { ... }, ... }`. */
+type BatchResponse = Record<string, { pullRequest: GraphQLPullRequestNode | null } | null>;
+
+const PR_FIELDS = `
+  databaseId
+  number
+  title
+  url
+  mergeable
+  body
+  createdAt
+  updatedAt
+  comments(last: ${COMMENTS_CAP}) {
+    totalCount
+    nodes { author { login } body createdAt }
+  }
+  reviews(last: ${REVIEWS_CAP}) {
+    totalCount
+    nodes { databaseId state body submittedAt author { login } }
+  }
+  reviewThreads(last: ${REVIEW_THREADS_CAP}) {
+    totalCount
+    nodes {
+      comments(last: ${THREAD_COMMENTS_CAP}) {
+        totalCount
+        nodes {
+          databaseId
+          body
+          createdAt
+          author { login }
+          replyTo { databaseId }
+          pullRequestReview { databaseId }
+        }
+      }
+    }
+  }
+  commits(last: 1) {
+    nodes {
+      commit {
+        oid
+        authoredDate
+        author { user { login } }
+        status { state contexts { context state description } }
+        statusCheckRollup {
+          contexts(first: ${CI_CONTEXTS_CAP}) {
+            totalCount
+            nodes {
+              __typename
+              ... on CheckRun { name conclusion status startedAt }
+              ... on StatusContext { context state description }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * Build a parameterized aliased GraphQL query for a batch of PRs. Owner / repo /
+ * number are passed as GraphQL variables — never string-interpolated into the
+ * query body — so there is no injection surface.
+ */
+export function buildBatchQuery(refs: PRRef[]): { query: string; variables: Record<string, string | number> } {
+  const varDefs: string[] = [];
+  const selections: string[] = [];
+  const variables: Record<string, string | number> = {};
+
+  refs.forEach((ref, i) => {
+    varDefs.push(`$o${i}: String!, $r${i}: String!, $n${i}: Int!`);
+    variables[`o${i}`] = ref.owner;
+    variables[`r${i}`] = ref.repo;
+    variables[`n${i}`] = ref.number;
+    selections.push(
+      `pr${i}: repository(owner: $o${i}, name: $r${i}) {\n  pullRequest(number: $n${i}) {${PR_FIELDS}}\n}`,
+    );
+  });
+
+  const query = `query batchPRDetails(${varDefs.join(', ')}) {\n${selections.join('\n')}\n}`;
+  return { query, variables };
+}
+
+/** Map GraphQL `mergeable` enum to the REST `mergeConflict` boolean. */
+function toMergeConflict(mergeable: GraphQLPullRequestNode['mergeable']): boolean {
+  // CONFLICTING mirrors REST `mergeable === false` / `mergeable_state === 'dirty'`.
+  // UNKNOWN mirrors REST `mergeable === null` (GitHub hasn't computed it yet) → not a conflict.
+  return mergeable === 'CONFLICTING';
+}
+
+/** Map a GraphQL commit's rollup + legacy status into the CI result via the shared computer. */
+function toCIStatus(commit: GraphQLCommitNode | undefined): CIStatusResult {
+  // Check runs come from the rollup (mirrors `checks.listForRef`); only CheckRun
+  // nodes are read here so StatusContexts aren't double-counted.
+  const checkRuns: RawCheckRun[] = (commit?.statusCheckRollup?.contexts.nodes ?? [])
+    .filter((n): n is GraphQLCheckRunNode => n.__typename === 'CheckRun')
+    .map((n) => ({
+      name: n.name,
+      conclusion: n.conclusion ? n.conclusion.toLowerCase() : null,
+      status: (n.status ?? '').toLowerCase(),
+      started_at: n.startedAt ?? null,
+    }));
+
+  // Combined statuses come from the legacy status object (mirrors
+  // `repos.getCombinedStatusForRef`). When absent, an empty statuses list is
+  // equivalent to the REST empty-combined-status response (the `state` field is
+  // ignored by `analyzeCombinedStatus` when there are no statuses).
+  const combinedStatus: RawCombinedStatus = commit?.status
+    ? {
+        state: commit.status.state.toLowerCase(),
+        statuses: commit.status.contexts.map((c) => ({
+          state: c.state.toLowerCase(),
+          context: c.context,
+          description: c.description ?? null,
+        })),
+      }
+    : { state: 'success', statuses: [] };
+
+  return computeCIStatus(checkRuns, combinedStatus);
+}
+
+/** Discriminated outcome of normalizing one PR node. */
+type NormalizeOutcome = { kind: 'ok'; data: NormalizedPRData } | { kind: 'overflow' } | { kind: 'missing' };
+
+/**
+ * Normalize a single GraphQL pull-request node into {@link NormalizedPRData},
+ * or signal that it must fall back to REST (`overflow` — a connection cap was
+ * hit; `missing` — the node was absent, inaccessible, or lacked a database id).
+ */
+export function normalizePRNode(node: GraphQLPullRequestNode | null | undefined): NormalizeOutcome {
+  if (!node || node.databaseId == null) return { kind: 'missing' };
+
+  // Any connection that hit its cap means data is incomplete — REST paginates fully.
+  const rollupTotal = node.commits.nodes[0]?.commit?.statusCheckRollup?.contexts.totalCount ?? 0;
+  if (
+    node.comments.totalCount > COMMENTS_CAP ||
+    node.reviews.totalCount > REVIEWS_CAP ||
+    node.reviewThreads.totalCount > REVIEW_THREADS_CAP ||
+    node.reviewThreads.nodes.some((t) => t.comments.totalCount > THREAD_COMMENTS_CAP) ||
+    rollupTotal > CI_CONTEXTS_CAP
+  ) {
+    return { kind: 'overflow' };
+  }
+
+  const comments: AssemblyComment[] = node.comments.nodes.map((c) => ({
+    user: c.author ? { login: c.author.login } : null,
+    body: c.body,
+    created_at: c.createdAt,
+  }));
+
+  // Drop PENDING reviews: REST `listReviews` only returns submitted reviews, and
+  // a PENDING (draft) review has no `submittedAt`. Filtering keeps parity.
+  const reviews: AssemblyReview[] = node.reviews.nodes
+    .filter((r) => r.state !== 'PENDING')
+    .map((r) => ({
+      user: r.author ? { login: r.author.login } : null,
+      body: r.body,
+      submitted_at: r.submittedAt,
+      state: r.state,
+      id: r.databaseId ?? undefined,
+    }));
+
+  const reviewComments: ReviewComment[] = node.reviewThreads.nodes.flatMap((thread) =>
+    thread.comments.nodes.map((c) => ({
+      id: c.databaseId ?? 0,
+      user: c.author ? { login: c.author.login } : null,
+      body: c.body,
+      created_at: c.createdAt,
+      in_reply_to_id: c.replyTo?.databaseId ?? undefined,
+      pull_request_review_id: c.pullRequestReview?.databaseId ?? null,
+    })),
+  );
+
+  const commit = node.commits.nodes[0]?.commit;
+  const commitInfo: CommitInfo = {
+    date: commit?.authoredDate ?? undefined,
+    author: commit?.author?.user?.login ?? undefined,
+  };
+
+  return {
+    kind: 'ok',
+    data: {
+      id: node.databaseId,
+      title: node.title,
+      body: node.body ?? '',
+      createdAt: node.createdAt,
+      updatedAt: node.updatedAt,
+      hasMergeConflict: toMergeConflict(node.mergeable),
+      headSha: commit?.oid ?? '',
+      comments,
+      reviews,
+      reviewComments,
+      ciStatus: toCIStatus(commit),
+      commitInfo,
+    },
+  };
+}
+
+/** Split an array into fixed-size chunks. */
+function chunk<T>(items: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+}
+
+/**
+ * Detect GitHub's primary GraphQL rate limit. Unlike a REST 429/403, an
+ * exhausted GraphQL point budget arrives as an HTTP 200 with an
+ * `errors[].type === 'RATE_LIMITED'` entry and NO numeric `.status`, so the
+ * HTTP-status-based {@link isRateLimitOrAuthError} misses it. Treat it as fatal
+ * (rethrow) rather than silently absorbing it into the REST fallback.
+ */
+export function isGraphqlRateLimited(err: unknown): boolean {
+  const errors = (err as { errors?: Array<{ type?: string } | null> } | null)?.errors;
+  return Array.isArray(errors) && errors.some((e) => e?.type === 'RATE_LIMITED');
+}
+
+/**
+ * Run one batch's GraphQL query and return the raw alias→node response. On a
+ * partial-data GraphQL error, returns the resolved aliases attached to the
+ * error's `.data`. Fatal errors (401 / auth / rate limit — REST-style OR the
+ * GraphQL-native `RATE_LIMITED`) rethrow; any other error returns `null` so the
+ * whole batch falls back to REST.
+ */
+async function runBatch(octokit: Octokit, refs: PRRef[]): Promise<BatchResponse | null> {
+  const { query, variables } = buildBatchQuery(refs);
+  try {
+    return await octokit.graphql<BatchResponse>(query, variables);
+  } catch (err) {
+    // Fatal signals must propagate BEFORE the partial-data fallback, so a
+    // RATE_LIMITED error that arrives alongside partial data isn't swallowed.
+    if (isRateLimitOrAuthError(err) || isGraphqlRateLimited(err)) throw err;
+    // octokit's GraphqlResponseError attaches the resolved aliases to `.data`
+    // when only some PRs in the batch errored (e.g. one repo went private).
+    const partial = (err as { data?: BatchResponse }).data;
+    if (partial) return partial;
+    warn(MODULE, `GraphQL batch failed, falling back to REST: ${errorMessage(err)}`);
+    return null;
+  }
+}
+
+/**
+ * Enrich a set of PRs via batched GraphQL queries.
+ *
+ * Returns the PRs that resolved cleanly plus the URLs that must fall back to the
+ * REST enrichment path. Batches run sequentially (GitHub recommends serial
+ * requests); with ~3 queries for 30 PRs there is no concurrency benefit.
+ */
+export async function batchFetchPRDetails(octokit: Octokit, refs: PRRef[]): Promise<BatchPRResult> {
+  const resolved = new Map<string, NormalizedPRData>();
+  const restFallbackUrls: string[] = [];
+  if (refs.length === 0) return { resolved, restFallbackUrls };
+
+  // No GraphQL client available (e.g. a stubbed Octokit in tests) — everything
+  // to REST. Guards against calling a non-function `.graphql`.
+  if (typeof octokit.graphql !== 'function') {
+    return { resolved, restFallbackUrls: refs.map((r) => r.url) };
+  }
+
+  for (const batch of chunk(refs, BATCH_SIZE)) {
+    const data = await runBatch(octokit, batch);
+    if (!data) {
+      // Whole-batch failure — every PR in this batch falls back to REST.
+      for (const ref of batch) restFallbackUrls.push(ref.url);
+      continue;
+    }
+
+    batch.forEach((ref, i) => {
+      // A malformed node (unexpected null sub-connection, etc.) routes just this
+      // one PR to REST rather than rejecting the whole batch and discarding the
+      // siblings that resolved cleanly.
+      let outcome: NormalizeOutcome;
+      try {
+        outcome = normalizePRNode(data[`pr${i}`]?.pullRequest);
+      } catch (err) {
+        warn(MODULE, `Failed to normalize ${ref.url}, falling back to REST: ${errorMessage(err)}`);
+        outcome = { kind: 'missing' };
+      }
+      if (outcome.kind === 'ok') {
+        resolved.set(ref.url, outcome.data);
+      } else {
+        restFallbackUrls.push(ref.url);
+      }
+    });
+  }
+
+  return { resolved, restFallbackUrls };
+}

--- a/packages/core/src/core/pr-monitor.ts
+++ b/packages/core/src/core/pr-monitor.ts
@@ -16,11 +16,9 @@
 import { Octokit } from '@octokit/rest';
 import { getOctokit } from './github.js';
 import { getStateManager } from './state.js';
-import { daysBetween } from './dates.js';
 import { parseGitHubUrl, extractOwnerRepo, isOwnRepo } from './urls.js';
 import { DEFAULT_CONCURRENCY, runWorkerPool } from './concurrency.js';
 import { FetchedPR, DailyDigest, ClosedPR, MergedPR, StarFilter } from './types.js';
-import { determineStatus } from './status-determination.js';
 import {
   ConfigurationError,
   ValidationError,
@@ -33,17 +31,10 @@ import { paginateAllDetailed, type PaginateAllResult } from './pagination.js';
 import { debug, warn, timed } from './logger.js';
 import { getHttpCache, cachedRequest } from './http-cache.js';
 
-import { categorizeCIStatus, classifyFailingChecks, getCIStatus } from './ci-analysis.js';
-import {
-  type ReviewComment,
-  determineReviewDecision,
-  getLatestChangesRequestedDate,
-  checkUnrespondedComments,
-  getFirstMaintainerResponseAt,
-} from './review-analysis.js';
-import { analyzeChecklist } from './checklist-analysis.js';
-import { extractMaintainerActionHints } from './maintainer-analysis.js';
-import { computeDisplayLabel } from './display-utils.js';
+import { getCIStatus } from './ci-analysis.js';
+import { type ReviewComment } from './review-analysis.js';
+import { assembleFetchedPR, type CommitInfo } from './pr-assembly.js';
+import { batchFetchPRDetails, type PRRef, type NormalizedPRData, type BatchPRResult } from './pr-graphql.js';
 import {
   type PRCountsResult,
   fetchUserMergedPRCounts as fetchUserMergedPRCountsImpl,
@@ -301,19 +292,63 @@ export class PRMonitor {
 
     debug('pr-monitor', `Filtered to ${filteredItems.length} PRs after excluding own repos`);
 
-    // Fetch detailed info using a worker pool for bounded concurrency.
-    await timed('pr-monitor', `Fetch details for ${filteredItems.length} PRs`, async () => {
+    // Build PR references for the batched GraphQL enrichment. `parseGitHubUrl`
+    // is the authoritative parser (the filter above used `extractOwnerRepo`);
+    // anything it can't parse as a PR is skipped with a warning.
+    const refs: PRRef[] = [];
+    const refByUrl = new Map<string, PRRef>();
+    for (const item of filteredItems) {
+      const parsed = parseGitHubUrl(item.html_url);
+      if (!parsed || parsed.type !== 'pull') {
+        warn(MODULE, `Skipping PR with unparseable URL: ${item.html_url}`);
+        continue;
+      }
+      const ref: PRRef = { owner: parsed.owner, repo: parsed.repo, number: parsed.number, url: item.html_url };
+      refs.push(ref);
+      refByUrl.set(item.html_url, ref);
+    }
+
+    // Enrich PRs. The batched GraphQL path (separate 5000-point/hr bucket) handles
+    // the common case in a handful of ~1-point queries; anything it can't resolve
+    // (connection cap overflow, missing node, GraphQL outage) falls back to the
+    // per-PR REST path via the worker pool.
+    await timed('pr-monitor', `Fetch details for ${refs.length} PRs`, async () => {
+      let batch: BatchPRResult;
+      try {
+        batch = await batchFetchPRDetails(this.octokit, refs);
+      } catch (error) {
+        // A fatal batch-level GraphQL error (rate limit / auth). Don't crash the
+        // run — route every PR to the REST path, which surfaces per-PR failures
+        // exactly as the pre-GraphQL implementation did.
+        warn(MODULE, `GraphQL batch enrichment failed (${errorMessage(error)}); falling back to REST for all PRs`);
+        batch = { resolved: new Map(), restFallbackUrls: refs.map((r) => r.url) };
+      }
+
+      // Assemble GraphQL-resolved PRs (no additional network calls).
+      for (const [url, data] of batch.resolved) {
+        const ref = refByUrl.get(url);
+        if (!ref) continue;
+        try {
+          prs.push(await this.assembleFromNormalized(ref, data));
+        } catch (error) {
+          const errMsg = errorMessage(error);
+          warn('pr-monitor', `Error assembling ${url}: ${errMsg}`);
+          failures.push({ prUrl: url, error: errMsg });
+        }
+      }
+
+      // REST fallback for the remainder, using a worker pool for bounded concurrency.
       await runWorkerPool(
-        filteredItems,
-        async (item) => {
+        batch.restFallbackUrls,
+        async (url) => {
           try {
-            debug('pr-monitor', `Fetching details for ${item.html_url}`);
-            const pr = await this.fetchPRDetails(item.html_url, warnings);
+            debug('pr-monitor', `Fetching details for ${url} (REST fallback)`);
+            const pr = await this.fetchPRDetails(url, warnings);
             if (pr) prs.push(pr);
           } catch (error) {
             const errMsg = errorMessage(error);
-            warn('pr-monitor', `Error fetching ${item.html_url}: ${errMsg}`);
-            failures.push({ prUrl: item.html_url, error: errMsg });
+            warn('pr-monitor', `Error fetching ${url}: ${errMsg}`);
+            failures.push({ prUrl: url, error: errMsg });
           }
         },
         MAX_CONCURRENT_REQUESTS,
@@ -330,7 +365,13 @@ export class PRMonitor {
   }
 
   /**
-   * Fetch detailed information for a single PR
+   * Fetch detailed information for a single PR via the REST enrichment path.
+   *
+   * This is the fallback path in the GraphQL-batched architecture (#1539
+   * lineage): PRs that the batched GraphQL query couldn't resolve (a connection
+   * cap, a missing/inaccessible node, or a GraphQL outage) are enriched here.
+   * Both paths funnel through the shared {@link assembleFetchedPR} pipeline, so
+   * the computed status is identical regardless of transport.
    */
   private async fetchPRDetails(prUrl: string, warnings?: string[]): Promise<FetchedPR | null> {
     const parsed = parseGitHubUrl(prUrl);
@@ -397,155 +438,89 @@ export class PRMonitor {
     const ghPR = prResponse.data;
     const reviews = reviewsResponse.data;
 
-    // Determine review decision (delegated to review-analysis module)
-    const reviewDecision = determineReviewDecision(reviews);
+    const ciStatus = await getCIStatus(this.octokit, owner, repo, ghPR.head.sha);
 
-    // Check for merge conflict
-    const mergeConflict = hasMergeConflict(ghPR.mergeable, ghPR.mergeable_state);
-
-    // Check if there's an unresponded maintainer comment (delegated to review-analysis module)
-    const { hasUnrespondedComment, lastMaintainerComment } = checkUnrespondedComments(
-      comments,
-      reviews,
-      reviewComments,
-      config.githubUsername,
+    // The commit date is only consulted (and only fetched) when the PR has an
+    // unresponded maintainer comment or a changes-requested review — the shared
+    // pipeline decides via `needCommitDate` and invokes this thunk lazily.
+    return assembleFetchedPR(
+      {
+        prUrl,
+        owner,
+        repo,
+        number,
+        id: ghPR.id,
+        title: ghPR.title,
+        body: ghPR.body || '',
+        createdAt: ghPR.created_at,
+        updatedAt: ghPR.updated_at,
+        hasMergeConflict: hasMergeConflict(ghPR.mergeable, ghPR.mergeable_state),
+        comments,
+        reviews,
+        reviewComments,
+        ciStatus,
+      },
+      config,
+      () => this.fetchCommitInfo(owner, repo, ghPR.head.sha),
     );
-
-    // Earliest maintainer response, computed from the comment/review timeline
-    // already in memory (#1461). Rides into the persisted digest so the
-    // outcome ledger can recover it after the PR merges or closes.
-    const firstMaintainerResponseAt = getFirstMaintainerResponseAt(comments, reviews, config.githubUsername);
-
-    // Fetch CI status and (conditionally) latest commit date in parallel
-    // We need the commit date when hasUnrespondedComment is true (to distinguish
-    // "needs_response" from "waiting_on_maintainer") OR when reviewDecision is "changes_requested"
-    // (to detect needs_changes: review requested changes but no new commits pushed)
-    const ciPromise = getCIStatus(this.octokit, owner, repo, ghPR.head.sha);
-    const needCommitDate = hasUnrespondedComment || reviewDecision === 'changes_requested';
-    const commitInfoPromise = needCommitDate
-      ? this.octokit.repos
-          .getCommit({ owner, repo, ref: ghPR.head.sha })
-          .then((res) => ({
-            date: res.data.commit.author?.date,
-            // GitHub user login of the commit author (may differ from git author)
-            author: res.data.author?.login,
-          }))
-          .catch((err: unknown) => {
-            // Rate limit errors must propagate — silently swallowing them produces
-            // misleading status (e.g. needs_changes when changes were addressed) (#469).
-            const status = getHttpStatusCode(err);
-            if (status === 429) throw err;
-            if (status === 403) {
-              const msg = errorMessage(err).toLowerCase();
-              if (msg.includes('rate limit') || msg.includes('abuse detection')) throw err;
-              // Non-rate-limit 403 (DMCA, private repo, SSO) — degrade gracefully
-              warn(
-                'pr-monitor',
-                `403 fetching commit date for ${owner}/${repo}@${ghPR.head.sha.slice(0, 7)}: ${errorMessage(err)}`,
-              );
-              return undefined;
-            }
-            warn(
-              'pr-monitor',
-              `Failed to fetch commit date for ${owner}/${repo}@${ghPR.head.sha.slice(0, 7)}: ${errorMessage(err)}`,
-            );
-            return undefined;
-          })
-      : Promise.resolve(undefined);
-
-    const [{ status: ciStatus, failingCheckNames, failingCheckConclusions }, commitInfo] = await Promise.all([
-      ciPromise,
-      commitInfoPromise,
-    ]);
-    const latestCommitDate = commitInfo?.date;
-    const latestCommitAuthor = commitInfo?.author;
-
-    // Analyze PR body for incomplete checklists (delegated to checklist-analysis module)
-    const { hasIncompleteChecklist, checklistStats } = analyzeChecklist(ghPR.body || '');
-
-    // Extract maintainer action hints from comments (delegated to maintainer-analysis module)
-    const maintainerActionHints = extractMaintainerActionHints(lastMaintainerComment?.body, reviewDecision);
-
-    // Calculate days since activity
-    const daysSinceActivity = daysBetween(new Date(ghPR.updated_at), new Date());
-
-    // Find the date of the latest changes_requested review (delegated to review-analysis module)
-    const latestChangesRequestedDate = getLatestChangesRequestedDate(reviews);
-
-    // Classify failing checks (delegated to ci-analysis module)
-    const classifiedChecks = classifyFailingChecks(failingCheckNames, failingCheckConclusions);
-
-    // Aggregate 5-state CI categorization (#1272). Computed once here so
-    // agents read pr.ciCategorization rather than re-deriving the truth
-    // table in three separate prose forms.
-    const ciCategorization = categorizeCIStatus({ ciStatus, failingCheckNames, classifiedChecks });
-
-    // Determine status
-    const hasActionableCIFailure = ciStatus === 'failing' && classifiedChecks.some((c) => c.category === 'actionable');
-    const { status, actionReason, waitReason, stalenessTier, actionReasons } = determineStatus({
-      ciStatus,
-      hasMergeConflict: mergeConflict,
-      hasUnrespondedComment,
-      hasIncompleteChecklist,
-      reviewDecision,
-      daysSinceActivity,
-      dormantThreshold: config.dormantThresholdDays,
-      approachingThreshold: config.approachingDormantDays,
-      latestCommitDate,
-      latestCommitAuthor,
-      contributorUsername: config.githubUsername,
-      lastMaintainerCommentDate: lastMaintainerComment?.createdAt,
-      latestChangesRequestedDate,
-      hasActionableCIFailure,
-    });
-
-    return this.buildFetchedPR({
-      id: ghPR.id,
-      url: prUrl,
-      repo: `${owner}/${repo}`,
-      number,
-      title: ghPR.title,
-      status,
-      actionReason,
-      waitReason,
-      stalenessTier,
-      actionReasons,
-      createdAt: ghPR.created_at,
-      updatedAt: ghPR.updated_at,
-      firstMaintainerResponseAt,
-      daysSinceActivity,
-      ciStatus,
-      failingCheckNames,
-      classifiedChecks,
-      ciCategorization,
-      hasMergeConflict: mergeConflict,
-      reviewDecision,
-      hasUnrespondedComment,
-      lastMaintainerComment,
-      latestCommitDate,
-      hasIncompleteChecklist,
-      checklistStats,
-      maintainerActionHints,
-    });
   }
 
   /**
-   * Build a FetchedPR object from computed fields and attach display labels.
-   * Centralizes PR construction and display label computation (#79).
+   * Fetch the HEAD commit's author date and login via REST `repos.getCommit`.
+   * Rate-limit errors propagate (silently swallowing them produces misleading
+   * status, e.g. needs_changes when changes were addressed) (#469); other
+   * failures degrade to `undefined` so the PR is still returned.
    */
-  private buildFetchedPR(fields: Omit<FetchedPR, 'displayLabel' | 'displayDescription'>): FetchedPR {
-    const pr: FetchedPR = {
-      ...fields,
-      displayLabel: '', // computed below
-      displayDescription: '', // computed below
-    };
+  private async fetchCommitInfo(owner: string, repo: string, sha: string): Promise<CommitInfo | undefined> {
+    try {
+      const res = await this.octokit.repos.getCommit({ owner, repo, ref: sha });
+      return {
+        date: res.data.commit.author?.date,
+        // GitHub user login of the commit author (may differ from git author)
+        author: res.data.author?.login,
+      };
+    } catch (err) {
+      const status = getHttpStatusCode(err);
+      if (status === 429) throw err;
+      if (status === 403) {
+        const msg = errorMessage(err).toLowerCase();
+        if (msg.includes('rate limit') || msg.includes('abuse detection')) throw err;
+        // Non-rate-limit 403 (DMCA, private repo, SSO) — degrade gracefully
+        warn('pr-monitor', `403 fetching commit date for ${owner}/${repo}@${sha.slice(0, 7)}: ${errorMessage(err)}`);
+        return undefined;
+      }
+      warn('pr-monitor', `Failed to fetch commit date for ${owner}/${repo}@${sha.slice(0, 7)}: ${errorMessage(err)}`);
+      return undefined;
+    }
+  }
 
-    // Compute display labels (#79) — delegated to display-utils module
-    const { displayLabel, displayDescription } = computeDisplayLabel(pr);
-    pr.displayLabel = displayLabel;
-    pr.displayDescription = displayDescription;
-
-    return pr;
+  /**
+   * Assemble a {@link FetchedPR} from GraphQL-batched {@link NormalizedPRData}.
+   * No network calls: the batch already carries the commit info, so the shared
+   * pipeline's lazy commit thunk just returns it.
+   */
+  private assembleFromNormalized(ref: PRRef, data: NormalizedPRData): Promise<FetchedPR> {
+    const config = this.stateManager.getState().config;
+    return assembleFetchedPR(
+      {
+        prUrl: ref.url,
+        owner: ref.owner,
+        repo: ref.repo,
+        number: ref.number,
+        id: data.id,
+        title: data.title,
+        body: data.body,
+        createdAt: data.createdAt,
+        updatedAt: data.updatedAt,
+        hasMergeConflict: data.hasMergeConflict,
+        comments: data.comments,
+        reviews: data.reviews,
+        reviewComments: data.reviewComments,
+        ciStatus: data.ciStatus,
+      },
+      config,
+      async () => data.commitInfo,
+    );
   }
 
   /**


### PR DESCRIPTION
## What

Replaces the per-PR REST enrichment in `PRMonitor.fetchUserOpenPRs` with aliased GraphQL batches, and routes anything the batch can't cleanly resolve back to the existing REST path.

## Why

Today enriching one open PR makes ~6 core-quota REST calls: `pulls.get`, `issues.listComments` (paginated), `pulls.listReviews`, `pulls.listReviewComments` (paginated), CI status (`getCombinedStatusForRef` + `checks.listForRef`), plus a conditional `repos.getCommit`. For 30 open PRs that's ~180 core REST requests every daily run, which eats into the 5000/hr core bucket fast.

## Request count: before vs after

| | Before | After |
|---|---|---|
| 30 open PRs | ~180 core-quota REST requests | ~3 GraphQL queries |
| Quota bucket | core REST (5000/hr, shared with everything else) | separate GraphQL points (5000/hr; a multi-alias PR query ≈ 1 point) |

Batches are ~10 PRs per aliased query and run sequentially (GitHub recommends serial requests). Owner/repo/number travel as GraphQL variables, never string-interpolated into the query body.

## Status parity (the acceptance criterion)

Both transports funnel through a new shared `assembleFetchedPR` pipeline, and CI derivation is shared via an extracted `computeCIStatus`. Each GraphQL node is mapped back into the exact REST-equivalent shapes the pipeline already consumed, so the computed `FetchedPRStatus` (CI state, review decision, merge conflicts, unresponded maintainer comments) is identical regardless of transport. GraphQL enum values are lowercased into the REST vocabulary; `mergeable: CONFLICTING → true`; check runs come only from `statusCheckRollup` CheckRun nodes and combined statuses only from `commit.status`, mirroring the two REST endpoints. PENDING (draft) reviews are dropped to match REST `listReviews`.

## Fallbacks (all route the affected PR back to REST)

- **GraphQL unavailable** (e.g. a stubbed client) → every PR to REST.
- **Partial-data batch error** → only the failed aliases fall back (uses the `err.data` partial-result pattern); the resolved aliases are kept.
- **Connection-cap overflow** — comments > 100, reviews > 50, review threads > 50, a thread's comments > 20, or CI rollup > 100 → REST, so pagination stays complete and unresponded-comment / CI detection can't be silently truncated.
- **Missing / inaccessible / malformed node** → REST.
- **Fatal errors propagate**: REST-style 401 / 429 / 403-rate-limit *and* GitHub's GraphQL-native `RATE_LIMITED` (HTTP 200 + `errors[].type`, no numeric status), rethrown before the partial-data fallback so an exhausted GraphQL point budget is never swallowed into the REST path.

The entire REST path (`fetchPRDetails`) is kept intact and callable as the fallback.

## Tests

New `pr-graphql.test.ts` (19 cases): batch query construction (parameterized, no interpolation), node normalization, PENDING-review drop, review-thread → inline-comment mapping, every overflow cap, missing-node, partial-error fallback, whole-batch fallback, batch splitting, fatal rethrow (HTTP + GraphQL-native RATE_LIMITED, including alongside partial data), and two GraphQL-vs-REST status-parity fixtures asserting a byte-for-byte identical `FetchedPR`. All existing tests pass unchanged (core: 2990 passed).

## Notes

- `statusCheckRollup` returns the deduplicated latest-per-check set (which our REST path approximates via manual dedup), and REST `checks.listForRef` is itself single-page — so for very large check sets the GraphQL path is strictly more complete, not a regression. PRs beyond the 100-context cap fall back to REST.
- Pre-existing `packages/dashboard` test failures (`use-theme` jsdom/localStorage) are unrelated to this core-only change.