### PR TITLE
fix(github): retry transient 5xx/network errors via @octokit/plugin-retry

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -65,6 +65,7 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
+    "@octokit/plugin-retry": "^8.1.0",
     "@octokit/plugin-throttling": "^11.0.3",
     "@octokit/rest": "^22.0.1",
     "@oss-scout/core": "^1.2.4",

--- a/packages/core/src/core/github.test.ts
+++ b/packages/core/src/core/github.test.ts
@@ -5,12 +5,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 let mockOctokitInstance: any;
+let lastOctokitOptions: any;
 
 vi.mock('@octokit/rest', () => ({
   Octokit: {
     plugin: () =>
       class MockOctokit {
-        constructor() {
+        constructor(options: unknown) {
+          lastOctokitOptions = options;
           return mockOctokitInstance;
         }
       },
@@ -19,6 +21,10 @@ vi.mock('@octokit/rest', () => ({
 
 vi.mock('@octokit/plugin-throttling', () => ({
   throttling: {},
+}));
+
+vi.mock('@octokit/plugin-retry', () => ({
+  retry: {},
 }));
 
 // Must import after mocks are set up
@@ -108,6 +114,11 @@ describe('getOctokit', () => {
     expect(first).toBeDefined();
     const second = getOctokit('token-y');
     expect(second).toBeDefined();
+  });
+
+  it('should exclude 429 (and other non-retryable statuses) from plugin-retry so it never fights the throttling plugin', () => {
+    getOctokit('token-retry-config');
+    expect(lastOctokitOptions.retry.doNotRetry).toEqual([400, 401, 403, 404, 410, 422, 429, 451]);
   });
 });
 

--- a/packages/core/src/core/github.ts
+++ b/packages/core/src/core/github.ts
@@ -4,11 +4,15 @@
 
 import { Octokit } from '@octokit/rest';
 import { throttling } from '@octokit/plugin-throttling';
+import { retry } from '@octokit/plugin-retry';
 import { warn } from './logger.js';
 
 const MODULE = 'github';
 
-const ThrottledOctokit = Octokit.plugin(throttling);
+// Plugin order matches octokit.js's own composition (retry, then throttling):
+// throttling must be the outermost layer so its Bottleneck-based queueing sees
+// rate-limit errors first, before plugin-retry's own request-level retries.
+const ThrottledOctokit = Octokit.plugin(retry, throttling);
 
 /** Rate limit info returned by {@link checkRateLimit}. */
 export interface RateLimitInfo {
@@ -74,7 +78,8 @@ export function getRateLimitCallbacks() {
  * Returns a cached instance if the token matches, otherwise creates a new one.
  *
  * The client retries on primary rate limits (up to 2 retries) and
- * secondary rate limits (up to 3 retries).
+ * secondary rate limits (up to 3 retries), and separately retries
+ * transient 5xx/network errors (up to 3 retries) via `@octokit/plugin-retry`.
  *
  * @param token - GitHub personal access token
  * @returns Authenticated Octokit instance with rate limit throttling
@@ -95,6 +100,10 @@ export function getOctokit(token: string): Octokit {
   _octokit = new ThrottledOctokit({
     auth: token,
     throttle: callbacks,
+    // Mirrors plugin-retry's own default doNotRetry list (keep in sync on
+    // upgrade) plus 429, so primary rate limits stay owned by the throttling
+    // callbacks above instead of being retried again here with a shorter backoff.
+    retry: { doNotRetry: [400, 401, 403, 404, 410, 422, 429, 451] },
   });
 
   _currentToken = token;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@octokit/plugin-retry':
+        specifier: ^8.1.0
+        version: 8.1.0(@octokit/core@7.0.6)
       '@octokit/plugin-throttling':
         specifier: ^11.0.3
         version: 11.0.3(@octokit/core@7.0.6)
@@ -670,6 +673,12 @@ packages:
     engines: {node: '>= 20'}
     peerDependencies:
       '@octokit/core': '>=6'
+
+  '@octokit/plugin-retry@8.1.0':
+    resolution: {integrity: sha512-O1FZgXeiGb2sowEr/hYTr6YunGdSAFWnr2fyW39Ah85H8O33ELASQxcvOFF5LE6Tjekcyu2ms4qAzJVhSaJxTw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=7'
 
   '@octokit/plugin-throttling@11.0.3':
     resolution: {integrity: sha512-34eE0RkFCKycLl2D2kq7W+LovheM/ex3AwZCYN8udpi6bxsyjZidb2McXs69hZhLmJlDqTSP8cH+jSRpiaijBg==}
@@ -3290,6 +3299,13 @@ snapshots:
     dependencies:
       '@octokit/core': 7.0.6
       '@octokit/types': 16.0.0
+
+  '@octokit/plugin-retry@8.1.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      bottleneck: 2.19.5
 
   '@octokit/plugin-throttling@11.0.3(@octokit/core@7.0.6)':
     dependencies:


### PR DESCRIPTION
## Summary
- The shared Octokit client (`packages/core/src/core/github.ts`) only had `@octokit/plugin-throttling` — a transient 5xx or network blip on any GitHub API call surfaced immediately instead of retrying.
- Adds `@octokit/plugin-retry@^8.1.0` (peer-compatible with the installed `@octokit/core@^7.0.6`), composed as `Octokit.plugin(retry, throttling)` — the same order octokit.js itself uses, so throttling stays the outermost layer and sees rate-limit errors first.
- Passes `retry: { doNotRetry: [400, 401, 403, 404, 410, 422, 429, 451] }` (plugin-retry's own default list + `429`) so primary rate limits stay solely owned by the existing `onRateLimit`/`onSecondaryRateLimit` throttling callbacks, instead of being retried a second time by plugin-retry with a shorter, uncoordinated backoff.

## Known trade-off (flagging for visibility, not fixed in this PR)
`@octokit/plugin-retry` decides whether to retry purely by HTTP status code — it does not distinguish GET from POST/PATCH/PUT/DELETE. That means a transient 5xx on a write call (e.g. `createComment`, `addLabels`, merge) could now be retried and, in the rare case the original request actually succeeded server-side but the response was lost, produce a duplicate side effect (e.g. a duplicate PR comment).

This matches octokit.js's own default recommended composition (verified against its source), so it's a known, accepted trade-off of using this plugin as-is rather than a defect introduced here. I evaluated a global hook-based mitigation (force `retries: 0` for non-GET/HEAD requests) but rejected it after testing: mutating `options.request.retries` leaked across requests on the cached Octokit instance and silently disabled retries for all later calls once any write request went through it. The safe, documented alternative is passing `request: { retries: 0 }` at each individual mutating call site (verified this works correctly in isolation), but that touches every write call across `commands/` and is out of scope for this focused fix. Happy to file a follow-up issue if that tightening is wanted.

## Test plan
- [x] `pnpm run lint` — 0 errors (pre-existing warnings only)
- [x] `pnpm --filter @oss-autopilot/core test` — 2997 passed, 0 failed
- [x] `pnpm run bundle` (in `packages/core`) — CLI bundle builds cleanly with the new dependency; smoke-tested `node dist/cli.bundle.cjs status --json`
- [x] Extended `github.test.ts` to assert the composed `doNotRetry` list
- [x] Independently verified via a scratch script (not committed) that: a mocked 500 is retried up to the default 3 times, and a 429 is not double-retried once excluded from `doNotRetry`