### PR TITLE
fix(core): keep the bundled @oss-scout/core fresh within its semver range

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,7 +68,7 @@
     "@octokit/plugin-retry": "^8.1.0",
     "@octokit/plugin-throttling": "^11.0.3",
     "@octokit/rest": "^22.0.1",
-    "@oss-scout/core": "^1.2.4",
+    "@oss-scout/core": "^1.3.0",
     "commander": "^15.0.0",
     "zod": "^4.4.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@oss-scout/core':
-        specifier: ^1.2.4
-        version: 1.2.4(@octokit/core@7.0.6)
+        specifier: ^1.3.0
+        version: 1.3.0(@octokit/core@7.0.6)
       commander:
         specifier: ^15.0.0
         version: 15.0.0
@@ -701,8 +701,8 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@oss-scout/core@1.2.4':
-    resolution: {integrity: sha512-Oo6qmWHM4D20lJOwE/T2Wz02P4C5s1W/L7tWxQY0bBis1xEyFXRNiqCf+5QJ+t0qI90W/TiBIH+JfcXvko/Nzw==}
+  '@oss-scout/core@1.3.0':
+    resolution: {integrity: sha512-yBrx4TymLUq0q6HEomOBsy896r6Z8MGSPVafo6tX07llnjHLyRahYVKbhDp5dgoo9wHLfgC49cqQEseKOeO44Q==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
@@ -3397,8 +3397,9 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@oss-scout/core@1.2.4(@octokit/core@7.0.6)':
+  '@oss-scout/core@1.3.0(@octokit/core@7.0.6)':
     dependencies:
+      '@octokit/plugin-retry': 8.1.0(@octokit/core@7.0.6)
       '@octokit/plugin-throttling': 11.0.3(@octokit/core@7.0.6)
       '@octokit/rest': 22.0.1
       commander: 14.0.3

--- a/scripts/build-cli-if-stale.sh
+++ b/scripts/build-cli-if-stale.sh
@@ -7,6 +7,15 @@
 #   packages/core/package.json   (dep changes)
 #   packages/core/tsconfig.json  (compiler config changes)
 #
+# It is also considered stale when the installed @oss-scout/core dependency
+# is behind the newest version published within its declared semver range.
+# Local file mtimes never move when a dependency publishes a new version, so
+# without this check an installed plugin would run a stale @oss-scout/core
+# forever even though nothing in the plugin's own source changed. This check
+# hits the npm registry, so it's throttled to once per day via a stamp file
+# and is fully failure-tolerant: any network/registry error just skips the
+# check for this run (the stamp is left untouched so it retries next time).
+#
 # Editor swap files (.DS_Store, *~, *.swp, *.swo, .#*) and node_modules / .git
 # trees are excluded so an editor leaving a temp file alongside src/ does not
 # trigger a rebuild on every session.
@@ -67,6 +76,62 @@ else
   fi
 fi
 
+# --- Dependency-freshness check -------------------------------------------
+# Catches the case where @oss-scout/core has published a new version that
+# satisfies the range already declared in packages/core/package.json. The
+# mtime-based check above can't see this: nothing local changed.
+CORE_PKG_JSON="${PLUGIN_ROOT}/packages/core/package.json"
+INSTALLED_PKG_JSON="${PLUGIN_ROOT}/packages/core/node_modules/@oss-scout/core/package.json"
+# Lives under dist/, which is already gitignored wholesale, so the stamp
+# never shows up as an untracked file in a contributor's working tree.
+FRESHNESS_STAMP="${PLUGIN_ROOT}/packages/core/dist/.dep-freshness-checked"
+
+dep_refresh_needed=false
+dep_installed_version=""
+dep_latest_version=""
+
+if [ ! -f "${INSTALLED_PKG_JSON}" ]; then
+  # Not installed at all yet: needs an install regardless of the daily
+  # throttle below (there's nothing to compare against, and no network
+  # round-trip is needed to know this).
+  dep_refresh_needed=true
+else
+  dep_installed_version=$(grep -m1 '"version"[[:space:]]*:' "${INSTALLED_PKG_JSON}" 2>/dev/null |
+    sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')
+
+  today="$(date +%Y-%m-%d 2>/dev/null || true)"
+  last_checked=""
+  [ -f "${FRESHNESS_STAMP}" ] && last_checked=$(cat "${FRESHNESS_STAMP}" 2>/dev/null || true)
+
+  if [ -n "$today" ] && [ "$last_checked" != "$today" ] && [ -f "${CORE_PKG_JSON}" ] && command -v npm >/dev/null 2>&1; then
+    dep_range=$(grep -m1 '"@oss-scout/core"[[:space:]]*:' "${CORE_PKG_JSON}" 2>/dev/null |
+      sed -E 's/.*"@oss-scout\/core"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')
+
+    if [ -n "$dep_range" ]; then
+      # `npm view pkg@range version` resolves the highest version in the
+      # registry that satisfies the range directly, no manual semver compare
+      # needed. Any failure here (offline, registry down, range unparsable)
+      # is swallowed: the check is best-effort and must never fail the build.
+      dep_latest_version=$(npm view "@oss-scout/core@${dep_range}" version 2>/dev/null)
+      if [ -n "$dep_latest_version" ]; then
+        # Registry was reachable: record today's date so we don't hit it
+        # again until tomorrow, whether or not a refresh is needed. mkdir
+        # covers the first-ever run, before dist/ exists.
+        mkdir -p "${PLUGIN_ROOT}/packages/core/dist" 2>/dev/null || true
+        echo "$today" >"${FRESHNESS_STAMP}" 2>/dev/null || true
+        if [ "$dep_latest_version" != "$dep_installed_version" ]; then
+          dep_refresh_needed=true
+        fi
+      fi
+    fi
+  fi
+fi
+
+if [ "$dep_refresh_needed" = true ]; then
+  echo "build-cli-if-stale.sh: @oss-scout/core is stale (installed ${dep_installed_version:-none}, latest in range ${dep_latest_version:-unknown}); refreshing" >&2
+  needs_rebuild=true
+fi
+
 if [ "$needs_rebuild" = false ]; then
   exit 0
 fi
@@ -76,15 +141,32 @@ fi
 # packages/core/ would generate a stray package-lock.json next to
 # pnpm-lock.yaml. Fall back to npm only when pnpm isn't installed (works
 # today because @oss-autopilot/core has no workspace:* deps).
+#
+# When a dependency refresh is needed, an `install`/`pnpm install` alone
+# isn't enough: both tools honor the checked-in lockfile by default and will
+# happily keep resolving the already-locked (stale) version even though a
+# newer one now satisfies the declared range. `update` re-resolves that one
+# package against the range and rewrites the lockfile; a plain install after
+# it is then a no-op for that package but still catches everything else.
 remediation=""
 if command -v pnpm >/dev/null 2>&1; then
   remediation="cd ${PLUGIN_ROOT} && pnpm install && pnpm --filter @oss-autopilot/core run bundle"
-  if (cd "${PLUGIN_ROOT}" && pnpm install --silent && pnpm --silent --filter @oss-autopilot/core run bundle) >&2; then
+  if (
+    cd "${PLUGIN_ROOT}" &&
+      { [ "$dep_refresh_needed" = false ] || pnpm --silent --filter @oss-autopilot/core update @oss-scout/core; } &&
+      pnpm install --silent &&
+      pnpm --silent --filter @oss-autopilot/core run bundle
+  ) >&2; then
     exit 1
   fi
 else
   remediation="cd ${PLUGIN_ROOT}/packages/core && npm install && npm run bundle"
-  if (cd "${PLUGIN_ROOT}/packages/core" && npm install --silent && npm run bundle --silent) >&2; then
+  if (
+    cd "${PLUGIN_ROOT}/packages/core" &&
+      { [ "$dep_refresh_needed" = false ] || npm update @oss-scout/core --silent; } &&
+      npm install --silent &&
+      npm run bundle --silent
+  ) >&2; then
     exit 1
   fi
 fi

--- a/scripts/build-cli-if-stale.test.sh
+++ b/scripts/build-cli-if-stale.test.sh
@@ -33,16 +33,33 @@ pass() {
     PASS=$((PASS + 1))
 }
 
-# Build a fake plugin tree: <root>/packages/core/{src,package.json,tsconfig.json,dist/cli.bundle.cjs}.
+# Build a fake plugin tree: <root>/packages/core/{src,package.json,tsconfig.json,dist/cli.bundle.cjs,node_modules/@oss-scout/core}.
 # All freshness checks operate on file mtimes within this tree.
 setup() {
     WORK=$(mktemp -d)
     PLUGIN="${WORK}/plugin"
-    mkdir -p "${PLUGIN}/packages/core/src" "${PLUGIN}/packages/core/dist"
-    echo "{}" >"${PLUGIN}/packages/core/package.json"
+    mkdir -p "${PLUGIN}/packages/core/src" "${PLUGIN}/packages/core/dist" \
+        "${PLUGIN}/packages/core/node_modules/@oss-scout/core"
+    cat >"${PLUGIN}/packages/core/package.json" <<'EOF'
+{
+  "dependencies": {
+    "@oss-scout/core": "^1.3.0"
+  }
+}
+EOF
     echo "{}" >"${PLUGIN}/packages/core/tsconfig.json"
     echo "// existing bundle" >"${PLUGIN}/packages/core/dist/cli.bundle.cjs"
     echo "export const x = 1;" >"${PLUGIN}/packages/core/src/index.ts"
+    cat >"${PLUGIN}/packages/core/node_modules/@oss-scout/core/package.json" <<'EOF'
+{
+  "name": "@oss-scout/core",
+  "version": "1.3.0"
+}
+EOF
+    # Default fixture: dependency already matches the latest in range and
+    # was "checked" today, so unrelated test cases never hit the (fake or
+    # real) registry.
+    date +%Y-%m-%d >"${PLUGIN}/packages/core/dist/.dep-freshness-checked" 2>/dev/null
 
     # Make sure the bundle starts as the most-recent file so a later
     # `touch` of a source file unambiguously beats it.
@@ -195,6 +212,186 @@ EOF
     [ "$rc" = 1 ] && pass || fail "expected exit 1 when package.json is newer, got $rc"
 }
 
+case_dep_missing_triggers_install() {
+    # @oss-scout/core isn't installed at all -> needs install regardless of
+    # the daily stamp throttle (no comparison possible, no network needed).
+    rm -rf "${PLUGIN}/packages/core/node_modules/@oss-scout/core"
+
+    fake_bin=$(mktemp -d)
+    cat >"${fake_bin}/pnpm" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    cat >"${fake_bin}/npm" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "${fake_bin}/pnpm" "${fake_bin}/npm"
+
+    PATH="${fake_bin}:${PATH}" "$SUBJECT" "$PLUGIN" >/dev/null 2>&1
+    rc=$?
+    rm -rf "$fake_bin"
+    [ "$rc" = 1 ] && pass || fail "expected exit 1 (rebuilt) when @oss-scout/core isn't installed, got $rc"
+}
+
+case_dep_stamp_fresh_skips_check() {
+    # Installed version looks stale, but the daily stamp (set by setup() to
+    # today) means the registry must NOT be queried this run.
+    cat >"${PLUGIN}/packages/core/node_modules/@oss-scout/core/package.json" <<'EOF'
+{"name": "@oss-scout/core", "version": "1.2.4"}
+EOF
+
+    marker="${WORK}/npm-view-called"
+    fake_bin=$(mktemp -d)
+    cat >"${fake_bin}/npm" <<EOF
+#!/usr/bin/env bash
+if [ "\$1" = "view" ]; then
+  touch "${marker}"
+fi
+exit 0
+EOF
+    cat >"${fake_bin}/pnpm" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "${fake_bin}/npm" "${fake_bin}/pnpm"
+
+    PATH="${fake_bin}:${PATH}" "$SUBJECT" "$PLUGIN" >/dev/null 2>&1
+    rc=$?
+    called=false
+    [ -f "$marker" ] && called=true
+    rm -rf "$fake_bin"
+
+    if [ "$rc" != 0 ]; then
+        fail "expected exit 0 (stamp fresh, no rebuild) got $rc"
+        return
+    fi
+    if [ "$called" = true ]; then
+        fail "npm view was invoked despite a fresh (today) freshness stamp"
+        return
+    fi
+    pass
+}
+
+case_dep_versions_match_no_rebuild() {
+    # Stamp is stale (absent) so the check runs; the registry reports the
+    # installed version is already the newest in range -> no rebuild, but
+    # the stamp still advances to today.
+    rm -f "${PLUGIN}/packages/core/dist/.dep-freshness-checked"
+
+    fake_bin=$(mktemp -d)
+    cat >"${fake_bin}/npm" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "view" ]; then
+  echo "1.3.0"
+  exit 0
+fi
+exit 0
+EOF
+    cat >"${fake_bin}/pnpm" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "${fake_bin}/npm" "${fake_bin}/pnpm"
+
+    PATH="${fake_bin}:${PATH}" "$SUBJECT" "$PLUGIN" >/dev/null 2>&1
+    rc=$?
+    stamp_after=""
+    [ -f "${PLUGIN}/packages/core/dist/.dep-freshness-checked" ] &&
+        stamp_after=$(cat "${PLUGIN}/packages/core/dist/.dep-freshness-checked")
+    rm -rf "$fake_bin"
+
+    if [ "$rc" != 0 ]; then
+        fail "expected exit 0 when installed version already matches latest in range, got $rc"
+        return
+    fi
+    if [ -z "$stamp_after" ]; then
+        fail "expected freshness stamp to be written after a successful registry check"
+        return
+    fi
+    pass
+}
+
+case_dep_stale_version_triggers_refresh() {
+    # Stamp is stale and the registry reports a newer version than what's
+    # installed -> rebuild triggered purely by the dependency check (bundle
+    # is otherwise current per mtime).
+    rm -f "${PLUGIN}/packages/core/dist/.dep-freshness-checked"
+    cat >"${PLUGIN}/packages/core/node_modules/@oss-scout/core/package.json" <<'EOF'
+{"name": "@oss-scout/core", "version": "1.2.4"}
+EOF
+
+    fake_bin=$(mktemp -d)
+    cat >"${fake_bin}/npm" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "view" ]; then
+  echo "1.3.0"
+  exit 0
+fi
+exit 0
+EOF
+    cat >"${fake_bin}/pnpm" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "${fake_bin}/npm" "${fake_bin}/pnpm"
+
+    out=$(PATH="${fake_bin}:${PATH}" "$SUBJECT" "$PLUGIN" 2>&1 >/dev/null)
+    rc=$?
+    rm -rf "$fake_bin"
+
+    if [ "$rc" != 1 ]; then
+        fail "expected exit 1 (rebuilt) when installed dep is behind latest in range, got $rc"
+        return
+    fi
+    if ! echo "$out" | grep -q "refreshing"; then
+        fail "expected a stderr log line about refreshing the stale dependency, got '$out'"
+        return
+    fi
+    pass
+}
+
+case_dep_registry_error_skips_gracefully() {
+    # npm view fails (offline/registry down) -> the check must be skipped
+    # silently, must NOT fail the build, and must leave the stamp untouched
+    # so the next run retries.
+    rm -f "${PLUGIN}/packages/core/dist/.dep-freshness-checked"
+    cat >"${PLUGIN}/packages/core/node_modules/@oss-scout/core/package.json" <<'EOF'
+{"name": "@oss-scout/core", "version": "1.2.4"}
+EOF
+
+    fake_bin=$(mktemp -d)
+    cat >"${fake_bin}/npm" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "view" ]; then
+  exit 1
+fi
+exit 0
+EOF
+    cat >"${fake_bin}/pnpm" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "${fake_bin}/npm" "${fake_bin}/pnpm"
+
+    PATH="${fake_bin}:${PATH}" "$SUBJECT" "$PLUGIN" >/dev/null 2>&1
+    rc=$?
+    stamp_after=""
+    [ -f "${PLUGIN}/packages/core/dist/.dep-freshness-checked" ] &&
+        stamp_after=$(cat "${PLUGIN}/packages/core/dist/.dep-freshness-checked")
+    rm -rf "$fake_bin"
+
+    if [ "$rc" != 0 ]; then
+        fail "expected exit 0 (registry error tolerated, no rebuild) got $rc"
+        return
+    fi
+    if [ -n "$stamp_after" ]; then
+        fail "expected freshness stamp to remain unwritten after a registry error, got '$stamp_after'"
+        return
+    fi
+    pass
+}
+
 # --- Driver ----------------------------------------------------------------
 
 echo "Running build-cli-if-stale.sh tests..."
@@ -206,6 +403,11 @@ run case_missing_bundle_triggers_rebuild  case_missing_bundle_triggers_rebuild
 run case_swap_files_do_not_trigger_rebuild case_swap_files_do_not_trigger_rebuild
 run case_build_failure_returns_2          case_build_failure_returns_2
 run case_package_json_newer_triggers_rebuild case_package_json_newer_triggers_rebuild
+run case_dep_missing_triggers_install         case_dep_missing_triggers_install
+run case_dep_stamp_fresh_skips_check          case_dep_stamp_fresh_skips_check
+run case_dep_versions_match_no_rebuild        case_dep_versions_match_no_rebuild
+run case_dep_stale_version_triggers_refresh   case_dep_stale_version_triggers_refresh
+run case_dep_registry_error_skips_gracefully  case_dep_registry_error_skips_gracefully
 
 echo
 echo "Results: ${PASS} passed, ${FAIL} failed."


### PR DESCRIPTION
The plugin bundle only rebuilds when its own src changes, so scout releases never propagate. The bundle sat on @oss-scout/core 1.2.4 for hours while 1.3.0 carried the rate-limit prefetch fix, which meant search runs kept hitting secondary limits with the fix already published.

Bumps @oss-scout/core to ^1.3.0 and teaches build-cli-if-stale.sh a once-daily registry freshness check. When the installed version is older than the latest satisfying the declared range, it runs a targeted `pnpm update` (a plain install honors the lockfile and would never bump) and rebundles. Registry or network failures skip the check without failing the build, and the stamp is left untouched so it retries next run. Exit-code contract unchanged (0=current, 1=rebuilt, 2=failed, 3=invocation error).

13/13 script harness cases pass (5 new: missing dep, fresh stamp skips registry, versions match, stale version refreshes, registry error skips gracefully). Both paths verified against the real registry.
