### PR TITLE
fix(core): supply searchRotation in buildScoutState for scout 1.4.0

### DIFF
--- a/packages/core/src/commands/scout-bridge.ts
+++ b/packages/core/src/commands/scout-bridge.ts
@@ -221,6 +221,15 @@ export function buildScoutState(diagnostics?: ScoutBridgeDiagnostics): ScoutStat
     })),
     skippedIssues: skippedIssuesLoad.issues,
     lastRunAt: state.lastRunAt,
+    // Scout 1.4.0 added `searchRotation` (persisted language-rotation cursor
+    // for the broad phase) as a required field on the inferred ScoutState type
+    // — its ZodDefault still applies at parse time, but a hand-built literal
+    // like this one must supply it. Autopilot runs scout in
+    // persistence:'provided' and synthesizes a fresh ScoutState per operation,
+    // so there is no durable cursor to carry across runs; scout's documented
+    // default (offset 0) is correct here, same as the ScoutPreferences
+    // defaults above.
+    searchRotation: { languageOffset: 0 },
   };
 }
 


### PR DESCRIPTION
Scout 1.4.0 made `searchRotation` a required field on the inferred `ScoutState` type. `buildScoutState` hand-builds the state literal, so `docs:check` (typedoc typecheck, gated to the Node 22/ubuntu matrix cell) failed on main right after the release's 1.4.0 bump landed.

Passes scout's documented default (`{ languageOffset: 0 }`), matching the existing pattern for the ScoutPreferences defaults in the same function. Autopilot runs scout in `persistence:'provided'` with a fresh ScoutState synthesized per operation, so there is no durable rotation cursor to carry across runs.

Reproduced the exact failure locally (`docs:check` → TS2741) and confirmed the fix (0 errors), plus typecheck across all packages and the 35 scout-bridge tests pass.