### PR TITLE
docs(contribution): encode four maintainer-review conventions

### DIFF
--- a/agents/pr-responder.md
+++ b/agents/pr-responder.md
@@ -49,6 +49,8 @@ You are a PR Response Specialist helping open source contributors craft effectiv
 2. Try the simplest implementation before estimating scope. Don't say "this would require significant refactoring" without trying the straightforward approach first.
 3. Flag conflicts to the user — never push back on a maintainer directly. Use AskUserQuestion and let the user decide.
 
+**Multi-Round, Severity-Tagged Review.** Expect maintainer review across several rounds, often with items tagged by severity (P1/P2/P3 or similar). When a reply is warranted, structure it point-by-point — one response per item, each citing the specific commit SHA that addressed it — rather than a single summary comment for the whole batch. Address every severity level; don't silently skip the low-priority ones. (This governs how to structure a reply once one is warranted; it does not override the "Code Over Comments" default above.)
+
 ## Data Access
 
 **Prefer MCP tools:**

--- a/skills/oss-contribution/SKILL.md
+++ b/skills/oss-contribution/SKILL.md
@@ -37,6 +37,18 @@ Every line in a PR diff must be directly related to the issue being fixed. Unrel
 
 **When formatting IS the fix:** If the issue itself is about formatting (e.g., "run prettier on codebase", "fix inconsistent indentation"), then formatting changes are in scope. In all other cases, they are not.
 
+## Minimize Public API Surface
+
+A narrow fix should not widen what the project must support forever. Prefer correcting behavior inside an existing public API over adding a new option, flag, method, or parameter. Every new surface is something maintainers have to document, test, and keep backward-compatible — reach for one only when the existing API genuinely cannot express the fix, and say so explicitly rather than defaulting to a new knob.
+
+## Fix the Root Cause, Not a Workaround
+
+Trace a bug to where it actually originates before patching. If the cause lives in an upstream dependency, fix or report it there rather than working around it downstream. If the maintainer rejects the root-cause fix as a known limitation, offer a documentation note that warns other users — don't submit a second local patch that papers over the same underlying problem.
+
+## Regression Tests Must Actually Regress
+
+A test added alongside a bug fix only earns its place if it fails without the fix. Before including it, check out the base branch (or revert your fix), run the new test, and confirm it FAILS; then restore the fix and confirm it passes. A test that passes on the unpatched base isn't guarding the bug — it's noise.
+
 ## Working on Issues
 
 ### Before Starting


### PR DESCRIPTION
## Summary

Encode maintainer-review patterns that recur across contribution sessions so an agent applies them automatically, instead of relying on a human to paste them into context each time.

## Changes

- `skills/oss-contribution/SKILL.md` - three implementation-discipline sections beside "Minimal Diff Discipline":
  - **Minimize Public API Surface** - fix inside existing APIs before adding a new option/flag/method.
  - **Fix the Root Cause, Not a Workaround** - fix/report upstream; offer a doc note when a fix is rejected as a known limitation.
  - **Regression Tests Must Actually Regress** - verify the test fails on the base branch before including it.
- `agents/pr-responder.md` - **Multi-Round, Severity-Tagged Review** rule beside the Maintainer Authority Principle: reply point-by-point citing the commit SHA per item; worded so it doesn't override the existing "Code Over Comments" default.

## Related Issues

Closes #1567

## Checklist

- [x] Tests pass (`pnpm test`) - docs-only; prettier ignores `*.md` and eslint targets `packages/` only, so no code surface. `format:check` green.
- [x] Commits follow conventional format
- [x] No manual version bumps or CHANGELOG edits