### PR TITLE
fix(grading): grade new repos on intrinsic merge rate; reconcile approve with grade

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,7 +68,7 @@
     "@octokit/plugin-retry": "^8.1.0",
     "@octokit/plugin-throttling": "^11.0.3",
     "@octokit/rest": "^22.0.1",
-    "@oss-scout/core": "^1.3.0",
+    "@oss-scout/core": "^1.5.0",
     "commander": "^15.0.0",
     "zod": "^4.4.3"
   },

--- a/packages/core/src/commands/vet-list.ts
+++ b/packages/core/src/commands/vet-list.ts
@@ -13,7 +13,7 @@ import {
 } from '../formatters/json.js';
 import { runParseList, pruneIssueList } from './parse-list.js';
 import { detectIssueList } from './startup.js';
-import { computeSuccessGrade, gradeFromCandidate } from '../core/issue-grading.js';
+import { computeSuccessGrade, gradeFromCandidate, reconcileRecommendation } from '../core/issue-grading.js';
 import { ValidationError } from '../core/errors.js';
 import {
   getStateManager,
@@ -286,7 +286,7 @@ export async function runVetList(options: VetListOptions = {}): Promise<VetListO
         url: candidate.issue.url,
         labels: candidate.issue.labels,
       },
-      recommendation: candidate.recommendation,
+      recommendation: reconcileRecommendation(candidate.recommendation, grade),
       reasonsToApprove: candidate.reasonsToApprove,
       reasonsToSkip: candidate.reasonsToSkip,
       projectHealth: candidate.projectHealth,

--- a/packages/core/src/commands/vet.ts
+++ b/packages/core/src/commands/vet.ts
@@ -6,7 +6,7 @@
 import { adaptScoutLinkedPR, buildCandidateLinkedPR, createAutopilotScout } from './scout-bridge.js';
 import { type VetOutput } from '../formatters/json.js';
 import { ISSUE_URL_PATTERN, validateGitHubUrl, validateUrl } from './validation.js';
-import { gradeFromCandidate } from '../core/issue-grading.js';
+import { gradeFromCandidate, reconcileRecommendation } from '../core/issue-grading.js';
 import { getStateManager, classifyLinkedPR } from '../core/index.js';
 
 export { type VetOutput } from '../formatters/json.js';
@@ -51,7 +51,7 @@ export async function runVet(options: VetOptions): Promise<VetOutput> {
       url: candidate.issue.url,
       labels: candidate.issue.labels,
     },
-    recommendation: candidate.recommendation,
+    recommendation: reconcileRecommendation(candidate.recommendation, grade),
     reasonsToApprove: candidate.reasonsToApprove,
     reasonsToSkip: candidate.reasonsToSkip,
     projectHealth: candidate.projectHealth,

--- a/packages/core/src/core/issue-grading.test.ts
+++ b/packages/core/src/core/issue-grading.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeSuccessGrade, deriveGradeSignals } from './issue-grading.js';
+import { computeSuccessGrade, deriveGradeSignals, reconcileRecommendation } from './issue-grading.js';
 
 // Success score is on a 1-10 scale (#249 follow-up). The three signal bands
 // map to 10 / 7 / 4 / 1 (best→worst); the overall score is the worst of the
@@ -274,6 +274,76 @@ describe('computeSuccessGrade', () => {
         repoScore: { mergedPRCount: -3, closedWithoutMergeCount: 10 },
       });
       expect(signals.mergeRate).toBeNull();
+    });
+
+    // #248: prefer scout's repo-intrinsic merge rate so a healthy repo we've
+    // never contributed to grades on its own merits instead of collapsing to F.
+    it('prefers repo-intrinsic recentMergeRate over relationship counts', () => {
+      const signals = deriveGradeSignals({
+        projectHealth: {
+          avgIssueResponseDays: 1,
+          daysSinceLastCommit: 1,
+          recentMergeRate: 0.85,
+        },
+        // Relationship says 0.2, but the repo-intrinsic rate must win.
+        repoScore: { mergedPRCount: 1, closedWithoutMergeCount: 4 },
+      });
+      expect(signals.mergeRate).toBeCloseTo(0.85);
+    });
+
+    it('gives a new repo (no repoScore) a merge rate from recentMergeRate', () => {
+      const signals = deriveGradeSignals({
+        projectHealth: {
+          avgIssueResponseDays: 2,
+          daysSinceLastCommit: 1,
+          recentMergeRate: 0.9,
+        },
+        repoScore: null,
+      });
+      // Previously null → grade collapsed to F; now a real, healthy rate.
+      expect(signals.mergeRate).toBeCloseTo(0.9);
+      expect(computeSuccessGrade(signals).score).toBeGreaterThan(4);
+    });
+
+    it('falls back to relationship counts when recentMergeRate is absent', () => {
+      const signals = deriveGradeSignals({
+        projectHealth: { avgIssueResponseDays: 1, daysSinceLastCommit: 1 },
+        repoScore: { mergedPRCount: 17, closedWithoutMergeCount: 3 },
+      });
+      expect(signals.mergeRate).toBeCloseTo(17 / 20);
+    });
+
+    it('ignores recentMergeRate when the health check failed', () => {
+      const signals = deriveGradeSignals({
+        projectHealth: {
+          avgIssueResponseDays: 0,
+          daysSinceLastCommit: 999,
+          recentMergeRate: 0.9,
+          checkFailed: true,
+        },
+        repoScore: null,
+      });
+      expect(signals.mergeRate).toBeNull();
+    });
+  });
+
+  describe('reconcileRecommendation (#1575 defect 2)', () => {
+    it('downgrades approve to needs_review at the bottom grade band', () => {
+      expect(reconcileRecommendation('approve', { score: 1, reason: 'unknown' })).toBe('needs_review');
+    });
+
+    it('keeps approve when the grade is trustworthy', () => {
+      expect(reconcileRecommendation('approve', { score: 7, reason: 'merges 80%' })).toBe('approve');
+    });
+
+    it('keeps approve exactly at the keep threshold (score 4)', () => {
+      expect(reconcileRecommendation('approve', { score: 4, reason: 'merges 30%' })).toBe('approve');
+    });
+
+    it('leaves non-approve recommendations unchanged', () => {
+      const worst = { score: 1, reason: 'unknown' };
+      expect(reconcileRecommendation('skip', worst)).toBe('skip');
+      expect(reconcileRecommendation('needs_review', worst)).toBe('needs_review');
     });
   });
 

--- a/packages/core/src/core/issue-grading.ts
+++ b/packages/core/src/core/issue-grading.ts
@@ -29,6 +29,34 @@ export interface GradeResult {
   reason: string;
 }
 
+/** Recommendation verdict, mirroring `@oss-scout/core`'s candidate field. */
+export type IssueRecommendation = 'approve' | 'skip' | 'needs_review';
+
+/**
+ * Grade bands are 10/7/4/1. At or above this an "approve" is trustworthy;
+ * below it (the bottom band, 1 — "unknown/worst") the grade and an "approve"
+ * contradict each other.
+ */
+export const KEEP_GRADE_THRESHOLD = 4;
+
+/**
+ * Reconcile a scout recommendation with the computed grade (#1575 defect 2).
+ * Scout derives "approve" from its own checks without consulting the grade, so
+ * an "approve" can coexist with a bottom-band grade. Downgrade such an
+ * "approve" to "needs_review" — never a hard skip — so the two signals a caller
+ * sees can't flatly contradict. Any non-approve recommendation is returned
+ * unchanged.
+ *
+ * Apply this ONLY where the grade is high-fidelity — i.e. computed from freshly
+ * fetched health (the `vet` / `vet-list` surfaces). The `search` and `features`
+ * surfaces pass a `checkFailed` health sentinel and grade from history alone, so
+ * any repo we lack history with scores the bottom band for missing data, not for
+ * being bad; reconciling there would wrongly downgrade well-vetted candidates.
+ */
+export function reconcileRecommendation(recommendation: IssueRecommendation, grade: GradeResult): IssueRecommendation {
+  return recommendation === 'approve' && grade.score < KEEP_GRADE_THRESHOLD ? 'needs_review' : recommendation;
+}
+
 type SignalScore = { score: number; detail: string };
 
 // Band values, best→worst. A signal always resolves to one of these, so
@@ -102,6 +130,14 @@ export function deriveGradeSignals(params: {
   projectHealth: {
     avgIssueResponseDays: number | null;
     daysSinceLastCommit: number | null;
+    /**
+     * Repo-intrinsic recent merge rate from `@oss-scout/core`'s
+     * `projectHealth.recentMergeRate` (repo-wide merged / closed over 90 days).
+     * Preferred over the relationship-derived rate so a healthy repo we've never
+     * contributed to grades on its own merits instead of collapsing to F (#248).
+     * Absent (undefined/null) until the scout release that supplies it.
+     */
+    recentMergeRate?: number | null;
     checkFailed?: boolean;
   };
   repoScore: {
@@ -121,8 +157,11 @@ export function deriveGradeSignals(params: {
     ? sanitize(projectHealth.daysSinceLastCommit, 0, Number.MAX_SAFE_INTEGER)
     : null;
 
-  let mergeRate: number | null = null;
-  if (repoScore) {
+  // Prefer scout's repo-intrinsic merge rate (#248); fall back to the
+  // relationship-derived rate (our own merged/closed counts) when scout didn't
+  // supply one, preserving prior behavior for repos with contribution history.
+  let mergeRate: number | null = healthTrusted ? sanitize(projectHealth.recentMergeRate, 0, 1) : null;
+  if (mergeRate === null && repoScore) {
     const merged = sanitize(repoScore.mergedPRCount, 0, Number.MAX_SAFE_INTEGER);
     const closed = sanitize(repoScore.closedWithoutMergeCount, 0, Number.MAX_SAFE_INTEGER);
     if (merged !== null && closed !== null) {
@@ -172,6 +211,12 @@ export function gradeFromCandidate(params: {
     : {
         avgIssueResponseDays: ph.avgIssueResponseDays,
         daysSinceLastCommit: ph.daysSinceLastCommit,
+        // Repo-intrinsic recent merge rate (#248). The cast is a forward-compat
+        // bridge: the field ships in the @oss-scout/core release that pairs with
+        // this change but isn't in the current pinned dep's types yet. Absent →
+        // null → deriveGradeSignals falls back to the relationship-derived rate,
+        // preserving prior behavior. Drop the cast once the dep is bumped.
+        recentMergeRate: (ph as { recentMergeRate?: number | null }).recentMergeRate ?? null,
         checkFailed: false,
       };
   return computeSuccessGrade(

--- a/packages/core/src/core/issue-grading.ts
+++ b/packages/core/src/core/issue-grading.ts
@@ -211,12 +211,10 @@ export function gradeFromCandidate(params: {
     : {
         avgIssueResponseDays: ph.avgIssueResponseDays,
         daysSinceLastCommit: ph.daysSinceLastCommit,
-        // Repo-intrinsic recent merge rate (#248). The cast is a forward-compat
-        // bridge: the field ships in the @oss-scout/core release that pairs with
-        // this change but isn't in the current pinned dep's types yet. Absent →
-        // null → deriveGradeSignals falls back to the relationship-derived rate,
-        // preserving prior behavior. Drop the cast once the dep is bumped.
-        recentMergeRate: (ph as { recentMergeRate?: number | null }).recentMergeRate ?? null,
+        // Repo-intrinsic recent merge rate (#248). Absent → null →
+        // deriveGradeSignals falls back to the relationship-derived rate,
+        // preserving prior behavior for repos with contribution history.
+        recentMergeRate: ph.recentMergeRate ?? null,
         checkFailed: false,
       };
   return computeSuccessGrade(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@oss-scout/core':
-        specifier: ^1.3.0
-        version: 1.3.0(@octokit/core@7.0.6)
+        specifier: ^1.5.0
+        version: 1.5.0(@octokit/core@7.0.6)
       commander:
         specifier: ^15.0.0
         version: 15.0.0
@@ -710,8 +710,8 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@oss-scout/core@1.3.0':
-    resolution: {integrity: sha512-yBrx4TymLUq0q6HEomOBsy896r6Z8MGSPVafo6tX07llnjHLyRahYVKbhDp5dgoo9wHLfgC49cqQEseKOeO44Q==}
+  '@oss-scout/core@1.5.0':
+    resolution: {integrity: sha512-08r5r9kaFBjBsBMm4qEBkYaBNIM8d53/N80LLkvvGsDE3in/sy6kV5ebvHXZAVd0t3EeEZmfCso18lpgJpXsgQ==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
@@ -3438,7 +3438,7 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@oss-scout/core@1.3.0(@octokit/core@7.0.6)':
+  '@oss-scout/core@1.5.0(@octokit/core@7.0.6)':
     dependencies:
       '@octokit/plugin-retry': 8.1.0(@octokit/core@7.0.6)
       '@octokit/plugin-throttling': 11.0.3(@octokit/core@7.0.6)


### PR DESCRIPTION
## Summary

Two coupled grading defects, now unblocked by `@oss-scout/core@1.5.0` (which supplies the repo-intrinsic merge signal).

**#248** - the success grade derived `mergeRate` only from the viewer's own merged/closed counts, so a healthy repo we'd never contributed to had a null merge signal and collapsed to the bottom band (F). `deriveGradeSignals` now prefers scout's `projectHealth.recentMergeRate` and falls back to the relationship-derived rate only when scout didn't supply one, preserving prior behavior for repos with contribution history.

**#1575 defect 2** - scout emits `recommendation: approve` without consulting the grade, so `approve` could coexist with a bottom-band grade. `reconcileRecommendation` downgrades such an `approve` to `needs_review` (never a hard skip). Applied only on the `vet` / `vet-list` surfaces, where the grade is computed from freshly fetched health; `search` and `features` grade from history alone (a `checkFailed` sentinel), so reconciling there would wrongly downgrade well-vetted new repos.

## Changes

- `core/issue-grading.ts` - prefer `recentMergeRate` in `deriveGradeSignals`; add `reconcileRecommendation` + `KEEP_GRADE_THRESHOLD`.
- `commands/vet.ts`, `commands/vet-list.ts` - reconcile the recommendation against the grade.
- `packages/core/package.json` - bump `@oss-scout/core` to `^1.5.0` (supplies `recentMergeRate`).

## Related Issues

Closes #1575
Closes costajohnt/oss-scout#248

## Checklist

- [x] Tests pass (`pnpm test`) - 3015 core tests; new tests cover the `recentMergeRate` preference, the new-repo-no-longer-F case, and the reconcile thresholds.
- [x] Commits follow conventional format
- [x] No manual version bumps or CHANGELOG edits (release-please)