### PR TITLE
fix(deps): unblock Dependabot updates; test(core): start cli-registry coverage ratchet

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,13 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
+    # pnpm workspace: Dependabot must update from the workspace root only.
+    # Listing package subdirectories made update jobs fail with
+    # misconfigured_tooling ("Updating workspaces from inside a workspace
+    # subdirectory is not supported") — see #1587. The root directory covers
+    # every workspace package's manifest.
     directories:
       - "/"
-      - "/packages/core"
-      - "/packages/mcp-server"
-      - "/packages/dashboard"
     schedule:
       interval: "weekly"
     commit-message:

--- a/package.json
+++ b/package.json
@@ -49,11 +49,6 @@
   "engines": {
     "node": ">=22.0.0"
   },
-  "pnpm": {
-    "overrides": {
-      "hono": ">=4.12.25"
-    }
-  },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@vitest/eslint-plugin": "1.6.20",

--- a/packages/core/src/cli-registry.test.ts
+++ b/packages/core/src/cli-registry.test.ts
@@ -33,6 +33,7 @@ vi.mock('./formatters/json.js', () => ({
   outputJson: vi.fn(),
   outputJsonError: vi.fn(),
   outputJsonValidated: vi.fn(),
+  toCompactDailyOutput: vi.fn((data: unknown) => ({ compacted: data })),
   // Schemas referenced by command actions — exported as opaque markers; the
   // mocked outputJsonValidated above doesn't actually validate.
   StatusOutputSchema: {},
@@ -57,6 +58,8 @@ vi.mock('./formatters/json.js', () => ({
   DetectFormattersOutputSchema: {},
   LocalReposOutputSchema: {},
   ManifestOutputSchema: {},
+  StrategyOutputSchema: {},
+  ComplianceScoreOutputSchema: {},
 }));
 
 // ─── Mock dynamic command-module imports ────────────────────────────────────
@@ -90,6 +93,36 @@ vi.mock('./commands/skip-add.js', () => ({ runSkipAdd: mockRunSkipAdd }));
 
 const mockRunVerifyIssue = vi.fn();
 vi.mock('./commands/verify-issue.js', () => ({ runVerifyIssue: mockRunVerifyIssue }));
+
+const mockRunStatus = vi.fn();
+vi.mock('./commands/status.js', () => ({ runStatus: mockRunStatus }));
+
+const mockRunStrategy = vi.fn();
+vi.mock('./commands/strategy.js', () => ({ runStrategy: mockRunStrategy }));
+
+const mockRunDaily = vi.fn();
+const mockRunDailyForDisplay = vi.fn();
+const mockPrintDigest = vi.fn();
+vi.mock('./commands/daily.js', () => ({
+  runDaily: mockRunDaily,
+  runDailyForDisplay: mockRunDailyForDisplay,
+  printDigest: mockPrintDigest,
+}));
+
+const mockRunTrack = vi.fn();
+vi.mock('./commands/track.js', () => ({ runTrack: mockRunTrack }));
+
+const mockRunComplianceScore = vi.fn();
+vi.mock('./commands/compliance-score.js', () => ({ runComplianceScore: mockRunComplianceScore }));
+
+const mockRunComments = vi.fn();
+const mockRunPost = vi.fn();
+const mockRunClaim = vi.fn();
+vi.mock('./commands/comments.js', () => ({
+  runComments: mockRunComments,
+  runPost: mockRunPost,
+  runClaim: mockRunClaim,
+}));
 
 // ─── Import after mocks ────────────────────────────────────────────────────
 
@@ -685,5 +718,380 @@ describe('manifest command (#1190)', () => {
 
     expect(mockOutputJsonValidated).not.toHaveBeenCalled();
     expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringMatching(/^oss-autopilot v\S+ \(\d+ commands\)$/));
+  });
+});
+
+// ─── status command display/json branching (#1586) ─────────────────────────
+
+describe('status command', () => {
+  const statusData = {
+    stats: { mergedPRs: 12, closedPRs: 3, mergeRate: '80%', needsResponse: 2 },
+    offline: false,
+    lastRunAt: '2026-07-24T00:00:00Z',
+  };
+
+  /** Concatenate everything written via console.log for content assertions. */
+  const logged = () => consoleLogSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+
+  it('routes --json through outputJsonValidated with the schema', async () => {
+    mockRunStatus.mockResolvedValue(statusData);
+    const program = buildProgram('status');
+
+    await program.parseAsync(['node', 'cli', 'status', '--json']);
+
+    expect(mockOutputJsonValidated).toHaveBeenCalledWith(expect.anything(), statusData);
+    expect(consoleLogSpy).not.toHaveBeenCalled();
+  });
+
+  it('renders stats and lastRunAt in display mode', async () => {
+    mockRunStatus.mockResolvedValue(statusData);
+    const program = buildProgram('status');
+
+    await program.parseAsync(['node', 'cli', 'status']);
+
+    expect(mockRunStatus).toHaveBeenCalledWith({ offline: undefined });
+    const out = logged();
+    expect(out).toContain('Merged PRs: 12');
+    expect(out).toContain('Merge Rate: 80%');
+    expect(out).toContain('Last Run: 2026-07-24T00:00:00Z');
+    expect(out).not.toContain('Last Updated:');
+  });
+
+  it('renders cache-freshness metadata with --offline', async () => {
+    mockRunStatus.mockResolvedValue({ ...statusData, offline: true, lastUpdated: '2026-07-23T00:00:00Z' });
+    const program = buildProgram('status');
+
+    await program.parseAsync(['node', 'cli', 'status', '--offline']);
+
+    expect(mockRunStatus).toHaveBeenCalledWith({ offline: true });
+    const out = logged();
+    expect(out).toContain('Last Updated: 2026-07-23T00:00:00Z');
+    expect(out).toContain('no GitHub API calls');
+  });
+
+  it('falls back to "Never" when lastRunAt is absent', async () => {
+    mockRunStatus.mockResolvedValue({ ...statusData, lastRunAt: undefined });
+    const program = buildProgram('status');
+
+    await program.parseAsync(['node', 'cli', 'status']);
+
+    expect(logged()).toContain('Last Run: Never');
+  });
+});
+
+// ─── strategy command display/json branching (#1586) ───────────────────────
+
+describe('strategy command', () => {
+  const logged = () => consoleLogSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+
+  const fullStrategy = {
+    strategy: {
+      profile: {
+        style: 'bug-fixer',
+        totalPRs: 20,
+        mergedCount: 15,
+        mergeRate: 0.75,
+        primaryLanguages: ['TypeScript', 'Ruby'],
+        favoriteRepos: ['org/repo'],
+      },
+      capacity: {
+        openPRCount: 4,
+        dormantPRCount: 2,
+        dormantRepoCount: 1,
+        overExtended: true,
+        suggestedAction: 'nudge dormant PRs',
+      },
+      patterns: {
+        trajectoryDirection: 'improving',
+        prTypeDistribution: { fix: 10, feat: 5, docs: 0 },
+      },
+      recommendations: { avoidPatterns: ['large refactors'] },
+    },
+  };
+
+  it('routes --json through outputJsonValidated', async () => {
+    mockRunStrategy.mockResolvedValue(fullStrategy);
+    const program = buildProgram('strategy');
+
+    await program.parseAsync(['node', 'cli', 'strategy', '--json']);
+
+    expect(mockOutputJsonValidated).toHaveBeenCalledWith(expect.anything(), fullStrategy);
+  });
+
+  it('prints the fallback message when strategy is null', async () => {
+    mockRunStrategy.mockResolvedValue({ strategy: null, message: 'Not enough tracked PRs.' });
+    const program = buildProgram('strategy');
+
+    await program.parseAsync(['node', 'cli', 'strategy']);
+
+    expect(logged()).toContain('Not enough tracked PRs.');
+    expect(logged()).not.toContain('Profile:');
+  });
+
+  it('renders profile, capacity, trajectory, and recommendations in display mode', async () => {
+    mockRunStrategy.mockResolvedValue(fullStrategy);
+    const program = buildProgram('strategy');
+
+    await program.parseAsync(['node', 'cli', 'strategy']);
+
+    const out = logged();
+    expect(out).toContain('Profile: bug-fixer');
+    expect(out).toContain('20 PRs tracked, 15 merged (75% merge rate).');
+    expect(out).toContain('Top languages: TypeScript, Ruby');
+    expect(out).toContain('Top repos: org/repo');
+    expect(out).toContain('Capacity: 4 open, 2 dormant across 1 repo(s).');
+    expect(out).toContain('Overextended — suggested action: nudge dormant PRs.');
+    expect(out).toContain('Trajectory: improving');
+    // Zero-count PR types are filtered from the distribution line.
+    expect(out).toContain('PR types (recent): fix=10, feat=5');
+    expect(out).not.toContain('docs=0');
+    expect(out).toContain('Watch for: large refactors');
+  });
+});
+
+// ─── daily command branching (#1586) ────────────────────────────────────────
+
+describe('daily command', () => {
+  it('routes --json through outputJsonValidated with the full payload', async () => {
+    const data = { prs: [], summary: { total: 0 } };
+    mockRunDaily.mockResolvedValue(data);
+    const program = buildProgram('daily');
+
+    await program.parseAsync(['node', 'cli', 'daily', '--json']);
+
+    expect(mockOutputJsonValidated).toHaveBeenCalledWith(expect.anything(), data);
+    expect(mockRunDailyForDisplay).not.toHaveBeenCalled();
+  });
+
+  it('routes --json --compact through toCompactDailyOutput', async () => {
+    const data = { prs: [], summary: { total: 0 } };
+    mockRunDaily.mockResolvedValue(data);
+    const program = buildProgram('daily');
+
+    await program.parseAsync(['node', 'cli', 'daily', '--json', '--compact']);
+
+    // The mocked toCompactDailyOutput wraps the payload; the wrapped shape
+    // must be what reaches outputJsonValidated.
+    expect(mockOutputJsonValidated).toHaveBeenCalledWith(expect.anything(), { compacted: data });
+  });
+
+  it('prints the digest via printDigest in display mode', async () => {
+    const digest = { needsResponse: [] };
+    const capacity = { openPRCount: 1 };
+    const commentedIssues = [{ url: ISSUE_URL }];
+    mockRunDailyForDisplay.mockResolvedValue({ digest, capacity, commentedIssues });
+    const program = buildProgram('daily');
+
+    await program.parseAsync(['node', 'cli', 'daily']);
+
+    expect(mockRunDaily).not.toHaveBeenCalled();
+    expect(mockPrintDigest).toHaveBeenCalledWith(digest, capacity, commentedIssues);
+  });
+
+  it('routes errors through handleCommandError in JSON mode', async () => {
+    mockRunDaily.mockRejectedValue(new Error('rate limited'));
+    const program = buildProgram('daily');
+
+    await expect(program.parseAsync(['node', 'cli', 'daily', '--json'])).rejects.toThrow('process.exit called');
+
+    expect(mockOutputJsonError).toHaveBeenCalledWith('rate limited', 'UNKNOWN');
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+});
+
+// ─── track command (#1586) ──────────────────────────────────────────────────
+
+describe('track command', () => {
+  const trackData = { pr: { repo: 'org/repo', number: 1, title: 'Fix bug' } };
+
+  it('routes --json through outputJson (tier-2, no schema)', async () => {
+    mockRunTrack.mockResolvedValue(trackData);
+    const program = buildProgram('track');
+
+    await program.parseAsync(['node', 'cli', 'track', PR_URL, '--json']);
+
+    expect(mockRunTrack).toHaveBeenCalledWith({ prUrl: PR_URL });
+    expect(mockOutputJson).toHaveBeenCalledWith(trackData);
+  });
+
+  it('prints PR metadata and the not-persisted note in display mode', async () => {
+    mockRunTrack.mockResolvedValue(trackData);
+    const program = buildProgram('track');
+
+    await program.parseAsync(['node', 'cli', 'track', PR_URL]);
+
+    const out = consoleLogSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+    expect(out).toContain('PR: org/repo#1 - Fix bug');
+    expect(out).toContain('Nothing is persisted locally.');
+  });
+});
+
+// ─── compliance-score command (#1586) ───────────────────────────────────────
+
+describe('compliance-score command', () => {
+  const scoreData = {
+    emoji: '🟢',
+    pr: { repo: 'org/repo', number: 7, title: 'Add docs' },
+    score: 85,
+    rating: 'very_good',
+    checks: {
+      description: { status: 'pass', weight: 30, detail: 'has description' },
+      tests: { status: 'warn', weight: 40, detail: 'partial coverage' },
+      size: { status: 'fail', weight: 30, detail: 'too large' },
+    },
+  };
+
+  it('routes --json through outputJsonValidated', async () => {
+    mockRunComplianceScore.mockResolvedValue(scoreData);
+    const program = buildProgram('compliance-score');
+
+    await program.parseAsync(['node', 'cli', 'compliance-score', PR_URL, '--json']);
+
+    expect(mockRunComplianceScore).toHaveBeenCalledWith({ prUrl: PR_URL });
+    expect(mockOutputJsonValidated).toHaveBeenCalledWith(expect.anything(), scoreData);
+  });
+
+  it('renders the score line and one status-tagged line per check', async () => {
+    mockRunComplianceScore.mockResolvedValue(scoreData);
+    const program = buildProgram('compliance-score');
+
+    await program.parseAsync(['node', 'cli', 'compliance-score', PR_URL]);
+
+    const out = consoleLogSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+    expect(out).toContain('PR org/repo#7: Add docs');
+    // rating underscores become spaces
+    expect(out).toContain('Score: 85/100 — very good');
+    expect(out).toContain('[OK ] description (30%) — has description');
+    expect(out).toContain('[WARN] tests (40%) — partial coverage');
+    expect(out).toContain('[FAIL] size (30%) — too large');
+  });
+});
+
+// ─── comments / post / claim commands (#1586) ───────────────────────────────
+
+describe('comments command', () => {
+  const logged = () => consoleLogSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+
+  const basePR = {
+    title: 'Fix flaky test',
+    state: 'open',
+    mergeable: true,
+    head: 'fix/flaky',
+    base: 'main',
+    url: PR_URL,
+  };
+  const emptyComments = {
+    pr: basePR,
+    reviews: [],
+    reviewComments: [],
+    issueComments: [],
+    summary: { reviewCount: 0, inlineCommentCount: 0, discussionCommentCount: 0 },
+  };
+
+  it('routes --json through outputJson (tier-2, no schema)', async () => {
+    mockRunComments.mockResolvedValue(emptyComments);
+    const program = buildProgram('comments');
+
+    await program.parseAsync(['node', 'cli', 'comments', PR_URL, '--json']);
+
+    expect(mockRunComments).toHaveBeenCalledWith({ prUrl: PR_URL, showBots: undefined });
+    expect(mockOutputJson).toHaveBeenCalledWith(emptyComments);
+  });
+
+  it('passes --bots through to runComments', async () => {
+    mockRunComments.mockResolvedValue(emptyComments);
+    const program = buildProgram('comments');
+
+    await program.parseAsync(['node', 'cli', 'comments', PR_URL, '--bots', '--json']);
+
+    expect(mockRunComments).toHaveBeenCalledWith({ prUrl: PR_URL, showBots: true });
+  });
+
+  it('prints the no-comments fallback when everything is empty', async () => {
+    mockRunComments.mockResolvedValue(emptyComments);
+    const program = buildProgram('comments');
+
+    await program.parseAsync(['node', 'cli', 'comments', PR_URL]);
+
+    const out = logged();
+    expect(out).toContain('## Fix flaky test');
+    expect(out).toContain('No comments from other users.');
+    expect(out).toContain('**Summary:** 0 reviews, 0 inline comments, 0 discussion comments');
+  });
+
+  it('renders reviews, inline comments, and discussion sections', async () => {
+    mockRunComments.mockResolvedValue({
+      pr: basePR,
+      reviews: [
+        { state: 'APPROVED', user: 'alice', submittedAt: new Date().toISOString(), body: 'LGTM' },
+        { state: 'COMMENTED', user: 'bob', submittedAt: null, body: '' },
+      ],
+      reviewComments: [
+        { user: 'carol', path: 'src/index.ts', createdAt: new Date().toISOString(), body: 'nit: rename' },
+      ],
+      issueComments: [{ user: 'dave', createdAt: new Date().toISOString(), body: null }],
+      summary: { reviewCount: 2, inlineCommentCount: 1, discussionCommentCount: 1 },
+    });
+    const program = buildProgram('comments');
+
+    await program.parseAsync(['node', 'cli', 'comments', PR_URL]);
+
+    const out = logged();
+    expect(out).toContain('### Reviews (newest first)');
+    expect(out).toContain('[Approved] **@alice** (APPROVED)');
+    // Unknown review states fall back to the [Comment] label.
+    expect(out).toContain('[Comment] **@bob** (COMMENTED)');
+    expect(out).toContain('> LGTM');
+    expect(out).toContain('### Inline Comments (newest first)');
+    expect(out).toContain('**@carol** on `src/index.ts`');
+    expect(out).toContain('> nit: rename');
+    expect(out).toContain('### Discussion (newest first)');
+    expect(out).toContain('**@dave**');
+    expect(out).not.toContain('No comments from other users.');
+    expect(out).toContain('**Summary:** 2 reviews, 1 inline comments, 1 discussion comments');
+  });
+});
+
+describe('post command', () => {
+  it('joins message parts and prints the comment URL', async () => {
+    mockRunPost.mockResolvedValue({ commentUrl: `${PR_URL}#issuecomment-1` });
+    const program = buildProgram('post');
+
+    await program.parseAsync(['node', 'cli', 'post', PR_URL, 'thanks', 'for', 'the', 'review']);
+
+    expect(mockRunPost).toHaveBeenCalledWith({ url: PR_URL, message: 'thanks for the review' });
+    expect(consoleLogSpy).toHaveBeenCalledWith(`Comment posted: ${PR_URL}#issuecomment-1`);
+  });
+
+  it('routes --json through outputJsonValidated', async () => {
+    const data = { commentUrl: `${PR_URL}#issuecomment-2` };
+    mockRunPost.mockResolvedValue(data);
+    const program = buildProgram('post');
+
+    await program.parseAsync(['node', 'cli', 'post', PR_URL, 'hi', '--json']);
+
+    expect(mockOutputJsonValidated).toHaveBeenCalledWith(expect.anything(), data);
+    expect(consoleLogSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('claim command', () => {
+  it('passes undefined message when no message parts are given', async () => {
+    mockRunClaim.mockResolvedValue({ commentUrl: `${ISSUE_URL}#issuecomment-3` });
+    const program = buildProgram('claim');
+
+    await program.parseAsync(['node', 'cli', 'claim', ISSUE_URL]);
+
+    expect(mockRunClaim).toHaveBeenCalledWith({ issueUrl: ISSUE_URL, message: undefined });
+    expect(consoleLogSpy).toHaveBeenCalledWith(`Issue claimed: ${ISSUE_URL}#issuecomment-3`);
+  });
+
+  it('joins message parts when provided', async () => {
+    mockRunClaim.mockResolvedValue({ commentUrl: `${ISSUE_URL}#issuecomment-4` });
+    const program = buildProgram('claim');
+
+    await program.parseAsync(['node', 'cli', 'claim', ISSUE_URL, 'I', 'can', 'take', 'this']);
+
+    expect(mockRunClaim).toHaveBeenCalledWith({ issueUrl: ISSUE_URL, message: 'I can take this' });
   });
 });

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -17,9 +17,9 @@ export default defineConfig({
       // carved out), so the gate is expressed as two glob sets instead:
       //   - everything except cli-registry.ts keeps the original 80% gate
       //     (picomatch negation; both sets are aggregate, not per-file);
-      //   - cli-registry.ts gets honest floors at its current level
-      //     (stmts 25.67 / branch 17.41 / funcs 41.57 / lines 25.73) so
-      //     regressions fail CI. Ratchet these up as direct tests are added.
+      //   - cli-registry.ts gets honest floors at its current level so
+      //     regressions fail CI. Ratchet these up as direct tests are added
+      //     (tracked in #1586).
       thresholds: {
         '!src/cli-registry.ts': {
           statements: 80,
@@ -27,13 +27,14 @@ export default defineConfig({
           functions: 80,
           lines: 80,
         },
-        // Floors re-measured after #1466 retired the override/shelve
-        // registrations and their registry tests (24.49/16.51/41.35/24.51).
+        // First ratchet (#1586): direct handler tests for status, strategy,
+        // daily, track, compliance-score, comments, post, and claim lifted
+        // measured coverage to 42.85/30.81/55.55/43.06.
         'src/cli-registry.ts': {
-          statements: 24,
-          branches: 16,
-          functions: 41,
-          lines: 24,
+          statements: 42,
+          branches: 30,
+          functions: 55,
+          lines: 42,
         },
       },
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,17 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  hono: '>=4.12.25'
+  hono: '>=4.12.27'
+  '@hono/node-server': '>=1.19.13'
+  express-rate-limit: '>=8.2.2'
+  ip-address: '>=10.1.1'
+  flatted: '>=3.4.2'
+  picomatch: '>=4.0.4'
+  path-to-regexp: '>=8.4.0'
+  yaml: '>=2.8.3'
+  fast-uri: '>=3.1.1'
+  undici: '>=7.28.0'
+  linkify-it: '>=5.0.1'
 
 importers:
 
@@ -586,7 +596,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.12.25'
+      hono: '>=4.12.27'
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -1364,8 +1374,8 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  body-parser@2.2.2:
-    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
   boolbase@1.0.0:
@@ -1458,6 +1468,10 @@ packages:
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
 
   convert-hrtime@5.0.0:
     resolution: {integrity: sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==}
@@ -1783,14 +1797,14 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@4.1.1:
+    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: '>=4.0.4'
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -1918,8 +1932,8 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
-  hono@4.12.25:
-    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
+  hono@4.12.32:
+    resolution: {integrity: sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@6.0.0:
@@ -1964,8 +1978,8 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -2262,6 +2276,10 @@ packages:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
 
+  media-typer@1.1.1:
+    resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
+    engines: {node: '>= 0.8'}
+
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
@@ -2382,10 +2400,6 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.2:
-    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
-    engines: {node: '>=8.6'}
-
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -2449,8 +2463,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
 
   quote-js-string@0.1.0:
@@ -2574,6 +2588,10 @@ packages:
 
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -2704,6 +2722,10 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typedoc@0.28.20:
     resolution: {integrity: sha512-uSKqkh8Cr48vllnEy+jdaAgOeR6Y+QCBW7usgUsKj7gJEfR7stw9U/fE49LBnj2tPRKPY0c0EBJSWe9Appmplg==}
     engines: {node: '>= 18', pnpm: '>= 10'}
@@ -2777,7 +2799,7 @@ packages:
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: '>=2.8.3'
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -3285,9 +3307,9 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@hono/node-server@1.19.14(hono@4.12.25)':
+  '@hono/node-server@1.19.14(hono@4.12.32)':
     dependencies:
-      hono: 4.12.25
+      hono: 4.12.32
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -3328,7 +3350,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.25)
+      '@hono/node-server': 1.19.14(hono@4.12.32)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -3338,7 +3360,7 @@ snapshots:
       eventsource-parser: 3.0.7
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.25
+      hono: 4.12.32
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -3543,7 +3565,7 @@ snapshots:
   '@rollup/pluginutils@4.2.1':
     dependencies:
       estree-walker: 2.0.2
-      picomatch: 2.3.2
+      picomatch: 4.0.5
 
   '@rollup/pluginutils@5.3.0(rollup@4.59.0)':
     dependencies:
@@ -3999,7 +4021,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 4.1.1
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4048,17 +4070,17 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
-  body-parser@2.2.2:
+  body-parser@2.3.0:
     dependencies:
       bytes: 3.1.2
-      content-type: 1.0.5
+      content-type: 2.0.0
       debug: 4.4.3
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.1
+      qs: 6.15.3
       raw-body: 3.0.2
-      type-is: 2.0.1
+      type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -4135,6 +4157,8 @@ snapshots:
   content-disposition@1.1.0: {}
 
   content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
 
   convert-hrtime@5.0.0: {}
 
@@ -4529,12 +4553,12 @@ snapshots:
   express-rate-limit@8.3.2(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.2.0
 
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2
+      body-parser: 2.3.0
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -4553,7 +4577,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.1
+      qs: 6.15.3
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -4572,7 +4596,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@4.1.1: {}
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -4690,7 +4714,7 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
-  hono@4.12.25: {}
+  hono@4.12.32: {}
 
   html-encoding-sniffer@6.0.0:
     dependencies:
@@ -4732,7 +4756,7 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.1.0
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -5006,6 +5030,8 @@ snapshots:
 
   media-typer@1.1.0: {}
 
+  media-typer@1.1.1: {}
+
   merge-descriptors@2.0.0: {}
 
   mime-db@1.54.0: {}
@@ -5108,8 +5134,6 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.2: {}
-
   picomatch@4.0.4: {}
 
   picomatch@4.0.5: {}
@@ -5156,9 +5180,10 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.15.1:
+  qs@6.15.3:
     dependencies:
-      side-channel: 1.1.0
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
 
   quote-js-string@0.1.0: {}
 
@@ -5363,6 +5388,14 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
 
   simple-code-frame@1.3.0:
@@ -5466,6 +5499,12 @@ snapshots:
     dependencies:
       content-type: 1.0.5
       media-typer: 1.1.0
+      mime-types: 3.0.2
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.1
       mime-types: 3.0.2
 
   typedoc@0.28.20(typescript@5.9.3):

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,13 +12,18 @@ onlyBuiltDependencies:
 # resolution. Revisit periodically with `pnpm why <pkg>` to confirm each
 # override is still hit by the dep graph (#963).
 overrides:
-  # Transitive via @modelcontextprotocol/sdk. Pin to avoid the pre-4.12.7
-  # security advisory family.
-  hono: '>=4.12.7'
-  # Transitive via @modelcontextprotocol/sdk. Pinned alongside hono.
-  '@hono/node-server': '>=1.19.10'
+  # Transitive via @modelcontextprotocol/sdk. Floor at the lowest
+  # non-vulnerable version for the advisory family through GHSA ranges
+  # < 4.12.27 (see #1587).
+  hono: '>=4.12.27'
+  # Transitive via @modelcontextprotocol/sdk. Advisories affect < 1.19.13.
+  '@hono/node-server': '>=1.19.13'
   # Transitive via @modelcontextprotocol/sdk. Known advisory.
   express-rate-limit: '>=8.2.2'
+  # Transitive via @modelcontextprotocol/sdk -> express-rate-limit, which
+  # exact-pins 10.1.0. XSS advisory in Address6 HTML-emitting methods;
+  # patched in 10.1.1.
+  ip-address: '>=10.1.1'
   # Dev-only, transitive via eslint -> flat-cache. ReDoS advisory.
   flatted: '>=3.4.2'
   # Dev-only, transitive via typescript-eslint -> tinyglobby. ReDoS advisory.


### PR DESCRIPTION
Works through #1586 and #1587 (2026-07-24 repo audit).

## #1587 — failed Dependabot update jobs

Root causes from the 2026-07-22 job logs:

- **preact**: `misconfigured_tooling` — dependabot.yml listed workspace package subdirectories, which Dependabot cannot update from inside a pnpm workspace. Now updates from the root only.
- **hono / body-parser** (and fast-uri / @hono/node-server the same night): `security_update_not_possible` — pnpm-lock.yaml still carried only the stale `package.json` `pnpm.overrides` entry (`hono >=4.12.25`, ignored by pnpm 10) and had never been regenerated against the real override set in pnpm-workspace.yaml.

Fixes: dependabot.yml root-only directories; dead `pnpm.overrides` block dropped from package.json; hono floor raised to >=4.12.27 and @hono/node-server to >=1.19.13; ip-address >=10.1.1 override added; lockfile regenerated (hono 4.12.32, body-parser 2.3.0, fast-uri 4.1.1, qs 6.15.3, ip-address 10.2.0).

`pnpm audit --prod` is down to one moderate finding (@hono/node-server <2.0.5), which needs a major bump blocked by @modelcontextprotocol/sdk's `^1.19.9` range.

## #1586 — cli-registry coverage ratchet (first step)

Direct handler tests for status, strategy, daily, track, compliance-score, comments, post, and claim via the existing mocked-Commander harness. cli-registry.ts coverage: 24.53/16.31/41.35/24.56 → 42.85/30.81/55.55/43.06; per-file floors ratcheted 24/16/41/24 → 42/30/55/42. #1586 stays open as the tracker for the remaining handlers.

## Verification

- `pnpm test` under Node 22: core 3043 passed, dashboard 279 passed, mcp-server 247 passed
- `pnpm typecheck`, `pnpm lint` (0 errors), `pnpm format:check` all clean

Closes #1587

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLThbYHJvtS3wRkRHkYW9n