### PR TITLE
fix(hooks): add missing hookEventName so guard decisions take effect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,12 @@ jobs:
         # a regression here silently disables all of them.
         run: bash hooks/pre-tool-use-dispatcher.test.sh
 
+      - name: Test hook JSON output shape
+        # Claude Code discards a hookSpecificOutput block that omits
+        # hookEventName, so a guard can emit a "deny" that never takes
+        # effect while still exiting 0. Covers every emitting hook script.
+        run: bash hooks/hook-json-shape.test.sh
+
       - name: Guard against phantom config field regressions
         # These keys were deleted from the v3 state schema (see
         # state-persistence.ts migrateV2ToV3). They must NOT reappear in

--- a/hooks/auto-format-before-push.sh
+++ b/hooks/auto-format-before-push.sh
@@ -23,6 +23,7 @@ warn_and_exit() {
   cat <<WARN_EOF
 {
   "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
     "permissionDecision": "allow",
     "updatedInput": {}
   },
@@ -238,6 +239,7 @@ fi
 cat <<EOF
 {
   "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
     "permissionDecision": "allow",
     "updatedInput": {}
   },

--- a/hooks/guard-git-operations.sh
+++ b/hooks/guard-git-operations.sh
@@ -26,6 +26,7 @@ if echo "$command" | grep -qE 'git\s+push\b' && echo "$command" | grep -qE '(\s-
   cat <<'EOF'
 {
   "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
     "permissionDecision": "deny",
     "updatedInput": {}
   },
@@ -40,6 +41,7 @@ if echo "$command" | grep -qE 'git\s+rebase\b'; then
   cat <<'EOF'
 {
   "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
     "permissionDecision": "ask",
     "updatedInput": {}
   },
@@ -56,6 +58,7 @@ if echo "$command" | grep -qE 'git\s+pull\b' && echo "$command" | grep -qE '(\s-
   cat <<'EOF'
 {
   "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
     "permissionDecision": "ask",
     "updatedInput": {}
   },
@@ -70,6 +73,7 @@ if echo "$command" | grep -qE 'git\s+push\b.*--force-with-lease'; then
   cat <<'EOF'
 {
   "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
     "permissionDecision": "ask",
     "updatedInput": {}
   },
@@ -87,6 +91,7 @@ if echo "$command" | grep -qE 'git\s+reset\s+--hard\b'; then
   cat <<'EOF'
 {
   "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
     "permissionDecision": "ask",
     "updatedInput": {}
   },

--- a/hooks/guard-public-posts.sh
+++ b/hooks/guard-public-posts.sh
@@ -39,14 +39,14 @@ emit_ask() {
     # for jq at startup below).
     if command -v jq >/dev/null 2>&1; then
         jq -nc --arg msg "$1" '{
-          hookSpecificOutput: {permissionDecision: "ask", updatedInput: {}},
+          hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "ask", updatedInput: {}},
           systemMessage: $msg
         }'
     else
         # If jq is missing, we already emit a loud ask from the startup
         # check below; this branch is a last-resort fallback.
         cat <<EOF
-{"hookSpecificOutput":{"permissionDecision":"ask","updatedInput":{}},"systemMessage":"guard-public-posts: refusing to parse tool input without jq. Install jq and retry."}
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","updatedInput":{}},"systemMessage":"guard-public-posts: refusing to parse tool input without jq. Install jq and retry."}
 EOF
     fi
 }

--- a/hooks/guard-public-posts.test.sh
+++ b/hooks/guard-public-posts.test.sh
@@ -34,10 +34,17 @@ expect_ask() {
     local out
     out=$(printf '%s' "$payload" | "$SUBJECT" 2>/dev/null)
     # Accept both compact and pretty-printed JSON shapes.
-    if echo "$out" | grep -qE '"permissionDecision"[[:space:]]*:[[:space:]]*"ask"'; then
+    if ! echo "$out" | grep -qE '"permissionDecision"[[:space:]]*:[[:space:]]*"ask"'; then
+        fail "$name" "expected ask decision; got: $out"
+        return
+    fi
+    # Claude Code discards the whole hookSpecificOutput block when
+    # hookEventName is absent, so an "ask" without it silently allows the
+    # post. Assert the field is present or the guard is decorative.
+    if echo "$out" | grep -qE '"hookEventName"[[:space:]]*:[[:space:]]*"PreToolUse"'; then
         pass "$name"
     else
-        fail "$name" "expected ask decision; got: $out"
+        fail "$name" "ask decision is missing hookEventName; got: $out"
     fi
 }
 

--- a/hooks/hook-json-shape.test.sh
+++ b/hooks/hook-json-shape.test.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Shape test for every hook script that emits a hookSpecificOutput block.
+#
+# Claude Code validates hook stdout and discards the ENTIRE hookSpecificOutput
+# block when the required "hookEventName" field is missing. The hook still
+# exits 0, so the run is logged as a non-blocking error and the permission
+# decision — including a "deny" — is silently dropped. A guard in that state
+# looks healthy in the source and does nothing at runtime.
+#
+# Run via: bash hooks/hook-json-shape.test.sh
+# Exits 0 on success, 1 on first failure.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+
+PASS=0
+FAIL=0
+
+for subject in "$SCRIPT_DIR"/*.sh; do
+    case "$subject" in
+        *.test.sh) continue ;;
+    esac
+
+    name=$(basename "$subject")
+    blocks=$(grep -c 'hookSpecificOutput' "$subject" 2>/dev/null || true)
+    [ "${blocks:-0}" -gt 0 ] || continue
+
+    events=$(grep -c 'hookEventName' "$subject" 2>/dev/null || true)
+    if [ "${events:-0}" -ge "$blocks" ]; then
+        echo "  PASS: ${name} (${blocks} block(s), each carries hookEventName)"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: ${name}: ${blocks} hookSpecificOutput block(s) but only ${events} hookEventName field(s) — the missing ones are discarded at runtime"
+        FAIL=$((FAIL + 1))
+    fi
+done
+
+echo "Results: ${PASS} passed, ${FAIL} failed."
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Problem

Three PreToolUse hooks emit `hookSpecificOutput` without the required `hookEventName` field:

- `hooks/guard-public-posts.sh` (2 blocks)
- `hooks/guard-git-operations.sh` (5 blocks)
- `hooks/auto-format-before-push.sh` (2 blocks)

Claude Code validates hook stdout and discards the entire `hookSpecificOutput` block when that field is missing:

```
Hook JSON output validation failed — hookSpecificOutput is missing required field "hookEventName"
```

The hook still exits 0, so the run is recorded as a non-blocking error and execution continues as if no hook had spoken. Every permission decision these three guards produced was silently dropped, including the `deny` on `git push --force` and the `ask` before public GitHub posts. A local transcript scan found 399 rejected outputs across 14 days.

`pre-tool-use-dispatcher.sh` and `session-start.sh` already emitted the field correctly, so the shape was inconsistent across `hooks/` rather than uniformly wrong.

## Fix

Add `"hookEventName": "PreToolUse"` as the first key of each affected block. No logic changes.

## Tests

The existing suite could not catch this. `expect_ask` in `guard-public-posts.test.sh` only grepped for `permissionDecision`, so it passed against output the runtime rejects.

- Tightened `expect_ask` to also require `hookEventName`. Against the pre-fix script, 47 of 72 cases now fail; against the fix, 72/72 pass.
- Added `hooks/hook-json-shape.test.sh`, a shape check over every emitting hook script. This covers `guard-git-operations.sh` and `auto-format-before-push.sh`, which had no test coverage at all. Verified red against pre-fix `guard-git-operations.sh`, green after.
- Wired the new test into CI next to the existing hook tests.

Local: `guard-public-posts` 72/72, `pre-tool-use-dispatcher` 5/5, `hook-json-shape` 5/5, `safe-refresh-marketplace` 8/8, shellcheck clean.
