### PR TITLE
fix(hooks): drop empty updatedInput that wiped tool input

### DIFF
--- a/hooks/auto-format-before-push.sh
+++ b/hooks/auto-format-before-push.sh
@@ -24,8 +24,7 @@ warn_and_exit() {
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
-    "permissionDecision": "allow",
-    "updatedInput": {}
+    "permissionDecision": "allow"
   },
   "systemMessage": "Auto-format hook: ${msg}"
 }
@@ -240,8 +239,7 @@ cat <<EOF
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
-    "permissionDecision": "allow",
-    "updatedInput": {}
+    "permissionDecision": "allow"
   },
   "systemMessage": "Auto-formatted changed files (${format_result}) and committed as 'style: auto-format before push'. The push will include this formatting commit."
 }

--- a/hooks/guard-git-operations.sh
+++ b/hooks/guard-git-operations.sh
@@ -27,8 +27,7 @@ if echo "$command" | grep -qE 'git\s+push\b' && echo "$command" | grep -qE '(\s-
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
-    "permissionDecision": "deny",
-    "updatedInput": {}
+    "permissionDecision": "deny"
   },
   "systemMessage": "BLOCKED: Never use `git push --force`. Use `git push --force-with-lease` instead — it prevents overwriting commits pushed by others. Before pushing, always fetch the remote branch first: `git fetch <remote> <branch>`."
 }
@@ -42,8 +41,7 @@ if echo "$command" | grep -qE 'git\s+rebase\b'; then
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
-    "permissionDecision": "ask",
-    "updatedInput": {}
+    "permissionDecision": "ask"
   },
   "systemMessage": "Before rebasing, you MUST fetch the remote tracking branch to avoid overwriting commits pushed by others (e.g. maintainer cleanup commits). Run `git fetch <remote> <branch>` first and verify no new remote commits exist. If the remote has commits you don't have locally, incorporate them before rebasing."
 }
@@ -59,8 +57,7 @@ if echo "$command" | grep -qE 'git\s+pull\b' && echo "$command" | grep -qE '(\s-
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
-    "permissionDecision": "ask",
-    "updatedInput": {}
+    "permissionDecision": "ask"
   },
   "systemMessage": "Before pulling with --rebase, you MUST fetch the remote tracking branch first to see what you're rebasing over. `git pull --rebase` rebases your local commits onto the latest remote head; if the remote has commits you didn't expect, this can rewrite history past them. Run `git fetch` and inspect `git log HEAD..@{u}` first."
 }
@@ -74,8 +71,7 @@ if echo "$command" | grep -qE 'git\s+push\b.*--force-with-lease'; then
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
-    "permissionDecision": "ask",
-    "updatedInput": {}
+    "permissionDecision": "ask"
   },
   "systemMessage": "Before force-pushing (even with --force-with-lease), verify you fetched the remote branch and incorporated any new commits. Maintainers may push directly to your PR branch. If you haven't fetched, --force-with-lease may still overwrite their work if your local remote-tracking ref is stale."
 }
@@ -92,8 +88,7 @@ if echo "$command" | grep -qE 'git\s+reset\s+--hard\b'; then
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
-    "permissionDecision": "ask",
-    "updatedInput": {}
+    "permissionDecision": "ask"
   },
   "systemMessage": "`git reset --hard` discards uncommitted work AND any local commits not in the target ref. If you have unpushed commits on this branch you want to keep, stash them first (`git stash`) or note them on a recovery branch (`git branch wip-recovery`). Confirm you've reviewed `git status` and `git log @{u}..HEAD` before proceeding."
 }

--- a/hooks/guard-public-posts.sh
+++ b/hooks/guard-public-posts.sh
@@ -39,14 +39,14 @@ emit_ask() {
     # for jq at startup below).
     if command -v jq >/dev/null 2>&1; then
         jq -nc --arg msg "$1" '{
-          hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "ask", updatedInput: {}},
+          hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "ask"},
           systemMessage: $msg
         }'
     else
         # If jq is missing, we already emit a loud ask from the startup
         # check below; this branch is a last-resort fallback.
         cat <<EOF
-{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","updatedInput":{}},"systemMessage":"guard-public-posts: refusing to parse tool input without jq. Install jq and retry."}
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask"},"systemMessage":"guard-public-posts: refusing to parse tool input without jq. Install jq and retry."}
 EOF
     fi
 }

--- a/hooks/hook-json-shape.test.sh
+++ b/hooks/hook-json-shape.test.sh
@@ -34,6 +34,21 @@ for subject in "$SCRIPT_DIR"/*.sh; do
         echo "  FAIL: ${name}: ${blocks} hookSpecificOutput block(s) but only ${events} hookEventName field(s) — the missing ones are discarded at runtime"
         FAIL=$((FAIL + 1))
     fi
+
+    # An empty "updatedInput": {} is not a no-op — it REPLACES the tool's
+    # arguments with nothing. On a Bash call the harness rejects the result
+    # ("required parameter `command` is missing") and the call dies before
+    # reaching a permission prompt; on an MCP call the server receives {}
+    # and fails on its own required fields. A guard that only wants to ask
+    # or warn must omit the field entirely.
+    empties=$(grep -cE '"?updatedInput"?[[:space:]]*:[[:space:]]*\{\}' "$subject" 2>/dev/null || true)
+    if [ "${empties:-0}" -eq 0 ]; then
+        echo "  PASS: ${name} (no empty updatedInput)"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: ${name}: ${empties} empty updatedInput block(s) — this wipes the tool input instead of passing it through"
+        FAIL=$((FAIL + 1))
+    fi
 done
 
 echo "Results: ${PASS} passed, ${FAIL} failed."


### PR DESCRIPTION
fix(hooks): drop empty updatedInput that wiped tool input

Every guard emitted "updatedInput": {} alongside its permissionDecision.
That field is not a no-op: it REPLACES the tool's arguments with an empty
object. On a Bash call the harness rejects the result with "The required
parameter `command` is missing" and the call dies before ever reaching a
permission prompt, so rebases, lease-force pushes, hard resets and every
gh write command were unrunnable with the plugin installed. On an MCP
call the server receives {} and fails on its own required fields
("missing required parameter: owner").

Guards that only ask, warn or deny have no input to rewrite, so the field
is removed from all nine emissions across the three hooks. The ask, allow
and deny decisions themselves are unchanged.

Adds an assertion to hook-json-shape.test.sh so an empty updatedInput
fails the suite instead of silently breaking every guarded call.
