### PR TITLE
feat: opt-in own-repo trust for the public-post guard

### DIFF
--- a/hooks/guard-public-posts.sh
+++ b/hooks/guard-public-posts.sh
@@ -60,6 +60,65 @@ if ! command -v jq >/dev/null 2>&1; then
     exit 0
 fi
 
+# --- Own-repo trust (opt-in, default off) ------------------------------------
+# The guard exists to stop unattended posts into repos owned by *other* people.
+# A user who also maintains their own repos hits the same gate on every
+# `gh pr merge` / `gh issue close` against their own work, where there is no
+# maintainer to show a draft to. `config.trustOwnRepoWrites` lets those through
+# when the target repo is owned by the configured `githubUsername`.
+#
+# Every path that cannot PROVE the target is owned by that user falls back to
+# the ask: feature off, no username configured, non-repo-scoped command, more
+# than one target, chained/substituted commands, an unresolvable target, or a
+# fork (where `gh pr create` targets the parent — someone else's repo — by
+# default). Fail-closed is the whole point; a missed ask is a public post.
+STATE_FILE="${HOME}/.oss-autopilot/state.json"
+
+read_config() {
+    local key="$1" default="$2"
+    [ -f "$STATE_FILE" ] || { printf '%s' "$default"; return 0; }
+    jq -r --arg d "$default" ".config.${key} // \$d" "$STATE_FILE" 2>/dev/null || printf '%s' "$default"
+}
+
+# Owner whose repos may be written without an ask. Empty output means "ask
+# about everything" — the default.
+trusted_owner() {
+    [ "$(read_config trustOwnRepoWrites false)" = "true" ] || return 0
+    read_config githubUsername ""
+}
+
+# Target repo of a `gh` invocation as owner/repo, or empty when it cannot be
+# resolved unambiguously. Mirrors gh's own precedence: an explicit -R/--repo
+# flag wins, otherwise the repo the cwd belongs to.
+gh_target_repo() {
+    local cmd="$1" cwd="$2" flags count
+    flags=$(printf '%s\n' "$cmd" | grep -oE '(^|[[:space:]])(-R|--repo)[[:space:]]+[^[:space:]]+' | awk '{print $NF}')
+    count=$(printf '%s' "$flags" | grep -c '[^[:space:]]' 2>/dev/null || true)
+    if [ "${count:-0}" -gt 1 ]; then return 0; fi
+    if [ "${count:-0}" -eq 1 ]; then printf '%s' "$flags"; return 0; fi
+    [ -n "$cwd" ] && [ -d "$cwd" ] || return 0
+    # `select(.parent == null)` prints nothing for a fork, so a fork checkout
+    # resolves to "unknown" and keeps the ask.
+    (cd "$cwd" && gh repo view --json nameWithOwner,parent -q 'select(.parent == null) | .nameWithOwner' 2>/dev/null) || true
+}
+
+# True when this Bash command writes only to a repo owned by the trusted user.
+own_repo_write() {
+    local cmd="$1" cwd="$2" owner target
+    owner=$(trusted_owner)
+    [ -n "$owner" ] || return 1
+    # Only repo-scoped verbs can be attributed to a single target repo.
+    # Account-level commands (`gh repo create`, `gh gist`), `hub`, raw curl and
+    # the oss-autopilot CLI keep asking unconditionally.
+    printf '%s' "$cmd" | grep -qE 'gh[[:space:]]+(pr|issue|release)[[:space:]]' || return 1
+    # Chaining or substitution can hide a second, untrusted target in the same
+    # invocation; the static analysis here only describes one command.
+    case "$cmd" in *';'*|*'&&'*|*'||'*|*'|'*|*'$('*|*'`'*) return 1 ;; esac
+    target=$(gh_target_repo "$cmd" "$cwd")
+    [ -n "$target" ] || return 1
+    [ "${target%%/*}" = "$owner" ]
+}
+
 input=$(cat 2>/dev/null || echo "")
 tool_name=$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null || true)
 
@@ -97,6 +156,9 @@ case "$tool_name" in
         #     false-positives on names like `oss-autopilot-post-processor`.
         if printf '%s' "$normalized" | grep -qE \
             '(gh[[:space:]]+api[^|&;]*(-X[[:space:]]*(POST|PATCH|PUT|DELETE)|--method[[:space:]]+(POST|PATCH|PUT|DELETE)|-XPOST|-XPATCH|-XPUT|-XDELETE))|(gh[[:space:]]+api[^|&;]*([[:space:]]|^)(-f|-F|--field|--raw-field)[[:space:]])|(gh[[:space:]]+pr[[:space:]]+(comment|review|create|close|reopen|ready|merge|edit))|(gh[[:space:]]+issue[[:space:]]+(create|comment|close|reopen))|(gh[[:space:]]+release[[:space:]]+(create|edit|delete))|(gh[[:space:]]+repo[[:space:]]+(create|delete|fork|edit|transfer))|(gh[[:space:]]+gist[[:space:]]+(create|edit|delete))|(hub[[:space:]]+(pull-request|issue|release|api))|(curl[[:space:]][^|&;]*-X[[:space:]]*(POST|PATCH|PUT|DELETE)[^|&;]*api\.github\.com/[^[:space:]|&;]*(comments|issues|pulls|releases|reviews))|((^|[[:space:]])(oss-autopilot|cli\.bundle\.cjs)[[:space:]][^|&;]*[[:space:]](post|claim)([[:space:]]|$))|((^|[[:space:]])(oss-autopilot|cli\.bundle\.cjs)[[:space:]](post|claim)([[:space:]]|$))'; then
+            if own_repo_write "$normalized" "$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null || true)"; then
+                exit 0
+            fi
             emit_ask "This command produces a public GitHub event (post / merge / close / create / release). Draft the content and present it to the user before running. The user must explicitly approve each external post per the global CLAUDE.md rule."
             exit 0
         fi
@@ -121,6 +183,15 @@ case "$tool_name" in
         # this script. Anything not in the read-only exclusion list above is
         # treated as mutating — including tools that did not exist when this
         # guard was written (fail-closed).
+        #
+        # These tools name their target repo in a structured `owner` argument,
+        # so own-repo trust needs no parsing here. Tools with no `owner` (e.g.
+        # create_repository) never match and keep asking.
+        mcp_owner=$(printf '%s' "$input" | jq -r '.tool_input.owner // empty' 2>/dev/null || true)
+        trusted=$(trusted_owner)
+        if [ -n "$trusted" ] && [ -n "$mcp_owner" ] && [ "$mcp_owner" = "$trusted" ]; then
+            exit 0
+        fi
         emit_ask "The '${tool_name}' MCP tool produces a public GitHub event (post / merge / close / create / push / fork / delete) under the user's identity. Show the user what will happen and wait for explicit approval before invoking. See draft-review-post for the canonical approval flow."
         exit 0
         ;;

--- a/hooks/guard-public-posts.test.sh
+++ b/hooks/guard-public-posts.test.sh
@@ -17,6 +17,28 @@ fi
 PASS=0
 FAIL=0
 
+# Every case runs against a fixture HOME so the developer's own
+# ~/.oss-autopilot/state.json can never change what these tests assert.
+# TEST_HOME defaults to a config-less dir, i.e. own-repo trust off.
+FIXTURE_ROOT=$(mktemp -d)
+trap 'rm -rf "$FIXTURE_ROOT"' EXIT
+
+# make_home <name> <state-json-config-object|"">  → prints the HOME path
+make_home() {
+    local name="$1" config="$2" home="${FIXTURE_ROOT}/$1"
+    mkdir -p "${home}/.oss-autopilot"
+    if [ -n "$config" ]; then
+        printf '{"config":%s}' "$config" > "${home}/.oss-autopilot/state.json"
+    fi
+    printf '%s' "$home"
+}
+
+HOME_NO_CONFIG=$(make_home no-config '')
+HOME_TRUST_OFF=$(make_home trust-off '{"githubUsername":"octocat","trustOwnRepoWrites":false}')
+HOME_TRUST_ON=$(make_home trust-on '{"githubUsername":"octocat","trustOwnRepoWrites":true}')
+HOME_TRUST_ON_NO_USER=$(make_home trust-on-no-user '{"trustOwnRepoWrites":true}')
+TEST_HOME="$HOME_NO_CONFIG"
+
 pass() {
     echo "  PASS: $1"
     PASS=$((PASS + 1))
@@ -32,7 +54,7 @@ expect_ask() {
     local name="$1"
     local payload="$2"
     local out
-    out=$(printf '%s' "$payload" | "$SUBJECT" 2>/dev/null)
+    out=$(printf '%s' "$payload" | HOME="$TEST_HOME" "$SUBJECT" 2>/dev/null)
     # Accept both compact and pretty-printed JSON shapes.
     if ! echo "$out" | grep -qE '"permissionDecision"[[:space:]]*:[[:space:]]*"ask"'; then
         fail "$name" "expected ask decision; got: $out"
@@ -54,7 +76,7 @@ expect_allow() {
     local name="$1"
     local payload="$2"
     local out
-    out=$(printf '%s' "$payload" | "$SUBJECT" 2>/dev/null)
+    out=$(printf '%s' "$payload" | HOME="$TEST_HOME" "$SUBJECT" 2>/dev/null)
     if [ -z "$out" ]; then
         pass "$name"
     else
@@ -68,10 +90,24 @@ bash_payload() {
     printf '{"tool_name":"Bash","tool_input":{"command":%s}}' "$(jq -Rn --arg c "$cmd" '$c')"
 }
 
+# Helper to build a Bash payload with the cwd Claude Code reports.
+bash_payload_cwd() {
+    local cmd="$1" cwd="$2"
+    printf '{"tool_name":"Bash","tool_input":{"command":%s},"cwd":%s}' \
+        "$(jq -Rn --arg c "$cmd" '$c')" "$(jq -Rn --arg d "$cwd" '$d')"
+}
+
 # Helper to build an MCP tool payload.
 mcp_payload() {
     local tool="$1"
     printf '{"tool_name":%s,"tool_input":{}}' "$(jq -Rn --arg t "$tool" '$t')"
+}
+
+# Helper to build an MCP tool payload carrying a target repo owner.
+mcp_payload_owner() {
+    local tool="$1" owner="$2"
+    printf '{"tool_name":%s,"tool_input":{"owner":%s,"repo":"dash"}}' \
+        "$(jq -Rn --arg t "$tool" '$t')" "$(jq -Rn --arg o "$owner" '$o')"
 }
 
 echo "Running guard-public-posts.sh tests..."
@@ -185,6 +221,48 @@ expect_allow "missing tool_name allows through"    '{}'
 # ── Mutating MCP tools NOT scoped to this guard (they do not post) ────
 expect_allow "MCP move tool is not guarded by this hook"   "$(mcp_payload 'mcp__plugin_oss-autopilot_oss-autopilot__move')"
 expect_allow "MCP track tool is not guarded by this hook"  "$(mcp_payload 'mcp__plugin_oss-autopilot_oss-autopilot__track')"
+
+# ── Own-repo trust (config.trustOwnRepoWrites) ────────────────────────
+# Default off: identical commands keep asking until the user opts in.
+TEST_HOME="$HOME_TRUST_OFF"
+expect_ask  "own-repo write asks while trust is off" \
+            "$(bash_payload 'gh pr merge 20 -R octocat/dash --squash')"
+
+TEST_HOME="$HOME_TRUST_ON"
+expect_allow "own-repo pr merge passes with -R"      "$(bash_payload 'gh pr merge 20 -R octocat/dash --squash')"
+expect_allow "own-repo issue close passes with -R"   "$(bash_payload 'gh issue close 18 --repo octocat/dash')"
+expect_allow "own-repo issue comment passes with -R" "$(bash_payload 'gh issue comment 18 --repo octocat/dash --body hi')"
+
+# Everything the hook cannot prove is own-repo keeps asking.
+expect_ask  "another owner still asks"               "$(bash_payload 'gh pr merge 20 -R someoneelse/dash --squash')"
+expect_ask  "two -R targets still ask"               "$(bash_payload 'gh issue close 1 -R octocat/dash -R someoneelse/dash')"
+expect_ask  "chained commands still ask"             "$(bash_payload 'gh issue close 1 -R octocat/dash && gh issue close 2 -R someoneelse/dash')"
+expect_ask  "piped commands still ask"               "$(bash_payload 'gh issue list -R octocat/dash | gh issue close -R someoneelse/dash')"
+expect_ask  "command substitution still asks"        "$(bash_payload 'gh pr merge $(cat n) -R octocat/dash')"
+expect_ask  "account-level gh repo create still asks" "$(bash_payload 'gh repo create dash --public')"
+expect_ask  "gh api still asks even for an own repo" "$(bash_payload 'gh api -X POST repos/octocat/dash/issues/1/comments -f body=hi')"
+expect_ask  "oss-autopilot post still asks"          "$(bash_payload 'oss-autopilot post https://github.com/octocat/dash/issues/1 hi')"
+# No -R: the target comes from the cwd's repo, and a cwd that resolves to
+# nothing (not a checkout, or a fork whose parent is someone else's) asks.
+expect_ask  "unresolvable cwd asks"                  "$(bash_payload_cwd 'gh pr merge 20 --squash' "${FIXTURE_ROOT}/not-a-repo")"
+expect_ask  "missing cwd asks"                       "$(bash_payload 'gh pr merge 20 --squash')"
+
+TEST_HOME="$HOME_TRUST_ON_NO_USER"
+expect_ask  "trust on but no githubUsername asks"    "$(bash_payload 'gh pr merge 20 -R octocat/dash --squash')"
+
+# The github MCP family names its target owner in tool_input.
+TEST_HOME="$HOME_TRUST_ON"
+expect_allow "MCP own-repo merge passes"             "$(mcp_payload_owner 'mcp__github__merge_pull_request' 'octocat')"
+expect_ask   "MCP other-owner merge asks"            "$(mcp_payload_owner 'mcp__github__merge_pull_request' 'someoneelse')"
+expect_ask   "MCP tool without an owner asks"        "$(mcp_payload 'mcp__github__create_repository')"
+expect_ask   "MCP oss-autopilot post asks even for own repos" \
+             "$(mcp_payload 'mcp__plugin_oss-autopilot_oss-autopilot__post')"
+
+TEST_HOME="$HOME_TRUST_OFF"
+expect_ask   "MCP own-repo merge asks while trust is off" \
+             "$(mcp_payload_owner 'mcp__github__merge_pull_request' 'octocat')"
+
+TEST_HOME="$HOME_NO_CONFIG"
 
 echo
 echo "Results: ${PASS} passed, ${FAIL} failed."

--- a/packages/core/src/commands/setup.ts
+++ b/packages/core/src/commands/setup.ts
@@ -217,6 +217,15 @@ export async function runSetup(options: SetupOptions): Promise<SetupOutput> {
             results[key] = String(enabled);
             break;
           }
+          case 'trustOwnRepoWrites': {
+            if (value !== 'true' && value !== 'false') {
+              throw new ValidationError(`Invalid value for trustOwnRepoWrites: "${value}". Must be "true" or "false".`);
+            }
+            const trusted = value === 'true';
+            stateManager.updateConfig({ trustOwnRepoWrites: trusted });
+            results[key] = String(trusted);
+            break;
+          }
           case 'includeDocIssues': {
             stateManager.updateConfig({ includeDocIssues: value === 'true' });
             results[key] = value === 'true' ? 'true' : 'false';

--- a/packages/core/src/core/config-registry.ts
+++ b/packages/core/src/core/config-registry.ts
@@ -256,6 +256,13 @@ export const CONFIG_KEY_REGISTRY: readonly ConfigKeyDef[] = [
     valueHint: 'true|false',
   },
   {
+    key: 'trustOwnRepoWrites',
+    description:
+      'Opt-in: skip the guard-public-posts approval prompt for GitHub writes (PR merge, issue close, comments) targeting repos owned by your own githubUsername. Off by default. Writes to any other owner, to a fork whose parent belongs to someone else, or from a chained command still ask.',
+    settableVia: 'setup',
+    valueHint: 'true|false',
+  },
+  {
     key: 'healthCheckFreshnessMinutes',
     description:
       'Suppress the SessionStart PR health one-liner when the cached digest is older than this many minutes. The line silently disappears between /oss runs, so what remains is always current. Defaults to 30 minutes (#1255).',

--- a/packages/core/src/core/state-schema.ts
+++ b/packages/core/src/core/state-schema.ts
@@ -298,6 +298,15 @@ export const AgentConfigSchema = z.object({
   autoFormatBeforePush: z.boolean().default(false),
 
   /**
+   * Opt-in gate for own-repo writes in the guard-public-posts hook. Default
+   * false: every GitHub-mutating command asks for approval. When true, writes
+   * whose target repo is owned by `githubUsername` skip the ask; anything the
+   * hook cannot prove is own-repo (forks, other owners, chained commands)
+   * still asks.
+   */
+  trustOwnRepoWrites: z.boolean().default(false),
+
+  /**
    * Threshold (in minutes) for the SessionStart PR health one-liner (#1255).
    * The cached digest only refreshes when the user runs `/oss`; SessionStart
    * fires every session. Without a freshness gate the line drifts arbitrarily


### PR DESCRIPTION
## Problem

`guard-public-posts.sh` asks for approval on every GitHub-mutating command. That is exactly right for other people's repos, and pure friction on your own: merging a PR or closing an issue in a repo you maintain prompts even though there is no maintainer to show a draft to. The prompt cannot be silenced from settings either, since a `PreToolUse` hook's `ask` is evaluated independently of `permissions.allow`.

## Change

New config key `trustOwnRepoWrites`, default **false** (existing behavior unchanged). When enabled, a write is allowed only when the target repo is provably owned by the configured `githubUsername`:

- **Bash** — target resolves from an explicit `-R/--repo` flag, else from the cwd's repo via `gh repo view --json nameWithOwner,parent`. The `select(.parent == null)` filter makes a fork resolve to empty, because `gh pr create` in a fork targets the parent (someone else's repo) by default.
- **github MCP tools** — the structured `tool_input.owner` must match. Tools with no `owner` (e.g. `create_repository`) never match.

Everything the hook cannot prove is own-repo stays fail-closed and keeps asking: feature off, no username configured, another owner, multiple `-R` targets, chained or substituted commands (`;`, `&&`, `||`, `|`, `$(...)`, backticks), account-level verbs (`gh repo create`, `gh gist`), `gh api`, `hub`, curl, and the oss-autopilot `post`/`claim` tools.

## Tests

`hooks/guard-public-posts.test.sh`: 92 passed, 0 failed (was 72). Every case now runs against a fixture `HOME`, so the suite no longer reads the developer's real `~/.oss-autopilot/state.json`. New cases cover the allow path (own repo via `-R`, own owner via MCP) and each fail-closed path listed above.

Also verified by hand against real checkouts: `gh pr merge` with cwd in `costajohnt/simon-dash` passes; the same command with an unresolvable cwd asks.

`packages/core`: 3043 passed. `packages/dashboard` has 30 pre-existing failures in `use-theme.test.ts` on main (confirmed with this branch stashed) — untouched by this change.