### PR TITLE
fix: read hook config from the gist mirror when it is newer

### DIFF
--- a/hooks/auto-format-before-push.sh
+++ b/hooks/auto-format-before-push.sh
@@ -15,7 +15,18 @@
 # No set -e: this hook must never abort mid-execution and leave a dirty tree.
 set -uo pipefail
 
-STATE_FILE="${HOME}/.oss-autopilot/state.json"
+# Config source. Under `persistence: gist` the live config is the gist mirror
+# (state-cache.json) and state.json is a stale local leftover; under local
+# persistence it's the other way round. The persistence mode itself lives in
+# the file being chosen, so pick whichever was written last — reading only
+# state.json makes an enabled autoFormatBeforePush look unset on gist setups.
+if [ -f "${HOME}/.oss-autopilot/state-cache.json" ] &&
+  { [ ! -f "${HOME}/.oss-autopilot/state.json" ] ||
+    [ "${HOME}/.oss-autopilot/state-cache.json" -nt "${HOME}/.oss-autopilot/state.json" ]; }; then
+  STATE_FILE="${HOME}/.oss-autopilot/state-cache.json"
+else
+  STATE_FILE="${HOME}/.oss-autopilot/state.json"
+fi
 FORMAT_ERROR_LOG="${HOME}/.oss-autopilot/last-format-error.log"
 
 warn_and_exit() {

--- a/hooks/guard-public-posts.sh
+++ b/hooks/guard-public-posts.sh
@@ -72,12 +72,29 @@ fi
 # than one target, chained/substituted commands, an unresolvable target, or a
 # fork (where `gh pr create` targets the parent — someone else's repo — by
 # default). Fail-closed is the whole point; a missed ask is a public post.
-STATE_FILE="${HOME}/.oss-autopilot/state.json"
+# Config source. Under `persistence: gist` the authoritative copy is the gist
+# mirror (state-cache.json) and state.json is a stale local leftover; under
+# local persistence it's the other way round. Reading the mode to decide is
+# circular — it lives in the file being chosen — so take whichever was written
+# last. Reading only state.json is what made an enabled trustOwnRepoWrites look
+# unset on gist-backed setups.
+state_file() {
+    local local_state="${HOME}/.oss-autopilot/state.json"
+    local gist_cache="${HOME}/.oss-autopilot/state-cache.json"
+    [ -f "$gist_cache" ] || { printf '%s' "$local_state"; return 0; }
+    [ -f "$local_state" ] || { printf '%s' "$gist_cache"; return 0; }
+    if [ "$gist_cache" -nt "$local_state" ]; then
+        printf '%s' "$gist_cache"
+    else
+        printf '%s' "$local_state"
+    fi
+}
 
 read_config() {
-    local key="$1" default="$2"
-    [ -f "$STATE_FILE" ] || { printf '%s' "$default"; return 0; }
-    jq -r --arg d "$default" ".config.${key} // \$d" "$STATE_FILE" 2>/dev/null || printf '%s' "$default"
+    local key="$1" default="$2" file
+    file=$(state_file)
+    [ -f "$file" ] || { printf '%s' "$default"; return 0; }
+    jq -r --arg d "$default" ".config.${key} // \$d" "$file" 2>/dev/null || printf '%s' "$default"
 }
 
 # Owner whose repos may be written without an ask. Empty output means "ask

--- a/hooks/guard-public-posts.test.sh
+++ b/hooks/guard-public-posts.test.sh
@@ -23,6 +23,19 @@ FAIL=0
 FIXTURE_ROOT=$(mktemp -d)
 trap 'rm -rf "$FIXTURE_ROOT"' EXIT
 
+# make_gist_home <name> <stale-state-config> <fresh-cache-config> → HOME path
+# Mirrors a `persistence: gist` setup: state.json is a stale local leftover and
+# state-cache.json is the newer gist mirror that holds the live config.
+make_gist_home() {
+    local name="$1" stale="$2" fresh="$3" home="${FIXTURE_ROOT}/$1"
+    mkdir -p "${home}/.oss-autopilot"
+    printf '{"config":%s}' "$stale" > "${home}/.oss-autopilot/state.json"
+    # Backdate state.json so the cache is unambiguously newer.
+    touch -t 202001010000 "${home}/.oss-autopilot/state.json"
+    printf '{"config":%s}' "$fresh" > "${home}/.oss-autopilot/state-cache.json"
+    printf '%s' "$home"
+}
+
 # make_home <name> <state-json-config-object|"">  → prints the HOME path
 make_home() {
     local name="$1" config="$2" home="${FIXTURE_ROOT}/$1"
@@ -37,6 +50,12 @@ HOME_NO_CONFIG=$(make_home no-config '')
 HOME_TRUST_OFF=$(make_home trust-off '{"githubUsername":"octocat","trustOwnRepoWrites":false}')
 HOME_TRUST_ON=$(make_home trust-on '{"githubUsername":"octocat","trustOwnRepoWrites":true}')
 HOME_TRUST_ON_NO_USER=$(make_home trust-on-no-user '{"trustOwnRepoWrites":true}')
+HOME_GIST_ON=$(make_gist_home gist-on \
+    '{"githubUsername":"octocat"}' \
+    '{"githubUsername":"octocat","persistence":"gist","trustOwnRepoWrites":true}')
+HOME_GIST_OFF=$(make_gist_home gist-off \
+    '{"githubUsername":"octocat","trustOwnRepoWrites":true}' \
+    '{"githubUsername":"octocat","persistence":"gist","trustOwnRepoWrites":false}')
 TEST_HOME="$HOME_NO_CONFIG"
 
 pass() {
@@ -261,6 +280,17 @@ expect_ask   "MCP oss-autopilot post asks even for own repos" \
 TEST_HOME="$HOME_TRUST_OFF"
 expect_ask   "MCP own-repo merge asks while trust is off" \
              "$(mcp_payload_owner 'mcp__github__merge_pull_request' 'octocat')"
+
+# Gist persistence: the live config is the newer state-cache.json, and reading
+# the stale state.json instead made an enabled key look unset.
+TEST_HOME="$HOME_GIST_ON"
+expect_allow "gist config enables own-repo trust"    "$(bash_payload 'gh pr merge 20 -R octocat/dash --squash')"
+expect_ask   "gist config still asks for other owners" "$(bash_payload 'gh pr merge 20 -R someoneelse/dash --squash')"
+
+# ...and a newer cache that turns the key back off wins over a stale local
+# state.json that still says true.
+TEST_HOME="$HOME_GIST_OFF"
+expect_ask   "newer gist config disabling trust wins" "$(bash_payload 'gh pr merge 20 -R octocat/dash --squash')"
 
 TEST_HOME="$HOME_NO_CONFIG"
 


### PR DESCRIPTION
## Problem

Both `PreToolUse` hooks read their config from `~/.oss-autopilot/state.json`. Under `persistence: gist` that file is a stale local leftover — the live config is the gist mirror, `state-cache.json`. So on a gist-backed setup every opt-in read comes back unset:

- `setup --set trustOwnRepoWrites=true` reports `✓ trustOwnRepoWrites: true` (written to the gist + cache), and `guard-public-posts.sh` keeps asking anyway, because it read the stale file.
- `autoFormatBeforePush` in `auto-format-before-push.sh` has the same latent bug — enabling it on a gist setup silently does nothing.

Found by enabling `trustOwnRepoWrites` on a real gist-backed install: the key read `true` in `state-cache.json`, `null` in `state.json`, and the guard still prompted.

## Change

Pick whichever of the two files was written last. Reading `config.persistence` to decide would be circular — the mode itself lives in the file being chosen — and mtime handles both directions: gist users get the fresher mirror, local-persistence users keep `state.json` even if an old `state-cache.json` is lying around.

## Tests

`hooks/guard-public-posts.test.sh`: 95 passed, 0 failed (was 92). Three new cases build a gist-shaped fixture (backdated `state.json` + newer `state-cache.json`): the newer cache enabling the key allows an own-repo write, other owners still ask, and a newer cache that *disables* the key beats a stale `state.json` that still says true.

Verified against the real install too: with this fix, `gh pr merge -R costajohnt/simon-dash` passes and `gh pr comment -R someoneelse/repo` still asks.