### PR TITLE
fix: drop empty updatedInput from hook permission payloads

### DIFF
--- a/hooks/auto-format-before-push.sh
+++ b/hooks/auto-format-before-push.sh
@@ -35,8 +35,7 @@ warn_and_exit() {
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
-    "permissionDecision": "allow",
-    "updatedInput": {}
+    "permissionDecision": "allow"
   },
   "systemMessage": "Auto-format hook: ${msg}"
 }
@@ -251,8 +250,7 @@ cat <<EOF
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
-    "permissionDecision": "allow",
-    "updatedInput": {}
+    "permissionDecision": "allow"
   },
   "systemMessage": "Auto-formatted changed files (${format_result}) and committed as 'style: auto-format before push'. The push will include this formatting commit."
 }

--- a/hooks/guard-git-operations.sh
+++ b/hooks/guard-git-operations.sh
@@ -27,8 +27,7 @@ if echo "$command" | grep -qE 'git\s+push\b' && echo "$command" | grep -qE '(\s-
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
-    "permissionDecision": "deny",
-    "updatedInput": {}
+    "permissionDecision": "deny"
   },
   "systemMessage": "BLOCKED: Never use `git push --force`. Use `git push --force-with-lease` instead — it prevents overwriting commits pushed by others. Before pushing, always fetch the remote branch first: `git fetch <remote> <branch>`."
 }
@@ -42,8 +41,7 @@ if echo "$command" | grep -qE 'git\s+rebase\b'; then
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
-    "permissionDecision": "ask",
-    "updatedInput": {}
+    "permissionDecision": "ask"
   },
   "systemMessage": "Before rebasing, you MUST fetch the remote tracking branch to avoid overwriting commits pushed by others (e.g. maintainer cleanup commits). Run `git fetch <remote> <branch>` first and verify no new remote commits exist. If the remote has commits you don't have locally, incorporate them before rebasing."
 }
@@ -59,8 +57,7 @@ if echo "$command" | grep -qE 'git\s+pull\b' && echo "$command" | grep -qE '(\s-
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
-    "permissionDecision": "ask",
-    "updatedInput": {}
+    "permissionDecision": "ask"
   },
   "systemMessage": "Before pulling with --rebase, you MUST fetch the remote tracking branch first to see what you're rebasing over. `git pull --rebase` rebases your local commits onto the latest remote head; if the remote has commits you didn't expect, this can rewrite history past them. Run `git fetch` and inspect `git log HEAD..@{u}` first."
 }
@@ -74,8 +71,7 @@ if echo "$command" | grep -qE 'git\s+push\b.*--force-with-lease'; then
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
-    "permissionDecision": "ask",
-    "updatedInput": {}
+    "permissionDecision": "ask"
   },
   "systemMessage": "Before force-pushing (even with --force-with-lease), verify you fetched the remote branch and incorporated any new commits. Maintainers may push directly to your PR branch. If you haven't fetched, --force-with-lease may still overwrite their work if your local remote-tracking ref is stale."
 }
@@ -92,8 +88,7 @@ if echo "$command" | grep -qE 'git\s+reset\s+--hard\b'; then
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
-    "permissionDecision": "ask",
-    "updatedInput": {}
+    "permissionDecision": "ask"
   },
   "systemMessage": "`git reset --hard` discards uncommitted work AND any local commits not in the target ref. If you have unpushed commits on this branch you want to keep, stash them first (`git stash`) or note them on a recovery branch (`git branch wip-recovery`). Confirm you've reviewed `git status` and `git log @{u}..HEAD` before proceeding."
 }

--- a/hooks/guard-public-posts.sh
+++ b/hooks/guard-public-posts.sh
@@ -33,20 +33,27 @@
 set -uo pipefail
 
 emit_ask() {
+    # NEVER emit `updatedInput` here. Claude Code treats a present
+    # updatedInput as a WHOLESALE REPLACEMENT of the tool input, so an empty
+    # object wipes the original parameters and the gated call fails schema
+    # validation ("required parameter `command` is missing") instead of
+    # prompting the user. The ask payload carries only hookEventName and
+    # permissionDecision.
+    #
     # Use jq -n when possible so future dynamic messages get proper JSON
     # escaping for free. Falls back to a handcrafted heredoc if jq is
     # broken (very unlikely by the time we reach this path — we check
     # for jq at startup below).
     if command -v jq >/dev/null 2>&1; then
         jq -nc --arg msg "$1" '{
-          hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "ask", updatedInput: {}},
+          hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "ask"},
           systemMessage: $msg
         }'
     else
         # If jq is missing, we already emit a loud ask from the startup
         # check below; this branch is a last-resort fallback.
         cat <<EOF
-{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","updatedInput":{}},"systemMessage":"guard-public-posts: refusing to parse tool input without jq. Install jq and retry."}
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask"},"systemMessage":"guard-public-posts: refusing to parse tool input without jq. Install jq and retry."}
 EOF
     fi
 }

--- a/hooks/guard-public-posts.test.sh
+++ b/hooks/guard-public-posts.test.sh
@@ -82,11 +82,20 @@ expect_ask() {
     # Claude Code discards the whole hookSpecificOutput block when
     # hookEventName is absent, so an "ask" without it silently allows the
     # post. Assert the field is present or the guard is decorative.
-    if echo "$out" | grep -qE '"hookEventName"[[:space:]]*:[[:space:]]*"PreToolUse"'; then
-        pass "$name"
-    else
+    if ! echo "$out" | grep -qE '"hookEventName"[[:space:]]*:[[:space:]]*"PreToolUse"'; then
         fail "$name" "ask decision is missing hookEventName; got: $out"
+        return
     fi
+    # Claude Code treats a present `updatedInput` as a wholesale replacement
+    # of the tool input, so emitting an empty object erased the original
+    # parameters and every gated call failed schema validation ("required
+    # parameter `command` is missing") instead of prompting the user. The ask
+    # payload must not carry the field at all.
+    if echo "$out" | grep -q 'updatedInput'; then
+        fail "$name" "ask payload carries updatedInput, which replaces the tool input; got: $out"
+        return
+    fi
+    pass "$name"
 }
 
 # expect_allow <case-name> <stdin-json>  — passes when the hook emits no output

--- a/hooks/hook-json-shape.test.sh
+++ b/hooks/hook-json-shape.test.sh
@@ -7,6 +7,10 @@
 # decision — including a "deny" — is silently dropped. A guard in that state
 # looks healthy in the source and does nothing at runtime.
 #
+# It also rejects any hook that emits "updatedInput": a present updatedInput
+# replaces the tool input wholesale, so an empty object strips the parameters
+# off the call the hook was only meant to gate.
+#
 # Run via: bash hooks/hook-json-shape.test.sh
 # Exits 0 on success, 1 on first failure.
 
@@ -33,6 +37,20 @@ for subject in "$SCRIPT_DIR"/*.sh; do
     else
         echo "  FAIL: ${name}: ${blocks} hookSpecificOutput block(s) but only ${events} hookEventName field(s) — the missing ones are discarded at runtime"
         FAIL=$((FAIL + 1))
+    fi
+
+    # Claude Code treats a present "updatedInput" as a WHOLESALE REPLACEMENT of
+    # the tool input. `"updatedInput": {}` therefore erases the original
+    # parameters and the intercepted call fails schema validation ("required
+    # parameter `command` is missing") instead of being asked about or allowed.
+    # None of these hooks rewrite tool input, so the field must be absent.
+    # Comment lines are stripped first so a hook may explain the rule in prose.
+    if grep -v '^[[:space:]]*#' "$subject" | grep -q 'updatedInput'; then
+        echo "  FAIL: ${name}: emits updatedInput, which replaces the tool input wholesale and breaks the intercepted call"
+        FAIL=$((FAIL + 1))
+    else
+        echo "  PASS: ${name} (no updatedInput)"
+        PASS=$((PASS + 1))
     fi
 done
 


### PR DESCRIPTION
The "ask" payloads emitted by guard-public-posts.sh, guard-git-operations.sh and auto-format-before-push.sh all included `"updatedInput": {}`. Claude Code treats a present `updatedInput` as a wholesale replacement of the tool input, so the empty object erased the original parameters and every gated call failed schema validation ("required parameter `command` is missing" for Bash, "missing required parameter: method" for the github MCP tools) instead of prompting the user for approval. Net effect on a live machine: every GitHub posting path was hard-broken rather than gated.

All seven emitters drop `updatedInput`; the payload keeps `hookEventName` + `permissionDecision` (+ `systemMessage`). A new `hook-json-shape.test.sh` pins the contract for every hook that emits a `hookSpecificOutput` block, so the field can't come back.

Tests: guard-public-posts.test.sh 95 passed, hook-json-shape.test.sh 10 passed.
