### PR TITLE
chore: revert @oss-scout/core bump to re-land as a release-triggering fix

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,7 +68,7 @@
     "@octokit/plugin-retry": "^8.1.0",
     "@octokit/plugin-throttling": "^11.0.3",
     "@octokit/rest": "^22.0.1",
-    "@oss-scout/core": "^1.5.2",
+    "@oss-scout/core": "^1.5.0",
     "commander": "^15.0.0",
     "zod": "^4.4.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,8 +76,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@oss-scout/core':
-        specifier: ^1.5.2
-        version: 1.5.2(@octokit/core@7.0.6)
+        specifier: ^1.5.0
+        version: 1.5.0(@octokit/core@7.0.6)
       commander:
         specifier: ^15.0.0
         version: 15.0.0
@@ -758,8 +758,8 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@oss-scout/core@1.5.2':
-    resolution: {integrity: sha512-KrogL+wN5U4aCnvqexP8hc7PTbbpeVxuDTQ/sHcD4v5BlU0UdJh0wau3tZepgXybMvvC+VsK+K/fEUnPKCrwrg==}
+  '@oss-scout/core@1.5.0':
+    resolution: {integrity: sha512-08r5r9kaFBjBsBMm4qEBkYaBNIM8d53/N80LLkvvGsDE3in/sy6kV5ebvHXZAVd0t3EeEZmfCso18lpgJpXsgQ==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
@@ -3551,7 +3551,7 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@oss-scout/core@1.5.2(@octokit/core@7.0.6)':
+  '@oss-scout/core@1.5.0(@octokit/core@7.0.6)':
     dependencies:
       '@octokit/plugin-retry': 8.1.0(@octokit/core@7.0.6)
       '@octokit/plugin-throttling': 11.0.3(@octokit/core@7.0.6)


### PR DESCRIPTION
Step 1 of 2 to get the `@oss-scout/core` 1.5.2 bump released.

The bump landed in #1608 as a `chore:` commit, which release-please does not treat as releasable. A follow-up empty `fix(deps):` commit (#1609) had no file paths, so release-please attributed it to `packages/mcp-server` instead of the core package — release PR #1610 bumps mcp to 5.7.2 and leaves core at 3.20.1.

Because `@oss-autopilot/mcp` depends on core via `workspace:^`, that release would pin mcp to core ^3.20.1, which still carries `@oss-scout/core ^1.5.0`. The bump would never reach npm.

This PR reverts the bump so it can be re-applied with a `fix(deps):` message and a real diff under `packages/core` — the path release-please needs to attribute the release to core. The re-land PR follows immediately; main sits on `^1.5.0` only in between.

---
_Generated by [Claude Code](https://claude.ai/code/session_014fDwCgjd8RFoE8nQ2srVtN)_