### PR TITLE
fix(build): build core types before bundling so root bundle works standalone

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "pnpm -r run build",
-    "bundle": "pnpm -r run bundle",
+    "bundle": "pnpm --filter @oss-autopilot/core run build && pnpm -r run bundle",
     "start": "pnpm --filter @oss-autopilot/core run start",
     "test": "pnpm -r run test",
     "test:watch": "pnpm -r run test:watch",


### PR DESCRIPTION
`pnpm run bundle` fails from a clean tree:

```
✘ [ERROR] Could not resolve "@oss-autopilot/core/commands"
    src/resources.ts:9:37
  The module "./dist/commands/index.js" was not found on the file system
```

`packages/mcp-server` bundles `src/index.ts`, which imports `@oss-autopilot/core/commands` — an export that resolves into core's `dist/`. That directory is produced by core's `build` (tsc), not its `bundle` (esbuild). `pnpm -r run bundle` orders packages topologically but only runs the `bundle` script, so core's types are never emitted and the mcp bundle can't resolve them.

CI doesn't catch it: the matrix job runs `Build core types` (ci.yml:127) long before `Build bundle` (ci.yml:260), so `dist/` already exists by then. The release workflow does the same explicitly. Only a fresh clone running the command CLAUDE.md documents as "Rebuild CLI bundle" hits the failure.

Fix is to build core first in the root script, matching what both workflows already do.

Verified by deleting `packages/core/dist` and `packages/mcp-server/dist` and running `pnpm run bundle` — both `cli.bundle.cjs` (914,519 bytes) and `mcp-server.bundle.cjs` (1,145,864 bytes) are produced, where previously the second failed.

---
_Generated by [Claude Code](https://claude.ai/code/session_014fDwCgjd8RFoE8nQ2srVtN)_