### PR TITLE
chore(deps): upgrade TypeScript to 6.0.3 across packages

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -78,7 +78,7 @@
     "esbuild": "^0.28.1",
     "tsx": "^4.23.1",
     "typedoc": "^0.28.20",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.9"
   }
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -9,7 +9,8 @@
     "rootDir": "./src",
     "declaration": true,
     "resolveJsonModule": true,
-    "skipLibCheck": false
+    "skipLibCheck": false,
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/*.e2e.test.ts", "src/test-lib/**"]

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -40,7 +40,7 @@
     "@types/canvas-confetti": "^1.9.0",
     "@vitest/coverage-v8": "^4.1.9",
     "jsdom": "^30.0.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vite": "^8.2.0",
     "vitest": "^4.1.9"
   }

--- a/packages/dashboard/src/vite-env.d.ts
+++ b/packages/dashboard/src/vite-env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="vite/client" />
+
+// Pulls in Vite's ambient declarations for asset imports (`*.css`, `*.svg`,
+// `import.meta.env`, …). TypeScript 5.9 tolerated a side-effect import of a
+// file it had no declaration for; TypeScript 6 reports TS2882 instead, which
+// made `import './styles.css'` in index.tsx a type error. Vite ships these
+// declarations — we just never referenced them.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -34,7 +34,7 @@
     "@types/node": "^26.1.2",
     "esbuild": "^0.28.1",
     "tsx": "^4.23.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "@vitest/coverage-v8": "^4.1.9",
     "vitest": "^4.1.9"
   },

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -12,7 +12,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["node"]
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,10 +99,10 @@ importers:
         version: 4.23.1
       typedoc:
         specifier: ^0.28.20
-        version: 0.28.20(typescript@5.9.3)
+        version: 0.28.20(typescript@6.0.3)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^4.1.9
         version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))
@@ -147,8 +147,8 @@ importers:
         specifier: ^30.0.1
         version: 30.0.1
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vite:
         specifier: ^8.2.0
         version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0)
@@ -181,8 +181,8 @@ importers:
         specifier: ^4.23.1
         version: 4.23.1
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^4.1.9
         version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))
@@ -2744,11 +2744,6 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
-
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
 
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
@@ -5537,13 +5532,13 @@ snapshots:
       media-typer: 1.1.1
       mime-types: 3.0.2
 
-  typedoc@0.28.20(typescript@5.9.3):
+  typedoc@0.28.20(typescript@6.0.3):
     dependencies:
       '@gerrit0/mini-shiki': 3.23.0
       lunr: 2.3.9
       markdown-it: 14.3.0
       minimatch: 10.2.5
-      typescript: 5.9.3
+      typescript: 6.0.3
       yaml: 2.9.0
 
   typescript-eslint@8.65.0(eslint@10.8.0)(typescript@6.0.3):
@@ -5556,8 +5551,6 @@ snapshots:
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
-
-  typescript@5.9.3: {}
 
   typescript@6.0.3: {}
 


### PR DESCRIPTION
Packages were pinned to `^5.9.3` while the root workspace already resolved `typescript@6.0.3` for the eslint toolchain — so the repo type-checked against one compiler and linted against another. This aligns everything on 6.0.3.

Two TypeScript 6 behaviour changes had to be handled.

**1. `@types/*` is no longer auto-discovered from pnpm's isolated `node_modules`.** Every Node global and `node:*` import stopped resolving — 155 errors in `packages/core` alone (`TS2591 Cannot find name 'process'`, `TS2503 Cannot find namespace 'NodeJS'`, and `TS7006` implicit-any cascading from them). Confirmed the cause by running `tsc --noEmit --types node`, which drops it to **0 errors**. Fix is `"types": ["node"]` in the two Node package tsconfigs. Both packages have `@types/node` as their only `@types` entry, so nothing else is affected by narrowing the global set.

**2. `TS2882` on side-effect imports.** TS 5.9 tolerated `import './styles.css'` with no declaration; TS 6 errors. Added the conventional `packages/dashboard/src/vite-env.d.ts` referencing `vite/client`, which ships those ambient declarations — the project just never referenced them.

**This is not specific to the 7.0 native port.** I closed #1601 attributing the `@types/node` failure to TS 7 being the Go rewrite; that was wrong. 6.0.3 and 7.0.2 produce the *identical* 155-error failure, so it is a TS≥6 resolution change and the `types` fix here is a prerequisite for any future 7.x attempt, not a workaround for the port.

Verification, all local:

| check | result |
|---|---|
| `pnpm run typecheck` | all 3 packages clean |
| `pnpm run build` | clean |
| `pnpm run bundle` | both bundles produced |
| `pnpm run lint` | 0 errors |
| core tests | 3067 passed |
| dashboard tests | 279 passed (22 files) |
| mcp-server tests | 247 passed (9 files) |

The 13 core test failures in my local run are the pre-existing environment ones — 3 chmod-based tests that fail as root, and 10 live-API E2E tests that run because this box has a placeholder `GITHUB_TOKEN`. The set is identical on `main` before this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_014fDwCgjd8RFoE8nQ2srVtN)_