### PR TITLE
docs(mcp): correct the 5.7.2 changelog entry

### DIFF
--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -2,10 +2,18 @@
 
 ## [5.7.2](https://github.com/costajohnt/oss-autopilot/compare/mcp-v5.7.1...mcp-v5.7.2) (2026-08-08)
 
+No functional change to the MCP server.
 
-### Bug Fixes
+This version was published as a side effect of release tooling. An empty
+`fix(deps):` commit ([#1609](https://github.com/costajohnt/oss-autopilot/issues/1609))
+was created to mark the `@oss-scout/core` bump in `@oss-autopilot/core` as
+releasable. Having no file paths, it could not be attributed by path, and
+release-please assigned it to this package instead. The entry previously shown
+here credited that bump to `@oss-autopilot/mcp`, which does not depend on
+`@oss-scout/core` — only `@oss-autopilot/core` does.
 
-* **deps:** bump @oss-scout/core to ^1.5.2 ([#1609](https://github.com/costajohnt/oss-autopilot/issues/1609)) ([3c014cf](https://github.com/costajohnt/oss-autopilot/commit/3c014cfe426b9f941c7694a043e2d51b4a345e54))
+The bump was subsequently re-landed correctly and shipped in
+`@oss-autopilot/core` 3.20.2 ([#1612](https://github.com/costajohnt/oss-autopilot/issues/1612)).
 
 ## [5.7.1](https://github.com/costajohnt/oss-autopilot/compare/mcp-v5.7.0...mcp-v5.7.1) (2026-07-15)
 


### PR DESCRIPTION
The `@oss-autopilot/mcp` 5.7.2 entry reads:

> **deps:** bump @oss-scout/core to ^1.5.2 (#1609)

which is wrong — `@oss-autopilot/mcp` does not depend on `@oss-scout/core`. Only `@oss-autopilot/core` does.

That line exists because of the release-tooling detour in #1609: an empty `fix(deps):` commit was created to mark the `@oss-scout/core` bump as releasable, but having no file paths it could not be attributed by path, so release-please assigned it to `packages/mcp-server` and published 5.7.2 containing no functional change at all. The bump was then re-landed correctly in #1612 and shipped in `@oss-autopilot/core` 3.20.2.

This replaces the misleading `### Bug Fixes` line with a plain statement of what 5.7.2 actually contains and why it exists. The `## [5.7.2](…)` header is left byte-for-byte intact so release-please can still parse the file, and no version or manifest state is touched.

Uses a `docs:` prefix so it is not itself releasable.

Two things this does **not** fix, both out of reach:
- The published npm tarball for `@oss-autopilot/mcp@5.7.2` still carries the old CHANGELOG. Republishing an existing version isn't possible, and it isn't worth a version bump.
- The [GitHub Release for `mcp-v5.7.2`](https://github.com/costajohnt/oss-autopilot/releases/tag/mcp-v5.7.2) has the same wrong body. My tooling here exposes read-only release access, so that one needs a manual edit if you want it corrected.

---
_Generated by [Claude Code](https://claude.ai/code/session_014fDwCgjd8RFoE8nQ2srVtN)_