### PR TITLE
fix: stop counting URL-bearing sub-bullets and prose paragraphs as available issues

### DIFF
--- a/packages/core/src/commands/parse-list.test.ts
+++ b/packages/core/src/commands/parse-list.test.ts
@@ -320,6 +320,16 @@ describe('parseIssueList — indented sub-bullets with URLs (nested-URL defect)'
     expect(result.completedCount).toBe(0);
   });
 
+  it('does not count a tab-indented URL-bearing sub-bullet as a new item', () => {
+    const content = `### Repo
+- [#1](https://github.com/owner/repo/issues/1) — Fix bug
+\t- **Maybe** — Competitor PR: [#99](https://github.com/owner/repo/pull/99)
+`;
+    const result = parseIssueList(content);
+    expect(result.availableCount).toBe(1);
+    expect(result.available[0].number).toBe(1);
+  });
+
   it('URL-bearing sub-bullet still contributes score to the parent', () => {
     const content = `- [#1](https://github.com/owner/repo/issues/1) — Fix bug
   - **Maybe** — Score 8/10. Competitor PR: [#99](https://github.com/owner/repo/pull/99)
@@ -359,6 +369,25 @@ describe('parseIssueList — decorated status keyword matching', () => {
     expect(result.completed).toHaveLength(1);
   });
 
+  it('moves unstruck parent to completed on "**Score 8/10 — ✅ MERGED (confirmed ...).**" sub-bullet', () => {
+    const content = `- [#1](https://github.com/owner/repo/issues/1) — Fix bug
+  - **Score 8/10 — ✅ MERGED (confirmed 2026-08-07).** PR [#2](https://github.com/owner/repo/pull/2)
+`;
+    const result = parseIssueList(content);
+    expect(result.availableCount).toBe(0);
+    expect(result.completed).toHaveLength(1);
+    expect(result.completed[0].number).toBe(1);
+  });
+
+  it('treats "**Skipped — ...**" as terminal', () => {
+    const content = `- [#9](https://github.com/owner/repo/issues/9) — Feature
+  - **Skipped — existing PR covers it.**
+`;
+    const result = parseIssueList(content);
+    expect(result.available).toHaveLength(0);
+    expect(result.completed).toHaveLength(1);
+  });
+
   it('does not match keyword prefixes of longer words (Holding is not Hold)', () => {
     const content = `- [#3](https://github.com/owner/repo/issues/3) — Feature
   - **Holding pattern notes** — Score 8/10
@@ -383,6 +412,71 @@ describe('pruneIssueList — decorated status keywords', () => {
     const content = `### Repo
 - [#5](https://github.com/owner/repo/issues/5) — Shipped item
   - **✅ Done — merged 2026-08-01.** Score 8/10
+`;
+    const { pruned, removedCount } = pruneIssueList(content);
+    expect(removedCount).toBe(1);
+    expect(pruned).not.toContain('issues/5');
+  });
+});
+
+describe('pruneIssueList — keyword followed by whitespace+word is NOT deletable', () => {
+  // pruneIssueList overwrites the file on disk. A status keyword followed by
+  // ordinary prose ("Merged upstream fix doesn't cover our case") is a
+  // sentence, not a status tag — deleting on it loses curator entries.
+  it('does NOT delete "**Merged upstream fix ... — still pursue.**"', () => {
+    const content = `### Repo
+- [#1](https://github.com/owner/repo/issues/1) — Fix bug
+  - **Merged upstream fix doesn't cover our case — still pursue.**
+`;
+    const { pruned, removedCount } = pruneIssueList(content);
+    expect(removedCount).toBe(0);
+    expect(pruned).toContain('issues/1');
+  });
+
+  it('does NOT delete "**Skip? Actually pursue — maintainer replied.**"', () => {
+    const content = `### Repo
+- [#2](https://github.com/owner/repo/issues/2) — Fix bug
+  - **Skip? Actually pursue — maintainer replied.**
+`;
+    const { pruned, removedCount } = pruneIssueList(content);
+    expect(removedCount).toBe(0);
+    expect(pruned).toContain('issues/2');
+  });
+
+  it('does NOT delete "**Closed the duplicate; this one is still open — pursue.**"', () => {
+    const content = `### Repo
+- [#3](https://github.com/owner/repo/issues/3) — Fix bug
+  - **Closed the duplicate; this one is still open — pursue.**
+`;
+    const { pruned, removedCount } = pruneIssueList(content);
+    expect(removedCount).toBe(0);
+    expect(pruned).toContain('issues/3');
+  });
+
+  it('still deletes "**✅ Done — merged 2026-08-01.**"', () => {
+    const content = `### Repo
+- [#4](https://github.com/owner/repo/issues/4) — Shipped
+  - **✅ Done — merged 2026-08-01.**
+`;
+    const { pruned, removedCount } = pruneIssueList(content);
+    expect(removedCount).toBe(1);
+    expect(pruned).not.toContain('issues/4');
+  });
+
+  it('does NOT delete "**Skipped — ...**" (terminal in memory, parked on disk)', () => {
+    const content = `### Repo
+- [#6](https://github.com/owner/repo/issues/6) — Feature
+  - **Skipped — existing PR covers it.**
+`;
+    const { pruned, removedCount } = pruneIssueList(content);
+    expect(removedCount).toBe(0);
+    expect(pruned).toContain('issues/6');
+  });
+
+  it('still deletes bare "**Merged.**"', () => {
+    const content = `### Repo
+- [#5](https://github.com/owner/repo/issues/5) — Shipped
+  - **Merged.**
 `;
     const { pruned, removedCount } = pruneIssueList(content);
     expect(removedCount).toBe(1);

--- a/packages/core/src/commands/parse-list.test.ts
+++ b/packages/core/src/commands/parse-list.test.ts
@@ -300,6 +300,96 @@ describe('parseIssueList — sub-bullet status detection', () => {
   });
 });
 
+describe('parseIssueList — indented sub-bullets with URLs (nested-URL defect)', () => {
+  it('does not count a URL-bearing sub-bullet under a struck parent as available', () => {
+    const content = `### Repo
+- ~~[owncast/owncast#4950](https://github.com/owncast/owncast/issues/4950) (11k★) — title~~
+  - **Score 8/10 — ✅ MERGED (confirmed 2026-08-07).** **PR [#4956](https://github.com/owncast/owncast/pull/4956)** (branch ...)
+`;
+    const result = parseIssueList(content);
+    expect(result.availableCount).toBe(0);
+    expect(result.completedCount).toBe(1);
+    expect(result.completed[0].number).toBe(4950);
+  });
+
+  it('does not count a bold-starting paragraph with a URL as a list item', () => {
+    const content = `**Dropped this round:** [go-git#827](https://github.com/go-git/go-git/issues/827) — someone else diagnosed it.
+`;
+    const result = parseIssueList(content);
+    expect(result.availableCount).toBe(0);
+    expect(result.completedCount).toBe(0);
+  });
+
+  it('URL-bearing sub-bullet still contributes score to the parent', () => {
+    const content = `- [#1](https://github.com/owner/repo/issues/1) — Fix bug
+  - **Maybe** — Score 8/10. Competitor PR: [#99](https://github.com/owner/repo/pull/99)
+`;
+    const result = parseIssueList(content);
+    expect(result.availableCount).toBe(1);
+    expect(result.available[0].number).toBe(1);
+    expect(result.available[0].score).toBe(8);
+  });
+});
+
+describe('parseIssueList — decorated status keyword matching', () => {
+  it('moves parent to completed on decorated "✅ MERGED — ..." sub-bullet', () => {
+    const content = `- [#1](https://github.com/owner/repo/issues/1) — Fix bug
+  - **✅ MERGED — re-vet 2026-08-07: PR #5042 merged 2026-07-20, issue closed.**
+`;
+    const result = parseIssueList(content);
+    expect(result.available).toHaveLength(0);
+    expect(result.completed).toHaveLength(1);
+  });
+
+  it('moves parent out of available on "✅ PR OPEN ..." sub-bullet (in-progress)', () => {
+    const content = `- [#765](https://github.com/vadimdemedes/ink/issues/765) — Feature
+  - **✅ PR OPEN 2026-08-09: #988**
+`;
+    const result = parseIssueList(content);
+    expect(result.available).toHaveLength(0);
+    expect(result.completed).toHaveLength(1);
+  });
+
+  it('moves parent out of available on IMPLEMENTED sub-bullet (in-progress)', () => {
+    const content = `- [#2](https://github.com/owner/repo/issues/2) — Feature
+  - **IMPLEMENTED — awaiting review**
+`;
+    const result = parseIssueList(content);
+    expect(result.available).toHaveLength(0);
+    expect(result.completed).toHaveLength(1);
+  });
+
+  it('does not match keyword prefixes of longer words (Holding is not Hold)', () => {
+    const content = `- [#3](https://github.com/owner/repo/issues/3) — Feature
+  - **Holding pattern notes** — Score 8/10
+`;
+    const result = parseIssueList(content);
+    expect(result.available).toHaveLength(1);
+  });
+});
+
+describe('pruneIssueList — decorated status keywords', () => {
+  it('does NOT delete decorated "**Hold — ...**" items', () => {
+    const content = `### Repo
+- [#1](https://github.com/owner/repo/issues/1) — Held back
+  - **Hold — author has 2 PRs in flight.** Score 8/10
+`;
+    const { pruned, removedCount } = pruneIssueList(content);
+    expect(removedCount).toBe(0);
+    expect(pruned).toContain('issues/1');
+  });
+
+  it('deletes decorated "**Done — ...**" items', () => {
+    const content = `### Repo
+- [#5](https://github.com/owner/repo/issues/5) — Shipped item
+  - **✅ Done — merged 2026-08-01.** Score 8/10
+`;
+    const { pruned, removedCount } = pruneIssueList(content);
+    expect(removedCount).toBe(1);
+    expect(pruned).not.toContain('issues/5');
+  });
+});
+
 describe('parseIssueList — URL deduplication (#1179)', () => {
   it('dedupes the same URL appearing in two sections to one available entry', () => {
     const content = `## Pursue

--- a/packages/core/src/commands/parse-list.test.ts
+++ b/packages/core/src/commands/parse-list.test.ts
@@ -484,6 +484,105 @@ describe('pruneIssueList — keyword followed by whitespace+word is NOT deletabl
   });
 });
 
+describe('pruneIssueList — keyword continuing as a hyphenated word is NOT deletable', () => {
+  // "Done-ish", "Merged-in-part" etc. are hedged prose, not status tags.
+  // Fixtures include a Score 9/10 sub-bullet so score-pruning is never the cause.
+  it('does NOT delete "**Done-ish** still worth a look"', () => {
+    const content = `### Repo
+- [#1](https://github.com/owner/repo/issues/1) — Fix bug
+  - **Done-ish** still worth a look
+  - **Score 9/10**
+`;
+    const { pruned, removedCount } = pruneIssueList(content);
+    expect(removedCount).toBe(0);
+    expect(pruned).toContain('issues/1');
+  });
+
+  it('does NOT delete "**Done-for-now, revisit**"', () => {
+    const content = `### Repo
+- [#2](https://github.com/owner/repo/issues/2) — Fix bug
+  - **Done-for-now, revisit**
+  - **Score 9/10**
+`;
+    const { pruned, removedCount } = pruneIssueList(content);
+    expect(removedCount).toBe(0);
+    expect(pruned).toContain('issues/2');
+  });
+
+  it('does NOT delete "**Merged-in-part; keep**"', () => {
+    const content = `### Repo
+- [#3](https://github.com/owner/repo/issues/3) — Fix bug
+  - **Merged-in-part; keep**
+  - **Score 9/10**
+`;
+    const { pruned, removedCount } = pruneIssueList(content);
+    expect(removedCount).toBe(0);
+    expect(pruned).toContain('issues/3');
+  });
+
+  it('does NOT delete "**Closed-loop analysis pending**"', () => {
+    const content = `### Repo
+- [#4](https://github.com/owner/repo/issues/4) — Fix bug
+  - **Closed-loop analysis pending**
+  - **Score 9/10**
+`;
+    const { pruned, removedCount } = pruneIssueList(content);
+    expect(removedCount).toBe(0);
+    expect(pruned).toContain('issues/4');
+  });
+
+  it('still deletes "**Done — merged.**"', () => {
+    const content = `### Repo
+- [#5](https://github.com/owner/repo/issues/5) — Shipped
+  - **Done — merged.**
+`;
+    const { pruned, removedCount } = pruneIssueList(content);
+    expect(removedCount).toBe(1);
+    expect(pruned).not.toContain('issues/5');
+  });
+});
+
+describe('parseIssueList — URL-less sub-bullet at equal indent to parent', () => {
+  it('treats an equal-indent URL-less status line as a sub-bullet of the previous item', () => {
+    const content = `### Repo
+  - [#13](https://github.com/o/r/issues/13) a
+  - **Done** meant as sub-bullet
+`;
+    const result = parseIssueList(content);
+    expect(result.availableCount).toBe(0);
+    expect(result.completedCount).toBe(1);
+    expect(result.completed[0].number).toBe(13);
+  });
+});
+
+describe('pruneIssueList — tab-indented sub-bullets', () => {
+  it('removes a tab-indented URL-less sub-bullet together with its struck parent', () => {
+    const content = `### Repo
+- ~~[#1](https://github.com/owner/repo/issues/1) — Done thing~~
+\t- notes about the fix
+- [#2](https://github.com/owner/repo/issues/2) — Keep me
+`;
+    const { pruned, removedCount } = pruneIssueList(content);
+    expect(removedCount).toBe(1);
+    expect(pruned).not.toContain('issues/1');
+    expect(pruned).not.toContain('notes about the fix');
+    expect(pruned).toContain('issues/2');
+  });
+
+  it('removes an unstruck parent when its tab-indented sub-bullet says **Done**', () => {
+    const content = `### Repo
+- [#3](https://github.com/owner/repo/issues/3) — Shipped
+\t- **Done**
+- [#4](https://github.com/owner/repo/issues/4) — Keep me
+`;
+    const { pruned, removedCount } = pruneIssueList(content);
+    expect(removedCount).toBe(1);
+    expect(pruned).not.toContain('issues/3');
+    expect(pruned).not.toContain('**Done**');
+    expect(pruned).toContain('issues/4');
+  });
+});
+
 describe('parseIssueList — URL deduplication (#1179)', () => {
   it('dedupes the same URL appearing in two sections to one available entry', () => {
     const content = `## Pursue

--- a/packages/core/src/commands/parse-list.ts
+++ b/packages/core/src/commands/parse-list.ts
@@ -52,8 +52,9 @@ function isCompleted(line: string): boolean {
   if (/~~.+~~/.test(line)) return true;
   // Checked checkbox: [x] or [X]
   if (/\[x\]/i.test(line)) return true;
-  // "Done" marker (standalone word, case insensitive)
-  if (/\bdone\b/i.test(line)) return true;
+  // "Done" marker (standalone word, case insensitive). Hyphenated
+  // continuations ("Done-ish", "well-done") are prose, not markers.
+  if (/(?<!-)\bdone\b(?!-)/i.test(line)) return true;
   return false;
 }
 
@@ -138,7 +139,9 @@ function isSubBulletTerminal(line: string): boolean {
 function isSubBulletDeletable(line: string): boolean {
   const kw = normalizedBoldSpan(line);
   if (!kw) return false;
-  return /^(?:Skip|Done|Dropped|Merged|Closed)\s*(?:$|[—–\-:.,;()!])/iu.test(kw);
+  // Negative lookahead: the keyword must not continue as a hyphenated word
+  // ("Done-ish", "Merged-in-part" are hedged prose, not status tags).
+  return /^(?:Skip|Done|Dropped|Merged|Closed)(?![\p{L}\p{N}-])\s*(?:$|[—–\-:.,;()!])/iu.test(kw);
 }
 
 /**
@@ -152,6 +155,11 @@ function isSubBulletInProgress(line: string): boolean {
     line,
     /^(?:In Progress|Waiting|Wait|Post findings first|Ship now|Viable not urgent|PR OPEN|IMPLEMENTED)(?![\p{L}\p{N}])/iu,
   );
+}
+
+/** Leading-whitespace width with tabs expanded to two columns. */
+function indentWidth(line: string): number {
+  return line.match(/^\s*/)![0].replace(/\t/g, '  ').length;
 }
 
 /** Parse a markdown string into structured issue items */
@@ -184,14 +192,17 @@ export function parseIssueList(content: string): ParseIssueListOutput {
       continue;
     }
 
-    // Lines indented deeper than the previous item are sub-bullets and NEVER
-    // create a new item, even when they contain GitHub URLs (merged-PR links,
-    // competitor PRs, cross-references in status annotations). Lines at the
-    // parent's own indent (siblings in wholly-indented lists) fall through
-    // and are treated as items, matching pre-existing behavior.
+    // Indented lines are sub-bullets and NEVER create a new item. For
+    // URL-bearing lines (merged-PR links, competitor PRs, cross-references)
+    // the line must be indented DEEPER than its parent — lines at the
+    // parent's own indent are siblings in wholly-indented lists and fall
+    // through to create items. URL-less lines can't create items anyway, so
+    // any >=2-space indent makes them sub-bullets, even at the parent's own
+    // indent (a `  - **Done**` status line beside an equally-indented item).
     // Tabs count as two columns so `\t- ...` sub-bullets nest correctly.
-    const indent = line.match(/^\s*/)![0].replace(/\t/g, '  ').length;
-    if (lastItem && indent >= 2 && indent > lastItemIndent) {
+    const indent = indentWidth(line);
+    const ghUrl = extractGitHubUrl(line);
+    if (lastItem && indent >= 2 && (ghUrl ? indent > lastItemIndent : true)) {
       const score = extractScore(line);
       if (score !== undefined) {
         lastItem.score = score;
@@ -209,8 +220,7 @@ export function parseIssueList(content: string): ParseIssueListOutput {
       continue;
     }
 
-    // Extract GitHub URL -- skip top-level lines without one
-    const ghUrl = extractGitHubUrl(line);
+    // Skip top-level lines without a GitHub URL
     if (!ghUrl) {
       continue;
     }
@@ -297,7 +307,7 @@ export function pruneIssueList(content: string, minScore: number = 6): { pruned:
     }
 
     // Sub-bullet of a removed item — skip it
-    if (skipSubBullets && /^\s{2,}/.test(line)) {
+    if (skipSubBullets && indentWidth(line) >= 2) {
       continue;
     }
     skipSubBullets = false;
@@ -317,7 +327,7 @@ export function pruneIssueList(content: string, minScore: number = 6): { pruned:
       // Look ahead at sub-bullets for terminal status or low score
       let shouldRemove = false;
       let j = i + 1;
-      while (j < lines.length && /^\s{2,}/.test(lines[j])) {
+      while (j < lines.length && indentWidth(lines[j]) >= 2) {
         if (isSubBulletDeletable(lines[j])) {
           shouldRemove = true;
         }

--- a/packages/core/src/commands/parse-list.ts
+++ b/packages/core/src/commands/parse-list.ts
@@ -89,11 +89,16 @@ function normalizedBoldSpan(line: string): string | null {
  * Match a status keyword as a PREFIX of the normalized bold span, ending at a
  * word boundary (end of span, whitespace, or punctuation). Real curator spans
  * look like `✅ MERGED — re-vet 2026-08-07: ...`, not a bare keyword.
+ *
+ * Curators also commonly lead with the score
+ * (`**Score 8/10 — ✅ MERGED (confirmed ...).**`), so a `Score N/10` +
+ * separator prefix is stripped before testing keywords.
  */
 function spanStartsWithKeyword(line: string, keywords: RegExp): boolean {
   const kw = normalizedBoldSpan(line);
   if (!kw) return false;
-  return keywords.test(kw);
+  const stripped = kw.replace(/^Score\s+\d+(?:\.\d+)?\/10\s*[—–\-:.,;]?\s*/iu, '').replace(/^[^\p{L}\p{N}]+/u, '');
+  return keywords.test(stripped);
 }
 
 /**
@@ -114,7 +119,7 @@ function spanStartsWithKeyword(line: string, keywords: RegExp): boolean {
 function isSubBulletTerminal(line: string): boolean {
   return spanStartsWithKeyword(
     line,
-    /^(?:Skip|Done|Dropped|Merged|Closed|Hold|Continue watch|Downgrade)(?![\p{L}\p{N}])/iu,
+    /^(?:Skipped|Skip|Done|Dropped|Merged|Closed|Hold|Continue watch|Downgrade)(?![\p{L}\p{N}])/iu,
   );
 }
 
@@ -123,9 +128,17 @@ function isSubBulletTerminal(line: string): boolean {
  * Strictly the original five keywords — `pruneIssueList` mutates the
  * markdown file in place, and a curator's `**Hold**` annotation means
  * "park", not "delete" (#1179).
+ *
+ * Stricter than the in-memory matchers: the keyword must be followed by
+ * end-of-span or a separator character, never whitespace + another word.
+ * `**Merged upstream fix doesn't cover our case — still pursue.**` is a
+ * sentence, not a status tag; deleting on it destroys curator entries.
+ * Under-counting availability is acceptable, disk deletion is not.
  */
 function isSubBulletDeletable(line: string): boolean {
-  return spanStartsWithKeyword(line, /^(?:Skip|Done|Dropped|Merged|Closed)(?![\p{L}\p{N}])/iu);
+  const kw = normalizedBoldSpan(line);
+  if (!kw) return false;
+  return /^(?:Skip|Done|Dropped|Merged|Closed)\s*(?:$|[—–\-:.,;()!])/iu.test(kw);
 }
 
 /**
@@ -176,7 +189,8 @@ export function parseIssueList(content: string): ParseIssueListOutput {
     // competitor PRs, cross-references in status annotations). Lines at the
     // parent's own indent (siblings in wholly-indented lists) fall through
     // and are treated as items, matching pre-existing behavior.
-    const indent = line.match(/^\s*/)![0].length;
+    // Tabs count as two columns so `\t- ...` sub-bullets nest correctly.
+    const indent = line.match(/^\s*/)![0].replace(/\t/g, '  ').length;
     if (lastItem && indent >= 2 && indent > lastItemIndent) {
       const score = extractScore(line);
       if (score !== undefined) {

--- a/packages/core/src/commands/parse-list.ts
+++ b/packages/core/src/commands/parse-list.ts
@@ -76,6 +76,27 @@ function firstBoldSpan(line: string): string | null {
 }
 
 /**
+ * First bold span with leading decoration (emoji, checkmarks, punctuation)
+ * stripped, so `**✅ MERGED — re-vet...**` normalizes to `MERGED — re-vet...`.
+ */
+function normalizedBoldSpan(line: string): string | null {
+  const span = firstBoldSpan(line);
+  if (!span) return null;
+  return span.replace(/^[^\p{L}\p{N}]+/u, '');
+}
+
+/**
+ * Match a status keyword as a PREFIX of the normalized bold span, ending at a
+ * word boundary (end of span, whitespace, or punctuation). Real curator spans
+ * look like `✅ MERGED — re-vet 2026-08-07: ...`, not a bare keyword.
+ */
+function spanStartsWithKeyword(line: string, keywords: RegExp): boolean {
+  const kw = normalizedBoldSpan(line);
+  if (!kw) return false;
+  return keywords.test(kw);
+}
+
+/**
  * Check if a sub-bullet's first bold span is a terminal status — completed,
  * abandoned, or being held back from pursuit (#1179). Used by
  * `parseIssueList` for in-memory bucketing.
@@ -91,9 +112,10 @@ function firstBoldSpan(line: string): string | null {
  * explicitly parked.
  */
 function isSubBulletTerminal(line: string): boolean {
-  const kw = firstBoldSpan(line);
-  if (!kw) return false;
-  return /^(?:Skip|Done|Dropped|Merged|Closed|Hold|Continue watch|Downgrade)$/i.test(kw);
+  return spanStartsWithKeyword(
+    line,
+    /^(?:Skip|Done|Dropped|Merged|Closed|Hold|Continue watch|Downgrade)(?![\p{L}\p{N}])/iu,
+  );
 }
 
 /**
@@ -103,9 +125,7 @@ function isSubBulletTerminal(line: string): boolean {
  * "park", not "delete" (#1179).
  */
 function isSubBulletDeletable(line: string): boolean {
-  const kw = firstBoldSpan(line);
-  if (!kw) return false;
-  return /^(?:Skip|Done|Dropped|Merged|Closed)$/i.test(kw);
+  return spanStartsWithKeyword(line, /^(?:Skip|Done|Dropped|Merged|Closed)(?![\p{L}\p{N}])/iu);
 }
 
 /**
@@ -115,9 +135,10 @@ function isSubBulletDeletable(line: string): boolean {
  * (#1179).
  */
 function isSubBulletInProgress(line: string): boolean {
-  const kw = firstBoldSpan(line);
-  if (!kw) return false;
-  return /^(?:In Progress|Wait|Waiting|Post findings first|Ship now|Viable not urgent)$/i.test(kw);
+  return spanStartsWithKeyword(
+    line,
+    /^(?:In Progress|Waiting|Wait|Post findings first|Ship now|Viable not urgent|PR OPEN|IMPLEMENTED)(?![\p{L}\p{N}])/iu,
+  );
 }
 
 /** Parse a markdown string into structured issue items */
@@ -129,6 +150,10 @@ export function parseIssueList(content: string): ParseIssueListOutput {
   let lastItem: ParsedIssueItem | null = null;
   // Track which array the last item was placed in so sub-bullets can move it
   let lastItemInAvailable = false;
+  // Indentation of the line that created lastItem — a line is a sub-bullet
+  // only when indented deeper than its parent (handles wholly-indented lists
+  // whose sibling items share the same indent).
+  let lastItemIndent = 0;
 
   for (const line of lines) {
     // Check for section headings (# or ##)
@@ -139,31 +164,40 @@ export function parseIssueList(content: string): ParseIssueListOutput {
       continue;
     }
 
-    // Skip empty lines and non-list items
-    if (!line.trim() || !/^\s*[-*+]|\s*\d+\.|\s*\[[ x]\]/i.test(line)) {
+    // Skip empty lines and non-list items. Bullet markers need trailing
+    // whitespace so a `**bold**`-opening paragraph isn't mistaken for a
+    // `*` bullet; each alternative is anchored to line start.
+    if (!line.trim() || !/^\s*(?:[-*+]\s|\d+\.\s|\[[ x]\])/i.test(line)) {
       continue;
     }
 
-    // Extract GitHub URL -- skip lines without one
-    const ghUrl = extractGitHubUrl(line);
-    if (!ghUrl) {
-      // No URL — check if this is a sub-bullet for the previous item
-      if (lastItem && /^\s{2,}/.test(line)) {
-        const score = extractScore(line);
-        if (score !== undefined) {
-          lastItem.score = score;
-        }
-        // Check if sub-bullet marks item as terminal or in-progress
-        if (lastItemInAvailable && (isSubBulletTerminal(line) || isSubBulletInProgress(line))) {
-          // Move from available to completed
-          const idx = available.indexOf(lastItem);
-          if (idx !== -1) {
-            available.splice(idx, 1);
-            completed.push(lastItem);
-            lastItemInAvailable = false;
-          }
+    // Lines indented deeper than the previous item are sub-bullets and NEVER
+    // create a new item, even when they contain GitHub URLs (merged-PR links,
+    // competitor PRs, cross-references in status annotations). Lines at the
+    // parent's own indent (siblings in wholly-indented lists) fall through
+    // and are treated as items, matching pre-existing behavior.
+    const indent = line.match(/^\s*/)![0].length;
+    if (lastItem && indent >= 2 && indent > lastItemIndent) {
+      const score = extractScore(line);
+      if (score !== undefined) {
+        lastItem.score = score;
+      }
+      // Check if sub-bullet marks item as terminal or in-progress
+      if (lastItemInAvailable && (isSubBulletTerminal(line) || isSubBulletInProgress(line))) {
+        // Move from available to completed
+        const idx = available.indexOf(lastItem);
+        if (idx !== -1) {
+          available.splice(idx, 1);
+          completed.push(lastItem);
+          lastItemInAvailable = false;
         }
       }
+      continue;
+    }
+
+    // Extract GitHub URL -- skip top-level lines without one
+    const ghUrl = extractGitHubUrl(line);
+    if (!ghUrl) {
       continue;
     }
 
@@ -184,6 +218,7 @@ export function parseIssueList(content: string): ParseIssueListOutput {
       lastItemInAvailable = true;
     }
     lastItem = item;
+    lastItemIndent = indent;
   }
 
   // Dedupe by URL across both buckets (#1179). Curated lists routinely


### PR DESCRIPTION
## Problem

`parseIssueList` wildly inflates `availableCount` on real curated lists (reported 14 available when 1 was true). Three compounding defects:

1. Indented sub-bullets containing GitHub URLs (merged-PR links, competitor PRs, cross-references) created phantom top-level items — sub-bullet handling only ran for URL-less lines.
2. The list-item filter regex had unanchored alternatives and no whitespace requirement, so `**bold**`-opening prose paragraphs matched as `*` bullets and their URLs became items.
3. Status keyword matching required the entire first bold span to equal a keyword, so real curator spans like `**✅ MERGED — re-vet 2026-08-07: ...**` or `**Score 8/10 — ✅ MERGED (confirmed ...)**` never registered as terminal.

## Solution

- URL-bearing lines indented deeper than the previous item are always routed to sub-bullet handling (tab indentation normalized to 2 columns, shared helper also applied to `pruneIssueList`). URL-less lines keep the old any-indent sub-bullet rule.
- List-item filter requires whitespace after the bullet marker, matching `pruneIssueList`'s existing `isList` regex.
- Bold-span normalization strips leading emoji/decoration and an optional `Score N/10 —` prefix before keyword testing; `PR OPEN`/`IMPLEMENTED` added to the in-progress set and `Skipped` to the terminal set (in-memory only).
- `isSubBulletDeletable` — the matcher gating on-disk deletion in `pruneIssueList` — stays strict: bare keyword followed by a separator, with a negative lookahead so hyphenated words (`Done-ish`, `Merged-in-part`) never delete. `isCompleted`'s `\bdone\b` likewise no longer matches inside hyphenated words (`get-shit-done`).

Deliberate asymmetry: in-memory availability matching is loose (under-counting is acceptable), disk deletion is strict (over-deletion is not).

## Verification

- 23 new tests across three TDD rounds, each red before its fix; suite 3072 passed, `tsc --noEmit` clean.
- Acceptance on the real curated list: availableCount 14 → 1, matching a manual audit.
- `pruneIssueList` A/B on a copy of the real list vs main: nothing new deleted; the branch additionally rescues one entry main wrongly pruned via the `\bdone\b` substring match.