### PR TITLE
feat: pass preferredOrgs config through to oss-scout's orgs search phase

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,7 +68,7 @@
     "@octokit/plugin-retry": "^8.1.1",
     "@octokit/plugin-throttling": "^11.0.5",
     "@octokit/rest": "^22.0.1",
-    "@oss-scout/core": "^1.5.2",
+    "@oss-scout/core": "^1.6.0",
     "commander": "^15.0.0",
     "zod": "^4.4.3"
   },

--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -370,7 +370,7 @@ export const commands: CLICommandDef[] = [
         .option('--json', 'Output as JSON')
         .option(
           '--strategy <strategies>',
-          "Comma-separated discovery phases to run (merged,starred,broad,maintained,all). Omit to run scout's default staged pipeline.",
+          "Comma-separated discovery phases to run (merged,orgs,starred,broad,maintained,all). Omit to run scout's default staged pipeline.",
         )
         .action(async (count, options) => {
           const { SearchOutputSchema } = await import('./formatters/json.js');

--- a/packages/core/src/commands/scout-bridge.test.ts
+++ b/packages/core/src/commands/scout-bridge.test.ts
@@ -84,6 +84,7 @@ describe('buildScoutState', () => {
     expect(result.preferences.scope).toEqual(['beginner']);
     expect(result.preferences.excludeRepos).toEqual(['owner/excluded']);
     expect(result.preferences.excludeOrgs).toEqual(['bad-org']);
+    expect(result.preferences.preferredOrgs).toEqual(['microsoft', 'vercel']);
     expect(result.preferences.aiPolicyBlocklist).toEqual(['matplotlib/matplotlib']);
     expect(result.preferences.projectCategories).toEqual(['devtools', 'infrastructure']);
     expect(result.preferences.minStars).toBe(100);
@@ -170,7 +171,7 @@ describe('buildScoutState', () => {
     expect(result.preferences.boostIssueTypes).toEqual([]);
   });
 
-  it.each(['excludeOrgs', 'projectCategories'] as const)(
+  it.each(['excludeOrgs', 'projectCategories', 'preferredOrgs'] as const)(
     'should default %s to [] when undefined in config',
     (field) => {
       const state = makeAgentState({ config: { [field]: undefined } });

--- a/packages/core/src/commands/scout-bridge.ts
+++ b/packages/core/src/commands/scout-bridge.ts
@@ -129,6 +129,7 @@ export function buildScoutState(diagnostics?: ScoutBridgeDiagnostics): ScoutStat
       scope: config.scope,
       excludeRepos: config.excludeRepos,
       excludeOrgs: config.excludeOrgs ?? [],
+      preferredOrgs: config.preferredOrgs ?? [],
       aiPolicyBlocklist: config.aiPolicyBlocklist,
       projectCategories: config.projectCategories ?? [],
       minStars: config.minStars,

--- a/packages/core/src/commands/search.test.ts
+++ b/packages/core/src/commands/search.test.ts
@@ -663,12 +663,18 @@ describe('parseSearchStrategies (#1244 selector)', () => {
     expect(parseSearchStrategies('merged, starred ,broad')).toEqual(['merged', 'starred', 'broad']);
   });
 
+  it('accepts the orgs strategy (scout 1.6.0)', () => {
+    expect(parseSearchStrategies('orgs')).toEqual(['orgs']);
+  });
+
   it('accepts the "all" sentinel', () => {
     expect(parseSearchStrategies('all')).toEqual(['all']);
   });
 
   it('throws with a helpful message on an unknown strategy', () => {
     expect(() => parseSearchStrategies('bogus')).toThrow(/Unknown search strategy "bogus"/);
-    expect(() => parseSearchStrategies('broad,nope')).toThrow(/Valid strategies:/);
+    expect(() => parseSearchStrategies('broad,nope')).toThrow(
+      /Valid strategies: merged, orgs, starred, broad, maintained, all/,
+    );
   });
 });

--- a/packages/core/src/commands/search.ts
+++ b/packages/core/src/commands/search.ts
@@ -75,7 +75,9 @@ export function parseSearchStrategies(raw: string | undefined): SearchStrategy[]
   for (const token of tokens) {
     const parsed = SearchStrategySchema.safeParse(token);
     if (!parsed.success) {
-      throw new Error(`Unknown search strategy "${token}". Valid strategies: merged, starred, broad, maintained, all`);
+      throw new Error(
+        `Unknown search strategy "${token}". Valid strategies: merged, orgs, starred, broad, maintained, all`,
+      );
     }
     strategies.push(parsed.data);
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,8 +68,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@oss-scout/core':
-        specifier: ^1.5.2
-        version: 1.5.2(@octokit/core@7.0.6)
+        specifier: ^1.6.0
+        version: 1.6.0(@octokit/core@7.0.6)
       commander:
         specifier: ^15.0.0
         version: 15.0.0
@@ -711,8 +711,8 @@ packages:
   '@octokit/types@17.0.0':
     resolution: {integrity: sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==}
 
-  '@oss-scout/core@1.5.2':
-    resolution: {integrity: sha512-KrogL+wN5U4aCnvqexP8hc7PTbbpeVxuDTQ/sHcD4v5BlU0UdJh0wau3tZepgXybMvvC+VsK+K/fEUnPKCrwrg==}
+  '@oss-scout/core@1.6.0':
+    resolution: {integrity: sha512-O/69INlctKK52xrWSPRc1hxFfhCB4FapTq4z6E/14HEHcnYPjy3BfKugzlWeybPCCWxegVWDJr8AMVSHeYfujw==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
@@ -3415,7 +3415,7 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 28.0.0
 
-  '@oss-scout/core@1.5.2(@octokit/core@7.0.6)':
+  '@oss-scout/core@1.6.0(@octokit/core@7.0.6)':
     dependencies:
       '@octokit/plugin-retry': 8.1.1(@octokit/core@7.0.6)
       '@octokit/plugin-throttling': 11.0.5(@octokit/core@7.0.6)


### PR DESCRIPTION
## Problem

The `preferredOrgs` config key ("GitHub orgs to prioritize during discovery") has existed end to end in autopilot since it was introduced (state schema, config registry, setup command, formatter) but was never passed to oss-scout, and scout had no way to consume it. Setting it silently did nothing.

## Solution

oss-scout 1.6.0 added an `orgs` search phase that targets `preferredOrgs`. This PR closes the autopilot side of the gap:

- Bump `@oss-scout/core` to ^1.6.0.
- Pass `preferredOrgs: config.preferredOrgs ?? []` through `buildScoutState()` so the new phase actually receives the configured orgs.
- Update the two stale strategy lists (`parseSearchStrategies` error text, `--strategy` help) to include `orgs`; validation already accepts it via scout's schema.

## Testing

The existing scout-bridge test fixture already carried `preferredOrgs: ['microsoft','vercel']` unasserted; it now asserts the mapping (proven red before the fix). Added `parseSearchStrategies('orgs')` coverage and tightened the error-message test to the full list. Full suite 3074 passed, typecheck and eslint clean, esbuild bundle builds against 1.6.0.
