### PR TITLE
fix(hooks): skip rebase asks on the user's own repos when trustOwnRepoWrites is on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,11 @@ jobs:
       - name: Test guard-public-posts hook
         run: bash hooks/guard-public-posts.test.sh
 
+      - name: Test guard-git-operations hook
+        # Own-repo trust must skip rebase asks only when origin is provably
+        # owned by githubUsername, and never relax force-push / reset --hard.
+        run: bash hooks/guard-git-operations.test.sh
+
       - name: Test pre-tool-use dispatcher hook (#1449)
         # The dispatcher is the fan-out point for every PreToolUse Bash guard
         # (guard-public-posts, guard-git-operations, auto-format-before-push);

--- a/hooks/guard-git-operations.sh
+++ b/hooks/guard-git-operations.sh
@@ -20,6 +20,53 @@ if [ -z "$command" ]; then
   exit 0
 fi
 
+# --- Own-repo trust (opt-in, shares config with guard-public-posts.sh) -------
+# The rebase asks below exist so a contributor fetches before rewriting a PR
+# branch a maintainer may have pushed to. On a repo the user owns there is no
+# maintainer, so `config.trustOwnRepoWrites` skips them when the working repo's
+# `origin` belongs to `githubUsername`. Force pushes and `git reset --hard`
+# keep their guards regardless: they destroy history whoever owns the remote.
+state_file() {
+  local local_state="${HOME}/.oss-autopilot/state.json"
+  local gist_cache="${HOME}/.oss-autopilot/state-cache.json"
+  [ -f "$gist_cache" ] || { printf '%s' "$local_state"; return 0; }
+  [ -f "$local_state" ] || { printf '%s' "$gist_cache"; return 0; }
+  if [ "$gist_cache" -nt "$local_state" ]; then printf '%s' "$gist_cache"; else printf '%s' "$local_state"; fi
+}
+
+read_config() {
+  local key="$1" default="$2" file
+  file=$(state_file)
+  [ -f "$file" ] || { printf '%s' "$default"; return 0; }
+  jq -r --arg d "$default" ".config.${key} // \$d" "$file" 2>/dev/null || printf '%s' "$default"
+}
+
+# Directory the git command runs in: a leading `cd <dir> &&` wins (the hook's
+# cwd is the session's, not the subshell's), then `git -C <dir>`, then cwd.
+git_workdir() {
+  local cmd="$1" cwd="$2" dir
+  dir=$(printf '%s' "$cmd" | grep -oE '^[[:space:]]*cd[[:space:]]+[^[:space:];&|]+' | awk '{print $2}')
+  [ -n "$dir" ] || dir=$(printf '%s' "$cmd" | grep -oE 'git[[:space:]]+-C[[:space:]]+[^[:space:];&|]+' | head -1 | awk '{print $3}')
+  [ -n "$dir" ] || dir="$cwd"
+  printf '%s' "${dir/#\~/$HOME}"
+}
+
+# True when `origin` of the working repo is owned by the trusted user.
+# Anything unresolvable (no owner, no repo, non-GitHub remote) fails closed.
+own_repo() {
+  local owner dir url
+  [ "$(read_config trustOwnRepoWrites false)" = "true" ] || return 1
+  owner=$(read_config githubUsername "")
+  [ -n "$owner" ] || return 1
+  dir=$(git_workdir "$command" "$(echo "$input" | jq -r '.cwd // empty')")
+  [ -d "$dir" ] || return 1
+  url=$(git -C "$dir" remote get-url origin 2>/dev/null) || return 1
+  case "$url" in
+    https://github.com/"$owner"/*|git@github.com:"$owner"/*|ssh://git@github.com/"$owner"/*) return 0 ;;
+  esac
+  return 1
+}
+
 # Block `git push --force` (without --force-with-lease)
 # Match --force or -f but NOT --force-with-lease
 if echo "$command" | grep -qE 'git\s+push\b' && echo "$command" | grep -qE '(\s--force\b|\s-f\b)' && ! echo "$command" | grep -qE '\s--force-with-lease'; then
@@ -35,8 +82,8 @@ EOF
   exit 0
 fi
 
-# Warn before rebase: remind to fetch first
-if echo "$command" | grep -qE 'git\s+rebase\b'; then
+# Warn before rebase: remind to fetch first (skipped on the user's own repos)
+if echo "$command" | grep -qE 'git\s+rebase\b' && ! own_repo; then
   cat <<'EOF'
 {
   "hookSpecificOutput": {
@@ -52,7 +99,7 @@ fi
 # Warn before `git pull --rebase` (#1259) — same risk profile as `git rebase`.
 # `git\s+rebase\b` above doesn't match the `pull --rebase` form because the
 # verb is "pull". Local commits silently rebased over remote changes here too.
-if echo "$command" | grep -qE 'git\s+pull\b' && echo "$command" | grep -qE '(\s--rebase\b|\s-r\b)'; then
+if echo "$command" | grep -qE 'git\s+pull\b' && echo "$command" | grep -qE '(\s--rebase\b|\s-r\b)' && ! own_repo; then
   cat <<'EOF'
 {
   "hookSpecificOutput": {

--- a/hooks/guard-git-operations.test.sh
+++ b/hooks/guard-git-operations.test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Tests for guard-git-operations.sh own-repo trust: rebase asks are skipped on
+# repos owned by config.githubUsername when trustOwnRepoWrites is on; force
+# push / reset --hard keep asking; every unresolvable case fails closed.
+#
+# Run with: bash hooks/guard-git-operations.test.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+SUBJECT="${SCRIPT_DIR}/guard-git-operations.sh"
+
+FAIL=0
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+export HOME="$TMP/home"
+mkdir -p "$HOME/.oss-autopilot"
+printf '{"config":{"trustOwnRepoWrites":true,"githubUsername":"alice"}}' > "$HOME/.oss-autopilot/state.json"
+
+mkrepo() { # name url
+    git init -q "$TMP/$1" && git -C "$TMP/$1" remote add origin "$2"
+}
+mkrepo own https://github.com/alice/thing.git
+mkrepo own-ssh git@github.com:alice/thing.git
+mkrepo other https://github.com/bob/thing.git
+mkrepo prefix https://github.com/alicealt/thing.git
+
+decision() { # cwd command
+    local out
+    out=$(printf '{"tool_name":"Bash","cwd":"%s","tool_input":{"command":"%s"}}' "$1" "$2" | bash "$SUBJECT")
+    [ -n "$out" ] || { echo pass; return; }
+    printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecision // "pass"'
+}
+
+check() { # label expected cwd command
+    local got
+    got=$(decision "$3" "$4")
+    if [ "$got" = "$2" ]; then
+        echo "  PASS: $1"
+    else
+        echo "  FAIL: $1 (expected $2, got $got)"
+        FAIL=1
+    fi
+}
+
+check "own repo rebase passes"                 pass "$TMP/own"     "git rebase main"
+check "own repo (ssh remote) rebase passes"    pass "$TMP/own-ssh" "git rebase main"
+check "own repo pull --rebase passes"          pass "$TMP/own"     "git pull --rebase"
+check "own repo via leading cd passes"         pass "$TMP"         "cd $TMP/own && git rebase --continue"
+check "own repo via git -C passes"             pass "$TMP"         "git -C $TMP/own rebase main"
+check "own repo reset --hard still asks"       ask  "$TMP/own"     "git reset --hard HEAD"
+check "own repo force-with-lease still asks"   ask  "$TMP/own"     "git push --force-with-lease"
+check "own repo bare force push still denied"  deny "$TMP/own"     "git push --force"
+check "other owner rebase asks"                ask  "$TMP/other"   "git rebase main"
+check "owner prefix collision asks"            ask  "$TMP/prefix"  "git rebase main"
+check "no git repo asks"                       ask  "$TMP"         "git rebase main"
+check "missing cd target asks"                 ask  "$TMP"         "cd $TMP/nope && git rebase main"
+
+printf '{"config":{"trustOwnRepoWrites":false,"githubUsername":"alice"}}' > "$HOME/.oss-autopilot/state.json"
+check "feature off asks on own repo"           ask  "$TMP/own"     "git rebase main"
+
+printf '{"config":{"trustOwnRepoWrites":true}}' > "$HOME/.oss-autopilot/state.json"
+check "no username asks on own repo"           ask  "$TMP/own"     "git rebase main"
+
+exit $FAIL


### PR DESCRIPTION
guard-git-operations.sh asked before every git rebase / pull --rebase, including on repos the user owns where there is no maintainer whose commits a fetch would surface. This reuses the existing trustOwnRepoWrites + githubUsername config and skips those two asks when the working repo's origin (leading cd, git -C, or hook cwd) is provably owned by that user. Force pushes and git reset --hard keep their guards.

Fails closed: feature off, no username, no repo, non-GitHub or other-owner remote, owner-prefix collision (alicealt vs alice) all still ask.

Adds hooks/guard-git-operations.test.sh (14 cases) and a CI step.