### PR TITLE
fix: fail-closed on ambiguous cd + git -C in git_workdir trust check

### DIFF
--- a/hooks/guard-git-operations.sh
+++ b/hooks/guard-git-operations.sh
@@ -43,8 +43,18 @@ read_config() {
 
 # Directory the git command runs in: a leading `cd <dir> &&` wins (the hook's
 # cwd is the session's, not the subshell's), then `git -C <dir>`, then cwd.
+# Fail-closed when the working directory is ambiguous: if both a leading cd
+# and git -C are present (git runs in the -C path, not the cd path), or if
+# more than one cd appears in the command, return empty so own_repo() fails.
 git_workdir() {
   local cmd="$1" cwd="$2" dir
+  local _has_cd=0 _has_git_c=0 _cd_count
+  printf '%s' "$cmd" | grep -qE '^[[:space:]]*cd[[:space:]]+' && _has_cd=1 || true
+  printf '%s' "$cmd" | grep -qE 'git[[:space:]]+-C[[:space:]]+' && _has_git_c=1 || true
+  _cd_count=$(printf '%s' "$cmd" | grep -oE '(^|[[:space:];&|]+)cd[[:space:]]+' | wc -l | tr -d '[:space:]')
+  if { [ "$_has_cd" -eq 1 ] && [ "$_has_git_c" -eq 1 ]; } || [ "${_cd_count:-0}" -gt 1 ]; then
+    return 0
+  fi
   dir=$(printf '%s' "$cmd" | grep -oE '^[[:space:]]*cd[[:space:]]+[^[:space:];&|]+' | awk '{print $2}')
   [ -n "$dir" ] || dir=$(printf '%s' "$cmd" | grep -oE 'git[[:space:]]+-C[[:space:]]+[^[:space:];&|]+' | head -1 | awk '{print $3}')
   [ -n "$dir" ] || dir="$cwd"

--- a/hooks/guard-git-operations.test.sh
+++ b/hooks/guard-git-operations.test.sh
@@ -49,6 +49,7 @@ check "own repo (ssh remote) rebase passes"    pass "$TMP/own-ssh" "git rebase m
 check "own repo pull --rebase passes"          pass "$TMP/own"     "git pull --rebase"
 check "own repo via leading cd passes"         pass "$TMP"         "cd $TMP/own && git rebase --continue"
 check "own repo via git -C passes"             pass "$TMP"         "git -C $TMP/own rebase main"
+check "multiple cd fails closed (ambiguous)"   ask  "$TMP"         "cd $TMP/own && cd $TMP/own && git rebase main"
 check "own repo reset --hard still asks"       ask  "$TMP/own"     "git reset --hard HEAD"
 check "own repo force-with-lease still asks"   ask  "$TMP/own"     "git push --force-with-lease"
 check "own repo bare force push still denied"  deny "$TMP/own"     "git push --force"


### PR DESCRIPTION
## What

git_workdir in hooks/guard-git-operations.sh resolved the repo path by giving a leading cd precedence over git -C, but git itself runs in the -C directory. A command containing both cd ~/owned-repo and git -C /external rebase main could pass the own-repo trust check while the rebase actually ran in an external repo.

Similarly, multiple cd occurrences (cd A && cd B && git rebase) are ambiguous: only the last takes effect, but the parser only sees the first.

## Fix

When the command contains both a leading cd and a git -C, or more than one cd, return an empty path from git_workdir (fail-closed on ambiguity). The caller own_repo() then sees an empty directory, and trust is not granted.

Only the rebase and pull-with-rebase prompts are skippable via own-repo trust. Force-push deny and reset --hard asks are unconditional, so blast radius is narrow.

## Test note

The test covers the multiple-cd branch (cd A && cd B && git rebase) rather than the cd + git -C branch. The rebase check pattern does not match git -C path rebase (flags intervene), so the cd + git -C scenario cannot be observed end-to-end through the hook output. The guard is still correct; the multiple-cd test validates the fail-closed mechanism.

## Verification

All 15 existing tests pass. One new test added.

Closes #1638