### PR TITLE
docs: drop the last references to the removed session-start hook

### DIFF
--- a/.claude-plugin/expected-cli-contract.json
+++ b/.claude-plugin/expected-cli-contract.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Plugin → CLI contract (#1190). The markdown command/agent/skill layer expects the CLI to register every command listed below, and expects every workflow file referenced from commands/*.md to exist on disk. The session-start hook verifies this and prints a single warning on drift. Tests in cli-registry.docs.test.ts pin both lists at CI time so contract changes can never ship silently.",
+  "_comment": "Plugin → CLI contract (#1190). The markdown command/agent/skill layer expects the CLI to register every command listed below, and expects every workflow file referenced from commands/*.md to exist on disk. Tests in cli-registry.docs.test.ts pin both lists at CI time so contract changes can never ship silently.",
   "schemaVersion": 1,
   "expectedCommands": [
     "checkSetup",

--- a/.claude/hooks/no-commit-on-main.test.sh
+++ b/.claude/hooks/no-commit-on-main.test.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 # Test harness for no-commit-on-main.sh's git-target-dir resolution.
 #
-# `.claude/hooks/` is a local, gitignored-settings hook (not wired into CI
-# like the top-level `hooks/*.test.sh` files — see `.claude/settings.json`,
-# which is gitignored). Run manually via:
+# `.claude/hooks/` is a local, gitignored-settings hook (not wired into CI —
+# see `.claude/settings.json`, which is gitignored). Run manually via:
 #   bash .claude/hooks/no-commit-on-main.test.sh
 # Exits 0 on success, 1 on first failure.
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,9 +13,8 @@
 /.github/ @costajohnt
 /workflows/ @costajohnt
 
-# Plugin manifest and hooks
+# Plugin manifest
 /.claude-plugin/ @costajohnt
-/hooks/ @costajohnt
 
 # Documentation
 /docs/ @costajohnt

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -144,7 +144,7 @@ Debug and warning output goes to stderr via the logger, so it never contaminates
 esbuild src/cli.ts --bundle --platform=node --target=node22 --format=cjs --outfile=dist/cli.bundle.cjs  # run from packages/core/
 ```
 
-The bundle is a single CommonJS file (gitignored, auto-generated). The `SessionStart` hook rebuilds it if `package.json` is newer than the bundle.
+The bundle is a single CommonJS file (gitignored, auto-generated). Commands rebuild it on demand via `scripts/build-cli-if-stale.sh` when the sources or `package.json` are newer than the bundle.
 
 ## Core Domain Layer (`packages/core/src/core/`)
 

--- a/commands/oss-help.md
+++ b/commands/oss-help.md
@@ -67,6 +67,3 @@ Settings are stored in `~/.oss-autopilot/state.json`. Run `/setup-oss` to reconf
 
 Key settings: GitHub username, max active PRs, dormant threshold, preferred languages, issue labels, squash preference.
 
-### Session Start Health Check
-
-On every session start, the plugin shows a one-liner PR status summary (e.g., "OSS: 15 active PRs — 3 need addressing, 12 waiting on maintainer (2h ago)"). This reads cached state from your last `/oss` run — no network calls.

--- a/packages/core/src/cli-registry.docs.test.ts
+++ b/packages/core/src/cli-registry.docs.test.ts
@@ -69,7 +69,7 @@ describe('cli-registry ↔ .claude-plugin/expected-cli-contract.json parity (#11
     expect(
       unlisted,
       `New CLI commands not yet pinned in the plugin contract: ${unlisted.join(', ')}. ` +
-        `Add them to .claude-plugin/expected-cli-contract.json so plugin/markdown drift is caught at session start.`,
+        `Add them to .claude-plugin/expected-cli-contract.json so plugin/markdown drift is caught here at CI time.`,
     ).toEqual([]);
   });
 

--- a/packages/core/src/cli-registry.ts
+++ b/packages/core/src/cli-registry.ts
@@ -120,10 +120,10 @@ function printRepos(repos: Record<string, { path: string; currentBranch: string 
 
 export const commands: CLICommandDef[] = [
   // ── Manifest (#1190) ───────────────────────────────────────────────────
-  // Lets the plugin's session-start hook verify CLI/plugin contract drift —
-  // it diffs the registered commands against `.claude-plugin/expected-cli-contract.json`
-  // and warns when the markdown layer references commands the CLI no longer
-  // exposes. Local-only: no GitHub access needed.
+  // Exposes the registered commands for CLI/plugin contract checks —
+  // cli-registry.docs.test.ts diffs them against `.claude-plugin/expected-cli-contract.json`
+  // at CI time and fails when the markdown layer references commands the CLI no
+  // longer exposes. Local-only: no GitHub access needed.
   {
     name: 'manifest',
     localOnly: true,

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -800,8 +800,8 @@ export const InitOutputSchema = z.object({
 
 // ── #1190: plugin → CLI contract ─────────────────────────────────────
 //
-// Pinned shape lets the plugin's session-start hook verify that the bundled
-// CLI exposes the subcommands the markdown layer expects. Bumping
+// Pinned shape, checked by cli-registry.docs.test.ts at CI time, so the bundled
+// CLI keeps exposing the subcommands the markdown layer expects. Bumping
 // `schemaVersion` is a breaking change to that contract.
 export const ManifestOutputSchema = z.object({
   schemaVersion: z.literal(1),


### PR DESCRIPTION
#1642 deleted `hooks/` and the health-check script, but a few places still described them:

- `commands/oss-help.md`: the "Session Start Health Check" section (nothing emits that one-liner now)
- `ARCHITECTURE.md`: credited a SessionStart hook with rebuilding the bundle; commands do it on demand via `scripts/build-cli-if-stale.sh`
- `.github/CODEOWNERS`: owned `/hooks/`, which no longer exists
- four comments (json.ts, cli-registry.ts, expected-cli-contract.json, cli-registry.docs.test.ts) saying the session-start hook verifies the CLI contract; the contract is pinned by `cli-registry.docs.test.ts` at CI time
- `.claude/hooks/no-commit-on-main.test.sh`: compared itself to the deleted top-level `hooks/*.test.sh`

Text only. `pnpm format:check` clean, core suite 3102 passed. Dead config keys are tracked separately in #1643.

Filed by repo-autopilot on 2026-08-30.