### PR TITLE
docs: mark three config keys as no-ops after #1642 removed their consumers

### DIFF
--- a/packages/core/src/core/config-registry.ts
+++ b/packages/core/src/core/config-registry.ts
@@ -251,21 +251,21 @@ export const CONFIG_KEY_REGISTRY: readonly ConfigKeyDef[] = [
   {
     key: 'autoFormatBeforePush',
     description:
-      'Opt-in: run the project formatter and append a `style:` commit before every `git push`. Off by default because formatting commits surprise OSS maintainers; the hook also skips automatically when the branch tracks a fork upstream.',
+      'No effect. The hook that used this setting was removed in #1642; the key is kept in the schema for state-file compatibility.',
     settableVia: 'setup',
     valueHint: 'true|false',
   },
   {
     key: 'trustOwnRepoWrites',
     description:
-      'Opt-in: skip the guard-public-posts approval prompt for GitHub writes (PR merge, issue close, comments) targeting repos owned by your own githubUsername. Off by default. Writes to any other owner, to a fork whose parent belongs to someone else, or from a chained command still ask.',
+      'No effect. The hook that used this setting was removed in #1642; the key is kept in the schema for state-file compatibility.',
     settableVia: 'setup',
     valueHint: 'true|false',
   },
   {
     key: 'healthCheckFreshnessMinutes',
     description:
-      'Suppress the SessionStart PR health one-liner when the cached digest is older than this many minutes. The line silently disappears between /oss runs, so what remains is always current. Defaults to 30 minutes (#1255).',
+      'No effect. The hook that used this setting was removed in #1642; the key is kept in the schema for state-file compatibility.',
     settableVia: 'setup',
     valueHint: 'positive integer',
   },

--- a/packages/core/src/core/state-schema.ts
+++ b/packages/core/src/core/state-schema.ts
@@ -292,27 +292,20 @@ export const AgentConfigSchema = z.object({
   diffToolCustomCommand: z.string().optional(),
 
   /**
-   * Opt-in gate for the auto-format-before-push hook (#1045). Default false:
-   * the hook does nothing on every push unless the user explicitly enables it.
+   * No effect since the hook was removed in #1642; kept for state-file
+   * compatibility.
    */
   autoFormatBeforePush: z.boolean().default(false),
 
   /**
-   * Opt-in gate for own-repo writes in the guard-public-posts hook. Default
-   * false: every GitHub-mutating command asks for approval. When true, writes
-   * whose target repo is owned by `githubUsername` skip the ask; anything the
-   * hook cannot prove is own-repo (forks, other owners, chained commands)
-   * still asks.
+   * No effect since the hook was removed in #1642; kept for state-file
+   * compatibility.
    */
   trustOwnRepoWrites: z.boolean().default(false),
 
   /**
-   * Threshold (in minutes) for the SessionStart PR health one-liner (#1255).
-   * The cached digest only refreshes when the user runs `/oss`; SessionStart
-   * fires every session. Without a freshness gate the line drifts arbitrarily
-   * stale between runs. When the cache is older than this many minutes (and
-   * not yet 7 days old, which keeps the existing catch-up nudge), the line is
-   * suppressed entirely. Default 30 minutes.
+   * No effect since the hook was removed in #1642; kept for state-file
+   * compatibility.
    */
   healthCheckFreshnessMinutes: z.number().int().positive().default(30),
 


### PR DESCRIPTION
autoFormatBeforePush and trustOwnRepoWrites had their hook consumers removed in #1642. healthCheckFreshnessMinutes had its only consumer (scripts/health-check.cjs) removed in the same wave. All three keys are kept in the schema for state-file compatibility, but their descriptions in config-registry.ts and JSDoc in state-schema.ts still advertised their original behavior. A user who sets any of these values gets silently no-op'd.

This updates all three descriptions and JSDoc blocks to say "No effect. The hook that used this setting was removed in #1642; the key is kept in the schema for state-file compatibility."

No behavior change, no migration, no test changes needed.

Closes #1643