### PR TITLE
fix(deps): override fast-uri, qs, and nanoid to patched versions

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1748,8 +1748,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2253,8 +2253,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2362,6 +2362,10 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.7:
+    resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
+    engines: {node: '>=12'}
+
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
@@ -2422,8 +2426,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.15.3:
-    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   quote-js-string@0.1.0:
@@ -3915,7 +3919,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3972,7 +3976,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       on-finished: 2.4.1
-      qs: 6.15.3
+      qs: 6.16.0
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -4477,7 +4481,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.3
+      qs: 6.16.0
       range-parser: 1.3.0
       router: 2.2.0
       send: 1.2.1
@@ -4496,7 +4500,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -4950,7 +4954,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -5042,6 +5046,9 @@ snapshots:
 
   picomatch@4.0.5: {}
 
+  picomatch@4.0.7:
+    optional: true
+
   pkce-challenge@5.0.1: {}
 
   pluralize@8.0.0: {}
@@ -5050,7 +5057,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -5086,7 +5093,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.15.3:
+  qs@6.16.0:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1
@@ -5381,7 +5388,7 @@ snapshots:
 
   ts-declaration-location@1.0.7(typescript@6.0.3):
     dependencies:
-      picomatch: 4.0.5
+      picomatch: 4.0.7
       typescript: 6.0.3
     optional: true
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,12 +33,18 @@ overrides:
   # Dev-only, transitive via vitest -> vite. Code-execution advisory.
   yaml: '>=2.8.3'
   # Transitive via @modelcontextprotocol/sdk -> ajv. Path-traversal advisory
-  # GHSA-q3j6-qgpj-74h6.
-  fast-uri: '>=3.1.1'
+  # GHSA-q3j6-qgpj-74h6, plus later advisories patched in 3.1.6.
+  fast-uri: '>=3.1.6'
+  # Transitive via @modelcontextprotocol/sdk -> express/body-parser.
+  # Advisory affects >=6.14.2 <=6.15.3; patched in 6.16.0.
+  qs: '>=6.16.0'
   # Dev-only, transitive via @oss-autopilot/dashboard -> jsdom -> undici.
   # Clears the high TLS-validation / WebSocket-DoS / SOCKS5 advisories in
   # undici <7.28.0 (GHSA-vmh5-mc38-953g, GHSA-vxpw-j846-p89q, GHSA-vh2q-...).
   undici: '>=7.28.0'
+  # Dev-only, transitive via vite -> postcss. Advisory: custom generators
+  # can loop indefinitely when size is zero; patched in 3.3.18.
+  nanoid: '>=3.3.18'
   # Dev-only, transitive via @oss-autopilot/core -> typedoc -> markdown-it.
   # Quadratic-complexity ReDoS advisory GHSA-22p9-wv53-3rq4 in linkify-it
   # <=5.0.0; patched in 5.0.1.


### PR DESCRIPTION
## Summary

Clears the 5 open Dependabot alerts (fast-uri HIGH x4, qs MEDIUM) plus a new pnpm-audit HIGH finding (nanoid). Dependabot's own security update failed with security_update_not_possible for fast-uri, so this pins the patched versions via the pnpm workspace overrides instead.

## Changes

- pnpm-workspace.yaml: bump fast-uri override floor >=3.1.1 -> >=3.1.6; add qs >=6.16.0 and nanoid >=3.3.18 overrides
- pnpm-lock.yaml: re-resolved via pnpm update -r; fast-uri 3.1.5 -> 3.1.7, qs 6.15.3 -> 6.16.0, nanoid 3.3.17 -> 3.3.18, plus an incidental picomatch 4.0.5 -> 4.0.7 patch bump within its existing override range

## Vulnerable paths

- fast-uri: @modelcontextprotocol/sdk -> ajv@8.20.0 -> fast-uri (runtime)
- qs: @modelcontextprotocol/sdk -> express/body-parser -> qs (runtime)
- nanoid: vite -> postcss -> nanoid (dev-only)

## Verification (local)

- pnpm install --frozen-lockfile: clean
- pnpm audit --audit-level=high: "No known vulnerabilities found"
- core tests: 3080 passed, mcp tests: 243 passed
- lint: 0 errors; format:check: clean; typecheck: clean
- dashboard tests: 62 failures, identical to the failures on main at e907eef (pre-existing localStorage/jsdom issue, unrelated to this change)

Filed by repo-autopilot on 2026-09-05.