### PR TITLE
chore(ci): raise BUNDLE_MAX_CORE to 1100000 for zod 4.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ env:
   #   - **Don't bump for a flaky measurement:** esbuild output is
   #     deterministic. If the threshold trips on a no-op rebuild, it's a
   #     real increase somewhere upstream — not noise.
-  BUNDLE_MAX_CORE: 920000 # ~898 KB (increased for the June-12 audit batch: per-call MCP state reload, envelope warning fields, outcome-ledger plumbing; current ~859 KB)
+  BUNDLE_MAX_CORE: 1100000 # ~1074 KB (raised for zod 4.4.3 -> 4.5.4, which grew its in-bundle share 330 -> 437 KB: JIT compile, json-schema processors, locales; current ~998 KB)
   BUNDLE_MAX_MCP: 2000000 # ~1953 KB
   STARTUP_WARN_MS: 500 # Warn if CLI startup exceeds 500ms
 


### PR DESCRIPTION
Unblocks #1646 (zod 4.4.3 -> 4.5.4). Measured locally with an esbuild metafile: zod's in-bundle share goes 330 KB -> 437 KB, core bundle 894 KB -> 998 KB, one zod copy. Threshold 920000 -> 1100000.