### PR TITLE
fix(parse-list): let pruneIssueList remove top-level PR-URL entries again

### DIFF
--- a/packages/core/src/commands/parse-list.test.ts
+++ b/packages/core/src/commands/parse-list.test.ts
@@ -475,6 +475,23 @@ describe('parseIssueList — decorated status keyword matching', () => {
   });
 });
 
+describe('pruneIssueList — top-level PR-URL entries (#1637)', () => {
+  it('prunes a PR entry whose sub-bullet says MERGED, and its sub-bullets', () => {
+    const content = `## Open PRs
+- https://github.com/owner/repo/pull/42 My PR
+  - **Merged** 2026-08-01
+- https://github.com/owner/repo/pull/43 Still open
+  - waiting on review
+`;
+    const { pruned, removedCount } = pruneIssueList(content);
+    expect(removedCount).toBe(1);
+    expect(pruned).not.toContain('pull/42');
+    expect(pruned).not.toContain('2026-08-01');
+    expect(pruned).toContain('pull/43');
+    expect(pruned).toContain('waiting on review');
+  });
+});
+
 describe('pruneIssueList — decorated status keywords', () => {
   it('does NOT delete decorated "**Hold — ...**" items', () => {
     const content = `### Repo

--- a/packages/core/src/commands/parse-list.ts
+++ b/packages/core/src/commands/parse-list.ts
@@ -324,8 +324,10 @@ export function pruneIssueList(content: string, minScore: number = 6): { pruned:
       continue;
     }
 
-    const ghUrl = extractGitHubUrl(line);
-    if (ghUrl) {
+    // Prune looks at issue AND PR entries: a curator's PR line with a MERGED
+    // sub-bullet must still be removable even though extractGitHubUrl (Guard 1)
+    // refuses PR URLs as issue candidates (#1637).
+    if (/https:\/\/github\.com\/[^/]+\/[^/]+\/(?:issues|pull)\/\d+/.test(line)) {
       // Look ahead at sub-bullets for terminal status or low score
       let shouldRemove = false;
       let j = i + 1;


### PR DESCRIPTION
Closes #1637

The prune lookahead in pruneIssueList used extractGitHubUrl, which since #1632 (Guard 1) returns null for /pull/ URLs. That silently stopped pruning top-level PR entries with MERGED sub-bullets. The loop only uses the URL as a boolean, so it now has its own issues-or-pull matcher. Regression test added.