### PR TITLE
fix(search): checkpoint the Gist after recording the search seen-set

### DIFF
--- a/packages/core/src/commands/search.contract.test.ts
+++ b/packages/core/src/commands/search.contract.test.ts
@@ -40,6 +40,8 @@ vi.mock('../core/index.js', async () => {
       getState: () => ({ mergedPRs: [], closedPRs: [], repoScores: {}, lastDigest: null }),
       getSearchSeen: () => [],
       setSearchSeen: () => {},
+      // Local-file mode: maybeCheckpoint (#1629) no-ops, golden shape unchanged.
+      isGistMode: () => false,
     }),
   };
 });

--- a/packages/core/src/commands/search.test.ts
+++ b/packages/core/src/commands/search.test.ts
@@ -21,6 +21,7 @@ vi.mock('../core/index.js', async () => {
   return {
     ...actual,
     getStateManager: vi.fn(),
+    maybeCheckpoint: vi.fn().mockResolvedValue(null),
   };
 });
 
@@ -31,11 +32,12 @@ vi.mock('../core/starred-repos.js', () => ({
   refreshStarredReposIfStale: vi.fn().mockResolvedValue(0),
 }));
 
-import { getStateManager } from '../core/index.js';
+import { getStateManager, maybeCheckpoint } from '../core/index.js';
 import { createAutopilotScout, type ScoutBridgeDiagnostics } from './scout-bridge.js';
 import { runSearch, recordSearchSeen, parseSearchStrategies, SEARCH_SEEN_RETENTION_DAYS } from './search.js';
 
 const mockGetStateManager = vi.mocked(getStateManager);
+const mockMaybeCheckpoint = vi.mocked(maybeCheckpoint);
 
 describe('runSearch', () => {
   beforeEach(() => {
@@ -51,6 +53,37 @@ describe('runSearch', () => {
       getSearchSeen: vi.fn().mockReturnValue([]),
       setSearchSeen: vi.fn(),
     } as any);
+  });
+
+  it('checkpoints the Gist after recording the seen-set and surfaces a failed push (#1629)', async () => {
+    mockMaybeCheckpoint.mockResolvedValueOnce('Gist checkpoint push failed');
+    mockSearch.mockResolvedValue({
+      candidates: [],
+      excludedRepos: [],
+      aiPolicyBlocklist: [],
+      strategiesUsed: ['broad'],
+    });
+
+    const out = await runSearch({ maxResults: 5 });
+
+    const sm = mockGetStateManager.mock.results[0].value;
+    expect(mockMaybeCheckpoint).toHaveBeenCalledWith(sm, 'search');
+    expect(sm.setSearchSeen.mock.invocationCallOrder[0]).toBeLessThan(mockMaybeCheckpoint.mock.invocationCallOrder[0]);
+    expect(out.gistSyncWarning).toBe('Gist checkpoint push failed');
+  });
+
+  it('omits gistSyncWarning when the checkpoint succeeds (#1629)', async () => {
+    mockSearch.mockResolvedValue({
+      candidates: [],
+      excludedRepos: [],
+      aiPolicyBlocklist: [],
+      strategiesUsed: ['broad'],
+    });
+
+    const out = await runSearch({ maxResults: 5 });
+
+    expect(mockMaybeCheckpoint).toHaveBeenCalledTimes(1);
+    expect(out).not.toHaveProperty('gistSyncWarning');
   });
 
   it('passes the diversity counterweight ratio to scout (#1244)', async () => {

--- a/packages/core/src/commands/search.ts
+++ b/packages/core/src/commands/search.ts
@@ -11,7 +11,7 @@ import {
   type ScoutBridgeDiagnostics,
 } from './scout-bridge.js';
 import { SearchStrategySchema, type SearchStrategy } from '@oss-scout/core';
-import { classifyLinkedPR, getStateManager } from '../core/index.js';
+import { classifyLinkedPR, getStateManager, maybeCheckpoint } from '../core/index.js';
 import { type SearchOutput } from '../formatters/json.js';
 import { gradeFromCandidate } from '../core/issue-grading.js';
 import { computeStrategy } from '../core/strategy.js';
@@ -232,6 +232,10 @@ export async function runSearch(options: SearchOptions): Promise<SearchOutput> {
     stateManager,
     result.candidates.map((c) => c.issue.url),
   );
+  // In Gist mode setSearchSeen only writes the local cache; without a
+  // checkpoint the seen-set never reaches the Gist and the next startup's
+  // Gist refetch overwrites the cache with the empty remote copy (#1629).
+  const gistSyncWarning = await maybeCheckpoint(stateManager, MODULE);
 
   // #1354: never surface issues the user already has an open PR for. Uses
   // scout's structured linked-PR metadata when present; candidates without it
@@ -321,6 +325,9 @@ export async function runSearch(options: SearchOptions): Promise<SearchOutput> {
     aiPolicyBlocklist: result.aiPolicyBlocklist,
     hiddenOwnPRCount,
   };
+  if (gistSyncWarning) {
+    searchOutput.gistSyncWarning = gistSyncWarning;
+  }
   if (result.rateLimitWarning) {
     searchOutput.rateLimitWarning = result.rateLimitWarning;
   }

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -1164,6 +1164,9 @@ export interface SearchOutput {
   /** Candidates dropped because the authenticated user already has an open PR
    * linked to the issue (#1354). Surfaced as a count so the filter is visible. */
   hiddenOwnPRCount: number;
+  /** Set when the seen-set write could not be pushed to the Gist (#1629);
+   * the local cache has it but the next startup's Gist refetch will drop it. */
+  gistSyncWarning?: string;
   /** Present when rate limits affected the search — either low pre-flight quota or mid-search rate limit hits (#100). */
   rateLimitWarning?: string;
   /**


### PR DESCRIPTION
Closes #1629

Root cause: in Gist mode, setSearchSeen's autoSave only writes state-cache.json; the Gist is written by checkpoint(). runSearch never checkpointed, so the seen-set never reached the Gist and startup's Gist refetch overwrote the cache with the empty remote copy. The issue's hypothesis (local state.json migration pushing defaults) is wrong: with a gist-id file present, bootstrapWithMigration fetches the Gist rather than migrating.

Fix: runSearch calls maybeCheckpoint after recordSearchSeen (same pattern as claim/comments/init) and threads a failed push into the output as gistSyncWarning. Tests: order assertion (setSearchSeen before checkpoint), warning surfaced, warning absent on success; contract-test stub gained isGistMode.