### PR TITLE
fix(search): persist scout's broad-phase language rotation cursor

### DIFF
--- a/packages/core/src/commands/scout-bridge.ts
+++ b/packages/core/src/commands/scout-bridge.ts
@@ -222,15 +222,12 @@ export function buildScoutState(diagnostics?: ScoutBridgeDiagnostics): ScoutStat
     })),
     skippedIssues: skippedIssuesLoad.issues,
     lastRunAt: state.lastRunAt,
-    // Scout 1.4.0 added `searchRotation` (persisted language-rotation cursor
-    // for the broad phase) as a required field on the inferred ScoutState type
-    // — its ZodDefault still applies at parse time, but a hand-built literal
-    // like this one must supply it. Autopilot runs scout in
-    // persistence:'provided' and synthesizes a fresh ScoutState per operation,
-    // so there is no durable cursor to carry across runs; scout's documented
-    // default (offset 0) is correct here, same as the ScoutPreferences
-    // defaults above.
-    searchRotation: { languageOffset: 0 },
+    // Broad-phase language rotation cursor (#1630). Scout advances it in its
+    // own state after a search whose broad phase ran; under
+    // persistence:'provided' that write is discarded with the process, so
+    // search.ts copies it back into AgentState and it is fed in from there.
+    // Scout's documented default (offset 0) applies until the first search.
+    searchRotation: state.searchRotation ?? { languageOffset: 0 },
   };
 }
 

--- a/packages/core/src/commands/search.contract.test.ts
+++ b/packages/core/src/commands/search.contract.test.ts
@@ -40,6 +40,8 @@ vi.mock('../core/index.js', async () => {
       getState: () => ({ mergedPRs: [], closedPRs: [], repoScores: {}, lastDigest: null }),
       getSearchSeen: () => [],
       setSearchSeen: () => {},
+      // Local-file mode: maybeCheckpoint (#1629) no-ops, golden shape unchanged.
+      isGistMode: () => false,
     }),
   };
 });

--- a/packages/core/src/commands/search.contract.test.ts
+++ b/packages/core/src/commands/search.contract.test.ts
@@ -24,7 +24,10 @@ vi.mock('./scout-bridge.js', async () => {
   const actual = await vi.importActual<typeof import('./scout-bridge.js')>('./scout-bridge.js');
   return {
     ...actual,
-    createAutopilotScout: vi.fn(async () => ({ search: mocks.search })),
+    createAutopilotScout: vi.fn(async () => ({
+      search: mocks.search,
+      getState: () => ({ searchRotation: { languageOffset: 0 } }),
+    })),
   };
 });
 
@@ -40,6 +43,7 @@ vi.mock('../core/index.js', async () => {
       getState: () => ({ mergedPRs: [], closedPRs: [], repoScores: {}, lastDigest: null }),
       getSearchSeen: () => [],
       setSearchSeen: () => {},
+      setSearchRotation: () => {},
       // Local-file mode: maybeCheckpoint (#1629) no-ops, golden shape unchanged.
       isGistMode: () => false,
     }),

--- a/packages/core/src/commands/search.test.ts
+++ b/packages/core/src/commands/search.test.ts
@@ -21,6 +21,7 @@ vi.mock('../core/index.js', async () => {
   return {
     ...actual,
     getStateManager: vi.fn(),
+    maybeCheckpoint: vi.fn().mockResolvedValue(null),
   };
 });
 
@@ -31,11 +32,12 @@ vi.mock('../core/starred-repos.js', () => ({
   refreshStarredReposIfStale: vi.fn().mockResolvedValue(0),
 }));
 
-import { getStateManager } from '../core/index.js';
+import { getStateManager, maybeCheckpoint } from '../core/index.js';
 import { createAutopilotScout, type ScoutBridgeDiagnostics } from './scout-bridge.js';
 import { runSearch, recordSearchSeen, parseSearchStrategies, SEARCH_SEEN_RETENTION_DAYS } from './search.js';
 
 const mockGetStateManager = vi.mocked(getStateManager);
+const mockMaybeCheckpoint = vi.mocked(maybeCheckpoint);
 
 describe('runSearch', () => {
   beforeEach(() => {
@@ -51,6 +53,37 @@ describe('runSearch', () => {
       getSearchSeen: vi.fn().mockReturnValue([]),
       setSearchSeen: vi.fn(),
     } as any);
+  });
+
+  it('checkpoints the Gist after recording the seen-set and surfaces a failed push (#1629)', async () => {
+    mockMaybeCheckpoint.mockResolvedValueOnce('Gist checkpoint push failed');
+    mockSearch.mockResolvedValue({
+      candidates: [],
+      excludedRepos: [],
+      aiPolicyBlocklist: [],
+      strategiesUsed: ['broad'],
+    });
+
+    const out = await runSearch({ maxResults: 5 });
+
+    const sm = mockGetStateManager.mock.results[0].value;
+    expect(mockMaybeCheckpoint).toHaveBeenCalledWith(sm, 'search');
+    expect(sm.setSearchSeen.mock.invocationCallOrder[0]).toBeLessThan(mockMaybeCheckpoint.mock.invocationCallOrder[0]);
+    expect(out.gistSyncWarning).toBe('Gist checkpoint push failed');
+  });
+
+  it('omits gistSyncWarning when the checkpoint succeeds (#1629)', async () => {
+    mockSearch.mockResolvedValue({
+      candidates: [],
+      excludedRepos: [],
+      aiPolicyBlocklist: [],
+      strategiesUsed: ['broad'],
+    });
+
+    const out = await runSearch({ maxResults: 5 });
+
+    expect(mockMaybeCheckpoint).toHaveBeenCalledTimes(1);
+    expect(out).not.toHaveProperty('gistSyncWarning');
   });
 
   it('passes the diversity counterweight ratio to scout (#1244)', async () => {

--- a/packages/core/src/commands/search.test.ts
+++ b/packages/core/src/commands/search.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockSearch = vi.fn();
+const mockScoutState = { searchRotation: { languageOffset: 0 } as { languageOffset: number; lastRotatedAt?: string } };
 
 vi.mock('./scout-bridge.js', async () => {
   const actual = await vi.importActual<typeof import('./scout-bridge.js')>('./scout-bridge.js');
@@ -12,6 +13,7 @@ vi.mock('./scout-bridge.js', async () => {
     ...actual,
     createAutopilotScout: vi.fn(async () => ({
       search: mockSearch,
+      getState: () => mockScoutState,
     })),
   };
 });
@@ -52,7 +54,28 @@ describe('runSearch', () => {
       getRepoScore: vi.fn().mockReturnValue(null),
       getSearchSeen: vi.fn().mockReturnValue([]),
       setSearchSeen: vi.fn(),
+      setSearchRotation: vi.fn(),
+      setSearchRotation: vi.fn(),
     } as any);
+    mockScoutState.searchRotation = { languageOffset: 0 };
+  });
+
+  it('writes back the rotation cursor scout advanced, before the Gist checkpoint (#1630)', async () => {
+    mockScoutState.searchRotation = { languageOffset: 3, lastRotatedAt: '2026-09-05T00:00:00.000Z' };
+    mockSearch.mockResolvedValue({
+      candidates: [],
+      excludedRepos: [],
+      aiPolicyBlocklist: [],
+      strategiesUsed: ['broad'],
+    });
+
+    await runSearch({ maxResults: 5 });
+
+    const sm = mockGetStateManager.mock.results[0].value;
+    expect(sm.setSearchRotation).toHaveBeenCalledWith({ languageOffset: 3, lastRotatedAt: '2026-09-05T00:00:00.000Z' });
+    expect(sm.setSearchRotation.mock.invocationCallOrder[0]).toBeLessThan(
+      mockMaybeCheckpoint.mock.invocationCallOrder[0],
+    );
   });
 
   it('checkpoints the Gist after recording the seen-set and surfaces a failed push (#1629)', async () => {
@@ -241,6 +264,7 @@ describe('runSearch', () => {
       }),
       getSearchSeen: vi.fn().mockReturnValue([]),
       setSearchSeen: vi.fn(),
+      setSearchRotation: vi.fn(),
     } as any);
 
     const result = await runSearch({ maxResults: 5 });
@@ -296,7 +320,7 @@ describe('runSearch', () => {
     // Degraded run: bridge flags the unreadable skip file via the diagnostics out-param.
     vi.mocked(createAutopilotScout).mockImplementationOnce(async (diagnostics?: ScoutBridgeDiagnostics) => {
       if (diagnostics) diagnostics.skipListUnavailable = true;
-      return { search: mockSearch } as any;
+      return { search: mockSearch, getState: () => mockScoutState } as any;
     });
     const degradedResult = await runSearch({ maxResults: 10 });
     expect(degradedResult.skipListUnavailable).toBe(true);
@@ -402,6 +426,7 @@ describe('runSearch', () => {
       }),
       getSearchSeen: vi.fn().mockReturnValue([]),
       setSearchSeen: vi.fn(),
+      setSearchRotation: vi.fn(),
     } as any);
 
     const result = await runSearch({ maxResults: 5 });
@@ -551,6 +576,7 @@ describe('runSearch', () => {
         getRepoScore: vi.fn().mockReturnValue(null),
         getSearchSeen: vi.fn().mockReturnValue([]),
         setSearchSeen: vi.fn(),
+        setSearchRotation: vi.fn(),
       } as any);
     }
 

--- a/packages/core/src/commands/search.ts
+++ b/packages/core/src/commands/search.ts
@@ -232,6 +232,10 @@ export async function runSearch(options: SearchOptions): Promise<SearchOutput> {
     stateManager,
     result.candidates.map((c) => c.issue.url),
   );
+  // Scout advanced its broad-phase language cursor in its own (provided,
+  // non-persisted) state; copy it back so the next run starts from the next
+  // language slice instead of offset 0 every time (#1630).
+  stateManager.setSearchRotation(scout.getState().searchRotation);
   // In Gist mode setSearchSeen only writes the local cache; without a
   // checkpoint the seen-set never reaches the Gist and the next startup's
   // Gist refetch overwrites the cache with the empty remote copy (#1629).

--- a/packages/core/src/commands/search.ts
+++ b/packages/core/src/commands/search.ts
@@ -11,7 +11,7 @@ import {
   type ScoutBridgeDiagnostics,
 } from './scout-bridge.js';
 import { SearchStrategySchema, type SearchStrategy } from '@oss-scout/core';
-import { classifyLinkedPR, getStateManager } from '../core/index.js';
+import { classifyLinkedPR, getStateManager, maybeCheckpoint } from '../core/index.js';
 import { type SearchOutput } from '../formatters/json.js';
 import { gradeFromCandidate } from '../core/issue-grading.js';
 import { computeStrategy } from '../core/strategy.js';
@@ -232,6 +232,10 @@ export async function runSearch(options: SearchOptions): Promise<SearchOutput> {
     stateManager,
     result.candidates.map((c) => c.issue.url),
   );
+  // In Gist mode setSearchSeen only writes the local cache; without a
+  // checkpoint the seen-set never reaches the Gist and the next startup's
+  // Gist refetch overwrites the cache with the empty remote copy (#1629).
+  const gistSyncWarning = await maybeCheckpoint(stateManager, MODULE);
 
   // #1354: never surface issues the user already has an open PR for. Uses
   // scout's structured linked-PR metadata when present; candidates without it
@@ -321,6 +325,9 @@ export async function runSearch(options: SearchOptions): Promise<SearchOutput> {
     aiPolicyBlocklist: result.aiPolicyBlocklist,
     hiddenOwnPRCount,
   };
+  if (gistSyncWarning) {
+    searchOutput.gistSyncWarning = gistSyncWarning;
+  }
   if (result.rateLimitWarning) {
     searchOutput.rateLimitWarning = result.rateLimitWarning;
   }

--- a/packages/core/src/core/state-schema.ts
+++ b/packages/core/src/core/state-schema.ts
@@ -454,6 +454,12 @@ export const SearchSeenEntrySchema = z.object({
   lastSeenAt: z.string(),
 });
 
+/** Mirrors oss-scout's `searchRotation` (broad-phase language cursor). */
+export const SearchRotationSchema = z.object({
+  languageOffset: z.number().int().nonnegative().default(0),
+  lastRotatedAt: z.string().optional(),
+});
+
 export const AgentStateSchema = z.object({
   version: z.literal(4),
   gistId: z.string().optional(),
@@ -518,6 +524,14 @@ export const AgentStateSchema = z.object({
    * it cannot grow without bound.
    */
   searchSeen: z.array(SearchSeenEntrySchema).default([]),
+
+  /**
+   * Broad-phase language rotation cursor (#1630), oss-scout's `searchRotation`.
+   * Scout advances it after every search whose broad phase ran; autopilot runs
+   * scout in persistence:'provided', so the advanced cursor is written back
+   * here and fed into the next scout state. Absent until the first search.
+   */
+  searchRotation: SearchRotationSchema.optional(),
 });
 
 // ── Inferred types ───────────────────────────────────────────────────
@@ -528,6 +542,7 @@ export type ProjectCategory = z.infer<typeof ProjectCategorySchema>;
 export type IssueScope = z.infer<typeof IssueScopeSchema>;
 export type DiffTool = z.infer<typeof DiffToolSchema>;
 export type SearchSeenEntry = z.infer<typeof SearchSeenEntrySchema>;
+export type SearchRotation = z.infer<typeof SearchRotationSchema>;
 export type RepoSignals = z.infer<typeof RepoSignalsSchema>;
 export type RepoScore = z.infer<typeof RepoScoreSchema>;
 export type StoredMergedPR = z.infer<typeof StoredMergedPRSchema>;

--- a/packages/core/src/core/state.ts
+++ b/packages/core/src/core/state.ts
@@ -17,6 +17,7 @@ import {
   StoredMergedPR,
   StoredClosedPR,
   SearchSeenEntry,
+  SearchRotation,
 } from './types.js';
 import { AgentStateSchema } from './state-schema.js';
 import {
@@ -988,6 +989,17 @@ export class StateManager {
    */
   setSearchSeen(seen: SearchSeenEntry[]): void {
     this.state.searchSeen = seen;
+    this.autoSave();
+  }
+
+  /** Broad-phase language rotation cursor (#1630); `undefined` before the first search. */
+  getSearchRotation(): SearchRotation | undefined {
+    return this.state.searchRotation;
+  }
+
+  /** Persist the cursor scout advanced during a search (#1630). */
+  setSearchRotation(rotation: SearchRotation): void {
+    this.state.searchRotation = rotation;
     this.autoSave();
   }
 

--- a/packages/core/src/core/test-utils.ts
+++ b/packages/core/src/core/test-utils.ts
@@ -221,6 +221,10 @@ export function makeStateManagerMock(
     setSearchSeen: (seen: AgentState['searchSeen']) => {
       state.searchSeen = seen;
     },
+    getSearchRotation: () => state.searchRotation,
+    setSearchRotation: (rotation: NonNullable<AgentState['searchRotation']>) => {
+      state.searchRotation = rotation;
+    },
     getRepoScore: () => undefined,
     updateRepoScore: () => {},
     incrementMergedCount: () => {},

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -47,6 +47,7 @@ export type {
   DailyDigest,
   AgentState,
   SearchSeenEntry,
+  SearchRotation,
 } from './state-schema.js';
 
 // ── Ephemeral types (never persisted, hand-written) ──────────────────

--- a/packages/core/src/formatters/json.ts
+++ b/packages/core/src/formatters/json.ts
@@ -1164,6 +1164,9 @@ export interface SearchOutput {
   /** Candidates dropped because the authenticated user already has an open PR
    * linked to the issue (#1354). Surfaced as a count so the filter is visible. */
   hiddenOwnPRCount: number;
+  /** Set when the seen-set write could not be pushed to the Gist (#1629);
+   * the local cache has it but the next startup's Gist refetch will drop it. */
+  gistSyncWarning?: string;
   /** Present when rate limits affected the search — either low pre-flight quota or mid-search rate limit hits (#100). */
   rateLimitWarning?: string;
   /**


### PR DESCRIPTION
Closes #1630

Stacked on #1653 (the Gist checkpoint), which this needs so the cursor actually reaches the Gist; the diff shrinks to this commit once that merges.

- AgentState gains an optional searchRotation (languageOffset, lastRotatedAt), mirroring scout's schema.
- scout-bridge feeds the stored cursor into the scout state instead of the hardcoded offset 0.
- runSearch writes scout.getState().searchRotation back before the checkpoint.

strategiesUsed is still not surfaced in search --json; left out of this PR.