### PR TITLE
test(cli-registry): cover every handler directly and ratchet the coverage floors

### DIFF
--- a/packages/core/src/cli-registry.test.ts
+++ b/packages/core/src/cli-registry.test.ts
@@ -34,32 +34,36 @@ vi.mock('./formatters/json.js', () => ({
   outputJsonError: vi.fn(),
   outputJsonValidated: vi.fn(),
   toCompactDailyOutput: vi.fn((data: unknown) => ({ compacted: data })),
+  toCompactStartupOutput: vi.fn((data: unknown) => ({ compacted: data })),
   // Schemas referenced by command actions — exported as opaque markers; the
-  // mocked outputJsonValidated above doesn't actually validate.
-  StatusOutputSchema: {},
-  SearchOutputSchema: {},
-  DailyOutputSchema: {},
-  CompactDailyOutputSchema: {},
-  DoctorOutputSchema: {},
-  SkipAddOutputSchema: {},
-  ListMoveTierOutputSchema: {},
-  ListMarkDoneOutputSchema: {},
-  PostOutputSchema: {},
-  ClaimOutputSchema: {},
-  InitOutputSchema: {},
-  CheckSetupOutputSchema: {},
-  SetupOutputSchema: {},
-  ConfigCommandOutputSchema: {},
-  MoveOutputSchema: {},
-  VerifyIssueOutputSchema: {},
-  PRTemplateOutputSchema: {},
-  ParseIssueListOutputSchema: {},
-  CheckIntegrationOutputSchema: {},
-  DetectFormattersOutputSchema: {},
-  LocalReposOutputSchema: {},
-  ManifestOutputSchema: {},
-  StrategyOutputSchema: {},
-  ComplianceScoreOutputSchema: {},
+  // mocked outputJsonValidated above doesn't actually validate. Each marker
+  // carries its own name so a deep-equality assertion can tell them apart.
+  StatusOutputSchema: { name: 'StatusOutputSchema' },
+  SearchOutputSchema: { name: 'SearchOutputSchema' },
+  DailyOutputSchema: { name: 'DailyOutputSchema' },
+  CompactDailyOutputSchema: { name: 'CompactDailyOutputSchema' },
+  DoctorOutputSchema: { name: 'DoctorOutputSchema' },
+  SkipAddOutputSchema: { name: 'SkipAddOutputSchema' },
+  ListMoveTierOutputSchema: { name: 'ListMoveTierOutputSchema' },
+  ListMarkDoneOutputSchema: { name: 'ListMarkDoneOutputSchema' },
+  PostOutputSchema: { name: 'PostOutputSchema' },
+  ClaimOutputSchema: { name: 'ClaimOutputSchema' },
+  InitOutputSchema: { name: 'InitOutputSchema' },
+  CheckSetupOutputSchema: { name: 'CheckSetupOutputSchema' },
+  SetupOutputSchema: { name: 'SetupOutputSchema' },
+  ConfigCommandOutputSchema: { name: 'ConfigCommandOutputSchema' },
+  MoveOutputSchema: { name: 'MoveOutputSchema' },
+  VerifyIssueOutputSchema: { name: 'VerifyIssueOutputSchema' },
+  PRTemplateOutputSchema: { name: 'PRTemplateOutputSchema' },
+  ParseIssueListOutputSchema: { name: 'ParseIssueListOutputSchema' },
+  CheckIntegrationOutputSchema: { name: 'CheckIntegrationOutputSchema' },
+  DetectFormattersOutputSchema: { name: 'DetectFormattersOutputSchema' },
+  LocalReposOutputSchema: { name: 'LocalReposOutputSchema' },
+  ManifestOutputSchema: { name: 'ManifestOutputSchema' },
+  StrategyOutputSchema: { name: 'StrategyOutputSchema' },
+  ComplianceScoreOutputSchema: { name: 'ComplianceScoreOutputSchema' },
+  FeaturesOutputSchema: { name: 'FeaturesOutputSchema' },
+  RepoVetOutputSchema: { name: 'RepoVetOutputSchema' },
 }));
 
 // ─── Mock dynamic command-module imports ────────────────────────────────────
@@ -124,10 +128,102 @@ vi.mock('./commands/comments.js', () => ({
   runClaim: mockRunClaim,
 }));
 
+const mockRunStateShow = vi.fn();
+const mockRunStateSync = vi.fn();
+const mockRunStateUnlink = vi.fn();
+vi.mock('./commands/state-cmd.js', () => ({
+  runStateShow: mockRunStateShow,
+  runStateSync: mockRunStateSync,
+  runStateUnlink: mockRunStateUnlink,
+}));
+
+const mockRunFeatures = vi.fn();
+vi.mock('./commands/features.js', () => ({ runFeatures: mockRunFeatures, MAX_FEATURES_RESULTS: 50 }));
+
+const mockRunVet = vi.fn();
+vi.mock('./commands/vet.js', () => ({ runVet: mockRunVet }));
+
+const mockRunVetList = vi.fn();
+vi.mock('./commands/vet-list.js', () => ({ runVetList: mockRunVetList }));
+
+const mockRunListMoveTier = vi.fn();
+vi.mock('./commands/list-move-tier.js', () => ({ runListMoveTier: mockRunListMoveTier }));
+
+const mockRunMarkDone = vi.fn();
+vi.mock('./commands/list-mark-done.js', () => ({ runMarkIssueListItemDone: mockRunMarkDone }));
+
+const mockRunConfig = vi.fn();
+vi.mock('./commands/config.js', () => ({ runConfig: mockRunConfig }));
+
+const mockRunInit = vi.fn();
+vi.mock('./commands/init.js', () => ({ runInit: mockRunInit }));
+
+const mockRunSetup = vi.fn();
+const mockRunCheckSetup = vi.fn();
+vi.mock('./commands/setup.js', () => ({ runSetup: mockRunSetup, runCheckSetup: mockRunCheckSetup }));
+
+const mockRunParseList = vi.fn();
+vi.mock('./commands/parse-list.js', () => ({ runParseList: mockRunParseList }));
+
+const mockRunCheckIntegration = vi.fn();
+vi.mock('./commands/check-integration.js', () => ({ runCheckIntegration: mockRunCheckIntegration }));
+
+const mockRunDoctor = vi.fn();
+vi.mock('./commands/doctor.js', () => ({ runDoctor: mockRunDoctor }));
+
+const mockRunStartup = vi.fn();
+vi.mock('./commands/startup.js', () => ({ runStartup: mockRunStartup }));
+
+const mockRunPRTemplate = vi.fn();
+vi.mock('./commands/pr-template.js', () => ({ runPRTemplate: mockRunPRTemplate }));
+
+const mockRunRepoVet = vi.fn();
+vi.mock('./commands/repo-vet.js', () => ({ runRepoVet: mockRunRepoVet }));
+
+const mockRunDetectFormatters = vi.fn();
+vi.mock('./commands/detect-formatters.js', () => ({ runDetectFormatters: mockRunDetectFormatters }));
+
+const mockRunStats = vi.fn();
+vi.mock('./commands/stats.js', () => ({
+  runStats: mockRunStats,
+  formatStatsMarkdown: vi.fn(() => '# md report'),
+  formatStatsBadge: vi.fn(() => ({ schemaVersion: 1, label: 'merged', message: '3' })),
+}));
+
+const mockGuidelinesList = vi.fn();
+const mockGuidelinesView = vi.fn();
+const mockGuidelinesStore = vi.fn();
+const mockGuidelinesReset = vi.fn();
+const mockFetchCorpus = vi.fn();
+vi.mock('./commands/guidelines.js', () => ({
+  runGuidelinesList: mockGuidelinesList,
+  runGuidelinesView: mockGuidelinesView,
+  runGuidelinesStore: mockGuidelinesStore,
+  runGuidelinesReset: mockGuidelinesReset,
+  runFetchCorpus: mockFetchCorpus,
+}));
+
 // ─── Import after mocks ────────────────────────────────────────────────────
 
 import { commands } from './cli-registry.js';
-import { outputJson, outputJsonError, outputJsonValidated, MoveOutputSchema } from './formatters/json.js';
+import {
+  outputJson,
+  outputJsonError,
+  outputJsonValidated,
+  CheckIntegrationOutputSchema,
+  CheckSetupOutputSchema,
+  ConfigCommandOutputSchema,
+  DetectFormattersOutputSchema,
+  DoctorOutputSchema,
+  FeaturesOutputSchema,
+  InitOutputSchema,
+  ListMarkDoneOutputSchema,
+  MoveOutputSchema,
+  ParseIssueListOutputSchema,
+  PRTemplateOutputSchema,
+  RepoVetOutputSchema,
+  SetupOutputSchema,
+} from './formatters/json.js';
 
 const mockOutputJson = vi.mocked(outputJson);
 const mockOutputJsonError = vi.mocked(outputJsonError);
@@ -148,6 +244,26 @@ function buildProgram(commandName: string): Command {
   if (!def) throw new Error(`Unknown command: ${commandName}`);
   def.register(program);
   return program;
+}
+
+/**
+ * Run `fn` with process.stdin replaced: a TTY (no data) when `text` is null,
+ * otherwise a piped stream yielding `text`. Spies on the getter so Node's
+ * real descriptor is restored afterwards.
+ */
+async function withStdin<T>(text: string | null, fn: () => Promise<T>): Promise<T> {
+  const fake = {
+    isTTY: text === null,
+    async *[Symbol.asyncIterator]() {
+      yield Buffer.from(text ?? '');
+    },
+  };
+  const spy = vi.spyOn(process, 'stdin', 'get').mockReturnValue(fake as unknown as typeof process.stdin);
+  try {
+    return await fn();
+  } finally {
+    spy.mockRestore();
+  }
 }
 
 // ─── Shared setup/teardown ──────────────────────────────────────────────────
@@ -311,6 +427,20 @@ describe('search text-mode display', () => {
     expect(lines).toContain('  Why surfaced: merged PR history, preferred org');
     expect(lines).toContain('  Diversity slot: outside your usual languages/repos');
     expect(lines).toContain('Found 2 candidates:\n');
+  });
+});
+
+describe('search empty-result display', () => {
+  const empty = { candidates: [], excludedRepos: [], aiPolicyBlocklist: [], hiddenOwnPRCount: 0 };
+
+  it('prints the no-match note, or the rate-limit warning when present', async () => {
+    mockRunSearch.mockResolvedValueOnce(empty);
+    await buildProgram('search').parseAsync(['node', 'cli', 'search']);
+    expect(consoleLogSpy).toHaveBeenCalledWith('No matching issues found.');
+
+    mockRunSearch.mockResolvedValueOnce({ ...empty, rateLimitWarning: 'rate limited' });
+    await buildProgram('search').parseAsync(['node', 'cli', 'search']);
+    expect(consoleWarnSpy).toHaveBeenCalledWith('\nrate limited\n');
   });
 });
 
@@ -1073,6 +1203,16 @@ describe('post command', () => {
     expect(mockOutputJsonValidated).toHaveBeenCalledWith(expect.anything(), data);
     expect(consoleLogSpy).not.toHaveBeenCalled();
   });
+
+  it('--stdin reads and trims the message from stdin, ignoring positional parts', async () => {
+    mockRunPost.mockResolvedValue({ commentUrl: `${PR_URL}#issuecomment-5` });
+
+    await withStdin('  from stdin \n', () =>
+      buildProgram('post').parseAsync(['node', 'cli', 'post', PR_URL, 'ignored', '--stdin']),
+    );
+
+    expect(mockRunPost).toHaveBeenCalledWith({ url: PR_URL, message: 'from stdin' });
+  });
 });
 
 describe('claim command', () => {
@@ -1093,5 +1233,1053 @@ describe('claim command', () => {
     await program.parseAsync(['node', 'cli', 'claim', ISSUE_URL, 'I', 'can', 'take', 'this']);
 
     expect(mockRunClaim).toHaveBeenCalledWith({ issueUrl: ISSUE_URL, message: 'I can take this' });
+  });
+});
+
+// ─── executeAction: schema validation path (#1586) ──────────────────────────
+
+describe('executeAction schema validation', () => {
+  it('routes a schema mismatch through the JSON error envelope', async () => {
+    mockRunStatus.mockResolvedValue({ stats: {} });
+    // outputJsonValidated is what throws on drift (#1105); executeAction must
+    // not swallow it.
+    mockOutputJsonValidated.mockImplementationOnce(() => {
+      throw new Error('Output validation failed: stats.mergedPRs required');
+    });
+    const program = buildProgram('status');
+
+    await expect(program.parseAsync(['node', 'cli', 'status', '--json'])).rejects.toThrow('process.exit called');
+
+    expect(mockOutputJsonError).toHaveBeenCalledWith('Output validation failed: stats.mergedPRs required', 'UNKNOWN');
+    expect(mockOutputJson).not.toHaveBeenCalled();
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('routes a display() throw through the text error path', async () => {
+    // vet's display dereferences data.issue; a malformed payload throws inside
+    // display, which executeAction's catch must still route to exit(1).
+    mockRunVet.mockResolvedValue({});
+    const program = buildProgram('vet');
+
+    await expect(program.parseAsync(['node', 'cli', 'vet', ISSUE_URL])).rejects.toThrow('process.exit called');
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringMatching(/^Error: /));
+    expect(mockOutputJsonError).not.toHaveBeenCalled();
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+});
+
+// ─── state command (#1586) ──────────────────────────────────────────────────
+
+describe('state command', () => {
+  const logged = () => consoleLogSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+
+  it('defaults to --show and passes --validate through', async () => {
+    mockRunStateShow.mockResolvedValue({
+      persistence: 'gist',
+      gistId: 'abc123',
+      gistDegraded: true,
+      lastRunAt: undefined,
+      invalidEntries: [{ kind: 'pr', url: PR_URL, title: 'bad' }],
+    });
+    const program = buildProgram('state');
+
+    await program.parseAsync(['node', 'cli', 'state', '--validate']);
+
+    expect(mockRunStateShow).toHaveBeenCalledWith({ validate: true });
+    const out = logged();
+    expect(out).toContain('Persistence: gist');
+    expect(out).toContain('Gist ID: abc123');
+    expect(out).toContain('Status: DEGRADED (using local cache)');
+    expect(out).toContain('Last run: Never');
+    expect(out).toContain('Validation: 1 stored PR(s) with invalid URLs:');
+    expect(out).toContain(`[pr] ${PR_URL}  bad`);
+  });
+
+  it('reports a clean validation pass', async () => {
+    mockRunStateShow.mockResolvedValue({ persistence: 'local', lastRunAt: '2026-01-01', invalidEntries: [] });
+    const program = buildProgram('state');
+
+    await program.parseAsync(['node', 'cli', 'state', '--show', '--validate']);
+
+    expect(logged()).toContain('Validation: no invalid PR URLs in stored state.');
+  });
+
+  it('--sync prints the pushed Gist id, or the not-in-gist-mode note', async () => {
+    mockRunStateSync.mockResolvedValueOnce({ pushed: true, gistId: 'g1' });
+    await buildProgram('state').parseAsync(['node', 'cli', 'state', '--sync']);
+    expect(logged()).toContain('State pushed to Gist g1');
+
+    consoleLogSpy.mockClear();
+    mockRunStateSync.mockResolvedValueOnce({ pushed: false });
+    await buildProgram('state').parseAsync(['node', 'cli', 'state', '--sync']);
+    expect(logged()).toContain('Not in Gist mode. Nothing to sync.');
+  });
+
+  it('--unlink prints the local path and the retained previous Gist', async () => {
+    mockRunStateUnlink.mockResolvedValue({ localStatePath: '/tmp/state.json', previousGistId: 'g1' });
+    const program = buildProgram('state');
+
+    await program.parseAsync(['node', 'cli', 'state', '--unlink']);
+
+    const out = logged();
+    expect(out).toContain('State written to /tmp/state.json');
+    expect(out).toContain('Previous Gist (g1) was NOT deleted.');
+  });
+
+  it('--json routes through outputJson (tier-2, no schema)', async () => {
+    const data = { persistence: 'local' };
+    mockRunStateShow.mockResolvedValue(data);
+    const program = buildProgram('state');
+
+    await program.parseAsync(['node', 'cli', 'state', '--json']);
+
+    expect(mockOutputJson).toHaveBeenCalledWith(data);
+    expect(mockOutputJsonValidated).not.toHaveBeenCalled();
+  });
+});
+
+// ─── features command (#1586) ───────────────────────────────────────────────
+
+describe('features command', () => {
+  const logged = () => consoleLogSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+  const candidate = {
+    issue: { repo: 'octo/alpha', number: 3, title: 'Add flag', url: 'https://github.com/octo/alpha/issues/3' },
+    recommendation: 'approve',
+    reasonsToApprove: ['anchor repo'],
+    reasonsToSkip: ['large'],
+    viabilityScore: 70,
+  };
+  const empty = { anchorRepos: [], quickWins: [], biggerBets: [] };
+
+  it('defaults maxResults to 10 and routes --json through the schema', async () => {
+    mockRunFeatures.mockResolvedValue(empty);
+    const program = buildProgram('features');
+
+    await program.parseAsync(['node', 'cli', 'features', '--json']);
+
+    expect(mockRunFeatures).toHaveBeenCalledWith({ maxResults: 10, anchorThreshold: undefined, splitRatio: undefined });
+    expect(mockOutputJsonValidated).toHaveBeenCalledWith(FeaturesOutputSchema, empty);
+  });
+
+  it('parses count and threshold overrides, capping count at the max', async () => {
+    mockRunFeatures.mockResolvedValue(empty);
+    const program = buildProgram('features');
+
+    await program.parseAsync(['node', 'cli', 'features', '80', '--anchor-threshold', '5', '--split-ratio', '0.4']);
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith('Capping features to 50 results (requested: 80)');
+    expect(mockRunFeatures).toHaveBeenCalledWith({ maxResults: 50, anchorThreshold: 5, splitRatio: 0.4 });
+    expect(logged()).toContain('Searching for feature opportunities (max 50)');
+  });
+
+  it.each([
+    [['abc'], 'Invalid count "abc". Must be a positive integer.'],
+    [['--anchor-threshold', '99'], 'Invalid --anchor-threshold "99". Must be an integer in [1, 50].'],
+    [['--split-ratio', '2'], 'Invalid --split-ratio "2". Must be a number in [0, 1].'],
+  ])('rejects invalid args %j', async (args, message) => {
+    const program = buildProgram('features');
+
+    await expect(program.parseAsync(['node', 'cli', 'features', ...args, '--json'])).rejects.toThrow(
+      'process.exit called',
+    );
+
+    expect(mockOutputJsonError).toHaveBeenCalledWith(message, 'UNKNOWN');
+    expect(mockRunFeatures).not.toHaveBeenCalled();
+  });
+
+  it('prints the empty-result fallbacks', async () => {
+    mockRunFeatures.mockResolvedValueOnce({ ...empty, rateLimitWarning: 'slow down' });
+    await buildProgram('features').parseAsync(['node', 'cli', 'features']);
+    expect(consoleWarnSpy).toHaveBeenCalledWith('\nslow down\n');
+
+    mockRunFeatures.mockResolvedValueOnce({ ...empty, message: 'Need 3 merged PRs first.' });
+    await buildProgram('features').parseAsync(['node', 'cli', 'features']);
+    expect(logged()).toContain('Need 3 merged PRs first.');
+
+    mockRunFeatures.mockResolvedValueOnce(empty);
+    await buildProgram('features').parseAsync(['node', 'cli', 'features']);
+    expect(logged()).toContain('No feature opportunities found.');
+  });
+
+  it('renders anchor repos and both buckets', async () => {
+    mockRunFeatures.mockResolvedValue({
+      anchorRepos: ['octo/alpha'],
+      quickWins: [candidate],
+      biggerBets: [{ ...candidate, reasonsToApprove: [], reasonsToSkip: [] }],
+      rateLimitWarning: 'near limit',
+    });
+    const program = buildProgram('features');
+
+    await program.parseAsync(['node', 'cli', 'features']);
+
+    const out = logged();
+    expect(out).toContain('Anchor repos (1): octo/alpha');
+    expect(consoleWarnSpy).toHaveBeenCalledWith('\nnear limit\n');
+    expect(out).toContain('Quick wins (1):');
+    expect(out).toContain('Bigger bets (1):');
+    expect(out).toContain('[APPROVE] octo/alpha#3: Add flag');
+    expect(out).toContain('Viability: 70/100');
+    expect(out).toContain('Approve: anchor repo');
+    expect(out).toContain('Skip: large');
+  });
+});
+
+// ─── vet / vet-list commands (#1586) ────────────────────────────────────────
+
+describe('vet command', () => {
+  it('renders grade and reasons in display mode', async () => {
+    mockRunVet.mockResolvedValue({
+      issue: { repo: 'octo/alpha', number: 3, title: 'Add flag', url: ISSUE_URL },
+      recommendation: 'skip',
+      reasonsToApprove: ['small'],
+      reasonsToSkip: ['claimed'],
+      grade: { score: 4, reason: 'contested' },
+    });
+    const program = buildProgram('vet');
+
+    await program.parseAsync(['node', 'cli', 'vet', ISSUE_URL]);
+
+    expect(mockRunVet).toHaveBeenCalledWith({ issueUrl: ISSUE_URL });
+    const out = consoleLogSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+    expect(out).toContain(`Vetting issue: ${ISSUE_URL}`);
+    expect(out).toContain('[SKIP] octo/alpha#3: Add flag');
+    expect(out).toContain('Success score: 4/10 (contested)');
+    expect(out).toContain('Approve: small');
+    expect(out).toContain('Skip: claimed');
+  });
+
+  it('--json routes through outputJson (tier-2)', async () => {
+    const data = { issue: {}, recommendation: 'approve' };
+    mockRunVet.mockResolvedValue(data);
+
+    await buildProgram('vet').parseAsync(['node', 'cli', 'vet', ISSUE_URL, '--json']);
+
+    expect(mockOutputJson).toHaveBeenCalledWith(data);
+  });
+});
+
+describe('vet-list command', () => {
+  const summary = {
+    total: 3,
+    stillAvailable: 1,
+    atRisk: 1,
+    claimed: 0,
+    ownOpenPr: 0,
+    closed: 0,
+    hasPR: 0,
+    hasStalledPR: 0,
+    errors: 1,
+  };
+  const issue = { repo: 'octo/alpha', number: 1, title: 'T' };
+
+  it('parses --concurrency and --prune and renders per-status annotations', async () => {
+    mockRunVetList.mockResolvedValue({
+      summary,
+      results: [
+        { listStatus: 'still_available', issue },
+        { listStatus: 'at_risk', issue },
+        { listStatus: 'error', issue, errorMessage: 'boom' },
+        { listStatus: 'has_stalled_pr', issue },
+        { listStatus: 'own_open_pr', issue },
+      ],
+      pruneResult: { removedCount: 2 },
+    });
+    const program = buildProgram('vet-list');
+
+    await program.parseAsync(['node', 'cli', 'vet-list', '--path', '/tmp/list.md', '--concurrency', '3', '--prune']);
+
+    expect(mockRunVetList).toHaveBeenCalledWith({ issueListPath: '/tmp/list.md', concurrency: 3, prune: true });
+    const out = consoleLogSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+    expect(out).toContain('Re-vetted 3 issues:');
+    expect(out).toContain('Still available: 1');
+    expect(out).toContain('✅ [still_available] octo/alpha#1: T');
+    expect(out).toContain('[at_risk] octo/alpha#1: T (at risk, mention only)');
+    expect(out).toContain('❌ [error] octo/alpha#1: T');
+    expect(out).toContain('Error: boom');
+    expect(out).toContain('(stalled PR, revive opportunity)');
+    expect(out).toContain('(you already have an open PR)');
+    expect(out).toContain('Pruned 2 items from issue list.');
+  });
+
+  it('rejects a non-positive --concurrency', async () => {
+    const program = buildProgram('vet-list');
+
+    await expect(program.parseAsync(['node', 'cli', 'vet-list', '--concurrency', '0'])).rejects.toThrow(
+      'process.exit called',
+    );
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error: Invalid concurrency "0". Must be a positive integer.');
+    expect(mockRunVetList).not.toHaveBeenCalled();
+  });
+
+  it('--json routes through outputJson (tier-2)', async () => {
+    const data = { summary, results: [] };
+    mockRunVetList.mockResolvedValue(data);
+
+    await buildProgram('vet-list').parseAsync(['node', 'cli', 'vet-list', '--json']);
+
+    expect(mockRunVetList).toHaveBeenCalledWith({ issueListPath: undefined, concurrency: undefined, prune: undefined });
+    expect(mockOutputJson).toHaveBeenCalledWith(data);
+  });
+});
+
+// ─── list-move-tier / list-mark-done commands (#1586) ───────────────────────
+
+describe('list-move-tier command', () => {
+  const LIST = '/tmp/list.md';
+
+  it('lower-cases the tier and prints the moved line with from/count labels', async () => {
+    mockRunListMoveTier.mockResolvedValue({
+      moved: true,
+      url: ISSUE_URL,
+      toTier: 'skip',
+      fromTier: 'maybe',
+      count: 2,
+      filePath: LIST,
+    });
+    const program = buildProgram('list-move-tier');
+
+    await program.parseAsync(['node', 'cli', 'list-move-tier', ISSUE_URL, '--tier', 'SKIP', '--list-path', LIST]);
+
+    expect(mockRunListMoveTier).toHaveBeenCalledWith({ issueUrl: ISSUE_URL, tier: 'skip', listPath: LIST });
+    expect(consoleLogSpy).toHaveBeenCalledWith(`Moved ${ISSUE_URL} to skip (from maybe) × 2`);
+    expect(consoleLogSpy).toHaveBeenCalledWith(`  File: ${LIST}`);
+  });
+
+  it('prints the no-move line with the reason fallback', async () => {
+    mockRunListMoveTier.mockResolvedValue({ moved: false, url: ISSUE_URL, filePath: LIST });
+
+    await buildProgram('list-move-tier').parseAsync([
+      'node',
+      'cli',
+      'list-move-tier',
+      ISSUE_URL,
+      '--tier',
+      'pursue',
+      '--list-path',
+      LIST,
+    ]);
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(`No move: ${ISSUE_URL} — unchanged`);
+  });
+
+  it('rejects an unknown tier before calling the command', async () => {
+    const program = buildProgram('list-move-tier');
+
+    await expect(
+      program.parseAsync([
+        'node',
+        'cli',
+        'list-move-tier',
+        ISSUE_URL,
+        '--tier',
+        'later',
+        '--list-path',
+        LIST,
+        '--json',
+      ]),
+    ).rejects.toThrow('process.exit called');
+
+    expect(mockOutputJsonError).toHaveBeenCalledWith(
+      'Invalid --tier "later". Must be one of: pursue, maybe, skip.',
+      'UNKNOWN',
+    );
+    expect(mockRunListMoveTier).not.toHaveBeenCalled();
+  });
+});
+
+describe('list-mark-done command', () => {
+  const LIST = '/tmp/list.md';
+  const args = [
+    'node',
+    'cli',
+    'list-mark-done',
+    ISSUE_URL,
+    '--pr-url',
+    PR_URL,
+    '--pr-status',
+    'merged',
+    '--list-path',
+    LIST,
+  ];
+
+  it('passes all options through and prints the marked summary', async () => {
+    mockRunMarkDone.mockResolvedValue({
+      marked: true,
+      url: ISSUE_URL,
+      repoHeadingStruck: true,
+      filePath: LIST,
+      remainingUnderRepo: 0,
+    });
+
+    await buildProgram('list-mark-done').parseAsync(args);
+
+    expect(mockRunMarkDone).toHaveBeenCalledWith({
+      issueUrl: ISSUE_URL,
+      prUrl: PR_URL,
+      prStatus: 'merged',
+      listPath: LIST,
+    });
+    expect(consoleLogSpy).toHaveBeenCalledWith(`Marked ${ISSUE_URL} done (repo heading also struck)`);
+    expect(consoleLogSpy).toHaveBeenCalledWith('  Remaining under repo: 0');
+  });
+
+  it('prints the idempotent no-mark line', async () => {
+    mockRunMarkDone.mockResolvedValue({ marked: false, url: ISSUE_URL, filePath: LIST, reason: 'already done' });
+
+    await buildProgram('list-mark-done').parseAsync(args);
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(`No mark: ${ISSUE_URL} — already done`);
+  });
+
+  it('--json routes through outputJsonValidated', async () => {
+    const data = { marked: true, url: ISSUE_URL, filePath: LIST, remainingUnderRepo: 1 };
+    mockRunMarkDone.mockResolvedValue(data);
+
+    await buildProgram('list-mark-done').parseAsync([...args, '--json']);
+
+    expect(mockOutputJsonValidated).toHaveBeenCalledWith(ListMarkDoneOutputSchema, data);
+  });
+});
+
+// ─── config / init / setup / checkSetup commands (#1586) ────────────────────
+
+describe('config command', () => {
+  const logged = () => consoleLogSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+
+  it('renders the key catalogue with --list-keys', async () => {
+    mockRunConfig.mockResolvedValue({
+      keys: [
+        { key: 'maxActivePRs', settableVia: 'auto', description: 'Cap', valueHint: 'integer' },
+        { key: 'languages', settableVia: 'setup', description: 'Langs', valueHint: 'csv' },
+      ],
+    });
+
+    await buildProgram('config').parseAsync(['node', 'cli', 'config', '--list-keys']);
+
+    expect(mockRunConfig).toHaveBeenCalledWith({ key: undefined, value: undefined, listKeys: true });
+    const out = logged();
+    expect(out).toContain('Config keys');
+    expect(out).toMatch(/maxActivePRs\s+\(auto\)\s+Cap/);
+    expect(out).toMatch(/languages\s+\[setup\]\s+Langs/);
+    expect(out).toContain('value: integer');
+  });
+
+  it('dumps the full config when no key is given', async () => {
+    mockRunConfig.mockResolvedValue({ config: { githubUsername: 'octo' } });
+
+    await buildProgram('config').parseAsync(['node', 'cli', 'config']);
+
+    expect(logged()).toContain('"githubUsername": "octo"');
+  });
+
+  it('prints the set confirmation for key/value', async () => {
+    mockRunConfig.mockResolvedValue({ key: 'maxActivePRs', value: 7 });
+
+    await buildProgram('config').parseAsync(['node', 'cli', 'config', 'maxActivePRs', '7']);
+
+    expect(mockRunConfig).toHaveBeenCalledWith({ key: 'maxActivePRs', value: '7', listKeys: undefined });
+    expect(consoleLogSpy).toHaveBeenCalledWith('Set maxActivePRs to: 7');
+  });
+
+  it('--json routes through outputJsonValidated', async () => {
+    const data = { config: {} };
+    mockRunConfig.mockResolvedValue(data);
+
+    await buildProgram('config').parseAsync(['node', 'cli', 'config', '--json']);
+
+    expect(mockOutputJsonValidated).toHaveBeenCalledWith(ConfigCommandOutputSchema, data);
+  });
+});
+
+describe('init command', () => {
+  it('prints the username confirmation and routes --json through the schema', async () => {
+    const data = { username: 'octo' };
+    mockRunInit.mockResolvedValue(data);
+
+    await buildProgram('init').parseAsync(['node', 'cli', 'init', 'octo']);
+    expect(mockRunInit).toHaveBeenCalledWith({ username: 'octo' });
+    expect(consoleLogSpy).toHaveBeenCalledWith('\nUsername set to @octo.');
+
+    await buildProgram('init').parseAsync(['node', 'cli', 'init', 'octo', '--json']);
+    expect(mockOutputJsonValidated).toHaveBeenCalledWith(InitOutputSchema, data);
+  });
+});
+
+describe('setup command', () => {
+  const logged = () => consoleLogSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+
+  it('--set mode prints each setting and warns', async () => {
+    mockRunSetup.mockResolvedValue({ success: true, settings: { maxActivePRs: 5 }, warnings: ['ignored: foo'] });
+
+    await buildProgram('setup').parseAsync(['node', 'cli', 'setup', '--set', 'maxActivePRs=5', 'foo=bar']);
+
+    expect(mockRunSetup).toHaveBeenCalledWith({ reset: undefined, set: ['maxActivePRs=5', 'foo=bar'] });
+    expect(consoleLogSpy).toHaveBeenCalledWith('✓ maxActivePRs: 5');
+    expect(consoleWarnSpy).toHaveBeenCalledWith('ignored: foo');
+  });
+
+  it('already-complete mode prints current settings', async () => {
+    mockRunSetup.mockResolvedValue({
+      setupComplete: true,
+      config: {
+        githubUsername: '',
+        maxActivePRs: 5,
+        dormantThresholdDays: 14,
+        approachingDormantDays: 10,
+        languages: ['ts'],
+        labels: ['good first issue'],
+      },
+    });
+
+    await buildProgram('setup').parseAsync(['node', 'cli', 'setup', '--reset']);
+
+    expect(mockRunSetup).toHaveBeenCalledWith({ reset: true, set: undefined });
+    const out = logged();
+    expect(out).toContain('Setup already complete!');
+    expect(out).toContain('GitHub username:    (not set)');
+    expect(out).toContain('Dormant threshold:  14 days');
+    expect(out).toContain('Labels:             good first issue');
+  });
+
+  it('setup-required mode prints the prompt protocol', async () => {
+    mockRunSetup.mockResolvedValue({
+      setupRequired: true,
+      prompts: [
+        { setting: 'githubUsername', prompt: 'Your handle?', current: null, required: true, type: 'string' },
+        { setting: 'languages', prompt: 'Langs?', current: ['ts'], default: ['ts', 'go'] },
+      ],
+    });
+
+    await buildProgram('setup').parseAsync(['node', 'cli', 'setup']);
+
+    const out = logged();
+    expect(out).toContain('SETUP_REQUIRED');
+    expect(out).toContain('SETTING: githubUsername');
+    expect(out).toContain('CURRENT: (not set)');
+    expect(out).toContain('REQUIRED: true');
+    expect(out).toContain('TYPE: string');
+    expect(out).toContain('CURRENT: ts');
+    expect(out).toContain('DEFAULT: ts, go');
+    expect(out).toContain('END_SETUP_PROMPTS');
+  });
+
+  it('--json routes through outputJsonValidated', async () => {
+    const data = { setupRequired: true, prompts: [] };
+    mockRunSetup.mockResolvedValue(data);
+
+    await buildProgram('setup').parseAsync(['node', 'cli', 'setup', '--json']);
+
+    expect(mockOutputJsonValidated).toHaveBeenCalledWith(SetupOutputSchema, data);
+  });
+});
+
+describe('checkSetup command', () => {
+  it('prints SETUP_COMPLETE with the username, or SETUP_INCOMPLETE', async () => {
+    mockRunCheckSetup.mockResolvedValueOnce({ setupComplete: true, username: 'octo' });
+    await buildProgram('checkSetup').parseAsync(['node', 'cli', 'checkSetup']);
+    expect(consoleLogSpy).toHaveBeenCalledWith('SETUP_COMPLETE');
+    expect(consoleLogSpy).toHaveBeenCalledWith('username=octo');
+
+    mockRunCheckSetup.mockResolvedValueOnce({ setupComplete: false });
+    await buildProgram('checkSetup').parseAsync(['node', 'cli', 'checkSetup']);
+    expect(consoleLogSpy).toHaveBeenCalledWith('SETUP_INCOMPLETE');
+  });
+
+  it('--json routes through outputJsonValidated', async () => {
+    const data = { setupComplete: false };
+    mockRunCheckSetup.mockResolvedValue(data);
+
+    await buildProgram('checkSetup').parseAsync(['node', 'cli', 'checkSetup', '--json']);
+
+    expect(mockOutputJsonValidated).toHaveBeenCalledWith(CheckSetupOutputSchema, data);
+  });
+});
+
+// ─── parse-issue-list / orphan-files / doctor commands (#1586) ──────────────
+
+describe('parse-issue-list command', () => {
+  const item = { tier: 'pursue', repo: 'octo/alpha', number: 1, title: 'T' };
+
+  it('renders available and completed sections with the resolved path', async () => {
+    mockRunParseList.mockResolvedValue({
+      availableCount: 1,
+      completedCount: 1,
+      available: [item],
+      completed: [{ ...item, tier: 'maybe', number: 2 }],
+    });
+
+    await buildProgram('parse-issue-list').parseAsync(['node', 'cli', 'parse-issue-list', '/tmp/list.md']);
+
+    expect(mockRunParseList).toHaveBeenCalledWith({ filePath: '/tmp/list.md' });
+    const out = consoleLogSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+    expect(out).toContain('Issue List: /tmp/list.md');
+    expect(out).toContain('Available: 1 | Completed: 1');
+    expect(out).toContain('--- Available ---');
+    expect(out).toContain('[pursue] octo/alpha#1: T');
+    expect(out).toContain('--- Completed ---');
+    expect(out).toContain('[maybe] octo/alpha#2: T');
+  });
+
+  it('--json routes through outputJsonValidated', async () => {
+    const data = { availableCount: 0, completedCount: 0, available: [], completed: [] };
+    mockRunParseList.mockResolvedValue(data);
+
+    await buildProgram('parse-issue-list').parseAsync(['node', 'cli', 'parse-issue-list', '/tmp/list.md', '--json']);
+
+    expect(mockOutputJsonValidated).toHaveBeenCalledWith(ParseIssueListOutputSchema, data);
+  });
+});
+
+describe('orphan-files command', () => {
+  it('prints the no-new-files note', async () => {
+    mockRunCheckIntegration.mockResolvedValue({ newFiles: [], unreferencedCount: 0 });
+
+    await buildProgram('orphan-files').parseAsync(['node', 'cli', 'orphan-files']);
+
+    expect(mockRunCheckIntegration).toHaveBeenCalledWith({ base: 'main' });
+    expect(consoleLogSpy).toHaveBeenCalledWith('\nNo new code files to check.');
+  });
+
+  it('--json routes through outputJsonValidated', async () => {
+    const data = { newFiles: [], unreferencedCount: 0 };
+    mockRunCheckIntegration.mockResolvedValue(data);
+
+    await buildProgram('orphan-files').parseAsync(['node', 'cli', 'orphan-files', '--json']);
+
+    expect(mockOutputJsonValidated).toHaveBeenCalledWith(CheckIntegrationOutputSchema, data);
+  });
+
+  it('renders integrated and orphaned files under the check-integration alias', async () => {
+    mockRunCheckIntegration.mockResolvedValue({
+      newFiles: [
+        { path: 'src/a.ts', isIntegrated: true, referencedBy: ['src/index.ts'] },
+        { path: 'src/b.ts', isIntegrated: false, referencedBy: [], suggestedEntryPoints: ['src/cli.ts'] },
+      ],
+      unreferencedCount: 1,
+    });
+
+    await buildProgram('orphan-files').parseAsync(['node', 'cli', 'check-integration', '--base', 'develop']);
+
+    expect(mockRunCheckIntegration).toHaveBeenCalledWith({ base: 'develop' });
+    const out = consoleLogSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+    expect(out).toContain('Integration Check (base: develop)');
+    expect(out).toContain('New files: 2 | Unreferenced: 1');
+    expect(out).toContain('✅ src/a.ts');
+    expect(out).toContain('Referenced by: src/index.ts');
+    expect(out).toContain('⚠️ src/b.ts');
+    expect(out).toContain('Not referenced by any file');
+    expect(out).toContain('Suggested entry points: src/cli.ts');
+  });
+});
+
+describe('doctor command', () => {
+  it('renders one status-tagged line per check plus the summary', async () => {
+    mockRunDoctor.mockResolvedValue({
+      checks: [
+        { name: 'token', status: 'ok', message: 'present' },
+        { name: 'bundle', status: 'warning', message: 'stale', remediation: 'pnpm run bundle' },
+        { name: 'state', status: 'error', message: 'corrupt' },
+      ],
+      summary: { ok: 1, warnings: 1, errors: 1 },
+    });
+
+    await buildProgram('doctor').parseAsync(['node', 'cli', 'doctor']);
+
+    const out = consoleLogSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+    expect(out).toContain('[OK]   token: present');
+    expect(out).toContain('[WARN] bundle: stale');
+    expect(out).toContain('↳ pnpm run bundle');
+    expect(out).toContain('[ERR]  state: corrupt');
+    expect(out).toContain('1 ok / 1 warning / 1 error');
+  });
+
+  it('--json routes through outputJsonValidated', async () => {
+    const data = { checks: [], summary: { ok: 0, warnings: 0, errors: 0 } };
+    mockRunDoctor.mockResolvedValue(data);
+
+    await buildProgram('doctor').parseAsync(['node', 'cli', 'doctor', '--json']);
+
+    expect(mockOutputJsonValidated).toHaveBeenCalledWith(DoctorOutputSchema, data);
+  });
+});
+
+// ─── startup command (#1586) ────────────────────────────────────────────────
+
+describe('startup command', () => {
+  const ready = { setupComplete: true, version: '9.9.9', daily: { briefSummary: '2 PRs need attention' } };
+
+  it('--json emits the full payload; --compact wraps it', async () => {
+    mockRunStartup.mockResolvedValue(ready);
+
+    await buildProgram('startup').parseAsync(['node', 'cli', 'startup', '--json']);
+    expect(mockOutputJson).toHaveBeenCalledWith(ready);
+
+    await buildProgram('startup').parseAsync(['node', 'cli', 'startup', '--json', '--compact']);
+    expect(mockOutputJson).toHaveBeenCalledWith({ compacted: ready });
+  });
+
+  it('prints version and brief summary in display mode', async () => {
+    mockRunStartup.mockResolvedValue(ready);
+
+    await buildProgram('startup').parseAsync(['node', 'cli', 'startup']);
+
+    expect(consoleLogSpy).toHaveBeenCalledWith('OSS Autopilot v9.9.9');
+    expect(consoleLogSpy).toHaveBeenCalledWith('2 PRs need attention');
+  });
+
+  it('prints the setup-incomplete and auth-error branches', async () => {
+    mockRunStartup.mockResolvedValueOnce({ setupComplete: false });
+    await buildProgram('startup').parseAsync(['node', 'cli', 'startup']);
+    expect(consoleLogSpy).toHaveBeenCalledWith('Setup incomplete. Run /setup-oss first.');
+
+    mockRunStartup.mockResolvedValueOnce({ setupComplete: true, authError: 'bad token' });
+    await buildProgram('startup').parseAsync(['node', 'cli', 'startup']);
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error: bad token');
+    expect(processExitSpy).not.toHaveBeenCalled();
+  });
+
+  it('routes a thrown error through handleCommandError in JSON mode', async () => {
+    mockRunStartup.mockRejectedValue(new Error('offline'));
+
+    await expect(buildProgram('startup').parseAsync(['node', 'cli', 'startup', '--json'])).rejects.toThrow(
+      'process.exit called',
+    );
+
+    expect(mockOutputJsonError).toHaveBeenCalledWith('offline', 'UNKNOWN');
+  });
+});
+
+// ─── pr-template / repo-vet / detect-formatters commands (#1586) ────────────
+
+describe('pr-template command', () => {
+  it('prints the template, the warning, or the not-found note', async () => {
+    mockRunPRTemplate.mockResolvedValueOnce({ template: '## Summary', source: '.github/PULL_REQUEST_TEMPLATE.md' });
+    await buildProgram('pr-template').parseAsync(['node', 'cli', 'pr-template', 'octo/alpha']);
+    expect(mockRunPRTemplate).toHaveBeenCalledWith({ repo: 'octo/alpha' });
+    expect(consoleLogSpy).toHaveBeenCalledWith('\nPR template found at: .github/PULL_REQUEST_TEMPLATE.md\n');
+    expect(consoleLogSpy).toHaveBeenCalledWith('## Summary');
+
+    mockRunPRTemplate.mockResolvedValueOnce({ template: null, error: '404' });
+    await buildProgram('pr-template').parseAsync(['node', 'cli', 'pr-template', 'octo/alpha']);
+    expect(consoleErrorSpy).toHaveBeenCalledWith('\nWarning: Could not check for PR template: 404');
+
+    mockRunPRTemplate.mockResolvedValueOnce({ template: null });
+    await buildProgram('pr-template').parseAsync(['node', 'cli', 'pr-template', 'octo/alpha']);
+    expect(consoleLogSpy).toHaveBeenCalledWith('\nNo PR template found for this repository.');
+  });
+
+  it('--json routes through outputJsonValidated', async () => {
+    const data = { template: null };
+    mockRunPRTemplate.mockResolvedValue(data);
+
+    await buildProgram('pr-template').parseAsync(['node', 'cli', 'pr-template', 'octo/alpha', '--json']);
+
+    expect(mockOutputJsonValidated).toHaveBeenCalledWith(PRTemplateOutputSchema, data);
+  });
+});
+
+describe('repo-vet command', () => {
+  const base = {
+    repoSlug: 'octo/alpha',
+    rubricScore: 7.25,
+    rubricVerdict: 'recommended',
+    repoMeta: { stars: 120, lastPushed: '2026-08-01' },
+    prMergeTime: { medianDays: 3.456, sampleSize: 12 },
+    mergeRate: { percent: 66.6, merged: 2, opened: 3 },
+  };
+
+  it('renders the health line, history score, and 90d metrics', async () => {
+    mockRunRepoVet.mockResolvedValue({ ...base, historyScore: 8 });
+
+    await buildProgram('repo-vet').parseAsync(['node', 'cli', 'repo-vet', 'octo/alpha']);
+
+    expect(mockRunRepoVet).toHaveBeenCalledWith({ repo: 'octo/alpha' });
+    const out = consoleLogSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+    expect(out).toContain('✅ octo/alpha: health 7.3/10 — recommended');
+    expect(out).toContain('History score (your past PRs here): 8/10');
+    expect(out).toContain('Stars: 120  Last push: 2026-08-01');
+    expect(out).toContain('Median merge time (90d): 3.5 days (12 samples)');
+    expect(out).toContain('Merge rate (90d): 67% (2/3)');
+  });
+
+  it.each([
+    ['proceed_with_caution', '⚠️'],
+    ['avoid', '❌'],
+  ])('maps verdict %s to %s and omits null metrics', async (verdict, emoji) => {
+    mockRunRepoVet.mockResolvedValue({
+      ...base,
+      rubricVerdict: verdict,
+      prMergeTime: { medianDays: null, sampleSize: 0 },
+      mergeRate: { percent: null, merged: 0, opened: 0 },
+    });
+
+    await buildProgram('repo-vet').parseAsync(['node', 'cli', 'repo-vet', 'octo/alpha']);
+
+    const out = consoleLogSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+    expect(out).toContain(`${emoji} octo/alpha: health 7.3/10 — ${verdict}`);
+    expect(out).not.toContain('History score');
+    expect(out).not.toContain('Median merge time');
+    expect(out).not.toContain('Merge rate');
+  });
+
+  it('--json routes through outputJsonValidated', async () => {
+    mockRunRepoVet.mockResolvedValue(base);
+
+    await buildProgram('repo-vet').parseAsync(['node', 'cli', 'repo-vet', 'octo/alpha', '--json']);
+
+    expect(mockOutputJsonValidated).toHaveBeenCalledWith(RepoVetOutputSchema, base);
+  });
+});
+
+describe('detect-formatters command', () => {
+  it('prints the no-formatters note', async () => {
+    mockRunDetectFormatters.mockResolvedValue({ formatters: [], packageJsonScripts: [] });
+
+    await buildProgram('detect-formatters').parseAsync(['node', 'cli', 'detect-formatters']);
+
+    expect(mockRunDetectFormatters).toHaveBeenCalledWith({ repoPath: undefined, ciLog: undefined });
+    expect(consoleLogSpy).toHaveBeenCalledWith('\nNo formatters detected.');
+  });
+
+  it('renders formatters, scripts, and a positive CI diagnosis', async () => {
+    mockRunDetectFormatters.mockResolvedValue({
+      formatters: [
+        { name: 'prettier', configPath: '.prettierrc', fixCommand: 'prettier -w .', checkCommand: 'prettier -c .' },
+      ],
+      packageJsonScripts: [{ name: 'lint', command: 'eslint .' }],
+      ciDiagnosis: {
+        isFormattingFailure: true,
+        formatter: 'prettier',
+        fixCommand: 'prettier -w .',
+        evidence: ['Code style issues'],
+      },
+    });
+
+    await buildProgram('detect-formatters').parseAsync([
+      'node',
+      'cli',
+      'detect-formatters',
+      '/repo',
+      '--ci-log',
+      '/tmp/ci.log',
+    ]);
+
+    expect(mockRunDetectFormatters).toHaveBeenCalledWith({ repoPath: '/repo', ciLog: '/tmp/ci.log' });
+    const out = consoleLogSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+    expect(out).toContain('Detected 1 formatter(s):');
+    expect(out).toContain('prettier (.prettierrc)');
+    expect(out).toContain('Fix:   prettier -w .');
+    expect(out).toContain('Check: prettier -c .');
+    expect(out).toContain('lint: eslint .');
+    expect(out).toContain('CI Diagnosis: Formatting failure detected (prettier)');
+    expect(out).toContain('Evidence: Code style issues');
+  });
+
+  it('prints the negative CI diagnosis', async () => {
+    mockRunDetectFormatters.mockResolvedValue({
+      formatters: [],
+      packageJsonScripts: [],
+      ciDiagnosis: { isFormattingFailure: false },
+    });
+
+    await buildProgram('detect-formatters').parseAsync(['node', 'cli', 'detect-formatters', '--ci-log', '/tmp/ci.log']);
+
+    expect(consoleLogSpy).toHaveBeenCalledWith('CI Diagnosis: No formatting failure detected.');
+  });
+
+  it('--json routes through outputJsonValidated', async () => {
+    const data = { formatters: [], packageJsonScripts: [] };
+    mockRunDetectFormatters.mockResolvedValue(data);
+
+    await buildProgram('detect-formatters').parseAsync(['node', 'cli', 'detect-formatters', '--json']);
+
+    expect(mockOutputJsonValidated).toHaveBeenCalledWith(DetectFormattersOutputSchema, data);
+  });
+});
+
+// ─── stats command (#1586) ──────────────────────────────────────────────────
+
+describe('stats command', () => {
+  const stats = {
+    username: 'octo',
+    totalMerged: 3,
+    totalClosed: 1,
+    mergeRateFormatted: '75%',
+    activePRs: 2,
+    reposContributed: 2,
+    topRepos: [{ repo: 'octo/alpha', mergedCount: 2 }],
+  };
+
+  it('renders the text report with top repos', async () => {
+    mockRunStats.mockResolvedValue(stats);
+
+    await buildProgram('stats').parseAsync(['node', 'cli', 'stats']);
+
+    const out = consoleLogSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+    expect(out).toContain('OSS Contribution Stats (@octo)');
+    expect(out).toContain('Merged PRs:        3');
+    expect(out).toContain('Merge Rate:        75%');
+    expect(out).toContain('Top Repos:');
+    expect(out).toContain('octo/alpha: 2 merged');
+    expect(out).toContain('Use --markdown for a shareable report');
+  });
+
+  it('--badge wins over --markdown and --json', async () => {
+    mockRunStats.mockResolvedValue(stats);
+
+    await buildProgram('stats').parseAsync(['node', 'cli', 'stats', '--badge', '--markdown', '--json']);
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      JSON.stringify({ schemaVersion: 1, label: 'merged', message: '3' }, null, 2),
+    );
+    expect(mockOutputJson).not.toHaveBeenCalled();
+  });
+
+  it('--markdown prints the formatted report; --json routes through outputJson', async () => {
+    mockRunStats.mockResolvedValue(stats);
+
+    await buildProgram('stats').parseAsync(['node', 'cli', 'stats', '--markdown']);
+    expect(consoleLogSpy).toHaveBeenCalledWith('# md report');
+
+    await buildProgram('stats').parseAsync(['node', 'cli', 'stats', '--json']);
+    expect(mockOutputJson).toHaveBeenCalledWith(stats);
+  });
+
+  it('routes a thrown error through handleCommandError', async () => {
+    mockRunStats.mockRejectedValue(new Error('no state'));
+
+    await expect(buildProgram('stats').parseAsync(['node', 'cli', 'stats'])).rejects.toThrow('process.exit called');
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error: no state');
+  });
+});
+
+// ─── guidelines subcommands (#1586) ─────────────────────────────────────────
+
+describe('guidelines subcommands', () => {
+  const REPO = 'octo/alpha';
+
+  it('list prints the empty note or the repo list', async () => {
+    mockGuidelinesList.mockResolvedValueOnce({ count: 0, repos: [], storageMode: 'local-unavailable' });
+    await buildProgram('guidelines').parseAsync(['node', 'cli', 'guidelines', 'list']);
+    expect(consoleLogSpy).toHaveBeenCalledWith('No guidelines stored for any repo (storage: local-unavailable).');
+
+    mockGuidelinesList.mockResolvedValueOnce({ count: 2, repos: ['a/b', 'c/d'], storageMode: 'gist' });
+    await buildProgram('guidelines').parseAsync(['node', 'cli', 'guidelines', 'list']);
+    expect(consoleLogSpy).toHaveBeenCalledWith('2 repo(s) with stored guidelines:');
+    expect(consoleLogSpy).toHaveBeenCalledWith('  a/b');
+  });
+
+  it('list --json routes through outputJson (tier-2)', async () => {
+    const data = { count: 0, repos: [], storageMode: 'gist' };
+    mockGuidelinesList.mockResolvedValue(data);
+
+    await buildProgram('guidelines').parseAsync(['node', 'cli', 'guidelines', 'list', '--json']);
+
+    expect(mockOutputJson).toHaveBeenCalledWith(data);
+  });
+
+  it('view prints the content header or the none-stored note', async () => {
+    mockGuidelinesView.mockResolvedValueOnce({ repo: REPO, content: '- be nice', byteSize: 9, storageMode: 'gist' });
+    await buildProgram('guidelines').parseAsync(['node', 'cli', 'guidelines', 'view', '--repo', REPO]);
+    expect(mockGuidelinesView).toHaveBeenCalledWith({ repo: REPO });
+    expect(consoleLogSpy).toHaveBeenCalledWith(`# Guidelines for ${REPO} (9 bytes)\n`);
+    expect(consoleLogSpy).toHaveBeenCalledWith('- be nice');
+
+    mockGuidelinesView.mockResolvedValueOnce({ repo: REPO, content: null, storageMode: 'local-unavailable' });
+    await buildProgram('guidelines').parseAsync(['node', 'cli', 'guidelines', 'view', '--repo', REPO]);
+    expect(consoleLogSpy).toHaveBeenCalledWith(`No guidelines stored for ${REPO} (storage: local-unavailable).`);
+  });
+
+  it('view --json routes through outputJson (tier-2)', async () => {
+    const data = { repo: REPO, content: null, storageMode: 'gist' };
+    mockGuidelinesView.mockResolvedValue(data);
+
+    await buildProgram('guidelines').parseAsync(['node', 'cli', 'guidelines', 'view', '--repo', REPO, '--json']);
+
+    expect(mockOutputJson).toHaveBeenCalledWith(data);
+  });
+
+  it('store uses --content inline and prints the byte count', async () => {
+    mockGuidelinesStore.mockResolvedValue({ repo: REPO, byteSize: 5 });
+
+    await buildProgram('guidelines').parseAsync([
+      'node',
+      'cli',
+      'guidelines',
+      'store',
+      '--repo',
+      REPO,
+      '--content',
+      'hello',
+    ]);
+
+    expect(mockGuidelinesStore).toHaveBeenCalledWith({ repo: REPO, content: 'hello' });
+    expect(consoleLogSpy).toHaveBeenCalledWith(`Stored 5 bytes of guidelines for ${REPO}.`);
+  });
+
+  it('store without --content reads the markdown from piped stdin', async () => {
+    mockGuidelinesStore.mockResolvedValue({ repo: REPO, byteSize: 6 });
+    await withStdin('piped\n', () =>
+      buildProgram('guidelines').parseAsync(['node', 'cli', 'guidelines', 'store', '--repo', REPO]),
+    );
+
+    expect(mockGuidelinesStore).toHaveBeenCalledWith({ repo: REPO, content: 'piped\n' });
+  });
+
+  it('store without --content fails clearly on a TTY stdin', async () => {
+    await expect(
+      withStdin(null, () =>
+        buildProgram('guidelines').parseAsync(['node', 'cli', 'guidelines', 'store', '--repo', REPO, '--json']),
+      ),
+    ).rejects.toThrow('process.exit called');
+
+    expect(mockOutputJsonError).toHaveBeenCalledWith(
+      'No --content provided and stdin is a TTY. Pipe content or pass --content "...".',
+      'UNKNOWN',
+    );
+    expect(mockGuidelinesStore).not.toHaveBeenCalled();
+  });
+
+  it('reset prints the deleted or nothing-to-reset line', async () => {
+    mockGuidelinesReset.mockResolvedValueOnce({ repo: REPO, deleted: true });
+    await buildProgram('guidelines').parseAsync(['node', 'cli', 'guidelines', 'reset', '--repo', REPO]);
+    expect(mockGuidelinesReset).toHaveBeenCalledWith({ repo: REPO });
+    expect(consoleLogSpy).toHaveBeenCalledWith(`Reset guidelines for ${REPO}.`);
+
+    mockGuidelinesReset.mockResolvedValueOnce({ repo: REPO, deleted: false });
+    await buildProgram('guidelines').parseAsync(['node', 'cli', 'guidelines', 'reset', '--repo', REPO]);
+    expect(consoleLogSpy).toHaveBeenCalledWith(`No guidelines existed for ${REPO}; nothing to reset.`);
+  });
+
+  it('fetch-corpus parses --limit, passes --force, and reports skipped PRs', async () => {
+    mockFetchCorpus.mockResolvedValue({ repo: REPO, prCount: 3, skipped: 2 });
+
+    await buildProgram('guidelines').parseAsync([
+      'node',
+      'cli',
+      'guidelines',
+      'fetch-corpus',
+      '--repo',
+      REPO,
+      '--limit',
+      '7',
+      '--force',
+    ]);
+
+    expect(mockFetchCorpus).toHaveBeenCalledWith({ repo: REPO, limit: 7, forceRefetch: true });
+    expect(consoleLogSpy).toHaveBeenCalledWith(`Fetched 3 PR comment bundle(s) for ${REPO}.`);
+    expect(consoleLogSpy).toHaveBeenCalledWith('  Skipped 2 PR(s) already processed (use --force to re-fetch).');
+  });
+
+  it('fetch-corpus omits the skipped line when nothing was skipped', async () => {
+    mockFetchCorpus.mockResolvedValue({ repo: REPO, prCount: 1, skipped: 0 });
+
+    await buildProgram('guidelines').parseAsync(['node', 'cli', 'guidelines', 'fetch-corpus', '--repo', REPO]);
+
+    expect(mockFetchCorpus).toHaveBeenCalledWith({ repo: REPO, limit: undefined, forceRefetch: undefined });
+    expect(consoleLogSpy).not.toHaveBeenCalledWith(expect.stringContaining('Skipped'));
   });
 });

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -17,9 +17,11 @@ export default defineConfig({
       // carved out), so the gate is expressed as two glob sets instead:
       //   - everything except cli-registry.ts keeps the original 80% gate
       //     (picomatch negation; both sets are aggregate, not per-file);
-      //   - cli-registry.ts gets honest floors at its current level so
-      //     regressions fail CI. Ratchet these up as direct tests are added
-      //     (tracked in #1586).
+      //   - cli-registry.ts has its own floors, set ~2 points under the
+      //     measured value. That slack is ~45 statements, so the gate catches
+      //     an untested new command or a deleted describe block, not a single
+      //     dropped `it`. When a new command lands, add its
+      //     cli-registry.test.ts cases in the same PR so the floors hold.
       thresholds: {
         '!src/cli-registry.ts': {
           statements: 80,
@@ -27,14 +29,15 @@ export default defineConfig({
           functions: 80,
           lines: 80,
         },
-        // First ratchet (#1586): direct handler tests for status, strategy,
-        // daily, track, compliance-score, comments, post, and claim lifted
-        // measured coverage to 42.85/30.81/55.55/43.06.
+        // Ratchet history (#1586): first pass (status, strategy, daily, track,
+        // compliance-score, comments, post, claim) measured 42.85/30.81/55.55/43.06;
+        // second pass covered every remaining handler plus executeAction's
+        // schema-mismatch and stdin paths and measured 99.68/90.33/100/99.84.
         'src/cli-registry.ts': {
-          statements: 42,
-          branches: 30,
-          functions: 55,
-          lines: 42,
+          statements: 97,
+          branches: 88,
+          functions: 98,
+          lines: 97,
         },
       },
     },


### PR DESCRIPTION
## Summary

- Adds direct commander-driven tests in `packages/core/src/cli-registry.test.ts` for every handler that was still only reached through the e2e bundle subprocess: `state`, `features`, `vet`, `vet-list`, `list-move-tier`, `list-mark-done`, `config`, `init`, `setup`, `checkSetup`, `parse-issue-list`, `orphan-files`, `doctor`, `startup`, `pr-template`, `repo-vet`, `detect-formatters`, `stats`, and the five `guidelines` subcommands.
- Covers `executeAction`'s remaining branches directly: a Zod schema mismatch surfacing through the JSON error envelope, a throw inside `display()` routed to `exit(1)`, and the two stdin readers (`post --stdin`, `guidelines store` without `--content`, plus the TTY refusal).
- Mocked schema markers now carry their own name, so the new `--json` tests assert the exact schema each command passes instead of `expect.anything()`.
- Raises the per-file thresholds for `cli-registry.ts` in `packages/core/vitest.config.ts` and rewrites the ratchet comment.

## Why

`cli-registry.ts` (1,731 lines) sat at 42/30/55/42 floors because its handlers ran only via the esbuild bundle, which emits no in-process coverage. The vitest config asked for the floors to be ratcheted as direct tests landed; #1586 tracks that.

## Coverage for `packages/core/src/cli-registry.ts`

| | statements | branches | functions | lines |
|---|---|---|---|---|
| before (main) | 42.85 | 30.81 | 55.55 | 43.06 |
| after | 99.68 | 90.33 | 100 | 99.84 |
| new thresholds | 97 | 88 | 98 | 97 |

The remaining uncovered line (414) is the `console.warn` for a rate-limit warning in the non-empty `search` display path.

## Test plan

- `pnpm vitest run --coverage` in `packages/core`: 3156 passed, 25 skipped, 3 todo; coverage gate passes with the new thresholds (was 3083 passed on main).
- `npx vitest run src/cli-registry.test.ts`: 133 tests in the file; 73 new across the suite.
- `tsc --noEmit` and `tsc --noEmit -p tsconfig.tests.json` clean.
- `pnpm run lint`: 0 errors.
- `prettier --check` on both touched files clean.

Closes #1586
