### PR TITLE
perf(bundle): ship only zod's English locale in the core and MCP bundles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,8 @@ env:
   #   - **Don't bump for a flaky measurement:** esbuild output is
   #     deterministic. If the threshold trips on a no-op rebuild, it's a
   #     real increase somewhere upstream — not noise.
-  BUNDLE_MAX_CORE: 1100000 # ~1074 KB (raised for zod 4.4.3 -> 4.5.4, which grew its in-bundle share 330 -> 437 KB: JIT compile, json-schema processors, locales; current ~998 KB)
-  BUNDLE_MAX_MCP: 2000000 # ~1953 KB
+  BUNDLE_MAX_CORE: 920000 # ~898 KB (lowered after scripts/bundle.mjs dropped zod's unused locales, 1009 -> 762 KB; #1651)
+  BUNDLE_MAX_MCP: 1160000 # ~1133 KB (lowered for the same reason, 1237 -> 990 KB; #1651)
   STARTUP_WARN_MS: 500 # Warn if CLI startup exceeds 500ms
 
 jobs:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -143,7 +143,7 @@ Debug and warning output goes to stderr via the logger, so it never contaminates
 ### Build
 
 ```
-esbuild src/cli.ts --bundle --platform=node --target=node22 --format=cjs --outfile=dist/cli.bundle.cjs  # run from packages/core/
+pnpm run bundle  # from packages/core/; runs the repo-root scripts/bundle.mjs (esbuild, plus a plugin that keeps only zod's `en` locale out of the ~40 it re-exports)
 ```
 
 The bundle is a single CommonJS file (gitignored, auto-generated). Commands rebuild it on demand via `scripts/build-cli-if-stale.sh` when the sources or `package.json` are newer than the bundle.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "bundle": "esbuild src/cli.ts --bundle --platform=node --target=node22 --format=cjs --minify --sourcemap --outfile=dist/cli.bundle.cjs",
+    "bundle": "node ../../scripts/bundle.mjs src/cli.ts dist/cli.bundle.cjs --sourcemap",
     "start": "tsx src/cli.ts",
     "dev": "tsx watch src/cli.ts",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.tests.json",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "bundle": "esbuild src/index.ts --bundle --platform=node --target=node22 --format=cjs --minify --outfile=dist/mcp-server.bundle.cjs",
+    "bundle": "node ../../scripts/bundle.mjs src/index.ts dist/mcp-server.bundle.cjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/scripts/build-cli-if-stale.sh
+++ b/scripts/build-cli-if-stale.sh
@@ -5,6 +5,7 @@
 # newer than the built artifact:
 #   packages/core/src/**         (source files)
 #   packages/core/package.json   (dep changes)
+#   scripts/bundle.mjs           (the esbuild build script)
 #   packages/core/tsconfig.json  (compiler config changes)
 #
 # It is also considered stale when the installed @oss-scout/core dependency
@@ -62,6 +63,7 @@ else
     "${PLUGIN_ROOT}/packages/core/src" \
     "${PLUGIN_ROOT}/packages/core/package.json" \
     "${PLUGIN_ROOT}/packages/core/tsconfig.json" \
+    "${PLUGIN_ROOT}/scripts/bundle.mjs" \
     -type f \
     ! -path '*/node_modules/*' \
     ! -path '*/.git/*' \

--- a/scripts/build-cli-if-stale.test.sh
+++ b/scripts/build-cli-if-stale.test.sh
@@ -48,6 +48,8 @@ setup() {
 }
 EOF
     echo "{}" >"${PLUGIN}/packages/core/tsconfig.json"
+    mkdir -p "${PLUGIN}/scripts"
+    echo "// bundle script stub" >"${PLUGIN}/scripts/bundle.mjs"
     echo "// existing bundle" >"${PLUGIN}/packages/core/dist/cli.bundle.cjs"
     echo "export const x = 1;" >"${PLUGIN}/packages/core/src/index.ts"
     cat >"${PLUGIN}/packages/core/node_modules/@oss-scout/core/package.json" <<'EOF'
@@ -210,6 +212,29 @@ EOF
     rc=$?
     rm -rf "$fake_bin"
     [ "$rc" = 1 ] && pass || fail "expected exit 1 when package.json is newer, got $rc"
+}
+
+case_bundle_script_newer_triggers_rebuild() {
+    # A change to the esbuild build script (e.g. its plugins) must rebuild
+    # even when src/ and package.json are untouched.
+    sleep 1
+    touch "${PLUGIN}/scripts/bundle.mjs"
+
+    fake_bin=$(mktemp -d)
+    cat >"${fake_bin}/pnpm" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    cat >"${fake_bin}/npm" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "${fake_bin}/pnpm" "${fake_bin}/npm"
+
+    PATH="${fake_bin}:${PATH}" "$SUBJECT" "$PLUGIN" >/dev/null 2>&1
+    rc=$?
+    rm -rf "$fake_bin"
+    [ "$rc" = 1 ] && pass || fail "expected exit 1 when scripts/bundle.mjs is newer, got $rc"
 }
 
 case_dep_missing_triggers_install() {
@@ -403,6 +428,7 @@ run case_missing_bundle_triggers_rebuild  case_missing_bundle_triggers_rebuild
 run case_swap_files_do_not_trigger_rebuild case_swap_files_do_not_trigger_rebuild
 run case_build_failure_returns_2          case_build_failure_returns_2
 run case_package_json_newer_triggers_rebuild case_package_json_newer_triggers_rebuild
+run case_bundle_script_newer_triggers_rebuild case_bundle_script_newer_triggers_rebuild
 run case_dep_missing_triggers_install         case_dep_missing_triggers_install
 run case_dep_stamp_fresh_skips_check          case_dep_stamp_fresh_skips_check
 run case_dep_versions_match_no_rebuild        case_dep_versions_match_no_rebuild

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * Build a package's single-file CJS bundle with esbuild. Run from the package
+ * directory (each package's `bundle` script does this):
+ *
+ *   node ../../scripts/bundle.mjs <entry> <outfile> [--sourcemap]
+ *
+ * Same flags as the old per-package esbuild one-liners, plus one plugin: zod's
+ * classic entry re-exports every locale (`export * as locales`) from both
+ * `v4/classic/external.js` and `v4/core/index.js`, and esbuild cannot
+ * tree-shake `export * as` namespaces, so all ~40 locales (~255 KB minified)
+ * landed in every bundle although nothing here reads `z.locales` (#1651).
+ * The plugin swaps zod's `locales/index.js` for a module that only re-exports
+ * `en` (which zod registers as the default locale anyway). Consequence: inside
+ * a bundle, `z.locales.<anything but en>` is `undefined` at runtime rather
+ * than a build-time error; no current caller uses it.
+ *
+ * Set BUNDLE_METAFILE=<path> to also write an esbuild metafile for size work.
+ */
+import { writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+// esbuild is a devDependency of each package, not of the workspace root.
+const { build } = createRequire(path.join(process.cwd(), 'package.json'))('esbuild');
+
+const [entry, outfile, ...flags] = process.argv.slice(2);
+if (!entry || !outfile) {
+  console.error('usage: node scripts/bundle.mjs <entry> <outfile> [--sourcemap]');
+  process.exit(2);
+}
+
+const onlyEnLocale = {
+  name: 'zod-only-en-locale',
+  setup(b) {
+    b.onResolve({ filter: /\/locales\/index\.js$/ }, (args) => {
+      if (!args.importer.includes(`${path.sep}node_modules${path.sep}zod${path.sep}`)) return null;
+      return { path: path.resolve(args.resolveDir, args.path), namespace: 'zod-only-en-locale' };
+    });
+    b.onLoad({ filter: /.*/, namespace: 'zod-only-en-locale' }, (args) => ({
+      contents: 'export { default as en } from "./en.js";',
+      resolveDir: path.dirname(args.path),
+    }));
+  },
+};
+
+const result = await build({
+  entryPoints: [entry],
+  bundle: true,
+  platform: 'node',
+  target: 'node22',
+  format: 'cjs',
+  minify: true,
+  sourcemap: flags.includes('--sourcemap'),
+  outfile,
+  metafile: Boolean(process.env.BUNDLE_METAFILE),
+  plugins: [onlyEnLocale],
+});
+if (process.env.BUNDLE_METAFILE) writeFileSync(process.env.BUNDLE_METAFILE, JSON.stringify(result.metafile));


### PR DESCRIPTION
## Summary

zod's classic entry re-exports every locale (`export * as locales`) from both `v4/classic/external.js` and `v4/core/index.js`, and esbuild cannot tree-shake `export * as` namespaces, so all ~40 locales (~255 KB minified) were landing in both bundles although nothing reads `z.locales`. Switching the import path (`zod/v4`, `import * as z`) changes nothing; the locale set is pulled in below the public entry.

This replaces the two per-package esbuild one-liners with a shared `scripts/bundle.mjs` whose plugin resolves zod's internal `locales/index.js` to a shim that only re-exports `en` (the locale zod registers by default anyway). Both `bundle` scripts now call it; flags are otherwise unchanged (core keeps its sourcemap, MCP never had one).

## Numbers

esbuild metafile, minified, no sourcemap, bytes.

| core CLI bundle (`cli.bundle.cjs`) | total | zod | zod/locales |
| --- | ---: | ---: | ---: |
| baseline (`import { z } from 'zod'`) | 1,032,903 | 436,765 | 255,374 |
| `import * as z from 'zod'` | 1,028,030 | 436,746 | 255,374 |
| `import { z } from 'zod/v4'` | 1,032,950 | 436,812 | 255,374 |
| en-only locale plugin (this PR) | 780,109 | 184,077 | 2,716 |

| MCP bundle (`mcp-server.bundle.cjs`) | total | zod | zod/locales |
| --- | ---: | ---: | ---: |
| baseline | 1,266,783 | 495,315 | 258,403 |
| en-only locale plugin (this PR) | 1,013,415 | 242,663 | 5,745 |

Core -252,794 bytes (-24.5%), MCP -253,368 bytes (-20.0%). `BUNDLE_MAX_CORE` goes back to 920000 (it was raised to 1100000 for the zod 4.5.4 bump) and `BUNDLE_MAX_MCP` drops to 1160000; both leave about 140 KB of headroom.

For reference, a `zod/mini` migration (issue option 2) would touch 762 `z.*` calls plus 283 chained method calls (112 `.optional()`, 48 `.int()`, 41 `.nonnegative()`, 39 `.default()`, 20 `.nullable()`, 11 `.passthrough()`, ...) across four files, and would still need this plugin: `v4/mini/external.js` re-exports the locales the same way.

## Why it is safe

- The only zod value importers in the bundles are our own schemas (`state-schema`, `dashboard-data-schema`, `formatters/json`), `@oss-scout/core`'s schemas, and `@modelcontextprotocol/sdk`. None of them reference `z.locales` or `z.config(...)` (grepped), so the removed exports are unreachable code.
- `en` is still bundled: zod's `ZodType` constructor imports `locales/en.js` directly and registers it as the default, so error messages are unchanged. Checked in both bundles: the English message strings are present and the Hebrew locale text is gone.
- Only the bundles are affected. The tsc `dist/` used by library consumers and by `packages/mcp-server` at typecheck time is untouched.
- The plugin only rewrites the `locales/index.js` import when the importer sits under `node_modules/zod/`, so a future dependency that ships its own `locales/index.js` is not touched.
- After this change `z.locales.<non-en>` evaluates to `undefined` at runtime inside a bundle instead of failing at build time; this is documented in the script header.

## Test plan

- [x] `pnpm run bundle` in `packages/core` and `packages/mcp-server`; both bundles start (`--version`, MCP `initialize` handshake)
- [x] `pnpm test` in `packages/core` (3211 passed) and `packages/mcp-server` (243 passed)
- [x] `pnpm run lint`, `pnpm run typecheck`, `pnpm run format:check` at the root
- [x] `bash scripts/build-cli-if-stale.test.sh` (14 passed, including the new `case_bundle_script_newer_triggers_rebuild`)
- [ ] CI bundle-size job passes against the lowered thresholds
