### PR TITLE
docs: correct Ink stars and Homebrew link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 ---
 
-**Built and used daily by [costajohnt](https://github.com/costajohnt)** — 3rd biggest contributor to [Ink](https://github.com/vadimdemedes/ink) (the React CLI framework behind Claude Code, Gemini CLI, and Codex — 32k+ stars) and repeat contributor to [Homebrew](https://github.com/Homebrew/homebrew-cask).
+**Built and used daily by [costajohnt](https://github.com/costajohnt)** — 3rd-largest contributor to [Ink](https://github.com/vadimdemedes/ink) by commits (the React CLI framework behind Claude Code, Gemini CLI, and Codex — 39k+ stars) and repeat contributor to [Homebrew](https://github.com/Homebrew/brew).
 
 <p align="center">
 <a href="https://github.com/costajohnt/oss-autopilot">


### PR DESCRIPTION
README line 27: Ink star count 32k+ was stale (39.8k as of 2026-09-05), Homebrew link pointed at homebrew-cask but all 9 merged PRs are in Homebrew/brew. Rank wording tightened to "3rd-largest by commits".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrkNmkb5sxNwmRveBD2ASD