### PR TITLE
docs: add SUPPORT.md with contact channels

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,6 @@
+# Support
+
+- **Bugs and feature requests:** open an issue at https://github.com/costajohnt/oss-autopilot/issues
+- **Everything else:** email costajohnt@gmail.com
+
+Questions about GitHub API usage, rate limits, or the ETag cache are welcome in issues too.


### PR DESCRIPTION
Public support contact (issues + email) required for the GitHub Developer Program registration of oss-autopilot as a GitHub API integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrkNmkb5sxNwmRveBD2ASD