### PR TITLE
chore(ci): publish to npm through trusted publishing instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -55,10 +55,22 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # npm trusted publishing (OIDC): the job's id-token mints the credential,
+      # so no long-lived NPM_TOKEN is needed. The 3.22.0 publish failed with
+      # `404 Not Found - PUT` on a fresh granular token after npm restricted
+      # 2FA-bypassing tokens; the trusted publisher for both packages is
+      # registered on npmjs.com (owner costajohnt, repo oss-autopilot, this
+      # workflow file). Needs npm >= 11.5.1, newer than Node 22's bundled npm.
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest && npm --version
+
+      - name: Build and pack @oss-autopilot/core
+        run: |
+          pnpm --filter @oss-autopilot/core run prepublishOnly
+          pnpm --filter @oss-autopilot/core pack --pack-destination "$RUNNER_TEMP/pkg-core"
+
       - name: Publish @oss-autopilot/core
-        run: pnpm --filter @oss-autopilot/core publish --access public --no-git-checks --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish "$RUNNER_TEMP"/pkg-core/*.tgz --access public --provenance
 
   publish-mcp-npm:
     name: Publish MCP server to npm
@@ -93,7 +105,15 @@ jobs:
       - name: Build core (required by mcp-server)
         run: pnpm --filter @oss-autopilot/core run build
 
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest && npm --version
+
+      # `pnpm pack` rewrites the `workspace:^` dependency on core to the
+      # released version; `npm publish <tarball>` then needs no pnpm at all.
+      - name: Build and pack @oss-autopilot/mcp
+        run: |
+          pnpm --filter @oss-autopilot/mcp run prepublishOnly
+          pnpm --filter @oss-autopilot/mcp pack --pack-destination "$RUNNER_TEMP/pkg-mcp"
+
       - name: Publish @oss-autopilot/mcp
-        run: pnpm --filter @oss-autopilot/mcp publish --access public --no-git-checks --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish "$RUNNER_TEMP"/pkg-mcp/*.tgz --access public --provenance


### PR DESCRIPTION
## Why
The 3.22.0 publish failed with `404 Not Found - PUT` on the expired token and again on a freshly minted granular token that authenticates (`/-/whoami` answers the maintainer), matching npm's notice that tokens bypassing 2FA are being restricted for direct publishing.

## What
Both publish jobs already run with `id-token: write` and `--provenance`. This switches them to npm trusted publishing (OIDC): upgrade npm to 11.5+, build and `pnpm pack` each package (rewrites the `workspace:^` dependency on core), then `npm publish <tarball> --access public --provenance` with no auth token in the environment.

## Prerequisite (done on npmjs.com by the maintainer)
Trusted publisher registered for `@oss-autopilot/core` and `@oss-autopilot/mcp`: owner costajohnt, repo oss-autopilot, workflow `release-please.yml`, no environment.

## Test plan
- [ ] CI green on this PR (the publish jobs only run on a release)
- [ ] merge release PR 1659 (3.22.1); publish jobs succeed; `npm view @oss-autopilot/core version` prints 3.22.1
- [ ] install the published version into a scratch prefix and run the bin