### PR TITLE
fix: --version returns 0.0.0 through bin symlink

### DIFF
--- a/packages/core/src/core/paths.ts
+++ b/packages/core/src/core/paths.ts
@@ -126,12 +126,25 @@ export function stateFileExists(): boolean {
   return fs.existsSync(stateFile);
 }
 
+// Injected by esbuild at bundle time via the `define` option in scripts/bundle.mjs.
+// Undefined in dev mode (tsx) and test environments.
+declare const __CLI_VERSION__: string | undefined;
+
 /**
- * Read the CLI package version from package.json relative to the running CLI bundle.
- * Resolves `../package.json` from `process.argv[1]` (the bundle entry point).
- * Falls back to '0.0.0' if the file is unreadable.
+ * Read the CLI package version.
+ *
+ * When running from the published bundle, esbuild inlines the version string as
+ * `__CLI_VERSION__` at build time, so no filesystem access is needed and the
+ * result is correct regardless of how the binary is invoked (direct path or bin
+ * symlink). In dev mode (tsx) or tests, falls back to reading package.json
+ * relative to process.argv[1].
  */
 export function getCLIVersion(): string {
+  // Bundle path: esbuild replaces __CLI_VERSION__ with the literal version string.
+  if (typeof __CLI_VERSION__ !== 'undefined') {
+    return __CLI_VERSION__;
+  }
+  // Dev/test fallback: resolve package.json from the entry point.
   try {
     const pkgPath = path.join(path.dirname(process.argv[1]), '..', 'package.json');
     return JSON.parse(fs.readFileSync(pkgPath, 'utf8')).version;

--- a/packages/core/src/core/utils.test.ts
+++ b/packages/core/src/core/utils.test.ts
@@ -17,7 +17,7 @@ import {
   resetGitHubTokenCache,
   detectGitHubUsername,
 } from './auth.js';
-import { getDataDir, getStatePath, getBackupDir, stateFileExists } from './paths.js';
+import { getDataDir, getStatePath, getBackupDir, stateFileExists, getCLIVersion } from './paths.js';
 import { execFileSync, execFile } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -620,5 +620,35 @@ describe('detectGitHubUsername', () => {
     });
     const username = await detectGitHubUsername();
     expect(username).toBeNull();
+  });
+});
+
+// ─── getCLIVersion (#1664) ────────────────────────────────────────────────────
+
+describe('getCLIVersion', () => {
+  afterEach(() => {
+    // Clean up any global we set during tests
+    delete (globalThis as Record<string, unknown>).__CLI_VERSION__;
+  });
+
+  it('returns the compile-time constant when __CLI_VERSION__ is defined (bundle path)', () => {
+    // Simulate esbuild's define replacement by setting the global before calling.
+    (globalThis as Record<string, unknown>).__CLI_VERSION__ = '9.8.7';
+    expect(getCLIVersion()).toBe('9.8.7');
+  });
+
+  it('does not return "0.0.0" when __CLI_VERSION__ is defined as a real version', () => {
+    (globalThis as Record<string, unknown>).__CLI_VERSION__ = '3.22.1';
+    expect(getCLIVersion()).not.toBe('0.0.0');
+    expect(getCLIVersion()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('falls back gracefully when __CLI_VERSION__ is not defined (dev/test path)', () => {
+    // No global set — the fallback runs. It either reads a local package.json
+    // (dev mode) or catches and returns the '0.0.0' sentinel. Either result is
+    // a semver-like string; the important thing is it does not throw.
+    expect(() => getCLIVersion()).not.toThrow();
+    expect(typeof getCLIVersion()).toBe('string');
+    expect(getCLIVersion().length).toBeGreaterThan(0);
   });
 });

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -17,12 +17,17 @@
  *
  * Set BUNDLE_METAFILE=<path> to also write an esbuild metafile for size work.
  */
-import { writeFileSync } from 'node:fs';
+import { writeFileSync, readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 
 // esbuild is a devDependency of each package, not of the workspace root.
 const { build } = createRequire(path.join(process.cwd(), 'package.json'))('esbuild');
+
+// Read the version from the package that owns this bundle entry (packages/core).
+// This is used to inline __CLI_VERSION__ at build time so --version is correct
+// regardless of whether the binary is invoked directly or via a bin symlink.
+const { version: CLI_VERSION } = JSON.parse(readFileSync(path.join(process.cwd(), 'package.json'), 'utf8'));
 
 const [entry, outfile, ...flags] = process.argv.slice(2);
 if (!entry || !outfile) {
@@ -55,5 +60,13 @@ const result = await build({
   outfile,
   metafile: Boolean(process.env.BUNDLE_METAFILE),
   plugins: [onlyEnLocale],
+  define: {
+    // Inline the package version at build time so getCLIVersion() returns the
+    // correct value even when the binary is invoked through a bin symlink
+    // (e.g. node_modules/.bin/oss-autopilot), where process.argv[1] does not
+    // point at the bundle file and the filesystem fallback resolves the wrong
+    // package.json (#1664).
+    __CLI_VERSION__: JSON.stringify(CLI_VERSION),
+  },
 });
 if (process.env.BUNDLE_METAFILE) writeFileSync(process.env.BUNDLE_METAFILE, JSON.stringify(result.metafile));


### PR DESCRIPTION
## What

`--version` printed `0.0.0` when run through the installed bin symlink. `getCLIVersion` resolved `package.json` relative to `process.argv[1]`, which points at the `.bin` symlink rather than the built CJS file when installed from npm. The path became `node_modules/package.json` (nonexistent), so the catch block returned the `0.0.0` fallback. `oss-autopilot-mcp --version` was unaffected because it uses a different resolution path.

## How

Inline the version at bundle time via esbuild's `define` option in `scripts/bundle.mjs`. The build script reads the version from `packages/core/package.json` and substitutes `__CLI_VERSION__` with the literal string in the compiled output. `getCLIVersion` in `packages/core/src/core/paths.ts` checks for the injected constant first and falls back to the filesystem read only in dev/test environments (where esbuild has not run).

A new test in `utils.test.ts` verifies that the constant path is taken when `__CLI_VERSION__` is defined.

## Verification

```sh
pnpm build
npm pack packages/core
npm i oss-autopilot-core-*.tgz --prefix /tmp/verify-1664
/tmp/verify-1664/node_modules/.bin/oss-autopilot --version
# prints the real version, not 0.0.0
```

Closes #1664