### PR TITLE
fix(cli): resolve the package version through the bin symlink

### DIFF
--- a/packages/core/src/core/paths.test.ts
+++ b/packages/core/src/core/paths.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { getCLIVersion } from './paths.js';
+
+// getCLIVersion locates package.json from process.argv[1]. Installed from npm
+// that argv entry is the node_modules/.bin symlink, not the bundle (#1664).
+describe('getCLIVersion', () => {
+  let tmp: string;
+  const savedArgv1 = process.argv[1];
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'oss-autopilot-version-'));
+    fs.mkdirSync(path.join(tmp, 'pkg', 'dist'), { recursive: true });
+    fs.mkdirSync(path.join(tmp, 'bin'));
+    fs.writeFileSync(path.join(tmp, 'pkg', 'package.json'), JSON.stringify({ version: '9.9.9' }));
+    fs.writeFileSync(path.join(tmp, 'pkg', 'dist', 'cli.bundle.cjs'), '');
+  });
+
+  afterEach(() => {
+    process.argv[1] = savedArgv1;
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('reads the version when argv[1] is the bundle itself', () => {
+    process.argv[1] = path.join(tmp, 'pkg', 'dist', 'cli.bundle.cjs');
+    expect(getCLIVersion()).toBe('9.9.9');
+  });
+
+  it('reads the version when argv[1] is a .bin-style symlink to the bundle', () => {
+    const link = path.join(tmp, 'bin', 'oss-autopilot');
+    fs.symlinkSync(path.join('..', 'pkg', 'dist', 'cli.bundle.cjs'), link);
+    process.argv[1] = link;
+    expect(getCLIVersion()).toBe('9.9.9');
+  });
+
+  it('falls back to 0.0.0 when no package.json sits beside the entry', () => {
+    process.argv[1] = path.join(tmp, 'bin', 'missing.cjs');
+    expect(getCLIVersion()).toBe('0.0.0');
+  });
+});

--- a/packages/core/src/core/paths.ts
+++ b/packages/core/src/core/paths.ts
@@ -128,12 +128,16 @@ export function stateFileExists(): boolean {
 
 /**
  * Read the CLI package version from package.json relative to the running CLI bundle.
- * Resolves `../package.json` from `process.argv[1]` (the bundle entry point).
+ * Resolves `../package.json` from the real path of `process.argv[1]` (the bundle
+ * entry point). An npm install runs the CLI through the `node_modules/.bin/oss-autopilot`
+ * symlink, and Node leaves `process.argv[1]` as the symlink, so without `realpathSync`
+ * the lookup lands on `node_modules/package.json` and every caller sees `0.0.0` (#1664).
  * Falls back to '0.0.0' if the file is unreadable.
  */
 export function getCLIVersion(): string {
   try {
-    const pkgPath = path.join(path.dirname(process.argv[1]), '..', 'package.json');
+    const entry = fs.realpathSync(process.argv[1]);
+    const pkgPath = path.join(path.dirname(entry), '..', 'package.json');
     return JSON.parse(fs.readFileSync(pkgPath, 'utf8')).version;
   } catch {
     return '0.0.0';


### PR DESCRIPTION
## Summary

`oss-autopilot --version` printed `0.0.0` for every npm install (3.21.1 and 3.22.1 alike). The same value feeds the dashboard's update check and the startup handshake, so those saw 0.0.0 too.

## Cause

`getCLIVersion` in `packages/core/src/core/paths.ts` located the manifest as `dirname(process.argv[1])/../package.json`. An installed CLI runs through the `node_modules/.bin/oss-autopilot` symlink, and Node leaves `process.argv[1]` as the symlink path, so the lookup landed on `node_modules/package.json`, which does not exist, and the catch returned the fallback. It only worked when invoked as `node dist/cli.bundle.cjs`.

## Fix

Resolve `process.argv[1]` with `fs.realpathSync` before taking `dirname`. One line; dev (`tsx src/cli.ts`) and the direct-bundle path are unchanged. The `0.0.0` fallback stays for a genuinely unreadable manifest.

## Verification

Built, bundled, `npm pack`ed 3.22.1 and installed the tarball into a scratch prefix:

```
$ readlink node_modules/.bin/oss-autopilot
../@oss-autopilot/core/dist/cli.bundle.cjs
$ node_modules/.bin/oss-autopilot --version
3.22.1
```

The published 3.22.1 prints `0.0.0` on the same command.

## Tests

New `packages/core/src/core/paths.test.ts`: bundle path, a `.bin`-style symlink to the bundle (fails on main), and the missing-manifest fallback. Core suite: 3214 passed, 17 skipped. Typecheck and lint clean.

Closes #1664

🤖 Generated with [Claude Code](https://claude.com/claude-code)