### PR TITLE
fix(overnight): deny npm/pnpm registry writes in the headless tool list

### DIFF
--- a/commands/oss-overnight.md
+++ b/commands/oss-overnight.md
@@ -100,7 +100,8 @@ nothing that mutates remote state: file tools, Task, git subcommands except
 `issue view`, `repo view`; no `gh api`), and `node`/`pnpm`/`npm` for the CLI
 and test suites. No `bash`, `sh`, or `npx`. A deny list (`--disallowedTools`,
 deny beats allow) additionally names `git push`, every `gh pr`/`gh issue`
-write, `gh run rerun`, `gh api`, and `AskUserQuestion`. The preparer agent's
+write, `gh run rerun`, `gh api`, the npm/pnpm registry writes
+(`publish`/`unpublish`/`deprecate`), and `AskUserQuestion`. The preparer agent's
 charter repeats the gate so an interactive `/oss-overnight` behaves the same. If running a repo's test
 suite under your own credentials is more trust than you want, run the job as
 a dedicated user with no push credentials. Two caveats

--- a/packages/core/src/commands/overnight.test.ts
+++ b/packages/core/src/commands/overnight.test.ts
@@ -402,6 +402,12 @@ describe('schedule', () => {
       'Bash(gh pr merge *)',
       'Bash(gh pr comment *)',
       'Bash(gh api *)',
+      'Bash(npm publish)',
+      'Bash(npm publish *)',
+      'Bash(npm unpublish *)',
+      'Bash(npm deprecate *)',
+      'Bash(pnpm publish)',
+      'Bash(pnpm publish *)',
       'AskUserQuestion',
     ]) {
       expect(denied).toContain(must);

--- a/packages/core/src/commands/overnight.ts
+++ b/packages/core/src/commands/overnight.ts
@@ -351,6 +351,15 @@ export const OVERNIGHT_DISALLOWED_TOOLS = [
   'Bash(gh issue close *)',
   'Bash(gh run rerun *)',
   'Bash(gh api *)',
+  // `npm`/`pnpm` are allowed for builds and tests, but a token in ~/.npmrc
+  // would let their registry writes ship a release unattended — exactly the
+  // credential-bearing writes the gate exists to keep out.
+  'Bash(npm publish)',
+  'Bash(npm publish *)',
+  'Bash(npm unpublish *)',
+  'Bash(npm deprecate *)',
+  'Bash(pnpm publish)',
+  'Bash(pnpm publish *)',
   'AskUserQuestion',
 ].join(',');
 


### PR DESCRIPTION
## What

The overnight scheduler's allowlist grants `Bash(npm *)` and `Bash(pnpm *)` for builds and test suites, but the deny list never blocked their registry writes. With a token in `~/.npmrc`, an unattended run could `npm publish`, `npm unpublish`, or `npm deprecate`. That is the credential-bearing write class the gate's own comment says the list keeps out, and it contradicts the morning report's "Nothing was pushed, posted, or merged" line.

## How

Deny beats allow: add `npm publish` (bare and wildcard), `npm unpublish`, `npm deprecate`, and `pnpm publish` to `OVERNIGHT_DISALLOWED_TOOLS`, assert them in the gate test, and name the registry writes in the /oss-overnight doc's deny-list prose.

## Verification

- `pnpm vitest run src/commands/overnight.test.ts`: 20 passed
- `tsc --noEmit -p tsconfig.tests.json`: clean
- eslint on the touched files: 0 errors; prettier clean

Found during the 2026-09-06 repo-autopilot delta audit of the #1656 overnight feature.